### PR TITLE
Uniform point sampling from triangle mesh

### DIFF
--- a/examples/Python/Basic/mesh_sampling.py
+++ b/examples/Python/Basic/mesh_sampling.py
@@ -1,0 +1,15 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Basic/mesh_sampling.py
+
+import numpy as np
+from open3d import *
+
+if __name__ == "__main__":
+  mesh = read_triangle_mesh('bathtub_0154.ply')
+  draw_geometries([mesh])
+
+  pcd = mesh.sample_points_uniformly(5000)
+  draw_geometries(pcd)

--- a/examples/Python/Basic/mesh_sampling.py
+++ b/examples/Python/Basic/mesh_sampling.py
@@ -8,8 +8,8 @@ import numpy as np
 from open3d import *
 
 if __name__ == "__main__":
-  mesh = read_triangle_mesh('bathtub_0154.ply')
-  draw_geometries([mesh])
+    mesh = read_triangle_mesh('bathtub_0154.ply')
+    draw_geometries([mesh])
 
-  pcd = mesh.sample_points_uniformly(5000)
-  draw_geometries(pcd)
+    pcd = mesh.sample_points_uniformly(5000)
+    draw_geometries(pcd)

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -28,9 +28,9 @@
 #include "Open3D/Geometry/PointCloud.h"
 
 #include <Eigen/Dense>
+#include <random>
 #include <tuple>
 #include <unordered_map>
-#include <random>
 
 #include "Open3D/Utility/Console.h"
 #include "Open3D/Utility/Helper.h"
