### PR TITLE
alexs7 - minor fix to make the realsense D415 recording work

### DIFF
--- a/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
+++ b/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
@@ -1,3 +1,7 @@
+# Might need these lines aswell on macOS Mojave 10.14.3
+# import sys
+# sys.path.append('/usr/local/lib')
+
 # pyrealsense2 is required.
 # Please see instructions in https://github.com/IntelRealSense/librealsense/tree/master/wrappers/python
 import pyrealsense2 as rs
@@ -93,7 +97,7 @@ if __name__ == "__main__":
     if args.record_imgs or args.record_rosbag:
         # note: using 640 x 480 depth resolution produces smooth depth boundaries
         #       using rs.format.bgr8 for color image format for OpenCV based image visualization
-        config.enable_stream(rs.stream.depth, 1280, 720, rs.format.z16, 30)
+        config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
         config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
         if args.record_rosbag:
             config.enable_record_to_file(path_bag)


### PR DESCRIPTION
Encountered a problem when running ```python3 realsense_recorder.py --record_imgs``` on my machine (Macbook Pro). Which was:

`Traceback (most recent call last):
  File "realsense_recorder.py", line 107, in <module>
    profile = pipeline.start(config)
RuntimeError: Couldn't resolve requests`

Changing the resolution of the depth camera solves this.

Also added:

```
# Might need these lines aswell on macOS Mojave 10.14.3
# import sys
# sys.path.append('/usr/local/lib')
```
On top, as it might be needed for macOS users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/833)
<!-- Reviewable:end -->
