### PR TITLE
fixing issue with no associated color-depth sync frame

### DIFF
--- a/examples/Python/ReconstructionSystem/scripts/synchronize_frames.py
+++ b/examples/Python/ReconstructionSystem/scripts/synchronize_frames.py
@@ -59,7 +59,11 @@ def run_synchronization(args):
         if args.debug_mode:
             print(temp_name)
             print(new_name)
-        os.rename(temp_name, new_name)
+        if not exists(temp_name):
+            assert(i+1 == len(color_files))
+            os.remove(color_files[-1])
+        else:
+            os.rename(temp_name, new_name)
     shutil.rmtree(os.path.join(folder_path, "temp"))
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is an edge case this script fails on, and that is the case where there is no associated synchronized depth frame for a given color frame.

I assume that this will only happen on the last color frame of a sequence, where the recording is killed before the associated depth frame is written. If this assumption holds, then the patch will delete the last color file since there is no depth frame to go with it.

This issue can be tested with Redwood class `toilet`, sequence `08597`.

As a side note, I could not find a statement _explicitly_ stating that the raw frames from Redwood need to be run through this script, but clearly they do. I would recommend adding that somewhere prominent in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelvcl/open3d/870)
<!-- Reviewable:end -->
