### PR TITLE
UpdateGeometry() for single geometries

### DIFF
--- a/src/Visualization/Shader/GeometryRenderer.h
+++ b/src/Visualization/Shader/GeometryRenderer.h
@@ -66,6 +66,10 @@ public:
         return bool(geometry_ptr_);
     }
 
+    bool HasGeometry(std::shared_ptr<const Geometry> geometry_ptr) const {
+        return geometry_ptr_ == geometry_ptr;
+    }
+
     bool IsVisible() const { return is_visible_; }
     void SetVisible(bool visible) { is_visible_ = visible; };
     

--- a/src/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Visualization/Visualizer/Visualizer.cpp
@@ -356,7 +356,7 @@ bool Visualizer::AddGeometry(std::shared_ptr<const Geometry> geometry_ptr)
     ResetViewPoint();
     PrintDebug("Add geometry and update bounding box to %s\n",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
-    return UpdateGeometry();
+    return UpdateGeometry(geometry_ptr);
 }
 
 bool Visualizer::UpdateGeometry(std::shared_ptr<const Geometry> geometry_ptr)

--- a/src/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Visualization/Visualizer/Visualizer.cpp
@@ -359,12 +359,14 @@ bool Visualizer::AddGeometry(std::shared_ptr<const Geometry> geometry_ptr)
     return UpdateGeometry();
 }
 
-bool Visualizer::UpdateGeometry()
+bool Visualizer::UpdateGeometry(std::shared_ptr<const Geometry> geometry_ptr)
 {
     glfwMakeContextCurrent(window_);
     bool success = true;
     for (const auto &renderer_ptr : geometry_renderer_ptrs_) {
-        success = (success && renderer_ptr->UpdateGeometry());
+        if (geometry_ptr == nullptr || renderer_ptr->HasGeometry(geometry_ptr)) {
+            success = (success && renderer_ptr->UpdateGeometry());
+        }
     }
     UpdateRender();
     return success;

--- a/src/Visualization/Visualizer/Visualizer.h
+++ b/src/Visualization/Visualizer/Visualizer.h
@@ -114,7 +114,9 @@ public:
     /// Function to update geometry
     /// This function must be called when geometry has been changed. Otherwise
     /// the behavior of Visualizer is undefined.
-    virtual bool UpdateGeometry();
+    /// If called without an argument, updates all geometries, otherwise only
+    /// updates the geometry specified.
+    virtual bool UpdateGeometry(std::shared_ptr<const Geometry> geometry_ptr=nullptr);
     virtual bool HasGeometry() const;
 
     /// Function to set the redraw flag as dirty


### PR DESCRIPTION
With many geometries loaded in the visualizer, UpdateGeometry() and AddGeometry() become slow. 

The reason is that in both cases, all geometries are invalidated.

With this pull request AddGeometry() only updates the new geometry and UpdateGeometry() gets an optional argument for updating only one specific geometry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/804)
<!-- Reviewable:end -->
