### PR TITLE
Initial Octree support

### DIFF
--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -1,0 +1,415 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Geometry/Octree.h"
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <unordered_map>
+
+#include "Open3D/Geometry/PointCloud.h"
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+namespace geometry {
+
+std::shared_ptr<OctreeNodeInfo> OctreeInternalNode::GetInsertionNodeInfo(
+        const std::shared_ptr<OctreeNodeInfo>& node_info,
+        const Eigen::Vector3d& point) {
+    if (!Octree::IsPointInBound(point, node_info->origin_, node_info->size_)) {
+        throw std::runtime_error(
+                "Internal error: cannot insert to child since point not in "
+                "parent node bound.");
+    }
+
+    double child_size = node_info->size_ / 2.0;
+    size_t x_index = point(0) < node_info->origin_(0) + child_size ? 0 : 1;
+    size_t y_index = point(1) < node_info->origin_(1) + child_size ? 0 : 1;
+    size_t z_index = point(2) < node_info->origin_(2) + child_size ? 0 : 1;
+    size_t child_index = x_index + y_index * 2 + z_index * 4;
+    Eigen::Vector3d child_origin =
+            node_info->origin_ + Eigen::Vector3d(x_index * child_size,
+                                                 y_index * child_size,
+                                                 z_index * child_size);
+    auto child_node_info = std::make_shared<OctreeNodeInfo>(
+            child_origin, child_size, node_info->depth_ + 1, child_index);
+    return child_node_info;
+}
+
+Octree::Octree(const Octree& src_octree)
+    : Geometry3D(Geometry::GeometryType::Octree),
+      max_depth_(src_octree.max_depth_),
+      origin_(src_octree.origin_),
+      size_(src_octree.size_) {
+    // First traversal: clone nodes without edges
+    std::unordered_map<std::shared_ptr<OctreeNode>, std::shared_ptr<OctreeNode>>
+            map_src_to_dst_node;
+    auto f_build_map =
+            [&map_src_to_dst_node](
+                    const std::shared_ptr<OctreeNode>& src_node,
+                    const std::shared_ptr<OctreeNodeInfo>& src_node_info)
+            -> void {
+        if (auto src_internal_node =
+                    std::dynamic_pointer_cast<OctreeInternalNode>(src_node)) {
+            auto dst_internal_node = std::make_shared<OctreeInternalNode>();
+            map_src_to_dst_node[src_internal_node] = dst_internal_node;
+        } else if (auto src_leaf_node =
+                           std::dynamic_pointer_cast<OctreeLeafNode>(
+                                   src_node)) {
+            auto dst_leaf_node = std::make_shared<OctreeLeafNode>();
+            dst_leaf_node->color_ = src_leaf_node->color_;
+            map_src_to_dst_node[src_leaf_node] = dst_leaf_node;
+        } else {
+            throw std::runtime_error("Internal error: unknown node type");
+        }
+    };
+    src_octree.Traverse(f_build_map);
+
+    // Second traversal: add edges
+    auto f_clone_edges =
+            [&map_src_to_dst_node](
+                    const std::shared_ptr<OctreeNode>& src_node,
+                    const std::shared_ptr<OctreeNodeInfo>& src_node_info)
+            -> void {
+        if (auto src_internal_node =
+                    std::dynamic_pointer_cast<OctreeInternalNode>(src_node)) {
+            auto dst_internal_node =
+                    std::dynamic_pointer_cast<OctreeInternalNode>(
+                            map_src_to_dst_node.at(src_internal_node));
+            for (size_t child_index = 0; child_index < 8; child_index++) {
+                auto src_child_node = src_internal_node->children_[child_index];
+                if (src_child_node != nullptr) {
+                    auto dst_child_node =
+                            map_src_to_dst_node.at(src_child_node);
+                    dst_internal_node->children_[child_index] = dst_child_node;
+                }
+            }
+        }
+    };
+    src_octree.Traverse(f_clone_edges);
+
+    // Save root node to dst_octree (this octree)
+    root_node_ = map_src_to_dst_node.at(src_octree.root_node_);
+}
+
+bool Octree::operator==(const Octree& that) const {
+    // Check basic properties
+    bool rc = true;
+    rc = rc && origin_.isApprox(that.origin_);
+    rc = rc && size_ == that.size_;
+    rc = rc && max_depth_ == that.max_depth_;
+    if (!rc) {
+        return rc;
+    }
+
+    // Assign and check node ids
+    std::unordered_map<std::shared_ptr<OctreeNode>, size_t> map_node_to_id;
+    std::unordered_map<size_t, std::shared_ptr<OctreeNode>> map_id_to_node;
+    size_t next_id = 0;
+    auto f_assign_node_id =
+            [&map_node_to_id, &map_id_to_node, &next_id](
+                    const std::shared_ptr<OctreeNode>& node,
+                    const std::shared_ptr<OctreeNodeInfo>& node_info) -> void {
+        map_node_to_id[node] = next_id;
+        map_id_to_node[next_id] = node;
+        next_id++;
+    };
+
+    map_node_to_id.clear();
+    map_id_to_node.clear();
+    next_id = 0;
+    Traverse(f_assign_node_id);
+    std::unordered_map<std::shared_ptr<OctreeNode>, size_t>
+            this_map_node_to_id = map_node_to_id;
+    std::unordered_map<size_t, std::shared_ptr<OctreeNode>>
+            this_map_id_to_node = map_id_to_node;
+    size_t num_nodes = next_id;
+
+    map_node_to_id.clear();
+    map_id_to_node.clear();
+    next_id = 0;
+    that.Traverse(f_assign_node_id);
+    std::unordered_map<std::shared_ptr<OctreeNode>, size_t>
+            that_map_node_to_id = map_node_to_id;
+    std::unordered_map<size_t, std::shared_ptr<OctreeNode>>
+            that_map_id_to_node = map_id_to_node;
+
+    rc = rc && this_map_node_to_id.size() == num_nodes &&
+         that_map_node_to_id.size() == num_nodes &&
+         this_map_id_to_node.size() == num_nodes &&
+         that_map_id_to_node.size() == num_nodes;
+    if (!rc) {
+        return rc;
+    }
+
+    // Check nodes
+    for (size_t id = 0; id < num_nodes; ++id) {
+        std::shared_ptr<OctreeNode> this_node = this_map_id_to_node.at(id);
+        std::shared_ptr<OctreeNode> that_node = that_map_id_to_node.at(id);
+        // Check if internal node
+        auto is_same_node_type = false;
+        auto this_internal_node =
+                std::dynamic_pointer_cast<OctreeInternalNode>(this_node);
+        auto that_internal_node =
+                std::dynamic_pointer_cast<OctreeInternalNode>(that_node);
+        if (this_internal_node != nullptr && that_internal_node != nullptr) {
+            is_same_node_type = true;
+            for (size_t child_index = 0; child_index < 8; child_index++) {
+                const std::shared_ptr<OctreeNode>& this_child =
+                        this_internal_node->children_[child_index];
+                int this_child_id = -1;
+                if (this_child != nullptr) {
+                    this_child_id = int(this_map_node_to_id.at(this_child));
+                }
+                const std::shared_ptr<OctreeNode>& that_child =
+                        that_internal_node->children_[child_index];
+                int that_child_id = -1;
+                if (that_child != nullptr) {
+                    that_child_id = int(that_map_node_to_id.at(that_child));
+                }
+                rc = rc && this_child_id == that_child_id;
+            }
+        }
+        // Check if leaf node
+        auto this_leaf_node =
+                std::dynamic_pointer_cast<OctreeLeafNode>(this_node);
+        auto that_leaf_node =
+                std::dynamic_pointer_cast<OctreeLeafNode>(that_node);
+        if (this_leaf_node != nullptr && that_leaf_node != nullptr) {
+            is_same_node_type = true;
+            rc = rc && this_leaf_node->color_.isApprox(this_leaf_node->color_);
+        }
+        // Handle case where node types are different
+        rc = rc && is_same_node_type;
+    }
+
+    return rc;
+}
+
+void Octree::Clear() {
+    // Inherited Clear function
+    root_node_ = nullptr;
+    origin_.setZero();
+    size_ = 0;
+}
+
+void Octree::Clear(bool reset_bounds) {
+    if (reset_bounds) {
+        Clear();
+    } else {
+        root_node_ = nullptr;
+    }
+}
+
+bool Octree::IsEmpty() const { throw std::runtime_error("Not implemented"); }
+Eigen::Vector3d Octree::GetMinBound() const {
+    throw std::runtime_error("Not implemented");
+}
+
+Eigen::Vector3d Octree::GetMaxBound() const {
+    throw std::runtime_error("Not implemented");
+}
+
+void Octree::Transform(const Eigen::Matrix4d& transformation) {
+    throw std::runtime_error("Not implemented");
+}
+
+void Octree::ConvertFromPointCloud(const geometry::PointCloud& point_cloud,
+                                   bool reset_bounds,
+                                   double size_expand) {
+    if (size_expand > 1 || size_expand < 0) {
+        throw std::runtime_error("size_expand shall be between 0 and 1");
+    }
+
+    // Set bounds
+    Clear(reset_bounds);
+    if (reset_bounds) {
+        // Reset with automatic centering
+        Eigen::Array3d min_bound = point_cloud.GetMinBound();
+        Eigen::Array3d max_bound = point_cloud.GetMaxBound();
+        Eigen::Array3d center = (min_bound + max_bound) / 2;
+        Eigen::Array3d half_sizes = center - min_bound;
+        double max_half_size = half_sizes.maxCoeff();
+        origin_ = min_bound.min(center - max_half_size);
+        if (max_half_size == 0) {
+            size_ = size_expand;
+        } else {
+            size_ = max_half_size * 2 * (1 + size_expand);
+        }
+    }
+
+    // Insert points
+    for (size_t idx = 0; idx < point_cloud.points_.size(); idx++) {
+        const Eigen::Vector3d& point = point_cloud.points_[idx];
+        const Eigen::Vector3d& color = point_cloud.colors_[idx];
+        InsertPoint(point, color);
+    }
+}
+
+void Octree::InsertPoint(const Eigen::Vector3d& point,
+                         const Eigen::Vector3d& color) {
+    if (root_node_ == nullptr) {
+        if (max_depth_ == 0) {
+            root_node_ = std::make_shared<OctreeLeafNode>();
+        } else {
+            root_node_ = std::make_shared<OctreeInternalNode>();
+        }
+    }
+    auto root_node_info =
+            std::make_shared<OctreeNodeInfo>(origin_, size_, 0, 0);
+    InsertPointRecurse(root_node_, root_node_info, point, color);
+}
+
+void Octree::InsertPointRecurse(
+        const std::shared_ptr<OctreeNode>& node,
+        const std::shared_ptr<OctreeNodeInfo>& node_info,
+        const Eigen::Vector3d& point,
+        const Eigen::Vector3d& color) {
+    if (!IsPointInBound(point, node_info->origin_, node_info->size_)) {
+        return;
+    }
+    if (node_info->depth_ > max_depth_) {
+        return;
+    } else if (node_info->depth_ == max_depth_) {
+        if (auto leaf_node = std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
+            leaf_node->color_ = color;
+        } else {
+            throw std::runtime_error(
+                    "Internal error: leaf node must be OctreeLeafNode");
+        }
+    } else {
+        if (auto internal_node =
+                    std::dynamic_pointer_cast<OctreeInternalNode>(node)) {
+            // Get child node info
+            std::shared_ptr<OctreeNodeInfo> child_node_info =
+                    internal_node->GetInsertionNodeInfo(node_info, point);
+
+            // Init child node if not yet initialized
+            size_t child_index = child_node_info->child_index_;
+            if (internal_node->children_[child_index] == nullptr) {
+                if (node_info->depth_ == max_depth_ - 1) {
+                    internal_node->children_[child_index] =
+                            std::make_shared<OctreeLeafNode>();
+                } else {
+                    internal_node->children_[child_index] =
+                            std::make_shared<OctreeInternalNode>();
+                }
+            }
+
+            // Insert to the child
+            InsertPointRecurse(internal_node->children_[child_index],
+                               child_node_info, point, color);
+        } else {
+            throw std::runtime_error(
+                    "Internal error: internal node must be OctreeInternalNode");
+        }
+    }
+}
+
+bool Octree::IsPointInBound(const Eigen::Vector3d& point,
+                            const Eigen::Vector3d& origin,
+                            const double& size) {
+    bool rc = (Eigen::Array3d(origin) <= Eigen::Array3d(point)).all() &&
+              (Eigen::Array3d(point) < Eigen::Array3d(origin) + size).all();
+    return rc;
+}
+
+void Octree::Traverse(
+        const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                 const std::shared_ptr<OctreeNodeInfo>&)>& f) {
+    // root_node_'s child index is 0, though it isn't a child node
+    TraverseRecurse(root_node_,
+                    std::make_shared<OctreeNodeInfo>(origin_, size_, 0, 0), f);
+}
+
+void Octree::Traverse(
+        const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                 const std::shared_ptr<OctreeNodeInfo>&)>& f)
+        const {
+    // root_node_'s child index is 0, though it isn't a child node
+    TraverseRecurse(root_node_,
+                    std::make_shared<OctreeNodeInfo>(origin_, size_, 0, 0), f);
+}
+
+void Octree::TraverseRecurse(
+        const std::shared_ptr<OctreeNode>& node,
+        const std::shared_ptr<OctreeNodeInfo>& node_info,
+        const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                 const std::shared_ptr<OctreeNodeInfo>&)>& f) {
+    if (node == nullptr) {
+        return;
+    } else if (auto internal_node =
+                       std::dynamic_pointer_cast<OctreeInternalNode>(node)) {
+        f(internal_node, node_info);
+        double child_size = node_info->size_ / 2.0;
+
+        for (size_t child_index = 0; child_index < 8; ++child_index) {
+            size_t x_index = child_index % 2;
+            size_t y_index = (child_index / 2) % 2;
+            size_t z_index = (child_index / 4) % 2;
+
+            auto child_node = internal_node->children_[child_index];
+            Eigen::Vector3d child_node_origin =
+                    node_info->origin_ +
+                    Eigen::Vector3d(x_index, y_index, z_index) * child_size;
+            auto child_node_info = std::make_shared<OctreeNodeInfo>(
+                    child_node_origin, child_size, node_info->depth_ + 1,
+                    child_index);
+            TraverseRecurse(child_node, child_node_info, f);
+        }
+    } else if (auto leaf_node =
+                       std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
+        f(leaf_node, node_info);
+    } else {
+        throw std::runtime_error("Internal error: unknown node type");
+    }
+}
+
+std::pair<std::shared_ptr<OctreeLeafNode>, std::shared_ptr<OctreeNodeInfo>>
+Octree::LocateLeafNode(const Eigen::Vector3d& point) const {
+    // TODO: add early stoping to callback function when the target has been
+    //       found, i.e. add return value to callback function.
+    // TODO: consider adding node's depth as parameter to the callback function.
+    std::shared_ptr<OctreeLeafNode> target_leaf_node = nullptr;
+    std::shared_ptr<OctreeNodeInfo> target_leaf_node_info = nullptr;
+    auto f_locate_leaf_node =
+            [&target_leaf_node, &target_leaf_node_info, &point](
+                    const std::shared_ptr<OctreeNode>& node,
+                    const std::shared_ptr<OctreeNodeInfo>& node_info) -> void {
+        if (IsPointInBound(point, node_info->origin_, node_info->size_)) {
+            if (auto leaf_node =
+                        std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
+                target_leaf_node = leaf_node;
+                target_leaf_node_info = node_info;
+            }
+        }
+    };
+    Traverse(f_locate_leaf_node);
+    return std::make_pair(target_leaf_node, target_leaf_node_info);
+}
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -1,0 +1,188 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "Open3D/Geometry/Geometry3D.h"
+
+namespace open3d {
+namespace geometry {
+
+class PointCloud;
+
+/// Design decision: do not store origin and size of a node in OctreeNode
+/// OctreeNodeInfo is computed on the fly
+class OctreeNodeInfo {
+public:
+    OctreeNodeInfo(const Eigen::Vector3d& origin,
+                   const double& size,
+                   const size_t& depth,
+                   const size_t& child_index)
+        : origin_(origin),
+          size_(size),
+          depth_(depth),
+          child_index_(child_index) {}
+    ~OctreeNodeInfo() {}
+    Eigen::Vector3d origin_ = Eigen::Vector3d(0, 0, 0);
+    double size_ = 0;
+    size_t depth_ = 0;
+    size_t child_index_ = 0;
+};
+
+/// OctreeNode class
+/// Design decision: do not store origin and size of a node
+///     - Good: better space efficiency
+///     - Bad: need to recompute origin and size when traversing
+class OctreeNode {
+public:
+    OctreeNode() {}
+    virtual ~OctreeNode() {}
+};
+
+/// Children node ordering conventions are as follows.
+///
+/// For illustration, assume,
+/// - root_node: origin == (0, 0, 0), size == 2
+///
+/// Then,
+/// - children_[0]: origin == (0, 0, 0), size == 1
+/// - children_[1]: origin == (1, 0, 0), size == 1, along X-axis next to child 0
+/// - children_[2]: origin == (0, 1, 0), size == 1, along Y-axis next to child 0
+/// - children_[3]: origin == (1, 1, 0), size == 1, in X-Y plane
+/// - children_[4]: origin == (0, 0, 1), size == 1, along Z-axis next to child 0
+/// - children_[5]: origin == (1, 0, 1), size == 1, in X-Z plane
+/// - children_[6]: origin == (0, 1, 1), size == 1, in Y-Z plane
+/// - children_[7]: origin == (1, 1, 1), size == 1, furthest from child 0
+class OctreeInternalNode : public OctreeNode {
+public:
+    static std::shared_ptr<OctreeNodeInfo> GetInsertionNodeInfo(
+            const std::shared_ptr<OctreeNodeInfo>& node_info,
+            const Eigen::Vector3d& point);
+
+public:
+    std::shared_ptr<OctreeNode> children_[8];
+};
+
+class OctreeLeafNode : public OctreeNode {
+public:
+    // TODO: flexible data, with lambda function for handling node
+    Eigen::Vector3d color_ = Eigen::Vector3d(0, 0, 0);
+};
+
+class Octree : public Geometry3D {
+public:
+    Octree() : Geometry3D(Geometry::GeometryType::Octree) {}
+    Octree(const size_t& max_depth)
+        : Geometry3D(Geometry::GeometryType::Octree), max_depth_(max_depth) {}
+    Octree(const size_t& max_depth,
+           const Eigen::Vector3d& origin,
+           const double& size)
+        : Geometry3D(Geometry::GeometryType::Octree),
+          max_depth_(max_depth),
+          origin_(origin),
+          size_(size) {}
+    Octree(const Octree& src_octree);
+    ~Octree() override {}
+
+public:
+    void Clear() override;
+    void Clear(bool reset_bounds);
+    bool IsEmpty() const override;
+    Eigen::Vector3d GetMinBound() const override;
+    Eigen::Vector3d GetMaxBound() const override;
+    void Transform(const Eigen::Matrix4d& transformation) override;
+
+public:
+    void ConvertFromPointCloud(const geometry::PointCloud& point_cloud,
+                               bool reset_bounds = true,
+                               double size_expand = 0.01);
+
+    /// Root of the octree
+    std::shared_ptr<OctreeNode> root_node_ = nullptr;
+
+    /// Global min bound (include). A point is within bound iff
+    /// origin_ <= point < origin_ + size_
+    Eigen::Vector3d origin_ = Eigen::Vector3d(0, 0, 0);
+
+    /// Outer bounding box edge size for the whole octree. A point is within
+    /// bound iff origin_ <= point < origin_ + size_
+    double size_ = 0;
+
+    /// Max depth of octree. The depth is defined as the distance from the
+    /// deepest leaf node to root. A tree with only the root node has depth 0.
+    size_t max_depth_ = 0;
+
+    /// Insert point
+    /// TODO: Running average of color
+    /// TODO: Lambda function for handling node
+    void InsertPoint(const Eigen::Vector3d& point,
+                     const Eigen::Vector3d& color);
+
+    /// DFS traversal of Octree from the root, with callback function called
+    /// for each node
+    void Traverse(
+            const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                     const std::shared_ptr<OctreeNodeInfo>&)>&
+                    f);
+
+    /// Const version of Traverse. DFS traversal of Octree from the root, with
+    /// callback function called for each node
+    void Traverse(
+            const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                     const std::shared_ptr<OctreeNodeInfo>&)>&
+                    f) const;
+
+    std::pair<std::shared_ptr<OctreeLeafNode>, std::shared_ptr<OctreeNodeInfo>>
+    LocateLeafNode(const Eigen::Vector3d& point) const;
+
+    /// Return true if point within bound, that is,
+    /// origin <= point < origin + size
+    static bool IsPointInBound(const Eigen::Vector3d& point,
+                               const Eigen::Vector3d& origin,
+                               const double& size);
+
+    /// Returns true if the Octree is completely the same, used for testing
+    bool operator==(const Octree& other) const;
+
+private:
+    static void TraverseRecurse(
+            const std::shared_ptr<OctreeNode>& node,
+            const std::shared_ptr<OctreeNodeInfo>& node_info,
+            const std::function<void(const std::shared_ptr<OctreeNode>&,
+                                     const std::shared_ptr<OctreeNodeInfo>&)>&
+                    f);
+
+    void InsertPointRecurse(const std::shared_ptr<OctreeNode>& node,
+                            const std::shared_ptr<OctreeNodeInfo>& node_info,
+                            const Eigen::Vector3d& point,
+                            const Eigen::Vector3d& color);
+};
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
@@ -264,7 +264,7 @@ TEST(HalfEdgeTriangleMesh, Constructor_TwoTrianglesFlipped) {
                  std::runtime_error);  // Non-manifold
 }
 
