### PR TITLE
Mesh Simplification

### DIFF
--- a/examples/Python/Basic/mesh_simplification.py
+++ b/examples/Python/Basic/mesh_simplification.py
@@ -11,34 +11,61 @@ def create_mesh_plane():
     mesh = TriangleMesh()
     mesh.vertices = Vector3dVector(
             np.array([[0,0,0], [0,1,0], [1,1,0], [1,0,0]], dtype=np.float32))
-    mesh.triangles = Vector3iVector(np.array([[0,1,2], [2,3,0]]))
+    mesh.triangles = Vector3iVector(np.array([[0,2,1], [2,0,3]]))
     return mesh
+
+def mesh_generator():
+    mesh = create_mesh_plane()
+    yield subdivide_midpoint(mesh, 2)
+
+    mesh = create_mesh_box()
+    yield subdivide_midpoint(mesh, 2)
+
+    mesh = create_mesh_sphere()
+    yield subdivide_midpoint(mesh, 2)
+
+    mesh = create_mesh_cone()
+    yield subdivide_midpoint(mesh, 2)
+
+    mesh = create_mesh_cylinder()
+    yield subdivide_midpoint(mesh, 2)
+
+    mesh = read_triangle_mesh("../../TestData/bathtub_0154.ply")
+    yield mesh
 
 if __name__ == "__main__":
     np.random.seed(42)
 
-    # mesh = create_mesh_plane()
-    # mesh = create_mesh_box()
-    # mesh = create_mesh_sphere()
-    # mesh = create_mesh_cone()
-    # mesh = create_mesh_cylinder()
-    # mesh.subdivide_midpoint(2)
+    for mesh in mesh_generator():
+        mesh.compute_vertex_normals()
+        n_verts = np.asarray(mesh.vertices).shape[0]
+        mesh.vertex_colors = Vector3dVector(np.random.uniform(0,1, size=(n_verts,3)))
 
-    mesh = read_triangle_mesh("../../TestData/bathtub_0154.ply")
+        print("original mesh has %d triangles and %d vertices" %
+                (np.asarray(mesh.triangles).shape[0],
+                    np.asarray(mesh.vertices).shape[0]))
+        draw_geometries([mesh])
 
-    mesh.compute_vertex_normals()
-    n_verts = np.asarray(mesh.vertices).shape[0]
-    mesh.vertex_colors = Vector3dVector(np.random.uniform(0,1, size=(n_verts,3)))
+        voxel_size = max(mesh.get_max_bound() - mesh.get_min_bound()) / 4
+        target_number_of_triangles = np.asarray(mesh.triangles).shape[0] // 2
 
-    print("original mesh has %d faces" % np.asarray(mesh.triangles).shape[0])
-    draw_geometries([mesh])
+        mesh_smp = simplify_vertex_clustering(mesh, voxel_size=voxel_size,
+                contraction=SimplificationContraction.Average)
+        print("vertex clustered mesh (average) has %d triangles and %d vertices" %
+                (np.asarray(mesh_smp.triangles).shape[0],
+                    np.asarray(mesh_smp.vertices).shape[0]))
+        draw_geometries([mesh_smp])
 
-    # mesh.simplify_vertex_clustering(500,
-    #         contraction=SimplificationContraction.Average)
-    # mesh.simplify_vertex_clustering(500,
-    #         contraction=SimplificationContraction.Quadric)
-    mesh.simplify_quadric_decimation(750)
-    print(np.asarray(mesh.vertices).shape)
-    print(np.asarray(mesh.triangles).shape)
-    print("simplified mesh has %d faces" % np.asarray(mesh.triangles).shape[0])
-    draw_geometries([mesh])
+        mesh_smp = simplify_vertex_clustering(mesh, voxel_size=voxel_size,
+                contraction=SimplificationContraction.Quadric)
+        print("vertex clustered mesh (quadric) has %d triangles and %d vertices" %
+                (np.asarray(mesh_smp.triangles).shape[0],
+                    np.asarray(mesh_smp.vertices).shape[0]))
+        draw_geometries([mesh_smp])
+
+        mesh_smp = simplify_quadric_decimation(mesh,
+                target_number_of_triangles=target_number_of_triangles)
+        print("quadric decimated mesh has %d triangles and %d vertices" %
+                (np.asarray(mesh_smp.triangles).shape[0],
+                    np.asarray(mesh_smp.vertices).shape[0]))
+        draw_geometries([mesh_smp])

--- a/examples/Python/Basic/mesh_simplification.py
+++ b/examples/Python/Basic/mesh_simplification.py
@@ -1,0 +1,44 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Basic/mesh_sampling.py
+
+import numpy as np
+from open3d import *
+
+def create_mesh_plane():
+    mesh = TriangleMesh()
+    mesh.vertices = Vector3dVector(
+            np.array([[0,0,0], [0,1,0], [1,1,0], [1,0,0]], dtype=np.float32))
+    mesh.triangles = Vector3iVector(np.array([[0,1,2], [2,3,0]]))
+    return mesh
+
+if __name__ == "__main__":
+    np.random.seed(42)
+
+    # mesh = create_mesh_plane()
+    # mesh = create_mesh_box()
+    # mesh = create_mesh_sphere()
+    # mesh = create_mesh_cone()
+    # mesh = create_mesh_cylinder()
+    # mesh.subdivide_midpoint(2)
+
+    mesh = read_triangle_mesh("../../TestData/bathtub_0154.ply")
+
+    mesh.compute_vertex_normals()
+    n_verts = np.asarray(mesh.vertices).shape[0]
+    mesh.vertex_colors = Vector3dVector(np.random.uniform(0,1, size=(n_verts,3)))
+
+    print("original mesh has %d faces" % np.asarray(mesh.triangles).shape[0])
+    draw_geometries([mesh])
+
+    # mesh.simplify_vertex_clustering(500,
+    #         contraction=SimplificationContraction.Average)
+    # mesh.simplify_vertex_clustering(500,
+    #         contraction=SimplificationContraction.Quadric)
+    mesh.simplify_quadric_decimation(750)
+    print(np.asarray(mesh.vertices).shape)
+    print(np.asarray(mesh.triangles).shape)
+    print("simplified mesh has %d faces" % np.asarray(mesh.triangles).shape[0])
+    draw_geometries([mesh])

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -28,7 +28,6 @@
 #include "Open3D/Geometry/PointCloud.h"
 
 #include <Eigen/Dense>
-#include <queue>
 #include <random>
 #include <tuple>
 
@@ -214,31 +213,31 @@ void TriangleMesh::Purge() {
     RemoveNonManifoldVertices();
 }
 
