### PR TITLE
Octree to VoxelGrid conversion

### DIFF
--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 
 #include "Open3D/Geometry/PointCloud.h"
+#include "Open3D/Geometry/VoxelGrid.h"
 #include "Open3D/Utility/Console.h"
 
 namespace open3d {
@@ -409,6 +410,12 @@ Octree::LocateLeafNode(const Eigen::Vector3d& point) const {
     };
     Traverse(f_locate_leaf_node);
     return std::make_pair(target_leaf_node, target_leaf_node_info);
+}
+
+std::shared_ptr<geometry::VoxelGrid> Octree::ToVoxelGrid() const {
+    auto voxel_grid = std::make_shared<geometry::VoxelGrid>();
+    voxel_grid->FromOctree(*this);
+    return voxel_grid;
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -35,6 +35,7 @@ namespace open3d {
 namespace geometry {
 
 class PointCloud;
+class VoxelGrid;
 
 /// Design decision: do not store origin and size of a node in OctreeNode
 /// OctreeNodeInfo is computed on the fly
@@ -169,6 +170,9 @@ public:
 
     /// Returns true if the Octree is completely the same, used for testing
     bool operator==(const Octree& other) const;
+
+    /// Convert to voxel grid
+    std::shared_ptr<geometry::VoxelGrid> ToVoxelGrid() const;
 
 private:
     static void TraverseRecurse(

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -26,6 +26,10 @@
 
 #include "Open3D/Geometry/VoxelGrid.h"
 
+#include <unordered_map>
+
+#include "Open3D/Geometry/Octree.h"
+
 namespace open3d {
 namespace geometry {
 
@@ -84,6 +88,45 @@ VoxelGrid VoxelGrid::operator+(const VoxelGrid &voxelgrid) const {
 Eigen::Vector3i VoxelGrid::GetVoxel(const Eigen::Vector3d &point) const {
     Eigen::Vector3d voxel_f = (point - origin_) / voxel_size_;
     return Eigen::floor(voxel_f.array()).cast<int>();
+}
+
+void VoxelGrid::FromOctree(const Octree &octree) {
+    // Get leaf nodes and their node_info
+    std::unordered_map<std::shared_ptr<OctreeLeafNode>,
+                       std::shared_ptr<OctreeNodeInfo>>
+            map_node_to_node_info;
+    auto f_collect_nodes =
+            [&map_node_to_node_info](
+                    const std::shared_ptr<OctreeNode> &node,
+                    const std::shared_ptr<OctreeNodeInfo> &node_info) -> void {
+        if (auto leaf_node = std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
+            map_node_to_node_info[leaf_node] = node_info;
+        }
+    };
+    octree.Traverse(f_collect_nodes);
+
+    // Prepare dimensions for voxel
+    origin_ = octree.origin_;
+    voxel_size_ = octree.size_;  // Maximum possible voxel size
+    voxels_.clear();
+    colors_.clear();
+    for (const auto &it : map_node_to_node_info) {
+        voxel_size_ = std::min(voxel_size_, it.second->size_);
+    }
+
+    // Convert nodes to voxels
+    for (const auto &it : map_node_to_node_info) {
+        const std::shared_ptr<OctreeLeafNode> &node = it.first;
+        const std::shared_ptr<OctreeNodeInfo> &node_info = it.second;
+        Eigen::Array3d node_center =
+                Eigen::Array3d(node_info->origin_) + node_info->size_ / 2.0;
+        Eigen::Vector3i voxel =
+                Eigen::floor((node_center - Eigen::Array3d(origin_)) /
+                             voxel_size_)
+                        .cast<int>();
+        voxels_.push_back(voxel);
+        colors_.push_back(node->color_);
+    }
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -37,6 +37,7 @@ namespace geometry {
 
 class PointCloud;
 class TriangleMesh;
+class Octree;
 
 class VoxelGrid : public Geometry3D {
 public:
@@ -61,6 +62,8 @@ public:
         return voxels_.size() > 0 && colors_.size() == voxels_.size();
     }
     Eigen::Vector3i GetVoxel(const Eigen::Vector3d &point) const;
+
+    void FromOctree(const Octree &octree);
 
 public:
     double voxel_size_;

--- a/src/UnitTest/Geometry/Octree.cpp
+++ b/src/UnitTest/Geometry/Octree.cpp
@@ -29,7 +29,9 @@
 
 #include "Open3D/Geometry/Octree.h"
 #include "Open3D/Geometry/PointCloud.h"
+#include "Open3D/Geometry/VoxelGrid.h"
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
+#include "Open3D/Visualization/Utility/DrawGeometry.h"
 #include "TestUtility/UnitTest.h"
 
 using namespace open3d;
@@ -263,4 +265,14 @@ TEST(Octree, ConvertFromPointCloudBoundTwoPoints) {
     octree.ConvertFromPointCloud(pcd, true, 0.01);
     ExpectEQ(octree.origin_, Eigen::Vector3d(-2, -1, 0));  // Auto-centered
     EXPECT_EQ(octree.size_, 4.04);  // 4.04 = 4 * (1 + 0.01)
+}
+
+TEST(Octree, ToVoxelGrid) {
+    geometry::PointCloud pcd;
+    io::ReadPointCloud(std::string(TEST_DATA_DIR) + "/fragment.ply", pcd);
+    size_t max_depth = 7;
+    geometry::Octree octree(max_depth);
+    octree.ConvertFromPointCloud(pcd);
+    std::shared_ptr<geometry::VoxelGrid> voxel_grid = octree.ToVoxelGrid();
+    // visualization::DrawGeometries({voxel_grid});
 }


### PR DESCRIPTION
Input PointCloud (PointCloud to Octree)
![Screenshot from 2019-04-16 16-58-44](https://user-images.githubusercontent.com/1501945/56251543-d5b84780-6068-11e9-89d1-3b8d6f62159a.png)

VoxelGrid (Octree to VoxelGrid)
![Screenshot from 2019-04-16 16-58-33](https://user-images.githubusercontent.com/1501945/56251584-f41e4300-6068-11e9-8fb8-38a77f17af67.png)

The visualization above depends on "VoxelGrid OpenGL 3.1+ visualizer fix" in #918 . Will polish and create another PR. Without the "VoxelGrid OpenGL 3.1+ visualizer fix", VoxelGrid can still be converted from Octree, but VoxelGrid cannot be optimized. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/914)
<!-- Reviewable:end -->

