### PR TITLE
Disable use of Eigen::SimplicialCholesky when EIGEN_MPL2_ONLY is defined

### DIFF
--- a/src/Open3D/Utility/Eigen.cpp
+++ b/src/Open3D/Utility/Eigen.cpp
@@ -68,6 +68,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
 
     Eigen::VectorXd x(b.size());
 
+#ifndef EIGEN_MPL2_ONLY
     if (prefer_sparse) {
         Eigen::SparseMatrix<double> A_sparse = A.sparseView();
         // TODO: avoid deprecated API SimplicialCholesky
@@ -85,6 +86,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
             PrintInfo("Cholesky decompose failed, switched to dense solver\n");
         }
     }
+#endif
 
     x = A.ldlt().solve(b);
     return std::make_tuple(true, std::move(x));


### PR DESCRIPTION
Fixes compilation error when LGPL-licensed components of Eigen are disabled through the `EIGEN_MPL2_ONLY` flag.

See #938

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/939)
<!-- Reviewable:end -->