@@ -216,15 +216,15 @@ void TriangleMesh::Purge() {
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
-  size_t number_of_points) {
-    if(number_of_points == 0 || triangles_.size() == 0) {
+        size_t number_of_points) {
+    if (number_of_points == 0 || triangles_.size() == 0) {
         return std::make_shared<PointCloud>();
     }
 
     // Compute area of each triangle and sum surface area
     std::vector<double> triangle_areas(triangles_.size());
     double surface_area = 0;
-    for(size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
         double triangle_area = TriangleArea(tidx);
         triangle_areas[tidx] = triangle_area;
         surface_area += triangle_area;
@@ -232,9 +232,9 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
 
     // triangle areas to cdf
     triangle_areas[0] /= surface_area;
-    for(size_t tidx = 1; tidx < triangles_.size(); ++tidx) {
-        triangle_areas[tidx] = triangle_areas[tidx] / surface_area +
-                               triangle_areas[tidx - 1];
+    for (size_t tidx = 1; tidx < triangles_.size(); ++tidx) {
+        triangle_areas[tidx] =
+                triangle_areas[tidx] / surface_area + triangle_areas[tidx - 1];
     }
 
     // sample point cloud
@@ -245,32 +245,32 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
     std::uniform_real_distribution<double> dist(0.0, 1.0);
     auto pcd = std::make_shared<PointCloud>();
     pcd->points_.resize(number_of_points);
-    if(has_vert_normal) {
+    if (has_vert_normal) {
         pcd->normals_.resize(number_of_points);
     }
-    if(has_vert_color) {
+    if (has_vert_color) {
         pcd->colors_.resize(number_of_points);
     }
     size_t point_idx = 0;
-    for(size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
         size_t n = std::round(triangle_areas[tidx] * number_of_points);
-        while(point_idx < n) {
+        while (point_idx < n) {
             double r1 = dist(mt);
             double r2 = dist(mt);
             double a = (1 - std::sqrt(r1));
             double b = std::sqrt(r1) * (1 - r2);
             double c = std::sqrt(r1) * r2;
 
-            const Eigen::Vector3i& triangle = triangles_[tidx];
+            const Eigen::Vector3i &triangle = triangles_[tidx];
             pcd->points_[point_idx] = a * vertices_[triangle(0)] +
                                       b * vertices_[triangle(1)] +
                                       c * vertices_[triangle(2)];
-            if(has_vert_normal) {
+            if (has_vert_normal) {
                 pcd->normals_[point_idx] = a * vertex_normals_[triangle(0)] +
                                            b * vertex_normals_[triangle(1)] +
                                            c * vertex_normals_[triangle(2)];
             }
-            if(has_vert_color) {
+            if (has_vert_color) {
                 pcd->colors_[point_idx] = a * vertex_colors_[triangle(0)] +
                                           b * vertex_colors_[triangle(1)] +
                                           c * vertex_colors_[triangle(2)];
@@ -440,10 +440,10 @@ void TriangleMesh::RemoveNonManifoldTriangles() {
 }
 
 double TriangleMesh::TriangleArea(size_t triangle_idx) {
-    const Eigen::Vector3i& triangle = triangles_[triangle_idx];
-    const Eigen::Vector3d& vertex0 = vertices_[triangle(0)];
-    const Eigen::Vector3d& vertex1 = vertices_[triangle(1)];
-    const Eigen::Vector3d& vertex2 = vertices_[triangle(2)];
+    const Eigen::Vector3i &triangle = triangles_[triangle_idx];
+    const Eigen::Vector3d &vertex0 = vertices_[triangle(0)];
+    const Eigen::Vector3d &vertex1 = vertices_[triangle(1)];
+    const Eigen::Vector3d &vertex2 = vertices_[triangle(2)];
     const Eigen::Vector3d x = vertex0 - vertex1;
     const Eigen::Vector3d y = vertex0 - vertex2;
     double area = 0.5 * x.cross(y).norm();

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -36,6 +36,8 @@
 namespace open3d {
 namespace geometry {
 
+class PointCloud;
+
 class TriangleMesh : public Geometry3D {
 public:
     TriangleMesh() : Geometry3D(Geometry::GeometryType::TriangleMesh){};
@@ -64,6 +66,9 @@ public:
     /// Function to remove duplicated and non-manifold vertices/triangles
     void Purge();
 
+    /// Function to sample number_of_points points uniformly from the mesh
+    std::shared_ptr<PointCloud> SamplePointsUniformly(size_t number_of_points);
+
 protected:
     // Forward child class type to avoid indirect nonvirtual base
     TriangleMesh(Geometry::GeometryType type) : Geometry3D(type){};
@@ -71,6 +76,10 @@ protected:
     virtual void RemoveDuplicatedTriangles();
     virtual void RemoveNonManifoldVertices();
     virtual void RemoveNonManifoldTriangles();
+
+    /// Function that computes the area of a mesh triangle identified by the
+    /// triangle index
+    virtual double TriangleArea(size_t triangle_idx);
 
 public:
     bool HasVertices() const { return vertices_.size() > 0; }

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -70,7 +70,8 @@ void pybind_trianglemesh(py::module &m) {
             .def("purge", &geometry::TriangleMesh::Purge,
                  "Function to remove duplicated and non-manifold "
                  "vertices/triangles")
-            .def("sample_points_uniformly", &geometry::TriangleMesh::SamplePointsUniformly,
+            .def("sample_points_uniformly",
+                 &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly points from the mesh",
                  "number_of_points"_a = 100)
             .def("has_vertices", &geometry::TriangleMesh::HasVertices,

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/Geometry/TriangleMesh.h"
+#include "Open3D/Geometry/PointCloud.h"
 #include "Python/docstring.h"
 #include "Python/geometry/geometry.h"
 #include "Python/geometry/geometry_trampoline.h"
@@ -69,6 +70,9 @@ void pybind_trianglemesh(py::module &m) {
             .def("purge", &geometry::TriangleMesh::Purge,
                  "Function to remove duplicated and non-manifold "
                  "vertices/triangles")
+            .def("sample_points_uniformly", &geometry::TriangleMesh::SamplePointsUniformly,
+                 "Function to uniformly points from the mesh",
+                 "number_of_points"_a = 100)
             .def("has_vertices", &geometry::TriangleMesh::HasVertices,
                  "Returns ``True`` if the mesh contains vertices.")
             .def("has_triangles", &geometry::TriangleMesh::HasTriangles,

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -144,7 +144,8 @@ void pybind_trianglemesh(py::module &m) {
     docstring::ClassMethodDocInject(m, "TriangleMesh", "normalize_normals");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "paint_uniform_color");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "purge");
-    docstring::ClassMethodDocInject(m, "TriangleMesh", "sample_points_uniformly");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "sample_points_uniformly");
 }
 
 void pybind_trianglemesh_methods(py::module &m) {

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -144,6 +144,7 @@ void pybind_trianglemesh(py::module &m) {
     docstring::ClassMethodDocInject(m, "TriangleMesh", "normalize_normals");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "paint_uniform_color");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "purge");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "sample_points_uniformly");
 }
 
 void pybind_trianglemesh_methods(py::module &m) {

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/Geometry/TriangleMesh.h"
+#include "Open3D/Geometry/PointCloud.h"
 #include "TestUtility/UnitTest.h"
 
 using namespace Eigen;
@@ -670,6 +671,44 @@ TEST(TriangleMesh, Purge) {
     ExpectEQ(ref_vertex_colors, tm.vertex_colors_);
     ExpectEQ(ref_triangles, tm.triangles_);
     ExpectEQ(ref_triangle_normals, tm.triangle_normals_);
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
+TEST(TriangleMesh, SamplePointsUniformly) {
+    auto mesh_empty = geometry::TriangleMesh();
+    auto pcd_empty = mesh_empty.SamplePointsUniformly(100);
+    EXPECT_TRUE(pcd_empty->points_.size() == 0);
+    EXPECT_TRUE(pcd_empty->colors_.size() == 0);
+    EXPECT_TRUE(pcd_empty->normals_.size() == 0);
+
+    vector<Vector3d> vertices = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+    vector<Vector3i> triangles = {{0, 1, 2}};
+
+    auto mesh_simple = geometry::TriangleMesh();
+    mesh_simple.vertices_ = vertices;
+    mesh_simple.triangles_ = triangles;
+
+    size_t n_points = 100;
+    auto pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
+    EXPECT_TRUE(pcd_simple->points_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->colors_.size() == 0);
+    EXPECT_TRUE(pcd_simple->normals_.size() == 0);
+
+    vector<Vector3d> colors = {{1, 0, 0}, {1, 0, 0}, {1, 0, 0}};
+    vector<Vector3d> normals = {{0, 1, 0}, {0, 1, 0}, {0, 1, 0}};
+    mesh_simple.vertex_colors_ = colors;
+    mesh_simple.vertex_normals_ = normals;
+    pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
+    EXPECT_TRUE(pcd_simple->points_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->normals_.size() == n_points);
+
+    for (size_t pidx = 0; pidx < n_points; ++pidx) {
+        ExpectEQ(pcd_simple->colors_[pidx], Vector3d(1, 0, 0));
+        ExpectEQ(pcd_simple->normals_[pidx], Vector3d(0, 1, 0));
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Implementation of uniform point cloud sampling from triangle mesh
respecting mesh vertex colors and vertex normals. Added utility
method TriangleArea to TriangleMesh that computes area of a
mesh triangle identified by its index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/907)
<!-- Reviewable:end -->