-std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
-        size_t number_of_points) {
-    if (number_of_points == 0 || triangles_.size() == 0) {
+std::shared_ptr<PointCloud> SamplePointsUniformly(const TriangleMesh &input,
+                                                  size_t number_of_points) {
+    if (number_of_points == 0 || input.triangles_.size() == 0) {
         return std::make_shared<PointCloud>();
     }
 
     // Compute area of each triangle and sum surface area
-    std::vector<double> triangle_areas(triangles_.size());
+    std::vector<double> triangle_areas(input.triangles_.size());
     double surface_area = 0;
-    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
-        double triangle_area = TriangleArea(tidx);
+    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
+        double triangle_area = input.GetTriangleArea(tidx);
         triangle_areas[tidx] = triangle_area;
         surface_area += triangle_area;
     }
 
     // triangle areas to cdf
     triangle_areas[0] /= surface_area;
-    for (size_t tidx = 1; tidx < triangles_.size(); ++tidx) {
+    for (size_t tidx = 1; tidx < input.triangles_.size(); ++tidx) {
         triangle_areas[tidx] =
                 triangle_areas[tidx] / surface_area + triangle_areas[tidx - 1];
     }
 
     // sample point cloud
-    bool has_vert_normal = HasVertexNormals();
-    bool has_vert_color = HasVertexColors();
+    bool has_vert_normal = input.HasVertexNormals();
+    bool has_vert_color = input.HasVertexColors();
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_real_distribution<double> dist(0.0, 1.0);
@@ -251,7 +250,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
         pcd->colors_.resize(number_of_points);
     }
     size_t point_idx = 0;
-    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
         size_t n = std::round(triangle_areas[tidx] * number_of_points);
         while (point_idx < n) {
             double r1 = dist(mt);
@@ -260,19 +259,21 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
             double b = std::sqrt(r1) * (1 - r2);
             double c = std::sqrt(r1) * r2;
 
-            const Eigen::Vector3i &triangle = triangles_[tidx];
-            pcd->points_[point_idx] = a * vertices_[triangle(0)] +
-                                      b * vertices_[triangle(1)] +
-                                      c * vertices_[triangle(2)];
+            const Eigen::Vector3i &triangle = input.triangles_[tidx];
+            pcd->points_[point_idx] = a * input.vertices_[triangle(0)] +
+                                      b * input.vertices_[triangle(1)] +
+                                      c * input.vertices_[triangle(2)];
             if (has_vert_normal) {
-                pcd->normals_[point_idx] = a * vertex_normals_[triangle(0)] +
-                                           b * vertex_normals_[triangle(1)] +
-                                           c * vertex_normals_[triangle(2)];
+                pcd->normals_[point_idx] =
+                        a * input.vertex_normals_[triangle(0)] +
+                        b * input.vertex_normals_[triangle(1)] +
+                        c * input.vertex_normals_[triangle(2)];
             }
             if (has_vert_color) {
-                pcd->colors_[point_idx] = a * vertex_colors_[triangle(0)] +
-                                          b * vertex_colors_[triangle(1)] +
-                                          c * vertex_colors_[triangle(2)];
+                pcd->colors_[point_idx] =
+                        a * input.vertex_colors_[triangle(0)] +
+                        b * input.vertex_colors_[triangle(1)] +
+                        c * input.vertex_colors_[triangle(2)];
             }
 
             point_idx++;
@@ -280,55 +281,6 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
     }
 
     return pcd;
-}
-
-void TriangleMesh::SubdivideMidpoint(int number_of_iterations) {
-    bool has_vert_normal = HasVertexNormals();
-    bool has_vert_color = HasVertexColors();
-    for (int iter = 0; iter < number_of_iterations; ++iter) {
-        std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>>
-                new_verts;
-        std::vector<Eigen::Vector3i> new_triangles(4 * triangles_.size());
-        auto get_add_edge = [&](int vidx0, int vidx1) {
-            int min = std::min(vidx0, vidx1);
-            int max = std::max(vidx0, vidx1);
-            Edge edge(min, max);
-            if (new_verts.count(edge) == 0) {
-                vertices_.push_back(0.5 * (vertices_[min] + vertices_[max]));
-                if (has_vert_normal) {
-                    vertex_normals_.push_back(0.5 * (vertex_normals_[min] +
-                                                     vertex_normals_[max]));
-                }
-                if (has_vert_color) {
-                    vertex_colors_.push_back(
-                            0.5 * (vertex_colors_[min] + vertex_colors_[max]));
-                }
-                int v01idx = vertices_.size() - 1;
-                new_verts[edge] = v01idx;
-                return v01idx;
-            } else {
-                return new_verts[edge];
-            }
-        };
-        for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
-            const auto &triangle = triangles_[tidx];
-            int vidx0 = triangle(0);
-            int vidx1 = triangle(1);
-            int vidx2 = triangle(2);
-            int vidx01 = get_add_edge(vidx0, vidx1);
-            int vidx12 = get_add_edge(vidx1, vidx2);
-            int vidx20 = get_add_edge(vidx2, vidx0);
-            new_triangles[tidx * 4 + 0] =
-                    Eigen::Vector3i(vidx0, vidx01, vidx20);
-            new_triangles[tidx * 4 + 1] =
-                    Eigen::Vector3i(vidx01, vidx1, vidx12);
-            new_triangles[tidx * 4 + 2] =
-                    Eigen::Vector3i(vidx12, vidx2, vidx20);
-            new_triangles[tidx * 4 + 3] =
-                    Eigen::Vector3i(vidx01, vidx12, vidx20);
-        }
-        triangles_ = new_triangles;
-    }
 }
 
 void TriangleMesh::RemoveDuplicatedVertices() {
@@ -487,63 +439,67 @@ void TriangleMesh::RemoveNonManifoldTriangles() {
             (int)(old_triangle_num - k));
 }
 