-TEST(HalfEdgeTriangleMesh, Constructo_rTwoTrianglesInvalidVertex) {
+TEST(HalfEdgeTriangleMesh, Constructor_TwoTrianglesInvalidVertex) {
     geometry::TriangleMesh mesh = get_mesh_two_triangles_invalid_vertex();
     ASSERT_THROW(geometry::CreateHalfEdgeMeshFromMesh(mesh),
                  std::runtime_error);  // Non-manifold

--- a/src/UnitTest/Geometry/Octree.cpp
+++ b/src/UnitTest/Geometry/Octree.cpp
@@ -1,0 +1,266 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <iostream>
+#include <memory>
+
+#include "Open3D/Geometry/Octree.h"
+#include "Open3D/Geometry/PointCloud.h"
+#include "Open3D/IO/ClassIO/PointCloudIO.h"
+#include "TestUtility/UnitTest.h"
+
+using namespace open3d;
+using namespace unit_test;
+
+TEST(Octree, ConstructorWithoutSize) {
+    geometry::Octree octree(10);
+    ExpectEQ(octree.origin_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(octree.size_, 0);
+}
+
+TEST(Octree, ConstructorWithSize) {
+    geometry::Octree octree(0, Eigen::Vector3d(-1, -1, -1), 2);
+    ExpectEQ(octree.origin_, Eigen::Vector3d(-1, -1, -1));
+    EXPECT_EQ(octree.size_, 2);
+}
+
+TEST(Octree, ZeroDepth) {
+    geometry::Octree octree(0, Eigen::Vector3d(-1, -1, -1), 2);
+    Eigen::Vector3d point(0, 0, 0);
+    Eigen::Vector3d color(0, 0.1, 0.2);
+    octree.InsertPoint(point, color);
+    if (auto leaf_node = std::dynamic_pointer_cast<geometry::OctreeLeafNode>(
+                octree.root_node_)) {
+        ExpectEQ(leaf_node->color_, color);
+    } else {
+        throw std::runtime_error("Leaf node must be OctreeLeafNode");
+    }
+}
+
+TEST(Octree, ZeroDepthOutOfBound) {
+    geometry::Octree octree(0, Eigen::Vector3d(-1, -1, -1), 2);
+
+    Eigen::Vector3d point_out(10, 10, 10);  // Outside bound
+    Eigen::Vector3d color_out(0, 0.1, 0.2);
+    octree.InsertPoint(point_out, color_out);
+
+    Eigen::Vector3d point_in(0, 0, 0);  // Within bound
+    Eigen::Vector3d color_in(0.1, 0.2, 0.3);
+    octree.InsertPoint(point_in, color_in);
+
+    if (auto leaf_node = std::dynamic_pointer_cast<geometry::OctreeLeafNode>(
+                octree.root_node_)) {
+        ExpectEQ(leaf_node->color_, color_in);
+    } else {
+        throw std::runtime_error("Leaf node must be OctreeLeafNode");
+    }
+}
+
+TEST(Octree, ZeroDepthValueOverwrite) {
+    geometry::Octree octree(0, Eigen::Vector3d(-1, -1, -1), 2);
+
+    Eigen::Vector3d point_old(0, 0, 0);
+    Eigen::Vector3d color_old(0.1, 0.2, 0.3);
+    Eigen::Vector3d point_new(0.01, 0.01, 0.01);
+    Eigen::Vector3d color_new(0.4, 0.5, 0.6);
+
+    octree.InsertPoint(point_old, color_old);
+    if (auto leaf_node = std::dynamic_pointer_cast<geometry::OctreeLeafNode>(
+                octree.root_node_)) {
+        ExpectEQ(leaf_node->color_, color_old);
+    } else {
+        throw std::runtime_error("Leaf node must be OctreeLeafNode");
+    }
+
+    octree.InsertPoint(point_new, color_new);
+    if (auto leaf_node = std::dynamic_pointer_cast<geometry::OctreeLeafNode>(
+                octree.root_node_)) {
+        ExpectEQ(leaf_node->color_, color_new);
+    } else {
+        throw std::runtime_error("Leaf node must be OctreeLeafNode");
+    }
+}
+
+TEST(Octree, EightCubes) {
+    // Build octree
+    std::vector<Eigen::Vector3d> points{
+            Eigen::Vector3d(0.5, 0.5, 0.5), Eigen::Vector3d(1.5, 0.5, 0.5),
+            Eigen::Vector3d(0.5, 1.5, 0.5), Eigen::Vector3d(1.5, 1.5, 0.5),
+            Eigen::Vector3d(0.5, 0.5, 1.5), Eigen::Vector3d(1.5, 0.5, 1.5),
+            Eigen::Vector3d(0.5, 1.5, 1.5), Eigen::Vector3d(1.5, 1.5, 1.5),
+    };
+    std::vector<Eigen::Vector3d> colors{
+            Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(0.1, 0.0, 0.0),
+            Eigen::Vector3d(0.0, 0.1, 0.0), Eigen::Vector3d(0.1, 0.1, 0.0),
+            Eigen::Vector3d(0.0, 0.0, 0.1), Eigen::Vector3d(0.1, 0.0, 0.1),
+            Eigen::Vector3d(0.0, 0.1, 0.1), Eigen::Vector3d(0.1, 0.1, 0.1),
+    };
+    geometry::Octree octree(1, Eigen::Vector3d(0, 0, 0), 2);
+    for (size_t i = 0; i < points.size(); ++i) {
+        octree.InsertPoint(points[i], colors[i]);
+    }
+
+    // Check dimensions
+    ExpectEQ(octree.origin_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(octree.size_, 2);
+
+    // Check node values
+    if (auto root_node =
+                std::dynamic_pointer_cast<geometry::OctreeInternalNode>(
+                        octree.root_node_)) {
+        for (size_t i = 0; i < 8; ++i) {
+            if (auto leaf_node =
+                        std::dynamic_pointer_cast<geometry::OctreeLeafNode>(
+                                root_node->children_[i])) {
+                ExpectEQ(leaf_node->color_, colors[i]);
+            } else {
+                throw std::runtime_error("Leaf node must be OctreeLeafNode");
+            };
+        }
+    } else {
+        throw std::runtime_error("Root node must be OctreeInternalNode");
+    }
+}
+
+TEST(Octree, EightCubesTraverse) {
+    // Data
+    std::vector<Eigen::Vector3d> points{
+            Eigen::Vector3d(0.5, 0.5, 0.5), Eigen::Vector3d(1.5, 0.5, 0.5),
+            Eigen::Vector3d(0.5, 1.5, 0.5), Eigen::Vector3d(1.5, 1.5, 0.5),
+            Eigen::Vector3d(0.5, 0.5, 1.5), Eigen::Vector3d(1.5, 0.5, 1.5),
+            Eigen::Vector3d(0.5, 1.5, 1.5), Eigen::Vector3d(1.5, 1.5, 1.5),
+    };
+    std::vector<Eigen::Vector3d> colors{
+            Eigen::Vector3d(0.0, 0.0, 0.0), Eigen::Vector3d(0.1, 0.0, 0.0),
+            Eigen::Vector3d(0.0, 0.1, 0.0), Eigen::Vector3d(0.1, 0.1, 0.0),
+            Eigen::Vector3d(0.0, 0.0, 0.1), Eigen::Vector3d(0.1, 0.0, 0.1),
+            Eigen::Vector3d(0.0, 0.1, 0.1), Eigen::Vector3d(0.1, 0.1, 0.1),
+    };
+
+    // Callback function
+    std::vector<Eigen::Vector3d> colors_traversed;
+    std::vector<size_t> child_indices_traversed;
+    auto f = [&colors_traversed, &child_indices_traversed](
+                     const std::shared_ptr<geometry::OctreeNode>& node,
+                     const std::shared_ptr<geometry::OctreeNodeInfo>& node_info)
+            -> void {
+        if (auto leaf_node =
+                    std::dynamic_pointer_cast<geometry::OctreeLeafNode>(node)) {
+            colors_traversed.push_back(leaf_node->color_);
+            child_indices_traversed.push_back(node_info->child_index_);
+        }
+    };
+
+    // Check tree depth 1, we know child index in this case
+    geometry::Octree octree_1(1, Eigen::Vector3d(0, 0, 0), 2);
+    for (size_t i = 0; i < points.size(); ++i) {
+        octree_1.InsertPoint(points[i], colors[i]);
+    }
+    colors_traversed.clear();
+    child_indices_traversed.clear();
+    octree_1.Traverse(f);
+    EXPECT_EQ(colors_traversed.size(), 8);
+    for (size_t i = 0; i < 8; ++i) {
+        ExpectEQ(colors_traversed[i], colors[i]);
+    }
+    for (size_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(child_indices_traversed[i], i);
+    }
+
+    // Check tree depth 5
+    geometry::Octree octree_5(5, Eigen::Vector3d(0, 0, 0), 2);
+    for (size_t i = 0; i < points.size(); ++i) {
+        octree_5.InsertPoint(points[i], colors[i]);
+    }
+    colors_traversed.clear();
+    child_indices_traversed.clear();
+    octree_5.Traverse(f);
+    EXPECT_EQ(colors_traversed.size(), 8);
+    ExpectEQ(colors_traversed, colors);
+}
+
+TEST(Octree, FragmentPLYCheckClone) {
+    // Build src_octree
+    geometry::PointCloud pcd;
+    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
+    geometry::Octree src_octree(5);
+    src_octree.ConvertFromPointCloud(pcd, true, 0.01);
+
+    // Build dst_octree
+    geometry::Octree dst_octree(src_octree);
+
+    // Also checks the equal operator
+    EXPECT_TRUE(src_octree == dst_octree);
+}
+
+TEST(Octree, EqualOperatorSpecialCase) {
+    geometry::Octree src_octree;
+    geometry::Octree dst_octree;
+    EXPECT_TRUE(src_octree == dst_octree);
+}
+
+TEST(Octree, FragmentPLYLocate) {
+    // Build src_octree
+    geometry::PointCloud pcd;
+    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
+    size_t max_depth = 5;
+    geometry::Octree octree(max_depth);
+    octree.ConvertFromPointCloud(pcd, true, 0.01);
+
+    // Try locating a few points
+    for (size_t idx = 0; idx < pcd.points_.size(); idx += 200) {
+        const Eigen::Vector3d& point = pcd.points_[idx];
+        std::shared_ptr<geometry::OctreeLeafNode> node;
+        std::shared_ptr<geometry::OctreeNodeInfo> node_info;
+        std::tie(node, node_info) = octree.LocateLeafNode(point);
+        EXPECT_TRUE(geometry::Octree::IsPointInBound(point, node_info->origin_,
+                                                     node_info->size_));
+        EXPECT_EQ(node_info->depth_, max_depth);
+        EXPECT_EQ(node_info->size_, octree.size_ / pow(2, max_depth));
+    }
+}
+
+TEST(Octree, ConvertFromPointCloudBoundSinglePoint) {
+    geometry::Octree octree(10);
+    geometry::PointCloud pcd;
+    pcd.points_.push_back(Eigen::Vector3d(0, 0, 0));
+    pcd.colors_.push_back(Eigen::Vector3d(0, 0.1, 0.2));
+    octree.ConvertFromPointCloud(pcd, true, 0.01);
+    ExpectEQ(octree.origin_, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(octree.size_, 0.01);
+}
+
+TEST(Octree, ConvertFromPointCloudBoundTwoPoints) {
+    geometry::Octree octree(10);
+    geometry::PointCloud pcd;
+    pcd.points_.push_back(Eigen::Vector3d(0, 0, 0));
+    pcd.points_.push_back(Eigen::Vector3d(0, 2, 4));
+    pcd.colors_.push_back(Eigen::Vector3d(0, 0.1, 0.2));
+    pcd.colors_.push_back(Eigen::Vector3d(0.3, 0.4, 0.5));
+    octree.ConvertFromPointCloud(pcd, true, 0.01);
+    ExpectEQ(octree.origin_, Eigen::Vector3d(-2, -1, 0));  // Auto-centered
+    EXPECT_EQ(octree.size_, 4.04);  // 4.04 = 4 * (1 + 0.01)
+}


### PR DESCRIPTION
- `Octree` class
    - Constructor
    - Copy constructor
    - Node insertion
    - Node locate
    - Convert from PointCloud
    - Traverse function with labmda
- `OctreeNode` class: two sub types
- `OctreeNodeInfo` class.
    - Design decision: do not store the origin and size of a node in `OctreeNode`, store in `OctreeNodeInfo`
    - `OctreeNodeInfo` is computed then disgraded
    - Gain space efficiency with more computes
- Unit tests

Currently `OctreeLeafNode` only takes `color` property. The plan is to expand this to support flexible datatype.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/903)
<!-- Reviewable:end -->
