### PR TITLE
Add octree I/O support for json

### DIFF
--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -38,6 +38,31 @@
 namespace open3d {
 namespace geometry {
 
+std::shared_ptr<OctreeNode> OctreeNode::ConstructFromJsonValue(
+        const Json::Value& value) {
+    // Construct node from class name
+    std::string class_name = value.get("class_name", "").asString();
+    std::shared_ptr<OctreeNode> node = nullptr;
+    if (value != Json::nullValue && class_name != "") {
+        if (class_name == "OctreeInternalNode") {
+            node = std::make_shared<OctreeInternalNode>();
+        } else if (class_name == "OctreeColorLeafNode") {
+            node = std::make_shared<OctreeColorLeafNode>();
+        } else {
+            utility::PrintWarning("Unhandled class name %s\n",
+                                  class_name.c_str());
+        }
+    }
+    // Convert from json
+    if (node != nullptr) {
+        bool convert_success = node->ConvertFromJsonValue(value);
+        if (!convert_success) {
+            node = nullptr;
+        }
+    }
+    return node;
+}
+
 std::shared_ptr<OctreeNodeInfo> OctreeInternalNode::GetInsertionNodeInfo(
         const std::shared_ptr<OctreeNodeInfo>& node_info,
         const Eigen::Vector3d& point) {
@@ -59,6 +84,43 @@ std::shared_ptr<OctreeNodeInfo> OctreeInternalNode::GetInsertionNodeInfo(
     auto child_node_info = std::make_shared<OctreeNodeInfo>(
             child_origin, child_size, node_info->depth_ + 1, child_index);
     return child_node_info;
+}
+
+bool OctreeInternalNode::ConvertToJsonValue(Json::Value& value) const {
+    bool rc = true;
+    value["class_name"] = "OctreeInternalNode";
+    value["children"] = Json::arrayValue;
+    value["children"].resize(8);
+    for (int cid = 0; cid < 8; ++cid) {
+        if (children_[cid] == nullptr) {
+            value["children"][Json::ArrayIndex(cid)] = Json::objectValue;
+        } else {
+            rc = rc && children_[cid]->ConvertToJsonValue(
+                               value["children"][Json::ArrayIndex(cid)]);
+        }
+    }
+    return rc;
+}
+
+bool OctreeInternalNode::ConvertFromJsonValue(const Json::Value& value) {
+    if (value.isObject() == false) {
+        utility::PrintWarning(
+                "ConvertFromJsonValue read JSON failed: unsupported json "
+                "format.\n");
+        return false;
+    }
+    std::string class_name = value.get("class_name", "").asString();
+    if (class_name != "OctreeInternalNode") {
+        utility::PrintWarning("class_name %s != OctreeInternalNode\n",
+                              class_name.c_str());
+        return false;
+    }
+    bool rc = true;
+    for (int cid = 0; cid < 8; ++cid) {
+        const auto& child_value = value["children"][Json::ArrayIndex(cid)];
+        children_[cid] = OctreeNode::ConstructFromJsonValue(child_value);
+    }
+    return rc;
 }
 
 std::function<std::shared_ptr<OctreeLeafNode>()>
@@ -493,70 +555,16 @@ std::shared_ptr<geometry::VoxelGrid> Octree::ToVoxelGrid() const {
 }
 
 bool Octree::ConvertToJsonValue(Json::Value& value) const {
-    // Return code for conversion
     bool rc = true;
-
-    // Assign id to each node
-    std::unordered_map<std::shared_ptr<OctreeNode>, size_t> map_node_to_id;
-    size_t next_id = 0;
-    auto f_assign_node_id =
-            [&map_node_to_id, &next_id](
-                    const std::shared_ptr<OctreeNode>& node,
-                    const std::shared_ptr<OctreeNodeInfo>& node_info) -> void {
-        map_node_to_id[node] = next_id++;
-    };
-    Traverse(f_assign_node_id);
-
-    // Write nodes to value
     value["class_name"] = "Octree";
-    value["nodes"] = Json::arrayValue;
-    value["nodes"].resize(next_id);
-    auto f_convert_nodes =
-            [&map_node_to_id, &value, &rc](
-                    const std::shared_ptr<OctreeNode>& node,
-                    const std::shared_ptr<OctreeNodeInfo>& node_info) -> void {
-        Json::Value json_node;
-        if (auto internal_node =
-                    std::dynamic_pointer_cast<OctreeInternalNode>(node)) {
-            // Internal node has 8 children
-            json_node["class_name"] = "OctreeInternalNode";
-            json_node["children"] = Json::arrayValue;
-            json_node["children"].resize(8);
-            for (size_t child_index = 0; child_index < 8; ++child_index) {
-                const std::shared_ptr<OctreeNode>& child_node =
-                        internal_node->children_[child_index];
-                if (child_node == nullptr) {
-                    json_node["children"][Json::ArrayIndex(child_index)] =
-                            Json::Int64(-1);
-                } else {
-                    const size_t& child_id = map_node_to_id.at(child_node);
-                    json_node["children"][Json::ArrayIndex(child_index)] =
-                            Json::Int64(child_id);
-                }
-            }
-        } else if (auto leaf_node =
-                           std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
-            rc = rc && leaf_node->ConvertToJsonValue(json_node);
-        } else {
-            utility::PrintError("Internal error: unknown node type");
-            rc = false;
-        }
-        size_t id = map_node_to_id.at(node);
-        json_node["id"] = Json::Int64(id);
-        value["nodes"][Json::ArrayIndex(id)] = json_node;
-    };
-    Traverse(f_convert_nodes);
-
-    // Write other info
-    if (root_node_ == nullptr) {
-        value["root_node"] = -1;
-    } else {
-        value["root_node"] = Json::Int64(map_node_to_id.at(root_node_));
-    }
-    rc = rc && EigenVector3dToJsonArray(origin_, value["origin"]);
     value["size"] = size_;
     value["max_depth"] = Json::Int64(max_depth_);
-
+    rc = rc && EigenVector3dToJsonArray(origin_, value["origin"]);
+    if (root_node_ == nullptr) {
+        value["tree"] = Json::objectValue;
+    } else {
+        rc = rc && root_node_->ConvertToJsonValue(value["tree"]);
+    }
     return rc;
 }
 
@@ -570,67 +578,14 @@ bool Octree::ConvertFromJsonValue(const Json::Value& value) {
         return false;
     }
 
-    bool rc = true;
-
     // Get octree attributes
+    bool rc = true;
     rc = EigenVector3dFromJsonArray(origin_, value["origin"]);
     size_ = value.get("size", 0.0).asDouble();
     max_depth_ = value.get("max_depth", 0).asInt64();
 
     // Create nodes
-    std::unordered_map<std::shared_ptr<OctreeNode>, size_t> map_node_to_id;
-    std::unordered_map<size_t, std::shared_ptr<OctreeNode>> map_id_to_node;
-    for (size_t i = 0; i < value["nodes"].size(); ++i) {
-        Json::Value json_node = value["nodes"].get(Json::ArrayIndex(i), 0);
-        size_t id = json_node.get("id", 0).asInt64();
-        std::shared_ptr<OctreeNode> node;
-        if (json_node.get("class_name", "") == "OctreeInternalNode") {
-            node = std::make_shared<OctreeInternalNode>();
-        } else if (json_node.get("class_name", "") == "OctreeColorLeafNode") {
-            node = std::make_shared<OctreeColorLeafNode>();
-            auto leaf_node =
-                    std::dynamic_pointer_cast<OctreeColorLeafNode>(node);
-            rc = rc && leaf_node->ConvertFromJsonValue(json_node);
-        } else {
-            rc = false;
-        }
-        if (map_id_to_node.find(id) != map_id_to_node.end()) {
-            utility::PrintError("Duplicated node id in json");
-            rc = false;
-        } else {
-            map_id_to_node[id] = node;
-        }
-    }
-
-    // Assign root node
-    int root_node_id =
-            value.get("root_node", -1).asInt64();  // Use int since -1
-    if (root_node_id != -1) {
-        root_node_ = map_id_to_node.at(root_node_id);
-    }
-
-    // Create edges
-    for (size_t i = 0; i < value["nodes"].size(); ++i) {
-        Json::Value json_node = value["nodes"].get(Json::ArrayIndex(i), 0);
-        size_t id = json_node.get("id", 0).asInt64();
-        if (json_node.get("class_name", "") == "OctreeInternalNode") {
-            auto internal_node = std::dynamic_pointer_cast<OctreeInternalNode>(
-                    map_id_to_node.at(id));
-            const std::shared_ptr<OctreeNode>& node = map_id_to_node.at(id);
-            for (size_t child_index = 0; child_index < 8; child_index++) {
-                int child_id = json_node["children"]
-                                       .get(Json::ArrayIndex(child_index), -1)
-                                       .asInt64();
-                if (child_id == -1) {
-                    internal_node->children_[child_index] = nullptr;
-                } else {
-                    internal_node->children_[child_index] =
-                            map_id_to_node.at(child_id);
-                }
-            }
-        }
-    }
-
+    root_node_ = OctreeNode::ConstructFromJsonValue(value["tree"]);
     return rc;
 }
 

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -65,10 +65,14 @@ public:
 /// Design decision: do not store origin and size of a node
 ///     - Good: better space efficiency
 ///     - Bad: need to recompute origin and size when traversing
-class OctreeNode {
+class OctreeNode : public utility::IJsonConvertible {
 public:
     OctreeNode() {}
     virtual ~OctreeNode() {}
+
+    /// Factory function to construct an OctreeNode by parsing the json value.
+    static std::shared_ptr<OctreeNode> ConstructFromJsonValue(
+            const Json::Value& value);
 };
 
 /// Children node ordering conventions are as follows.
@@ -92,6 +96,9 @@ public:
             const std::shared_ptr<OctreeNodeInfo>& node_info,
             const Eigen::Vector3d& point);
 
+    bool ConvertToJsonValue(Json::Value& value) const override;
+    bool ConvertFromJsonValue(const Json::Value& value) override;
+
 public:
     // Use vector instead of C-array for Pybind11, otherwise, need to define
     // more helper functions
@@ -99,12 +106,10 @@ public:
     std::vector<std::shared_ptr<OctreeNode>> children_;
 };
 
-class OctreeLeafNode : public OctreeNode, public utility::IJsonConvertible {
+class OctreeLeafNode : public OctreeNode {
 public:
     virtual bool operator==(const OctreeLeafNode& other) const = 0;
     virtual std::shared_ptr<OctreeLeafNode> Clone() const = 0;
-    virtual bool ConvertToJsonValue(Json::Value& value) const = 0;
-    virtual bool ConvertFromJsonValue(const Json::Value& value) = 0;
 };
 
 class OctreeColorLeafNode : public OctreeLeafNode {

--- a/src/Open3D/IO/ClassIO/OctreeIO.cpp
+++ b/src/Open3D/IO/ClassIO/OctreeIO.cpp
@@ -1,0 +1,113 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/IO/ClassIO/OctreeIO.h"
+
+#include <unordered_map>
+
+#include "Open3D/IO/ClassIO/IJsonConvertibleIO.h"
+#include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
+
+namespace open3d {
+namespace io {
+
+static const std::unordered_map<
+        std::string,
+        std::function<bool(const std::string &, geometry::Octree &)>>
+        file_extension_to_octree_read_function{
+                {"json", ReadOctreeFromJson},
+        };
+
+static const std::unordered_map<
+        std::string,
+        std::function<bool(const std::string &, const geometry::Octree &)>>
+        file_extension_to_octree_write_function{
+                {"json", WriteOctreeToJson},
+        };
+
+std::shared_ptr<geometry::Octree> CreateOctreeFromFile(
+        const std::string &filename, const std::string &format) {
+    auto octree = std::make_shared<geometry::Octree>();
+    WriteOctree(filename, *octree);
+    return octree;
+}
+
+bool ReadOctree(const std::string &filename,
+                geometry::Octree &octree,
+                const std::string &format) {
+    std::string filename_ext;
+    if (format == "auto") {
+        filename_ext =
+                utility::filesystem::GetFileExtensionInLowerCase(filename);
+    } else {
+        filename_ext = format;
+    }
+    if (filename_ext.empty()) {
+        utility::PrintWarning(
+                "Read geometry::Octree failed: unknown file extension.\n");
+        return false;
+    }
+    auto map_itr = file_extension_to_octree_read_function.find(filename_ext);
+    if (map_itr == file_extension_to_octree_read_function.end()) {
+        utility::PrintWarning(
+                "Read geometry::Octree failed: unknown file extension.\n");
+        return false;
+    }
+    bool success = map_itr->second(filename, octree);
+    utility::PrintDebug("Read geometry::Octree.\n");
+    return success;
+}
+
+bool WriteOctree(const std::string &filename, const geometry::Octree &octree) {
+    std::string filename_ext =
+            utility::filesystem::GetFileExtensionInLowerCase(filename);
+    if (filename_ext.empty()) {
+        utility::PrintWarning(
+                "Write geometry::Octree failed: unknown file extension.\n");
+        return false;
+    }
+    auto map_itr = file_extension_to_octree_write_function.find(filename_ext);
+    if (map_itr == file_extension_to_octree_write_function.end()) {
+        utility::PrintWarning(
+                "Write geometry::Octree failed: unknown file extension.\n");
+        return false;
+    }
+    bool success = map_itr->second(filename, octree);
+    utility::PrintDebug("Write geometry::Octree.\n");
+    return success;
+}
+
+bool ReadOctreeFromJson(const std::string &filename, geometry::Octree &octree) {
+    return ReadIJsonConvertible(filename, octree);
+}
+
+bool WriteOctreeToJson(const std::string &filename,
+                       const geometry::Octree &octree) {
+    return WriteIJsonConvertibleToJSON(filename, octree);
+}
+}  // namespace io
+}  // namespace open3d

--- a/src/Open3D/IO/ClassIO/OctreeIO.h
+++ b/src/Open3D/IO/ClassIO/OctreeIO.h
@@ -1,0 +1,61 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <string>
+
+#include "Open3D/Geometry/Octree.h"
+
+namespace open3d {
+namespace io {
+
+/// Factory function to create a octree from a file.
+/// \return return an empty octree if fail to read the file.
+std::shared_ptr<geometry::Octree> CreateOctreeFromFile(
+        const std::string &filename, const std::string &format = "auto");
+
+/// The general entrance for reading a Octree from a file
+/// The function calls read functions based on the extension name of filename.
+/// \return return true if the read function is successful, false otherwise.
+bool ReadOctree(const std::string &filename,
+                geometry::Octree &octree,
+                const std::string &format = "auto");
+
+/// The general entrance for writing a Octree to a file
+/// The function calls write functions based on the extension name of filename.
+/// If the write function supports binary encoding and compression, the later
+/// two parameters will be used. Otherwise they will be ignored.
+/// \return return true if the write function is successful, false otherwise.
+bool WriteOctree(const std::string &filename, const geometry::Octree &octree);
+
+bool ReadOctreeFromJson(const std::string &filename, geometry::Octree &octree);
+
+bool WriteOctreeToJson(const std::string &filename,
+                       const geometry::Octree &octree);
+
+}  // namespace io
+}  // namespace open3d

--- a/src/Python/geometry/octree.cpp
+++ b/src/Python/geometry/octree.cpp
@@ -96,7 +96,6 @@ void pybind_octree(py::module &m) {
     octree_node.def("__repr__", [](const geometry::OctreeNode &octree_node) {
         return "geometry::OctreeNode instance.";
     });
-    py::detail::bind_default_constructor<geometry::OctreeNode>(octree_node);
     docstring::ClassMethodDocInject(m, "OctreeNode", "__init__");
 
     // geometry::OctreeInternalNode

--- a/src/UnitTest/Geometry/Octree.cpp
+++ b/src/UnitTest/Geometry/Octree.cpp
@@ -24,6 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include <json/json.h>
+#include <iostream>
 #include <memory>
 
 #include "Open3D/Geometry/Octree.h"
@@ -232,7 +234,7 @@ TEST(Octree, FragmentPLYCheckClone) {
     geometry::Octree src_octree(5);
     src_octree.ConvertFromPointCloud(pcd, 0.01);
 
-    // Build dst_octree
+    // Build dst_octree clone
     geometry::Octree dst_octree(src_octree);
 
     // Also checks the equal operator
@@ -288,17 +290,6 @@ TEST(Octree, ConvertFromPointCloudBoundTwoPoints) {
     EXPECT_EQ(octree.size_, 4.04);  // 4.04 = 4 * (1 + 0.01)
 }
 
-TEST(Octree, ToVoxelGrid) {
-    geometry::PointCloud pcd;
-    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
-    size_t max_depth = 7;
-    geometry::Octree octree(max_depth);
-    octree.ConvertFromPointCloud(pcd);
-    std::shared_ptr<geometry::VoxelGrid> voxel_grid = octree.ToVoxelGrid();
-    // Uncomment the line below for visualization test
-    // visualization::DrawGeometries({voxel_grid});
-}
-
 TEST(Octree, Visualization) {
     geometry::PointCloud pcd;
     io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
@@ -306,4 +297,20 @@ TEST(Octree, Visualization) {
     octree->ConvertFromPointCloud(pcd, 0.01);
     // Uncomment the line below for visualization test
     // visualization::DrawGeometries({octree});
+}
+
+TEST(Octree, ConvertToJsonValue) {
+    geometry::PointCloud pcd;
+    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
+    size_t max_depth = 5;
+    geometry::Octree src_octree(max_depth);
+    src_octree.ConvertFromPointCloud(pcd, 0.01);
+
+    Json::Value json_value;
+    src_octree.ConvertToJsonValue(json_value);
+
+    geometry::Octree dst_octree;
+    dst_octree.ConvertFromJsonValue(json_value);
+
+    EXPECT_TRUE(src_octree == dst_octree);
 }

--- a/src/UnitTest/IO/ClassIO/OctreeIO.cpp
+++ b/src/UnitTest/IO/ClassIO/OctreeIO.cpp
@@ -1,0 +1,91 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <json/json.h>
+#include <cstdio>
+
+#include "Open3D/Geometry/Octree.h"
+#include "Open3D/Geometry/PointCloud.h"
+#include "Open3D/IO/ClassIO/OctreeIO.h"
+#include "Open3D/IO/ClassIO/PointCloudIO.h"
+#include "Open3D/Utility/IJsonConvertible.h"
+#include "TestUtility/UnitTest.h"
+
+using namespace open3d;
+using namespace unit_test;
+
+TEST(OctreeIO, JsonFileIOFragment) {
+    // Create octree
+    geometry::PointCloud pcd;
+    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
+    size_t max_depth = 6;
+    geometry::Octree src_octree(max_depth);
+    src_octree.ConvertFromPointCloud(pcd, 0.01);
+
+    // Write to file
+    std::string file_name =
+            std::string(TEST_DATA_DIR) + "/fragment_octree.json";
+    EXPECT_TRUE(io::WriteOctree(file_name, src_octree));
+
+    // Read from file
+    geometry::Octree dst_octree;
+    EXPECT_TRUE(io::ReadOctree(file_name, dst_octree));
+    EXPECT_TRUE(src_octree == dst_octree);
+    EXPECT_EQ(std::remove(file_name.c_str()), 0);
+}
+
+TEST(Octree, JsonFileIOEightCubes) {
+    // Build octree
+    std::vector<Eigen::Vector3d> points{
+            Eigen::Vector3d(0.5, 0.5, 0.5), Eigen::Vector3d(1.5, 0.5, 0.5),
+            Eigen::Vector3d(0.5, 1.5, 0.5), Eigen::Vector3d(1.5, 1.5, 0.5),
+            Eigen::Vector3d(0.5, 0.5, 1.5), Eigen::Vector3d(1.5, 0.5, 1.5),
+            Eigen::Vector3d(0.5, 1.5, 1.5), Eigen::Vector3d(1.5, 1.5, 1.5),
+    };
+    std::vector<Eigen::Vector3d> colors{
+            Eigen::Vector3d(0.0, 0.0, 0.0),   Eigen::Vector3d(0.25, 0.0, 0.0),
+            Eigen::Vector3d(0.0, 0.25, 0.0),  Eigen::Vector3d(0.25, 0.25, 0.0),
+            Eigen::Vector3d(0.0, 0.0, 0.25),  Eigen::Vector3d(0.25, 0.0, 0.25),
+            Eigen::Vector3d(0.0, 0.25, 0.25), Eigen::Vector3d(0.25, 0.25, 0.25),
+    };
+    geometry::Octree src_octree(1, Eigen::Vector3d(0, 0, 0), 2);
+    for (size_t i = 0; i < points.size(); ++i) {
+        src_octree.InsertPoint(
+                points[i], geometry::OctreeColorLeafNode::GetInitFunction(),
+                geometry::OctreeColorLeafNode::GetUpdateFunction(colors[i]));
+    }
+
+    // Write to file
+    std::string file_name =
+            std::string(TEST_DATA_DIR) + "/eight_cubes_octree.json";
+    EXPECT_TRUE(io::WriteOctree(file_name, src_octree));
+
+    // Read from file
+    geometry::Octree dst_octree;
+    EXPECT_TRUE(io::ReadOctree(file_name, dst_octree));
+    EXPECT_TRUE(src_octree == dst_octree);
+    EXPECT_EQ(std::remove(file_name.c_str()), 0);
+}


### PR DESCRIPTION
Add octree I/O support for json (ascii output). Based on https://github.com/intel-isl/Open3D/pull/903, merge https://github.com/intel-isl/Open3D/pull/903 first.

Example json output
```json
{
    "class_name" : "Octree",
    "max_depth" : 1,
    "nodes" : 
    [
        {
            "children" : [ 1, 2, 3, 4, 5, 6, 7, 8 ],
            "class_name" : "OctreeInternalNode",
            "id" : 0
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.0, 0.0, 0.0 ],
            "id" : 1
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.25, 0.0, 0.0 ],
            "id" : 2
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.0, 0.25, 0.0 ],
            "id" : 3
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.25, 0.25, 0.0 ],
            "id" : 4
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.0, 0.0, 0.25 ],
            "id" : 5
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.25, 0.0, 0.25 ],
            "id" : 6
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.0, 0.25, 0.25 ],
            "id" : 7
        },
        {
            "class_name" : "OctreeLeafNode",
            "color" : [ 0.25, 0.25, 0.25 ],
            "id" : 8
        }
    ],
    "origin" : [ 0.0, 0.0, 0.0 ],
    "root_node" : 0,
    "size" : 2.0
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/911)
<!-- Reviewable:end -->