-std::unordered_map<TriangleMesh::Edge,
-                   int,
-                   utility::hash_tuple::hash<TriangleMesh::Edge>>
-TriangleMesh::EdgeTriangleCount() const {
-    std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>> edges;
-    auto add_edge = [&](int vidx0, int vidx1) {
+std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>>
+TriangleMesh::GetEdgeTriangleCount() const {
+    std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>>
+            trias_per_edge;
+    auto AddEdge = [&](int vidx0, int vidx1) {
         int min0 = std::min(vidx0, vidx1);
         int max0 = std::max(vidx0, vidx1);
         Edge edge(min0, max0);
-        if (edges.count(edge) == 0) {
-            edges[edge] = 1;
+        if (trias_per_edge.count(edge) == 0) {
+            trias_per_edge[edge] = 1;
         } else {
-            edges[edge] += 1;
+            trias_per_edge[edge] += 1;
         }
     };
     for (auto triangle : triangles_) {
-        add_edge(triangle(0), triangle(1));
-        add_edge(triangle(0), triangle(2));
-        add_edge(triangle(1), triangle(2));
+        AddEdge(triangle(0), triangle(1));
+        AddEdge(triangle(1), triangle(2));
+        AddEdge(triangle(2), triangle(0));
     }
-    return edges;
+    return trias_per_edge;
 }
 
-double TriangleMesh::TriangleArea(const Eigen::Vector3d &p0,
-                                  const Eigen::Vector3d &p1,
-                                  const Eigen::Vector3d &p2) const {
+double ComputeTriangleArea(const Eigen::Vector3d &p0,
+                           const Eigen::Vector3d &p1,
+                           const Eigen::Vector3d &p2) {
     const Eigen::Vector3d x = p0 - p1;
     const Eigen::Vector3d y = p0 - p2;
     double area = 0.5 * x.cross(y).norm();
     return area;
 }
 
-double TriangleMesh::TriangleArea(size_t triangle_idx) {
+double TriangleMesh::GetTriangleArea(size_t triangle_idx) const {
     const Eigen::Vector3i &triangle = triangles_[triangle_idx];
     const Eigen::Vector3d &vertex0 = vertices_[triangle(0)];
     const Eigen::Vector3d &vertex1 = vertices_[triangle(1)];
     const Eigen::Vector3d &vertex2 = vertices_[triangle(2)];
-    return TriangleArea(vertex0, vertex1, vertex2);
+    return ComputeTriangleArea(vertex0, vertex1, vertex2);
 }
 
-Eigen::Vector4d TriangleMesh::TrianglePlane(const Eigen::Vector3d &p0,
-                                            const Eigen::Vector3d &p1,
-                                            const Eigen::Vector3d &p2) const {
+Eigen::Vector4d ComputeTrianglePlane(const Eigen::Vector3d &p0,
+                                     const Eigen::Vector3d &p1,
+                                     const Eigen::Vector3d &p2) {
     const Eigen::Vector3d e0 = p1 - p0;
     const Eigen::Vector3d e1 = p2 - p0;
     Eigen::Vector3d abc = e0.cross(e1);
+    double norm = abc.norm();
+    // if the three points are co-linear, return invalid plane
+    if (norm == 0) {
+        return Eigen::Vector4d(0, 0, 0, 0);
+    }
     abc /= abc.norm();
     double d = -abc.dot(p0);
     return Eigen::Vector4d(abc(0), abc(1), abc(2), d);
 }
 
-Eigen::Vector4d TriangleMesh::TrianglePlane(size_t triangle_idx) const {
+Eigen::Vector4d TriangleMesh::GetTrianglePlane(size_t triangle_idx) const {
     const Eigen::Vector3i &triangle = triangles_[triangle_idx];
     const Eigen::Vector3d &vertex0 = vertices_[triangle(0)];
     const Eigen::Vector3d &vertex1 = vertices_[triangle(1)];
     const Eigen::Vector3d &vertex2 = vertices_[triangle(2)];
-    return TrianglePlane(vertex0, vertex1, vertex2);
+    return ComputeTrianglePlane(vertex0, vertex1, vertex2);
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -258,6 +258,10 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
         tidx++;
     }
 
+    if(input.HasTriangleNormals()) {
+        mesh->ComputeTriangleNormals();
+    }
+
     return mesh;
 }
 
@@ -414,7 +418,7 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
             Eigen::Vector3d vert0 = mesh->vertices_[tria(0)];
             Eigen::Vector3d vert1 = mesh->vertices_[tria(1)];
             Eigen::Vector3d vert2 = mesh->vertices_[tria(2)];
-            Eigen::Vector3d norm_before = (vert2 - vert0).cross(vert2 - vert1);
+            Eigen::Vector3d norm_before = (vert1 - vert0).cross(vert2 - vert0);
             norm_before /= norm_before.norm();
 
             if (vidx1 == tria(0)) {
@@ -425,9 +429,9 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
                 vert2 = vbars[edge];
             }
 
-            Eigen::Vector3d norm_after = (vert2 - vert0).cross(vert2 - vert1);
+            Eigen::Vector3d norm_after = (vert1 - vert0).cross(vert2 - vert0);
             norm_after /= norm_after.norm();
-            if (norm_before.dot(norm_before) < 0) {
+            if (norm_before.dot(norm_after) < 0) {
                 flipped = true;
                 break;
             }
@@ -530,6 +534,10 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
         }
     }
     mesh->triangles_.resize(next_free);
+
+    if(input.HasTriangleNormals()) {
+        mesh->ComputeTriangleNormals();
+    }
 
     return mesh;
 }

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -258,7 +258,7 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
         tidx++;
     }
 
-    if(input.HasTriangleNormals()) {
+    if (input.HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 
@@ -535,7 +535,7 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
     }
     mesh->triangles_.resize(next_free);
 
-    if(input.HasTriangleNormals()) {
+    if (input.HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -35,71 +35,83 @@
 namespace open3d {
 namespace geometry {
 
-struct Quadric {
-    Eigen::Matrix3d A;
-    Eigen::Vector3d b;
-    double c;
-
+/// Error quadric that is used to minimize the squared distance of a point to
+/// its neigbhouring triangle planes.
+/// Cf. "Simplifying Surfaces with Color and Texture using Quadric Error
+/// Metrics" by Garland and Heckbert.
+class Quadric {
+public:
     Quadric() {
-        A.fill(0);
-        b.fill(0);
-        c = 0;
+        A_.fill(0);
+        b_.fill(0);
+        c_ = 0;
     }
 
     Quadric(const Eigen::Vector4d& plane, double weight = 1) {
         Eigen::Vector3d n = plane.head<3>();
-        A = weight * n * n.transpose();
-        b = weight * plane(3) * n;
-        c = weight * plane(3) * plane(3);
+        A_ = weight * n * n.transpose();
+        b_ = weight * plane(3) * n;
+        c_ = weight * plane(3) * plane(3);
     }
 
     Quadric& operator+=(const Quadric& other) {
-        A += other.A;
-        b += other.b;
-        c += other.c;
+        A_ += other.A_;
+        b_ += other.b_;
+        c_ += other.c_;
         return *this;
     }
 
     Quadric operator+(const Quadric& other) const {
         Quadric res;
-        res.A = A + other.A;
-        res.b = b + other.b;
-        res.c = c + other.c;
+        res.A_ = A_ + other.A_;
+        res.b_ = b_ + other.b_;
+        res.c_ = c_ + other.c_;
         return res;
     }
 
     double Eval(const Eigen::Vector3d& v) const {
-        Eigen::Vector3d Av = A * v;
-        double q = v.dot(Av) + 2 * b.dot(v) + c;
+        Eigen::Vector3d Av = A_ * v;
+        double q = v.dot(Av) + 2 * b_.dot(v) + c_;
         return q;
     }
 
-    bool IsInvertible() const { return abs(A.determinant()) > 1e-4; }
+    bool IsInvertible() const { return abs(A_.determinant()) > 1e-4; }
 
-    Eigen::Vector3d Minimum() const { return -A.ldlt().solve(b); }
+    Eigen::Vector3d Minimum() const { return -A_.ldlt().solve(b_); }
+
+public:
+    /// A_ = n . n^T, where n is the plane normal
+    Eigen::Matrix3d A_;
+    /// b_ = d . n, where n is the plane normal and d the non-normal component
+    /// of the plane parameters
+    Eigen::Vector3d b_;
+    /// c_ = d . d, where d the non-normal component pf the plane parameters
+    double c_;
 };
 
-void TriangleMesh::SimplifyVertexClustering(
+std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
+        const TriangleMesh& input,
         double voxel_size,
-        SimplificationContraction
+        TriangleMesh::SimplificationContraction
                 contraction /* = SimplificationContraction::Average */) {
+    auto mesh = std::make_shared<TriangleMesh>();
     if (voxel_size <= 0.0) {
         utility::PrintWarning("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
-        return;
+        return mesh;
     }
 
     Eigen::Vector3d voxel_size3 =
             Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
-    Eigen::Vector3d voxel_min_bound = GetMinBound() - voxel_size3 * 0.5;
-    Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_min_bound = input.GetMinBound() - voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_max_bound = input.GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
         utility::PrintWarning(
                 "[VoxelGridFromPointCloud] voxel_size is too small.\n");
-        return;
+        return mesh;
     }
 
-    auto get_voxel_index = [&](const Eigen::Vector3d& vert) {
+    auto GetVoxelIdx = [&](const Eigen::Vector3d& vert) {
         Eigen::Vector3d ref_coord = (vert - voxel_min_bound) / voxel_size;
         Eigen::Vector3i idx(int(floor(ref_coord(0))), int(floor(ref_coord(1))),
                             int(floor(ref_coord(2))));
@@ -113,8 +125,8 @@ void TriangleMesh::SimplifyVertexClustering(
                        utility::hash_eigen::hash<Eigen::Vector3i>>
             voxel_vert_ind;
     int new_vidx = 0;
-    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
-        const Eigen::Vector3i vox_idx = get_voxel_index(vertices_[vidx]);
+    for (size_t vidx = 0; vidx < input.vertices_.size(); ++vidx) {
+        const Eigen::Vector3i vox_idx = GetVoxelIdx(input.vertices_[vidx]);
         voxel_vertices[vox_idx].insert(vidx);
 
         if (voxel_vert_ind.count(vox_idx) == 0) {
@@ -124,62 +136,61 @@ void TriangleMesh::SimplifyVertexClustering(
     }
 
     // aggregate vertex info
-    bool has_vert_normal = HasVertexNormals();
-    bool has_vert_color = HasVertexColors();
-    std::vector<Eigen::Vector3d> vertices(voxel_vertices.size());
-    std::vector<Eigen::Vector3d> vertex_normals;
+    bool has_vert_normal = input.HasVertexNormals();
+    bool has_vert_color = input.HasVertexColors();
+    mesh->vertices_.resize(voxel_vertices.size());
     if (has_vert_normal) {
-        vertex_normals.resize(voxel_vertices.size());
+        mesh->vertex_normals_.resize(voxel_vertices.size());
     }
-    std::vector<Eigen::Vector3d> vertex_colors;
     if (has_vert_color) {
-        vertex_colors.resize(voxel_vertices.size());
+        mesh->vertex_colors_.resize(voxel_vertices.size());
     }
 
-    auto avg_vertex_fcn = [&](const std::unordered_set<int> ind) {
+    auto AvgVertex = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += vertices_[vidx];
+            aggr += input.vertices_[vidx];
         }
         aggr /= ind.size();
         return aggr;
     };
-    auto avg_normal_fcn = [&](const std::unordered_set<int> ind) {
+    auto AvgNormal = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += vertex_normals_[vidx];
+            aggr += input.vertex_normals_[vidx];
         }
         aggr /= ind.size();
         return aggr;
     };
-    auto avg_color_fcn = [&](const std::unordered_set<int> ind) {
+    auto AvgColor = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += vertex_colors_[vidx];
+            aggr += input.vertex_colors_[vidx];
         }
         aggr /= ind.size();
         return aggr;
     };
 
-    if (contraction == SimplificationContraction::Average) {
+    if (contraction == TriangleMesh::SimplificationContraction::Average) {
         for (const auto& voxel : voxel_vertices) {
             int vox_vidx = voxel_vert_ind[voxel.first];
-            vertices[vox_vidx] = avg_vertex_fcn(voxel.second);
+            mesh->vertices_[vox_vidx] = AvgVertex(voxel.second);
             if (has_vert_normal) {
-                vertex_normals[vox_vidx] = avg_normal_fcn(voxel.second);
+                mesh->vertex_normals_[vox_vidx] = AvgNormal(voxel.second);
             }
             if (has_vert_color) {
-                vertex_colors[vox_vidx] = avg_color_fcn(voxel.second);
+                mesh->vertex_colors_[vox_vidx] = AvgColor(voxel.second);
             }
         }
-    } else if (contraction == SimplificationContraction::Quadric) {
+    } else if (contraction ==
+               TriangleMesh::SimplificationContraction::Quadric) {
         // Map triangles
         std::unordered_map<int, std::unordered_set<int>> vert_to_triangles;
         int next_tidx = 0;
-        for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
-            vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
-            vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
-            vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
+        for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
+            vert_to_triangles[input.triangles_[tidx](0)].emplace(tidx);
+            vert_to_triangles[input.triangles_[tidx](1)].emplace(tidx);
+            vert_to_triangles[input.triangles_[tidx](2)].emplace(tidx);
         }
 
         for (const auto& voxel : voxel_vertices) {
@@ -188,23 +199,23 @@ void TriangleMesh::SimplifyVertexClustering(
             Quadric q;
             for (int vidx : voxel.second) {
                 for (int tidx : vert_to_triangles[vidx]) {
-                    Eigen::Vector4d p = TrianglePlane(tidx);
-                    double area = TriangleArea(tidx);
+                    Eigen::Vector4d p = input.GetTrianglePlane(tidx);
+                    double area = input.GetTriangleArea(tidx);
                     q += Quadric(p, area);
                 }
             }
             if (q.IsInvertible()) {
                 Eigen::Vector3d v = q.Minimum();
-                vertices[vox_vidx] = v;
+                mesh->vertices_[vox_vidx] = v;
             } else {
-                vertices[vox_vidx] = avg_vertex_fcn(voxel.second);
+                mesh->vertices_[vox_vidx] = AvgVertex(voxel.second);
             }
 
             if (has_vert_normal) {
-                vertex_normals[vox_vidx] = avg_normal_fcn(voxel.second);
+                mesh->vertex_normals_[vox_vidx] = AvgNormal(voxel.second);
             }
             if (has_vert_color) {
-                vertex_colors[vox_vidx] = avg_color_fcn(voxel.second);
+                mesh->vertex_colors_[vox_vidx] = AvgColor(voxel.second);
             }
         }
     }
@@ -213,10 +224,10 @@ void TriangleMesh::SimplifyVertexClustering(
     std::unordered_set<Eigen::Vector3i,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
             triangles;
-    for (const auto& triangle : triangles_) {
-        int vidx0 = voxel_vert_ind[get_voxel_index(vertices_[triangle(0)])];
-        int vidx1 = voxel_vert_ind[get_voxel_index(vertices_[triangle(1)])];
-        int vidx2 = voxel_vert_ind[get_voxel_index(vertices_[triangle(2)])];
+    for (const auto& triangle : input.triangles_) {
+        int vidx0 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(0)])];
+        int vidx1 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(1)])];
+        int vidx2 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(2)])];
 
         // only connect if in different voxels
         if (vidx0 == vidx1 || vidx0 == vidx2 || vidx1 == vidx2) {
@@ -224,7 +235,7 @@ void TriangleMesh::SimplifyVertexClustering(
         }
 
         // Note: there can be still double faces with different orientation
-        // The use has to clean up manually
+        // The user has to clean up manually
         if (vidx1 < vidx0 && vidx1 < vidx2) {
             int tmp = vidx0;
             vidx0 = vidx1;
@@ -240,71 +251,76 @@ void TriangleMesh::SimplifyVertexClustering(
         triangles.emplace(Eigen::Vector3i(vidx0, vidx1, vidx2));
     }
 
-    triangles_.resize(triangles.size());
+    mesh->triangles_.resize(triangles.size());
     int tidx = 0;
-    for (Eigen::Vector3i triangle : triangles) {
-        triangles_[tidx] = triangle;
+    for (const Eigen::Vector3i& triangle : triangles) {
+        mesh->triangles_[tidx] = triangle;
         tidx++;
     }
 
-    // set simplified properties to this
-    vertices_ = vertices;
-    vertex_normals_ = vertex_normals;
-    vertex_colors_ = vertex_colors;
+    return mesh;
 }
 
-void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
+std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
+        const TriangleMesh& input, int target_number_of_triangles) {
     typedef std::tuple<double, int, int> CostEdge;
 
-    std::vector<bool> vertices_deleted(vertices_.size(), false);
-    std::vector<bool> triangles_deleted(triangles_.size(), false);
+    auto mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = input.vertices_;
+    mesh->vertex_normals_ = input.vertex_normals_;
+    mesh->vertex_colors_ = input.vertex_colors_;
+    mesh->triangles_ = input.triangles_;
+
+    std::vector<bool> vertices_deleted(input.vertices_.size(), false);
+    std::vector<bool> triangles_deleted(input.triangles_.size(), false);
 
     // Map vertices to triangles and compute triangle planes and areas
-    std::vector<std::unordered_set<int>> vert_to_triangles(vertices_.size());
-    std::vector<Eigen::Vector4d> triangle_planes(triangles_.size());
-    std::vector<double> triangle_areas(triangles_.size());
-    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
-        vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
-        vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
-        vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
+    std::vector<std::unordered_set<int>> vert_to_triangles(
+            input.vertices_.size());
+    std::vector<Eigen::Vector4d> triangle_planes(input.triangles_.size());
+    std::vector<double> triangle_areas(input.triangles_.size());
+    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
+        vert_to_triangles[input.triangles_[tidx](0)].emplace(tidx);
+        vert_to_triangles[input.triangles_[tidx](1)].emplace(tidx);
+        vert_to_triangles[input.triangles_[tidx](2)].emplace(tidx);
 
-        triangle_planes[tidx] = TrianglePlane(tidx);
-        triangle_areas[tidx] = TriangleArea(tidx);
+        triangle_planes[tidx] = input.GetTrianglePlane(tidx);
+        triangle_areas[tidx] = input.GetTriangleArea(tidx);
     }
 
     // Compute the error metric per vertex
-    std::vector<Quadric> Qs(vertices_.size());
-    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+    std::vector<Quadric> Qs(input.vertices_.size());
+    for (size_t vidx = 0; vidx < input.vertices_.size(); ++vidx) {
         for (int tidx : vert_to_triangles[vidx]) {
             Qs[vidx] += Quadric(triangle_planes[tidx], triangle_areas[tidx]);
         }
     }
 
     // For boundary edges add perpendicular plane quadric
-    auto edge_triangle_count = EdgeTriangleCount();
-    auto add_perp_plan_quadric = [&](int vidx0, int vidx1, int vidx2,
-                                     double area) {
+    auto edge_triangle_count = input.GetEdgeTriangleCount();
+    auto AddPerpPlaneQuadric = [&](int vidx0, int vidx1, int vidx2,
+                                   double area) {
         int min = std::min(vidx0, vidx1);
         int max = std::max(vidx0, vidx1);
         Edge edge(min, max);
         if (edge_triangle_count[edge] != 1) {
             return;
         }
-        const auto& vert0 = vertices_[vidx0];
-        const auto& vert1 = vertices_[vidx1];
-        const auto& vert2 = vertices_[vidx2];
+        const auto& vert0 = mesh->vertices_[vidx0];
+        const auto& vert1 = mesh->vertices_[vidx1];
+        const auto& vert2 = mesh->vertices_[vidx2];
         Eigen::Vector3d vert2p = (vert2 - vert0).cross(vert2 - vert1);
-        Eigen::Vector4d plane = TrianglePlane(vert0, vert1, vert2p);
+        Eigen::Vector4d plane = ComputeTrianglePlane(vert0, vert1, vert2p);
         Quadric quad(plane, area);
         Qs[vidx0] += quad;
         Qs[vidx1] += quad;
     };
-    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
-        const auto& tria = triangles_[tidx];
+    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
+        const auto& tria = input.triangles_[tidx];
         double area = triangle_areas[tidx];
-        add_perp_plan_quadric(tria(0), tria(1), tria(2), area);
-        add_perp_plan_quadric(tria(1), tria(2), tria(0), area);
-        add_perp_plan_quadric(tria(2), tria(0), tria(1), area);
+        AddPerpPlaneQuadric(tria(0), tria(1), tria(2), area);
+        AddPerpPlaneQuadric(tria(1), tria(2), tria(0), area);
+        AddPerpPlaneQuadric(tria(2), tria(0), tria(1), area);
     }
 
     // Get valid edges and compute cost
@@ -312,14 +328,13 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
     std::unordered_map<Edge, Eigen::Vector3d, utility::hash_tuple::hash<Edge>>
             vbars;
     std::unordered_map<Edge, double, utility::hash_tuple::hash<Edge>> costs;
-    auto cost_edge_comp = [](const CostEdge& a, const CostEdge& b) {
+    auto CostEdgeComp = [](const CostEdge& a, const CostEdge& b) {
         return std::get<0>(a) > std::get<0>(b);
     };
-    std::priority_queue<CostEdge, std::vector<CostEdge>,
-                        decltype(cost_edge_comp)>
-            queue(cost_edge_comp);
+    std::priority_queue<CostEdge, std::vector<CostEdge>, decltype(CostEdgeComp)>
+            queue(CostEdgeComp);
 
-    auto add_edge = [&](int vidx0, int vidx1, bool update) {
+    auto AddEdge = [&](int vidx0, int vidx1, bool update) {
         int min = std::min(vidx0, vidx1);
         int max = std::max(vidx0, vidx1);
         Edge edge(min, max);
@@ -333,8 +348,8 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
                 vbar = Qbar.Minimum();
                 cost = Qbar.Eval(vbar);
             } else {
-                const Eigen::Vector3d& v0 = vertices_[vidx0];
-                const Eigen::Vector3d& v1 = vertices_[vidx0];
+                const Eigen::Vector3d& v0 = mesh->vertices_[vidx0];
+                const Eigen::Vector3d& v1 = mesh->vertices_[vidx0];
                 Eigen::Vector3d vmid = (v0 + v1) / 2;
                 double cost0 = Qbar.Eval(v0);
                 double cost1 = Qbar.Eval(v1);
@@ -355,16 +370,16 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
     };
 
     // add all edges to priority queue
-    for (const auto& triangle : triangles_) {
-        add_edge(triangle(0), triangle(1), false);
-        add_edge(triangle(1), triangle(2), false);
-        add_edge(triangle(2), triangle(0), false);
+    for (const auto& triangle : input.triangles_) {
+        AddEdge(triangle(0), triangle(1), false);
+        AddEdge(triangle(1), triangle(2), false);
+        AddEdge(triangle(2), triangle(0), false);
     }
 
     // perform incremental edge collapse
-    bool has_vert_normal = HasVertexNormals();
-    bool has_vert_color = HasVertexColors();
-    int n_triangles = triangles_.size();
+    bool has_vert_normal = input.HasVertexNormals();
+    bool has_vert_color = input.HasVertexColors();
+    int n_triangles = input.triangles_.size();
     while (n_triangles > target_number_of_triangles && !queue.empty()) {
         // retrieve edge from queue
         double cost;
@@ -387,7 +402,7 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
                 continue;
             }
 
-            Eigen::Vector3i tria = triangles_[tidx];
+            const Eigen::Vector3i& tria = mesh->triangles_[tidx];
             bool has_vidx0 =
                     vidx0 == tria(0) || vidx0 == tria(1) || vidx0 == tria(2);
             bool has_vidx1 =
@@ -396,9 +411,9 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
                 continue;
             }
 
-            Eigen::Vector3d vert0 = vertices_[tria(0)];
-            Eigen::Vector3d vert1 = vertices_[tria(1)];
-            Eigen::Vector3d vert2 = vertices_[tria(2)];
+            Eigen::Vector3d vert0 = mesh->vertices_[tria(0)];
+            Eigen::Vector3d vert1 = mesh->vertices_[tria(1)];
+            Eigen::Vector3d vert2 = mesh->vertices_[tria(2)];
             Eigen::Vector3d norm_before = (vert2 - vert0).cross(vert2 - vert1);
             norm_before /= norm_before.norm();
 
@@ -427,7 +442,7 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
                 continue;
             }
 
-            Eigen::Vector3i& tria = triangles_[tidx];
+            Eigen::Vector3i& tria = mesh->triangles_[tidx];
             bool has_vidx0 =
                     vidx0 == tria(0) || vidx0 == tria(1) || vidx0 == tria(2);
             bool has_vidx1 =
@@ -450,15 +465,15 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
         }
 
         // update vertex vidx0 to vbar
-        vertices_[vidx0] = vbars[edge];
+        mesh->vertices_[vidx0] = vbars[edge];
         Qs[vidx0] += Qs[vidx1];
         if (has_vert_normal) {
-            vertex_normals_[vidx0] =
-                    0.5 * (vertex_normals_[vidx0] + vertex_normals_[vidx1]);
+            mesh->vertex_normals_[vidx0] = 0.5 * (mesh->vertex_normals_[vidx0] +
+                                                  mesh->vertex_normals_[vidx1]);
         }
         if (has_vert_color) {
-            vertex_colors_[vidx0] =
-                    0.5 * (vertex_colors_[vidx0] + vertex_colors_[vidx1]);
+            mesh->vertex_colors_[vidx0] = 0.5 * (mesh->vertex_colors_[vidx0] +
+                                                 mesh->vertex_colors_[vidx1]);
         }
         vertices_deleted[vidx1] = true;
 
@@ -467,15 +482,15 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
             if (triangles_deleted[tidx]) {
                 continue;
             }
-            const Eigen::Vector3i& tria = triangles_[tidx];
+            const Eigen::Vector3i& tria = mesh->triangles_[tidx];
             if (tria(0) == vidx0 || tria(1) == vidx0) {
-                add_edge(tria(0), tria(1), true);
+                AddEdge(tria(0), tria(1), true);
             }
             if (tria(1) == vidx0 || tria(2) == vidx0) {
-                add_edge(tria(1), tria(2), true);
+                AddEdge(tria(1), tria(2), true);
             }
             if (tria(2) == vidx0 || tria(0) == vidx0) {
-                add_edge(tria(2), tria(0), true);
+                AddEdge(tria(2), tria(0), true);
             }
         }
     }
@@ -483,38 +498,40 @@ void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
     // Apply changes to the triangle mesh
     int next_free = 0;
     std::unordered_map<int, int> vert_remapping;
-    for (size_t idx = 0; idx < vertices_.size(); ++idx) {
+    for (size_t idx = 0; idx < mesh->vertices_.size(); ++idx) {
         if (!vertices_deleted[idx]) {
             vert_remapping[idx] = next_free;
-            vertices_[next_free] = vertices_[idx];
+            mesh->vertices_[next_free] = mesh->vertices_[idx];
             if (has_vert_normal) {
-                vertex_normals_[next_free] = vertex_normals_[idx];
+                mesh->vertex_normals_[next_free] = mesh->vertex_normals_[idx];
             }
             if (has_vert_color) {
-                vertex_colors_[next_free] = vertex_colors_[idx];
+                mesh->vertex_colors_[next_free] = mesh->vertex_colors_[idx];
             }
             next_free++;
         }
     }
-    vertices_.resize(next_free);
+    mesh->vertices_.resize(next_free);
     if (has_vert_normal) {
-        vertex_normals_.resize(next_free);
+        mesh->vertex_normals_.resize(next_free);
     }
     if (has_vert_color) {
-        vertex_colors_.resize(next_free);
+        mesh->vertex_colors_.resize(next_free);
     }
 
     next_free = 0;
-    for (size_t idx = 0; idx < triangles_.size(); ++idx) {
+    for (size_t idx = 0; idx < mesh->triangles_.size(); ++idx) {
         if (!triangles_deleted[idx]) {
-            Eigen::Vector3i tria = triangles_[idx];
-            triangles_[next_free](0) = vert_remapping[tria(0)];
-            triangles_[next_free](1) = vert_remapping[tria(1)];
-            triangles_[next_free](2) = vert_remapping[tria(2)];
+            Eigen::Vector3i tria = mesh->triangles_[idx];
+            mesh->triangles_[next_free](0) = vert_remapping[tria(0)];
+            mesh->triangles_[next_free](1) = vert_remapping[tria(1)];
+            mesh->triangles_[next_free](2) = vert_remapping[tria(2)];
             next_free++;
         }
     }
-    triangles_.resize(next_free);
+    mesh->triangles_.resize(next_free);
+
+    return mesh;
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -1,0 +1,521 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Geometry/TriangleMesh.h"
+
+#include <Eigen/Dense>
+#include <queue>
+#include <tuple>
+
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+namespace geometry {
+
+struct Quadric {
+    Eigen::Matrix3d A;
+    Eigen::Vector3d b;
+    double c;
+
+    Quadric() {
+        A.fill(0);
+        b.fill(0);
+        c = 0;
+    }
+
+    Quadric(const Eigen::Vector4d& plane, double weight = 1) {
+        Eigen::Vector3d n = plane.head<3>();
+        A = weight * n * n.transpose();
+        b = weight * plane(3) * n;
+        c = weight * plane(3) * plane(3);
+    }
+
+    Quadric& operator+=(const Quadric& other) {
+        A += other.A;
+        b += other.b;
+        c += other.c;
+        return *this;
+    }
+
+    Quadric operator+(const Quadric& other) const {
+        Quadric res;
+        res.A = A + other.A;
+        res.b = b + other.b;
+        res.c = c + other.c;
+        return res;
+    }
+
+    double Eval(const Eigen::Vector3d& v) const {
+        Eigen::Vector3d Av = A * v;
+        double q = v.dot(Av) + 2 * b.dot(v) + c;
+        return q;
+    }
+
+    bool IsInvertible() const { return abs(A.determinant()) > 1e-4; }
+
+    Eigen::Vector3d Minimum() const { return -A.ldlt().solve(b); }
+};
+
+void TriangleMesh::SimplifyVertexClustering(
+        double voxel_size,
+        SimplificationContraction
+                contraction /* = SimplificationContraction::Average */) {
+    if (voxel_size <= 0.0) {
+        utility::PrintWarning("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
+        return;
+    }
+
+    Eigen::Vector3d voxel_size3 =
+            Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
+    Eigen::Vector3d voxel_min_bound = GetMinBound() - voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
+    if (voxel_size * std::numeric_limits<int>::max() <
+        (voxel_max_bound - voxel_min_bound).maxCoeff()) {
+        utility::PrintWarning(
+                "[VoxelGridFromPointCloud] voxel_size is too small.\n");
+        return;
+    }
+
+    auto get_voxel_index = [&](const Eigen::Vector3d& vert) {
+        Eigen::Vector3d ref_coord = (vert - voxel_min_bound) / voxel_size;
+        Eigen::Vector3i idx(int(floor(ref_coord(0))), int(floor(ref_coord(1))),
+                            int(floor(ref_coord(2))));
+        return idx;
+    };
+
+    std::unordered_map<Eigen::Vector3i, std::unordered_set<int>,
+                       utility::hash_eigen::hash<Eigen::Vector3i>>
+            voxel_vertices;
+    std::unordered_map<Eigen::Vector3i, int,
+                       utility::hash_eigen::hash<Eigen::Vector3i>>
+            voxel_vert_ind;
+    int new_vidx = 0;
+    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        const Eigen::Vector3i vox_idx = get_voxel_index(vertices_[vidx]);
+        voxel_vertices[vox_idx].insert(vidx);
+
+        if (voxel_vert_ind.count(vox_idx) == 0) {
+            voxel_vert_ind[vox_idx] = new_vidx;
+            new_vidx++;
+        }
+    }
+
+    // aggregate vertex info
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    std::vector<Eigen::Vector3d> vertices(voxel_vertices.size());
+    std::vector<Eigen::Vector3d> vertex_normals;
+    if (has_vert_normal) {
+        vertex_normals.resize(voxel_vertices.size());
+    }
+    std::vector<Eigen::Vector3d> vertex_colors;
+    if (has_vert_color) {
+        vertex_colors.resize(voxel_vertices.size());
+    }
+
+    auto avg_vertex_fcn = [&](const std::unordered_set<int> ind) {
+        Eigen::Vector3d aggr(0, 0, 0);
+        for (int vidx : ind) {
+            aggr += vertices_[vidx];
+        }
+        aggr /= ind.size();
+        return aggr;
+    };
+    auto avg_normal_fcn = [&](const std::unordered_set<int> ind) {
+        Eigen::Vector3d aggr(0, 0, 0);
+        for (int vidx : ind) {
+            aggr += vertex_normals_[vidx];
+        }
+        aggr /= ind.size();
+        return aggr;
+    };
+    auto avg_color_fcn = [&](const std::unordered_set<int> ind) {
+        Eigen::Vector3d aggr(0, 0, 0);
+        for (int vidx : ind) {
+            aggr += vertex_colors_[vidx];
+        }
+        aggr /= ind.size();
+        return aggr;
+    };
+
+    if (contraction == SimplificationContraction::Average) {
+        for (const auto& voxel : voxel_vertices) {
+            int vox_vidx = voxel_vert_ind[voxel.first];
+            vertices[vox_vidx] = avg_vertex_fcn(voxel.second);
+            if (has_vert_normal) {
+                vertex_normals[vox_vidx] = avg_normal_fcn(voxel.second);
+            }
+            if (has_vert_color) {
+                vertex_colors[vox_vidx] = avg_color_fcn(voxel.second);
+            }
+        }
+    } else if (contraction == SimplificationContraction::Quadric) {
+        // Map triangles
+        std::unordered_map<int, std::unordered_set<int>> vert_to_triangles;
+        int next_tidx = 0;
+        for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+            vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
+            vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
+            vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
+        }
+
+        for (const auto& voxel : voxel_vertices) {
+            int vox_vidx = voxel_vert_ind[voxel.first];
+
+            Quadric q;
+            for (int vidx : voxel.second) {
+                for (int tidx : vert_to_triangles[vidx]) {
+                    Eigen::Vector4d p = TrianglePlane(tidx);
+                    double area = TriangleArea(tidx);
+                    q += Quadric(p, area);
+                }
+            }
+            if (q.IsInvertible()) {
+                Eigen::Vector3d v = q.Minimum();
+                vertices[vox_vidx] = v;
+            } else {
+                vertices[vox_vidx] = avg_vertex_fcn(voxel.second);
+            }
+
+            if (has_vert_normal) {
+                vertex_normals[vox_vidx] = avg_normal_fcn(voxel.second);
+            }
+            if (has_vert_color) {
+                vertex_colors[vox_vidx] = avg_color_fcn(voxel.second);
+            }
+        }
+    }
+
+    //  connect vertices
+    std::unordered_set<Eigen::Vector3i,
+                       utility::hash_eigen::hash<Eigen::Vector3i>>
+            triangles;
+    for (const auto& triangle : triangles_) {
+        int vidx0 = voxel_vert_ind[get_voxel_index(vertices_[triangle(0)])];
+        int vidx1 = voxel_vert_ind[get_voxel_index(vertices_[triangle(1)])];
+        int vidx2 = voxel_vert_ind[get_voxel_index(vertices_[triangle(2)])];
+
+        // only connect if in different voxels
+        if (vidx0 == vidx1 || vidx0 == vidx2 || vidx1 == vidx2) {
+            continue;
+        }
+
+        // Note: there can be still double faces with different orientation
+        // The use has to clean up manually
+        if (vidx1 < vidx0 && vidx1 < vidx2) {
+            int tmp = vidx0;
+            vidx0 = vidx1;
+            vidx1 = vidx2;
+            vidx2 = tmp;
+        } else if (vidx2 < vidx0 && vidx2 < vidx1) {
+            int tmp = vidx1;
+            vidx1 = vidx0;
+            vidx0 = vidx2;
+            vidx2 = tmp;
+        }
+
+        triangles.emplace(Eigen::Vector3i(vidx0, vidx1, vidx2));
+    }
+
+    triangles_.resize(triangles.size());
+    int tidx = 0;
+    for (Eigen::Vector3i triangle : triangles) {
+        triangles_[tidx] = triangle;
+        tidx++;
+    }
+
+    // set simplified properties to this
+    vertices_ = vertices;
+    vertex_normals_ = vertex_normals;
+    vertex_colors_ = vertex_colors;
+}
+
+void TriangleMesh::SimplifyQuadricDecimation(int target_number_of_triangles) {
+    typedef std::tuple<double, int, int> CostEdge;
+
+    std::vector<bool> vertices_deleted(vertices_.size(), false);
+    std::vector<bool> triangles_deleted(triangles_.size(), false);
+
+    // Map vertices to triangles and compute triangle planes and areas
+    std::vector<std::unordered_set<int>> vert_to_triangles(vertices_.size());
+    std::vector<Eigen::Vector4d> triangle_planes(triangles_.size());
+    std::vector<double> triangle_areas(triangles_.size());
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
+        vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
+        vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
+
+        triangle_planes[tidx] = TrianglePlane(tidx);
+        triangle_areas[tidx] = TriangleArea(tidx);
+    }
+
+    // Compute the error metric per vertex
+    std::vector<Quadric> Qs(vertices_.size());
+    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        for (int tidx : vert_to_triangles[vidx]) {
+            Qs[vidx] += Quadric(triangle_planes[tidx], triangle_areas[tidx]);
+        }
+    }
+
+    // For boundary edges add perpendicular plane quadric
+    auto edge_triangle_count = EdgeTriangleCount();
+    auto add_perp_plan_quadric = [&](int vidx0, int vidx1, int vidx2,
+                                     double area) {
+        int min = std::min(vidx0, vidx1);
+        int max = std::max(vidx0, vidx1);
+        Edge edge(min, max);
+        if (edge_triangle_count[edge] != 1) {
+            return;
+        }
+        const auto& vert0 = vertices_[vidx0];
+        const auto& vert1 = vertices_[vidx1];
+        const auto& vert2 = vertices_[vidx2];
+        Eigen::Vector3d vert2p = (vert2 - vert0).cross(vert2 - vert1);
+        Eigen::Vector4d plane = TrianglePlane(vert0, vert1, vert2p);
+        Quadric quad(plane, area);
+        Qs[vidx0] += quad;
+        Qs[vidx1] += quad;
+    };
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        const auto& tria = triangles_[tidx];
+        double area = triangle_areas[tidx];
+        add_perp_plan_quadric(tria(0), tria(1), tria(2), area);
+        add_perp_plan_quadric(tria(1), tria(2), tria(0), area);
+        add_perp_plan_quadric(tria(2), tria(0), tria(1), area);
+    }
+
+    // Get valid edges and compute cost
+    // Note: We could also select all vertex pairs as edges with dist < eps
+    std::unordered_map<Edge, Eigen::Vector3d, utility::hash_tuple::hash<Edge>>
+            vbars;
+    std::unordered_map<Edge, double, utility::hash_tuple::hash<Edge>> costs;
+    auto cost_edge_comp = [](const CostEdge& a, const CostEdge& b) {
+        return std::get<0>(a) > std::get<0>(b);
+    };
+    std::priority_queue<CostEdge, std::vector<CostEdge>,
+                        decltype(cost_edge_comp)>
+            queue(cost_edge_comp);
+
+    auto add_edge = [&](int vidx0, int vidx1, bool update) {
+        int min = std::min(vidx0, vidx1);
+        int max = std::max(vidx0, vidx1);
+        Edge edge(min, max);
+        if (update || vbars.count(edge) == 0) {
+            const Quadric& Q0 = Qs[min];
+            const Quadric& Q1 = Qs[max];
+            Quadric Qbar = Q0 + Q1;
+            double cost;
+            Eigen::Vector3d vbar;
+            if (Qbar.IsInvertible()) {
+                vbar = Qbar.Minimum();
+                cost = Qbar.Eval(vbar);
+            } else {
+                const Eigen::Vector3d& v0 = vertices_[vidx0];
+                const Eigen::Vector3d& v1 = vertices_[vidx0];
+                Eigen::Vector3d vmid = (v0 + v1) / 2;
+                double cost0 = Qbar.Eval(v0);
+                double cost1 = Qbar.Eval(v1);
+                double costmid = Qbar.Eval(vbar);
+                cost = std::min(cost0, std::min(cost1, costmid));
+                if (cost == costmid) {
+                    vbar = vmid;
+                } else if (cost == cost0) {
+                    vbar = v0;
+                } else {
+                    vbar = v1;
+                }
+            }
+            vbars[edge] = vbar;
+            costs[edge] = cost;
+            queue.push(CostEdge(cost, min, max));
+        }
+    };
+
+    // add all edges to priority queue
+    for (const auto& triangle : triangles_) {
+        add_edge(triangle(0), triangle(1), false);
+        add_edge(triangle(1), triangle(2), false);
+        add_edge(triangle(2), triangle(0), false);
+    }
+
+    // perform incremental edge collapse
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    int n_triangles = triangles_.size();
+    while (n_triangles > target_number_of_triangles && !queue.empty()) {
+        // retrieve edge from queue
+        double cost;
+        int vidx0, vidx1;
+        std::tie(cost, vidx0, vidx1) = queue.top();
+        queue.pop();
+
+        // test if the edge has been updated (reinserted into queue)
+        Edge edge(vidx0, vidx1);
+        bool valid = !vertices_deleted[vidx0] && !vertices_deleted[vidx1] &&
+                     cost == costs[edge];
+        if (!valid) {
+            continue;
+        }
+
+        // avoid flip of triangle normal
+        bool flipped = false;
+        for (int tidx : vert_to_triangles[vidx1]) {
+            if (triangles_deleted[tidx]) {
+                continue;
+            }
+
+            Eigen::Vector3i tria = triangles_[tidx];
+            bool has_vidx0 =
+                    vidx0 == tria(0) || vidx0 == tria(1) || vidx0 == tria(2);
+            bool has_vidx1 =
+                    vidx1 == tria(0) || vidx1 == tria(1) || vidx1 == tria(2);
+            if (has_vidx0 && has_vidx1) {
+                continue;
+            }
+
+            Eigen::Vector3d vert0 = vertices_[tria(0)];
+            Eigen::Vector3d vert1 = vertices_[tria(1)];
+            Eigen::Vector3d vert2 = vertices_[tria(2)];
+            Eigen::Vector3d norm_before = (vert2 - vert0).cross(vert2 - vert1);
+            norm_before /= norm_before.norm();
+
+            if (vidx1 == tria(0)) {
+                vert0 = vbars[edge];
+            } else if (vidx1 == tria(1)) {
+                vert1 = vbars[edge];
+            } else if (vidx1 == tria(2)) {
+                vert2 = vbars[edge];
+            }
+
+            Eigen::Vector3d norm_after = (vert2 - vert0).cross(vert2 - vert1);
+            norm_after /= norm_after.norm();
+            if (norm_before.dot(norm_before) < 0) {
+                flipped = true;
+                break;
+            }
+        }
+        if (flipped) {
+            continue;
+        }
+
+        // Connect triangles from vidx1 to vidx0, or mark deleted
+        for (int tidx : vert_to_triangles[vidx1]) {
+            if (triangles_deleted[tidx]) {
+                continue;
+            }
+
+            Eigen::Vector3i& tria = triangles_[tidx];
+            bool has_vidx0 =
+                    vidx0 == tria(0) || vidx0 == tria(1) || vidx0 == tria(2);
+            bool has_vidx1 =
+                    vidx1 == tria(0) || vidx1 == tria(1) || vidx1 == tria(2);
+
+            if (has_vidx0 && has_vidx1) {
+                triangles_deleted[tidx] = true;
+                n_triangles--;
+                continue;
+            }
+
+            if (vidx1 == tria(0)) {
+                tria(0) = vidx0;
+            } else if (vidx1 == tria(1)) {
+                tria(1) = vidx0;
+            } else if (vidx1 == tria(2)) {
+                tria(2) = vidx0;
+            }
+            vert_to_triangles[vidx0].insert(tidx);
+        }
+
+        // update vertex vidx0 to vbar
+        vertices_[vidx0] = vbars[edge];
+        Qs[vidx0] += Qs[vidx1];
+        if (has_vert_normal) {
+            vertex_normals_[vidx0] =
+                    0.5 * (vertex_normals_[vidx0] + vertex_normals_[vidx1]);
+        }
+        if (has_vert_color) {
+            vertex_colors_[vidx0] =
+                    0.5 * (vertex_colors_[vidx0] + vertex_colors_[vidx1]);
+        }
+        vertices_deleted[vidx1] = true;
+
+        // Update edge costs for all triangles connecting to vidx0
+        for (const auto& tidx : vert_to_triangles[vidx0]) {
+            if (triangles_deleted[tidx]) {
+                continue;
+            }
+            const Eigen::Vector3i& tria = triangles_[tidx];
+            if (tria(0) == vidx0 || tria(1) == vidx0) {
+                add_edge(tria(0), tria(1), true);
+            }
+            if (tria(1) == vidx0 || tria(2) == vidx0) {
+                add_edge(tria(1), tria(2), true);
+            }
+            if (tria(2) == vidx0 || tria(0) == vidx0) {
+                add_edge(tria(2), tria(0), true);
+            }
+        }
+    }
+
+    // Apply changes to the triangle mesh
+    int next_free = 0;
+    std::unordered_map<int, int> vert_remapping;
+    for (size_t idx = 0; idx < vertices_.size(); ++idx) {
+        if (!vertices_deleted[idx]) {
+            vert_remapping[idx] = next_free;
+            vertices_[next_free] = vertices_[idx];
+            if (has_vert_normal) {
+                vertex_normals_[next_free] = vertex_normals_[idx];
+            }
+            if (has_vert_color) {
+                vertex_colors_[next_free] = vertex_colors_[idx];
+            }
+            next_free++;
+        }
+    }
+    vertices_.resize(next_free);
+    if (has_vert_normal) {
+        vertex_normals_.resize(next_free);
+    }
+    if (has_vert_color) {
+        vertex_colors_.resize(next_free);
+    }
+
+    next_free = 0;
+    for (size_t idx = 0; idx < triangles_.size(); ++idx) {
+        if (!triangles_deleted[idx]) {
+            Eigen::Vector3i tria = triangles_[idx];
+            triangles_[next_free](0) = vert_remapping[tria(0)];
+            triangles_[next_free](1) = vert_remapping[tria(1)];
+            triangles_[next_free](2) = vert_remapping[tria(2)];
+            next_free++;
+        }
+    }
+    triangles_.resize(next_free);
+}
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
         mesh->triangles_ = new_triangles;
     }
 
-    if(input.HasTriangleNormals()) {
+    if (input.HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -45,6 +45,7 @@ std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
 
     bool has_vert_normal = input.HasVertexNormals();
     bool has_vert_color = input.HasVertexColors();
+    bool has_tria_normal = input.HasTriangleNormals();
     // Compute and return midpoint.
     // Also adds edge - new vertex refrence to new_verts map.
     auto SubdivideEdge =
@@ -96,6 +97,10 @@ std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
                     Eigen::Vector3i(vidx01, vidx12, vidx20);
         }
         mesh->triangles_ = new_triangles;
+    }
+
+    if(input.HasTriangleNormals()) {
+        mesh->ComputeTriangleNormals();
     }
 
     return mesh;

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -1,0 +1,105 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Geometry/TriangleMesh.h"
+
+#include <Eigen/Dense>
+#include <queue>
+#include <tuple>
+
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+namespace geometry {
+
+std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
+                                                int number_of_iterations) {
+    auto mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = input.vertices_;
+    mesh->vertex_colors_ = input.vertex_colors_;
+    mesh->vertex_normals_ = input.vertex_normals_;
+    mesh->triangles_ = input.triangles_;
+
+    bool has_vert_normal = input.HasVertexNormals();
+    bool has_vert_color = input.HasVertexColors();
+    // Compute and return midpoint.
+    // Also adds edge - new vertex refrence to new_verts map.
+    auto SubdivideEdge =
+            [&](std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>>&
+                        new_verts,
+                int vidx0, int vidx1) {
+                int min = std::min(vidx0, vidx1);
+                int max = std::max(vidx0, vidx1);
+                Edge edge(min, max);
+                if (new_verts.count(edge) == 0) {
+                    mesh->vertices_.push_back(0.5 * (mesh->vertices_[min] +
+                                                     mesh->vertices_[max]));
+                    if (has_vert_normal) {
+                        mesh->vertex_normals_.push_back(
+                                0.5 * (mesh->vertex_normals_[min] +
+                                       mesh->vertex_normals_[max]));
+                    }
+                    if (has_vert_color) {
+                        mesh->vertex_colors_.push_back(
+                                0.5 * (mesh->vertex_colors_[min] +
+                                       mesh->vertex_colors_[max]));
+                    }
+                    int v01idx = mesh->vertices_.size() - 1;
+                    new_verts[edge] = v01idx;
+                    return v01idx;
+                } else {
+                    return new_verts[edge];
+                }
+            };
+    for (int iter = 0; iter < number_of_iterations; ++iter) {
+        std::unordered_map<Edge, int, utility::hash_tuple::hash<Edge>>
+                new_verts;
+        std::vector<Eigen::Vector3i> new_triangles(4 * mesh->triangles_.size());
+        for (size_t tidx = 0; tidx < mesh->triangles_.size(); ++tidx) {
+            const auto& triangle = mesh->triangles_[tidx];
+            int vidx0 = triangle(0);
+            int vidx1 = triangle(1);
+            int vidx2 = triangle(2);
+            int vidx01 = SubdivideEdge(new_verts, vidx0, vidx1);
+            int vidx12 = SubdivideEdge(new_verts, vidx1, vidx2);
+            int vidx20 = SubdivideEdge(new_verts, vidx2, vidx0);
+            new_triangles[tidx * 4 + 0] =
+                    Eigen::Vector3i(vidx0, vidx01, vidx20);
+            new_triangles[tidx * 4 + 1] =
+                    Eigen::Vector3i(vidx01, vidx1, vidx12);
+            new_triangles[tidx * 4 + 2] =
+                    Eigen::Vector3i(vidx12, vidx2, vidx20);
+            new_triangles[tidx * 4 + 3] =
+                    Eigen::Vector3i(vidx01, vidx12, vidx20);
+        }
+        mesh->triangles_ = new_triangles;
+    }
+
+    return mesh;
+}
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -77,23 +77,6 @@ void pybind_trianglemesh(py::module &m) {
             .def("purge", &geometry::TriangleMesh::Purge,
                  "Function to remove duplicated and non-manifold "
                  "vertices/triangles")
-            .def("sample_points_uniformly",
-                 &geometry::TriangleMesh::SamplePointsUniformly,
-                 "Function to uniformly points from the mesh",
-                 "number_of_points"_a = 100)
-            .def("subdivide_midpoint",
-                 &geometry::TriangleMesh::SubdivideMidpoint,
-                 "Function subdivide mesh using midpoint algorithm",
-                 "number_of_iterations"_a = 1)
-            .def("simplify_vertex_clustering",
-                 &geometry::TriangleMesh::SimplifyVertexClustering,
-                 "Function to simplify mesh vertex clustering", "voxel_size"_a,
-                 "contraction"_a = geometry::TriangleMesh::
-                         SimplificationContraction::Average)
-            .def("simplify_quadric_decimation",
-                 &geometry::TriangleMesh::SimplifyQuadricDecimation,
-                 "Function to simplify mesh using quadric error decimation",
-                 "target_number_of_triangles"_a)
             .def("has_vertices", &geometry::TriangleMesh::HasVertices,
                  "Returns ``True`` if the mesh contains vertices.")
             .def("has_triangles", &geometry::TriangleMesh::HasTriangles,
@@ -164,13 +147,6 @@ void pybind_trianglemesh(py::module &m) {
     docstring::ClassMethodDocInject(m, "TriangleMesh", "normalize_normals");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "paint_uniform_color");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "purge");
-    docstring::ClassMethodDocInject(m, "TriangleMesh",
-                                    "sample_points_uniformly");
-    docstring::ClassMethodDocInject(m, "TriangleMesh", "subdivide_midpoint");
-    docstring::ClassMethodDocInject(m, "TriangleMesh",
-                                    "simplify_vertex_clustering");
-    docstring::ClassMethodDocInject(m, "TriangleMesh",
-                                    "simplify_quadric_decimation");
 }
 
 void pybind_trianglemesh_methods(py::module &m) {
@@ -197,6 +173,49 @@ void pybind_trianglemesh_methods(py::module &m) {
             {{"input", "The input triangle mesh."},
              {"min_bound", "Minimum bound for vertex coordinate."},
              {"max_bound", "Maximum bound for vertex coordinate."}});
+
+    m.def("sample_points_uniformly", &geometry::SamplePointsUniformly,
+          "Function to uniformly points from the mesh", "input"_a,
+          "number_of_points"_a = 100);
+    docstring::FunctionDocInject(
+            m, "sample_points_uniformly",
+            {{"input", "The input triangle mesh."},
+             {"number_of_points",
+              "Number of points that should be uniformly sampled."}});
+
+    m.def("subdivide_midpoint", &geometry::SubdivideMidpoint,
+          "Function subdivide mesh using midpoint algorithm.", "input"_a,
+          "number_of_iterations"_a = 1);
+    docstring::FunctionDocInject(
+            m, "subdivide_midpoint",
+            {{"input", "The input triangle mesh."},
+             {"number_of_iterations",
+              "Number of iterations. A single iteration splits each triangle "
+              "into four triangles that cover the same surface."}});
+
+    m.def("simplify_vertex_clustering", &geometry::SimplifyVertexClustering,
+          "Function to simplify mesh vertex clustering", "input"_a,
+          "voxel_size"_a,
+          "contraction"_a =
+                  geometry::TriangleMesh::SimplificationContraction::Average);
+    docstring::FunctionDocInject(
+            m, "simplify_vertex_clustering",
+            {{"input", "The input triangle mesh."},
+             {"voxel_size",
+              "The size of the voxel within vertices are pooled."},
+             {"contraction",
+              "Method to aggregate vertex information. Average computes a "
+              "simple average, Quadric minimizes the distance to the adjacent "
+              "planes."}});
+    m.def("simplify_quadric_decimation", &geometry::SimplifyQuadricDecimation,
+          "Function to simplify mesh using quadric error decimation", "input"_a,
+          "target_number_of_triangles"_a);
+    docstring::FunctionDocInject(
+            m, "simplify_quadric_decimation",
+            {{"input", "The input triangle mesh."},
+             {"target_number_of_triangles",
+              "The number of triangles that the simplified mesh should have. "
+              "It is not guranteed that this number will be reached."}});
 
     m.def("create_mesh_box", &geometry::CreateMeshBox,
           "Factory function to create a box. The left bottom corner on the "

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -42,6 +42,13 @@ void pybind_trianglemesh(py::module &m) {
                          "triangle normals, vertex normals and vertex colors.");
     py::detail::bind_default_constructor<geometry::TriangleMesh>(trianglemesh);
     py::detail::bind_copy_functions<geometry::TriangleMesh>(trianglemesh);
+    py::enum_<geometry::TriangleMesh::SimplificationContraction>(
+            m, "SimplificationContraction")
+            .value("Average",
+                   geometry::TriangleMesh::SimplificationContraction::Average)
+            .value("Quadric",
+                   geometry::TriangleMesh::SimplificationContraction::Quadric)
+            .export_values();
     trianglemesh
             .def("__repr__",
                  [](const geometry::TriangleMesh &mesh) {
@@ -74,6 +81,19 @@ void pybind_trianglemesh(py::module &m) {
                  &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly points from the mesh",
                  "number_of_points"_a = 100)
+            .def("subdivide_midpoint",
+                 &geometry::TriangleMesh::SubdivideMidpoint,
+                 "Function subdivide mesh using midpoint algorithm",
+                 "number_of_iterations"_a = 1)
+            .def("simplify_vertex_clustering",
+                 &geometry::TriangleMesh::SimplifyVertexClustering,
+                 "Function to simplify mesh vertex clustering", "voxel_size"_a,
+                 "contraction"_a = geometry::TriangleMesh::
+                         SimplificationContraction::Average)
+            .def("simplify_quadric_decimation",
+                 &geometry::TriangleMesh::SimplifyQuadricDecimation,
+                 "Function to simplify mesh using quadric error decimation",
+                 "target_number_of_triangles"_a)
             .def("has_vertices", &geometry::TriangleMesh::HasVertices,
                  "Returns ``True`` if the mesh contains vertices.")
             .def("has_triangles", &geometry::TriangleMesh::HasTriangles,
@@ -146,6 +166,11 @@ void pybind_trianglemesh(py::module &m) {
     docstring::ClassMethodDocInject(m, "TriangleMesh", "purge");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "sample_points_uniformly");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "subdivide_midpoint");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "simplify_vertex_clustering");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "simplify_quadric_decimation");
 }
 
 void pybind_trianglemesh_methods(py::module &m) {

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -678,7 +678,7 @@ TEST(TriangleMesh, Purge) {
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, SamplePointsUniformly) {
     auto mesh_empty = geometry::TriangleMesh();
-    auto pcd_empty = mesh_empty.SamplePointsUniformly(100);
+    auto pcd_empty = geometry::SamplePointsUniformly(mesh_empty, 100);
     EXPECT_TRUE(pcd_empty->points_.size() == 0);
     EXPECT_TRUE(pcd_empty->colors_.size() == 0);
     EXPECT_TRUE(pcd_empty->normals_.size() == 0);
@@ -691,7 +691,7 @@ TEST(TriangleMesh, SamplePointsUniformly) {
     mesh_simple.triangles_ = triangles;
 
     size_t n_points = 100;
-    auto pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
+    auto pcd_simple = geometry::SamplePointsUniformly(mesh_simple, n_points);
     EXPECT_TRUE(pcd_simple->points_.size() == n_points);
     EXPECT_TRUE(pcd_simple->colors_.size() == 0);
     EXPECT_TRUE(pcd_simple->normals_.size() == 0);
@@ -700,7 +700,7 @@ TEST(TriangleMesh, SamplePointsUniformly) {
     vector<Vector3d> normals = {{0, 1, 0}, {0, 1, 0}, {0, 1, 0}};
     mesh_simple.vertex_colors_ = colors;
     mesh_simple.vertex_normals_ = normals;
-    pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
+    pcd_simple = geometry::SamplePointsUniformly(mesh_simple, n_points);
     EXPECT_TRUE(pcd_simple->points_.size() == n_points);
     EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
     EXPECT_TRUE(pcd_simple->normals_.size() == n_points);


### PR DESCRIPTION
Implemented a vertex cluster mesh simplification (using vertex average and quadric minimization) and "Surface Simplification Using Quadric Error Metrics". For testing, I added also a simple mesh subdivision method (midpoint). The color and normal information is averaged in all implementations and not considered in the error minimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/945)
<!-- Reviewable:end -->
