### PR TITLE
Remove non manifold edges from triangle mesh

### DIFF
--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -99,7 +99,10 @@ int main(int argc, char *argv[]) {
         utility::PrintInfo(
                 "After merge, Mesh1 has %d vertices, %d triangles.\n",
                 mesh1->vertices_.size(), mesh1->triangles_.size());
-        mesh1->Purge();
+        mesh1->RemoveDuplicatedVertices();
+        mesh1->RemoveDuplicatedTriangles();
+        mesh1->RemoveUnreferencedVertices();
+        mesh1->RemoveDegenerateTriangles();
         utility::PrintInfo(
                 "After purge vertices, Mesh1 has %d vertices, %d triangles.\n",
                 mesh1->vertices_.size(), mesh1->triangles_.size());

--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -101,8 +101,8 @@ int main(int argc, char *argv[]) {
                 mesh1->vertices_.size(), mesh1->triangles_.size());
         mesh1->RemoveDuplicatedVertices();
         mesh1->RemoveDuplicatedTriangles();
-        mesh1->RemoveUnreferencedVertices();
         mesh1->RemoveDegenerateTriangles();
+        mesh1->RemoveUnreferencedVertices();
         utility::PrintInfo(
                 "After purge vertices, Mesh1 has %d vertices, %d triangles.\n",
                 mesh1->vertices_.size(), mesh1->triangles_.size());

--- a/examples/Python/Basic/convex_hull.py
+++ b/examples/Python/Basic/convex_hull.py
@@ -13,54 +13,15 @@ import shutil
 import time
 import open3d as o3d
 
-
-def create_mesh_plane():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([[0, 0, 0], [0, 0.2, 0], [1, 0.2, 0], [1, 0, 0]],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
-                                                                      3]]))
-    return mesh
-
-
-def armadillo_mesh():
-    armadillo_path = '../../TestData/Armadillo.ply'
-    if not os.path.exists(armadillo_path):
-        print('downloading armadillo mesh')
-        url = 'http://graphics.stanford.edu/pub/3Dscanrep/armadillo/Armadillo.ply.gz'
-        urllib.request.urlretrieve(url, armadillo_path + '.gz')
-        print('extract armadillo mesh')
-        with gzip.open(armadillo_path + '.gz', 'rb') as fin:
-            with open(armadillo_path, 'wb') as fout:
-                shutil.copyfileobj(fin, fout)
-        os.remove(armadillo_path + '.gz')
-    return o3d.io.read_triangle_mesh(armadillo_path)
-
-
-def bunny_mesh():
-    bunny_path = '../../TestData/Bunny.ply'
-    if not os.path.exists(bunny_path):
-        print('downloading bunny mesh')
-        url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'
-        urllib.request.urlretrieve(url, bunny_path + '.tar.gz')
-        print('extract bunny mesh')
-        with tarfile.open(bunny_path + '.tar.gz') as tar:
-            tar.extractall(path=os.path.dirname(bunny_path))
-        shutil.move(
-            os.path.join(os.path.dirname(bunny_path), 'bunny', 'reconstruction',
-                         'bun_zipper.ply'), bunny_path)
-        os.remove(bunny_path + '.tar.gz')
-        shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
-    return o3d.io.read_triangle_mesh(bunny_path)
+import meshes
 
 
 def mesh_generator():
     yield o3d.geometry.create_mesh_box()
     yield o3d.geometry.create_mesh_sphere()
-    yield o3d.io.read_triangle_mesh('../../TestData/knot.ply')
-    yield bunny_mesh()
-    yield armadillo_mesh()
+    yield meshes.knot()
+    yield meshes.bunny()
+    yield meshes.armadillo()
 
 
 if __name__ == "__main__":

--- a/examples/Python/Basic/mesh_filter.py
+++ b/examples/Python/Basic/mesh_filter.py
@@ -7,9 +7,11 @@
 import numpy as np
 import open3d as o3d
 
+import meshes
+
 
 def test_mesh(noise=0):
-    mesh = o3d.io.read_triangle_mesh('../../TestData/knot.ply')
+    mesh = meshes.knot()
     if noise > 0:
         vertices = np.asarray(mesh.vertices)
         vertices += np.random.uniform(0, noise, size=vertices.shape)

--- a/examples/Python/Basic/mesh_properties.py
+++ b/examples/Python/Basic/mesh_properties.py
@@ -25,33 +25,16 @@ def cat_meshes(mesh0, mesh1):
     mesh.triangles = Vector3iVector(triangles)
     return mesh
 
-def bunny_mesh():
-    bunny_path = '../../TestData/Bunny.ply'
-    if not os.path.exists(bunny_path):
-        print('downloading bunny mesh')
-        url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'
-        urllib.request.urlretrieve(url, bunny_path + '.tar.gz')
-        print('extract bunny mesh')
-        with tarfile.open(bunny_path + '.tar.gz') as tar:
-            tar.extractall(path=os.path.dirname(bunny_path))
-        shutil.move(
-                os.path.join(os.path.dirname(bunny_path),
-                    'bunny', 'reconstruction', 'bun_zipper.ply'),
-                bunny_path)
-        os.remove(bunny_path + '.tar.gz')
-        shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
-    return read_triangle_mesh(bunny_path)
-
 def mesh_generator():
-    # yield 'box', create_mesh_box()
-    # yield 'sphere', create_mesh_sphere()
-    # yield 'cone', create_mesh_cone()
-    # yield 'torus', create_mesh_torus(radial_resolution=30, tubular_resolution=20)
-    # yield 'moebius (twists=1)', create_mesh_moebius(twists=1)
-    # yield 'moebius (twists=2)', create_mesh_moebius(twists=2)
-    # yield 'moebius (twists=3)', create_mesh_moebius(twists=3)
+    yield 'box', create_mesh_box()
+    yield 'sphere', create_mesh_sphere()
+    yield 'cone', create_mesh_cone()
+    yield 'torus', create_mesh_torus(radial_resolution=30, tubular_resolution=20)
+    yield 'moebius (twists=1)', create_mesh_moebius(twists=1)
+    yield 'moebius (twists=2)', create_mesh_moebius(twists=2)
+    yield 'moebius (twists=3)', create_mesh_moebius(twists=3)
 
-    # yield 'knot', read_triangle_mesh('../../TestData/knot.ply')
+    yield 'knot', read_triangle_mesh('../../TestData/knot.ply')
 
     verts = np.array([[-1,0,0], [0,1,0], [1,0,0], [0,-1,0], [0,0,1]], dtype=np.float64)
     triangles = np.array([[0,1,3], [1,2,3], [1,3,4]])
@@ -60,28 +43,26 @@ def mesh_generator():
     mesh.triangles = Vector3iVector(triangles)
     yield 'non-manifold edge', mesh
 
-    # verts = np.array([[-1,0,-1], [1,0,-1], [0,1,-1], [0,0,0],
-    #                   [-1,0,1], [1,0,1], [0,1,1]], dtype=np.float64)
-    # triangles = np.array([[0,1,2], [0,1,3], [1,2,3], [2,0,3],
-    #                       [4,5,6], [4,5,3], [5,6,3], [4,6,3]])
-    # mesh = TriangleMesh()
-    # mesh.vertices = Vector3dVector(verts)
-    # mesh.triangles = Vector3iVector(triangles)
-    # yield 'non-manifold vertex', mesh
+    verts = np.array([[-1,0,-1], [1,0,-1], [0,1,-1], [0,0,0],
+                      [-1,0,1], [1,0,1], [0,1,1]], dtype=np.float64)
+    triangles = np.array([[0,1,2], [0,1,3], [1,2,3], [2,0,3],
+                          [4,5,6], [4,5,3], [5,6,3], [4,6,3]])
+    mesh = TriangleMesh()
+    mesh.vertices = Vector3dVector(verts)
+    mesh.triangles = Vector3iVector(triangles)
+    yield 'non-manifold vertex', mesh
 
-    # mesh = create_mesh_box()
-    # mesh.triangles = Vector3iVector(np.asarray(mesh.triangles)[:-2])
-    # yield 'open box', mesh
+    mesh = create_mesh_box()
+    mesh.triangles = Vector3iVector(np.asarray(mesh.triangles)[:-2])
+    yield 'open box', mesh
 
-    # mesh0 = create_mesh_box()
-    # T = np.eye(4)
-    # T[:, 3] += (0.5, 0.5, 0.5, 0)
-    # mesh1 = create_mesh_box()
-    # mesh1.transform(T)
-    # mesh = cat_meshes(mesh0, mesh1)
-    # yield 'boxes', mesh
-
-    yield 'bunny', bunny_mesh()
+    mesh0 = create_mesh_box()
+    T = np.eye(4)
+    T[:, 3] += (0.5, 0.5, 0.5, 0)
+    mesh1 = create_mesh_box()
+    mesh1.transform(T)
+    mesh = cat_meshes(mesh0, mesh1)
+    yield 'boxes', mesh
 
 def edges_to_lineset(mesh, edges, color):
     ls = LineSet()
@@ -103,10 +84,10 @@ def check_properties(name, mesh):
     print('  edge_manifold_boundary: %s' % fmt_bool(edge_manifold_boundary))
     vertex_manifold = mesh.is_vertex_manifold()
     print('  vertex_manifold:        %s' % fmt_bool(vertex_manifold))
-    # self_intersecting = mesh.is_self_intersecting()
-    # print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
-    # watertight = edge_manifold_boundary and vertex_manifold and not self_intersecting
-    # print('  watertight:             %s' % fmt_bool(watertight))
+    self_intersecting = mesh.is_self_intersecting()
+    print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
+    watertight = edge_manifold_boundary and vertex_manifold and not self_intersecting
+    print('  watertight:             %s' % fmt_bool(watertight))
     orientable = mesh.is_orientable()
     print('  orientable:             %s' % fmt_bool(orientable))
 
@@ -127,25 +108,25 @@ def check_properties(name, mesh):
         pcl.points = Vector3dVector(np.asarray(mesh.vertices)[verts])
         pcl.paint_uniform_color((0,0,1))
         draw_geometries([mesh, pcl])
-    # if self_intersecting:
-    #     intersecting_triangles = np.asarray(mesh.get_self_intersecting_triangles())
-    #     intersecting_triangles = intersecting_triangles[0:1]
-    #     intersecting_triangles = np.unique(intersecting_triangles)
-    #     print('  # visualize self-intersecting triangles')
-    #     triangles = np.asarray(mesh.triangles)[intersecting_triangles]
-    #     edges = [np.vstack((triangles[:,i], triangles[:,j])) for i,j in [(0,1), (1,2), (2,0)]]
-    #     edges = np.hstack(edges).T
-    #     edges = Vector2iVector(edges)
-    #     draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,1,0))])
-    # if watertight:
-    #     print('  # visualize watertight mesh')
-    #     draw_geometries([mesh])
+    if self_intersecting:
+        intersecting_triangles = np.asarray(mesh.get_self_intersecting_triangles())
+        intersecting_triangles = intersecting_triangles[0:1]
+        intersecting_triangles = np.unique(intersecting_triangles)
+        print('  # visualize self-intersecting triangles')
+        triangles = np.asarray(mesh.triangles)[intersecting_triangles]
+        edges = [np.vstack((triangles[:,i], triangles[:,j])) for i,j in [(0,1), (1,2), (2,0)]]
+        edges = np.hstack(edges).T
+        edges = Vector2iVector(edges)
+        draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,1,0))])
+    if watertight:
+        print('  # visualize watertight mesh')
+        draw_geometries([mesh])
 
     if not edge_manifold:
         print('  # Remove non-manifold edges')
         mesh.remove_non_manifold_edges()
-        edges = mesh.get_non_manifold_edges(allow_boundary_edges=True)
-        draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,0,0))])
+        print(f'  # Is mesh now edge-manifold: {fmt_bool(mesh.is_edge_manifold())}')
+        draw_geometries([mesh])
 
 if __name__ == "__main__":
     # test mesh properties

--- a/examples/Python/Basic/mesh_properties.py
+++ b/examples/Python/Basic/mesh_properties.py
@@ -6,6 +6,11 @@
 
 import numpy as np
 import time
+import os
+import urllib.request
+import gzip
+import tarfile
+import shutil
 
 from open3d import *
 
@@ -20,16 +25,33 @@ def cat_meshes(mesh0, mesh1):
     mesh.triangles = Vector3iVector(triangles)
     return mesh
 
-def mesh_generator():
-    yield 'box', create_mesh_box()
-    yield 'sphere', create_mesh_sphere()
-    yield 'cone', create_mesh_cone()
-    yield 'torus', create_mesh_torus(radial_resolution=30, tubular_resolution=20)
-    yield 'moebius (twists=1)', create_mesh_moebius(twists=1)
-    yield 'moebius (twists=2)', create_mesh_moebius(twists=2)
-    yield 'moebius (twists=3)', create_mesh_moebius(twists=3)
+def bunny_mesh():
+    bunny_path = '../../TestData/Bunny.ply'
+    if not os.path.exists(bunny_path):
+        print('downloading bunny mesh')
+        url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'
+        urllib.request.urlretrieve(url, bunny_path + '.tar.gz')
+        print('extract bunny mesh')
+        with tarfile.open(bunny_path + '.tar.gz') as tar:
+            tar.extractall(path=os.path.dirname(bunny_path))
+        shutil.move(
+                os.path.join(os.path.dirname(bunny_path),
+                    'bunny', 'reconstruction', 'bun_zipper.ply'),
+                bunny_path)
+        os.remove(bunny_path + '.tar.gz')
+        shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
+    return read_triangle_mesh(bunny_path)
 
-    yield 'knot', read_triangle_mesh('../../TestData/knot.ply')
+def mesh_generator():
+    # yield 'box', create_mesh_box()
+    # yield 'sphere', create_mesh_sphere()
+    # yield 'cone', create_mesh_cone()
+    # yield 'torus', create_mesh_torus(radial_resolution=30, tubular_resolution=20)
+    # yield 'moebius (twists=1)', create_mesh_moebius(twists=1)
+    # yield 'moebius (twists=2)', create_mesh_moebius(twists=2)
+    # yield 'moebius (twists=3)', create_mesh_moebius(twists=3)
+
+    # yield 'knot', read_triangle_mesh('../../TestData/knot.ply')
 
     verts = np.array([[-1,0,0], [0,1,0], [1,0,0], [0,-1,0], [0,0,1]], dtype=np.float64)
     triangles = np.array([[0,1,3], [1,2,3], [1,3,4]])
@@ -38,26 +60,28 @@ def mesh_generator():
     mesh.triangles = Vector3iVector(triangles)
     yield 'non-manifold edge', mesh
 
-    verts = np.array([[-1,0,-1], [1,0,-1], [0,1,-1], [0,0,0],
-                      [-1,0,1], [1,0,1], [0,1,1]], dtype=np.float64)
-    triangles = np.array([[0,1,2], [0,1,3], [1,2,3], [2,0,3],
-                          [4,5,6], [4,5,3], [5,6,3], [4,6,3]])
-    mesh = TriangleMesh()
-    mesh.vertices = Vector3dVector(verts)
-    mesh.triangles = Vector3iVector(triangles)
-    yield 'non-manifold vertex', mesh
+    # verts = np.array([[-1,0,-1], [1,0,-1], [0,1,-1], [0,0,0],
+    #                   [-1,0,1], [1,0,1], [0,1,1]], dtype=np.float64)
+    # triangles = np.array([[0,1,2], [0,1,3], [1,2,3], [2,0,3],
+    #                       [4,5,6], [4,5,3], [5,6,3], [4,6,3]])
+    # mesh = TriangleMesh()
+    # mesh.vertices = Vector3dVector(verts)
+    # mesh.triangles = Vector3iVector(triangles)
+    # yield 'non-manifold vertex', mesh
 
-    mesh = create_mesh_box()
-    mesh.triangles = Vector3iVector(np.asarray(mesh.triangles)[:-2])
-    yield 'open box', mesh
+    # mesh = create_mesh_box()
+    # mesh.triangles = Vector3iVector(np.asarray(mesh.triangles)[:-2])
+    # yield 'open box', mesh
 
-    mesh0 = create_mesh_box()
-    T = np.eye(4)
-    T[:, 3] += (0.5, 0.5, 0.5, 0)
-    mesh1 = create_mesh_box()
-    mesh1.transform(T)
-    mesh = cat_meshes(mesh0, mesh1)
-    yield 'boxes', mesh
+    # mesh0 = create_mesh_box()
+    # T = np.eye(4)
+    # T[:, 3] += (0.5, 0.5, 0.5, 0)
+    # mesh1 = create_mesh_box()
+    # mesh1.transform(T)
+    # mesh = cat_meshes(mesh0, mesh1)
+    # yield 'boxes', mesh
+
+    yield 'bunny', bunny_mesh()
 
 def edges_to_lineset(mesh, edges, color):
     ls = LineSet()
@@ -72,22 +96,21 @@ def edges_to_lineset(mesh, edges, color):
 def check_properties(name, mesh):
     def fmt_bool(b):
         return 'yes' if b else 'no'
-    edge_manifold = mesh.is_edge_manifold(allow_boundary_edges=True)
-    edge_manifold_boundary = mesh.is_edge_manifold(allow_boundary_edges=False)
-    vertex_manifold = mesh.is_vertex_manifold()
-    self_intersecting = mesh.is_self_intersecting()
-    watertight = edge_manifold_boundary and vertex_manifold and not self_intersecting
-    orientable = mesh.is_orientable()
     print(name)
+    edge_manifold = mesh.is_edge_manifold(allow_boundary_edges=True)
     print('  edge_manifold:          %s' % fmt_bool(edge_manifold))
+    edge_manifold_boundary = mesh.is_edge_manifold(allow_boundary_edges=False)
     print('  edge_manifold_boundary: %s' % fmt_bool(edge_manifold_boundary))
+    vertex_manifold = mesh.is_vertex_manifold()
     print('  vertex_manifold:        %s' % fmt_bool(vertex_manifold))
-    print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
-    print('  watertight:             %s' % fmt_bool(watertight))
+    # self_intersecting = mesh.is_self_intersecting()
+    # print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
+    # watertight = edge_manifold_boundary and vertex_manifold and not self_intersecting
+    # print('  watertight:             %s' % fmt_bool(watertight))
+    orientable = mesh.is_orientable()
     print('  orientable:             %s' % fmt_bool(orientable))
 
     mesh.compute_vertex_normals()
-    draw_geometries([mesh])
 
     if not edge_manifold:
         edges = mesh.get_non_manifold_edges(allow_boundary_edges=True)
@@ -104,16 +127,25 @@ def check_properties(name, mesh):
         pcl.points = Vector3dVector(np.asarray(mesh.vertices)[verts])
         pcl.paint_uniform_color((0,0,1))
         draw_geometries([mesh, pcl])
-    if self_intersecting:
-        intersecting_triangles = np.asarray(mesh.get_self_intersecting_triangles())
-        intersecting_triangles = intersecting_triangles[0:1]
-        intersecting_triangles = np.unique(intersecting_triangles)
-        print('  # visualize self-intersecting triangles')
-        triangles = np.asarray(mesh.triangles)[intersecting_triangles]
-        edges = [np.vstack((triangles[:,i], triangles[:,j])) for i,j in [(0,1), (1,2), (2,0)]]
-        edges = np.hstack(edges).T
-        edges = Vector2iVector(edges)
-        draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,1,0))])
+    # if self_intersecting:
+    #     intersecting_triangles = np.asarray(mesh.get_self_intersecting_triangles())
+    #     intersecting_triangles = intersecting_triangles[0:1]
+    #     intersecting_triangles = np.unique(intersecting_triangles)
+    #     print('  # visualize self-intersecting triangles')
+    #     triangles = np.asarray(mesh.triangles)[intersecting_triangles]
+    #     edges = [np.vstack((triangles[:,i], triangles[:,j])) for i,j in [(0,1), (1,2), (2,0)]]
+    #     edges = np.hstack(edges).T
+    #     edges = Vector2iVector(edges)
+    #     draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,1,0))])
+    # if watertight:
+    #     print('  # visualize watertight mesh')
+    #     draw_geometries([mesh])
+
+    if not edge_manifold:
+        print('  # Remove non-manifold edges')
+        mesh.remove_non_manifold_edges()
+        edges = mesh.get_non_manifold_edges(allow_boundary_edges=True)
+        draw_geometries([mesh, edges_to_lineset(mesh, edges, (1,0,0))])
 
 if __name__ == "__main__":
     # test mesh properties

--- a/examples/Python/Basic/mesh_sampling.py
+++ b/examples/Python/Basic/mesh_sampling.py
@@ -5,54 +5,10 @@
 # examples/Python/Basic/mesh_sampling.py
 
 import numpy as np
-import os
-import urllib.request
-import gzip
-import tarfile
-import shutil
 import time
 import open3d as o3d
 
-
-def create_mesh_plane():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([[0, 0, 0], [0, 0.2, 0], [1, 0.2, 0], [1, 0, 0]],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
-                                                                      3]]))
-    return mesh
-
-
-def armadillo_mesh():
-    armadillo_path = '../../TestData/Armadillo.ply'
-    if not os.path.exists(armadillo_path):
-        print('downloading armadillo mesh')
-        url = 'http://graphics.stanford.edu/pub/3Dscanrep/armadillo/Armadillo.ply.gz'
-        urllib.request.urlretrieve(url, armadillo_path + '.gz')
-        print('extract armadillo mesh')
-        with gzip.open(armadillo_path + '.gz', 'rb') as fin:
-            with open(armadillo_path, 'wb') as fout:
-                shutil.copyfileobj(fin, fout)
-        os.remove(armadillo_path + '.gz')
-    return o3d.io.read_triangle_mesh(armadillo_path)
-
-
-def bunny_mesh():
-    bunny_path = '../../TestData/Bunny.ply'
-    if not os.path.exists(bunny_path):
-        print('downloading bunny mesh')
-        url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'
-        urllib.request.urlretrieve(url, bunny_path + '.tar.gz')
-        print('extract bunny mesh')
-        with tarfile.open(bunny_path + '.tar.gz') as tar:
-            tar.extractall(path=os.path.dirname(bunny_path))
-        shutil.move(
-            os.path.join(os.path.dirname(bunny_path), 'bunny', 'reconstruction',
-                         'bun_zipper.ply'), bunny_path)
-        os.remove(bunny_path + '.tar.gz')
-        shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
-    return o3d.io.read_triangle_mesh(bunny_path)
+import meshes
 
 
 def time_fcn(fcn, *fcn_args, runs=5):
@@ -65,14 +21,14 @@ def time_fcn(fcn, *fcn_args, runs=5):
 
 
 def mesh_generator():
-    yield create_mesh_plane()
+    yield meshes.plane()
     yield o3d.geometry.create_mesh_sphere()
-    yield bunny_mesh()
-    yield armadillo_mesh()
+    yield meshes.bunny()
+    yield meshes.armadillo()
 
 
 if __name__ == "__main__":
-    plane = create_mesh_plane()
+    plane = meshes.plane()
     o3d.visualization.draw_geometries([plane])
 
     print('Uniform sampling can yield clusters of points on the surface')

--- a/examples/Python/Basic/mesh_simplification.py
+++ b/examples/Python/Basic/mesh_simplification.py
@@ -7,6 +7,8 @@
 import numpy as np
 import open3d as o3d
 
+import meshes
+
 
 def create_mesh_plane():
     mesh = o3d.geometry.TriangleMesh()
@@ -19,7 +21,7 @@ def create_mesh_plane():
 
 
 def mesh_generator():
-    mesh = create_mesh_plane()
+    mesh = meshes.plane()
     yield o3d.geometry.subdivide_midpoint(mesh, 2)
 
     mesh = o3d.geometry.create_mesh_box()
@@ -34,8 +36,7 @@ def mesh_generator():
     mesh = o3d.geometry.create_mesh_cylinder()
     yield o3d.geometry.subdivide_midpoint(mesh, 2)
 
-    mesh = o3d.io.read_triangle_mesh("../../TestData/bathtub_0154.ply")
-    yield mesh
+    yield meshes.bathtub()
 
 
 if __name__ == "__main__":

--- a/examples/Python/Basic/mesh_subdivision.py
+++ b/examples/Python/Basic/mesh_subdivision.py
@@ -7,31 +7,12 @@
 import numpy as np
 import open3d as o3d
 
-
-def create_mesh_triangle():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([(np.sqrt(8 / 9), 0, -1 / 3),
-                  (-np.sqrt(2 / 9), np.sqrt(2 / 3), -1 / 3),
-                  (-np.sqrt(2 / 9), -np.sqrt(2 / 3), -1 / 3)],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 1, 2]]))
-    return mesh
-
-
-def create_mesh_plane():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
-                                                                      3]]))
-    return mesh
+import meshes
 
 
 def mesh_generator():
-    yield create_mesh_triangle()
-    yield create_mesh_plane()
+    yield meshes.triangle()
+    yield meshes.plane()
     yield o3d.geometry.create_mesh_tetrahedron()
     yield o3d.geometry.create_mesh_box()
     yield o3d.geometry.create_mesh_octahedron()
@@ -39,8 +20,8 @@ def mesh_generator():
     yield o3d.geometry.create_mesh_sphere()
     yield o3d.geometry.create_mesh_cone()
     yield o3d.geometry.create_mesh_cylinder()
-    yield o3d.io.read_triangle_mesh("../../TestData/knot.ply")
-    yield o3d.io.read_triangle_mesh("../../TestData/bathtub_0154.ply")
+    yield meshes.knot()
+    yield meshes.bathtub()
 
 
 if __name__ == "__main__":

--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -1,0 +1,134 @@
+# Open3selfopen3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Basic/meshes.py
+
+import numpy as np
+import open3d as o3d
+import os
+import urllib.request
+import gzip
+import tarfile
+import shutil
+
+
+def cat_meshes(mesh0, mesh1):
+    mesh = o3d.geometry.TriangleMesh()
+    vertices0 = np.asarray(mesh0.vertices)
+    vertices = np.vstack((vertices0, np.asarray(mesh1.vertices)))
+    mesh.vertices = o3d.utility.Vector3dVector(vertices)
+    triangles = np.vstack((np.asarray(mesh0.triangles),
+                           np.asarray(mesh1.triangles) + vertices0.shape[0]))
+    mesh.triangles = o3d.utility.Vector3iVector(triangles)
+    return mesh
+
+
+def edges_to_lineset(mesh, edges, color):
+    ls = o3d.geometry.LineSet()
+    ls.points = mesh.vertices
+    ls.lines = edges
+    colors = np.empty((np.asarray(edges).shape[0], 3))
+    colors[:] = color
+    ls.colors = o3d.utility.Vector3dVector(colors)
+    return ls
+
+
+def triangle():
+    mesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(
+        np.array([(np.sqrt(8 / 9), 0, -1 / 3),
+                  (-np.sqrt(2 / 9), np.sqrt(2 / 3), -1 / 3),
+                  (-np.sqrt(2 / 9), -np.sqrt(2 / 3), -1 / 3)],
+                 dtype=np.float32))
+    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 1, 2]]))
+    return mesh
+
+
+def plane():
+    mesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(
+        np.array([[0, 0, 0], [0, 0.2, 0], [1, 0.2, 0], [1, 0, 0]],
+                 dtype=np.float32))
+    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
+                                                                      3]]))
+    return mesh
+
+
+def non_manifold_edge():
+    verts = np.array([[-1, 0, 0], [0, 1, 0], [1, 0, 0], [0, -1, 0], [0, 0, 1]],
+                     dtype=np.float64)
+    triangles = np.array([[0, 1, 3], [1, 2, 3], [1, 3, 4]])
+    mesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(verts)
+    mesh.triangles = o3d.utility.Vector3iVector(triangles)
+    return mesh
+
+
+def non_manifold_vertex():
+    verts = np.array([[-1, 0, -1], [1, 0, -1], [0, 1, -1], [0, 0, 0],
+                      [-1, 0, 1], [1, 0, 1], [0, 1, 1]],
+                     dtype=np.float64)
+    triangles = np.array([[0, 1, 2], [0, 1, 3], [1, 2, 3], [2, 0, 3], [4, 5, 6],
+                          [4, 5, 3], [5, 6, 3], [4, 6, 3]])
+    mesh = o3d.geometry.TriangleMesh()
+    mesh.vertices = o3d.utility.Vector3dVector(verts)
+    mesh.triangles = o3d.utility.Vector3iVector(triangles)
+    return mesh
+
+
+def open_box():
+    mesh = o3d.geometry.create_mesh_box()
+    mesh.triangles = o3d.utility.Vector3iVector(np.asarray(mesh.triangles)[:-2])
+    return mesh
+
+
+def intersecting_boxes():
+    mesh0 = o3d.geometry.create_mesh_box()
+    T = np.eye(4)
+    T[:, 3] += (0.5, 0.5, 0.5, 0)
+    mesh1 = o3d.geometry.create_mesh_box()
+    mesh1.transform(T)
+    mesh = cat_meshes(mesh0, mesh1)
+    return mesh
+
+
+def knot():
+    mesh = o3d.io.read_triangle_mesh('../../TestData/knot.ply')
+    return mesh
+
+
+def bathtub():
+    mesh = o3d.io.read_triangle_mesh("../../TestData/bathtub_0154.ply")
+    return mesh
+
+
+def armadillo():
+    armadillo_path = '../../TestData/Armadillo.ply'
+    if not os.path.exists(armadillo_path):
+        print('downloading armadillo mesh')
+        url = 'http://graphics.stanford.edu/pub/3Dscanrep/armadillo/Armadillo.ply.gz'
+        urllib.request.urlretrieve(url, armadillo_path + '.gz')
+        print('extract armadillo mesh')
+        with gzip.open(armadillo_path + '.gz', 'rb') as fin:
+            with open(armadillo_path, 'wb') as fout:
+                shutil.copyfileobj(fin, fout)
+        os.remove(armadillo_path + '.gz')
+    return o3d.io.read_triangle_mesh(armadillo_path)
+
+
+def bunny():
+    bunny_path = '../../TestData/Bunny.ply'
+    if not os.path.exists(bunny_path):
+        print('downloading bunny mesh')
+        url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'
+        urllib.request.urlretrieve(url, bunny_path + '.tar.gz')
+        print('extract bunny mesh')
+        with tarfile.open(bunny_path + '.tar.gz') as tar:
+            tar.extractall(path=os.path.dirname(bunny_path))
+        shutil.move(
+            os.path.join(os.path.dirname(bunny_path), 'bunny', 'reconstruction',
+                         'bun_zipper.ply'), bunny_path)
+        os.remove(bunny_path + '.tar.gz')
+        shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
+    return o3d.io.read_triangle_mesh(bunny_path)

--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -232,7 +232,10 @@ std::shared_ptr<TriangleMesh> SelectDownSample(
                 output->vertex_colors_.push_back(input.vertex_colors_[i]);
         }
     }
-    output->Purge();
+    output->RemoveDuplicatedVertices();
+    output->RemoveDuplicatedTriangles();
+    output->RemoveUnreferencedVertices();
+    output->RemoveDegenerateTriangles();
     utility::PrintDebug(
             "Triangle mesh sampled from %d vertices and %d triangles to %d "
             "vertices and %d triangles.\n",

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -275,7 +275,10 @@ std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(
     half_edge_mesh->adjacency_list_ = mesh.adjacency_list_;
 
     // Purge to remove duplications
-    half_edge_mesh->Purge();
+    half_edge_mesh->RemoveDuplicatedVertices();
+    half_edge_mesh->RemoveDuplicatedTriangles();
+    half_edge_mesh->RemoveUnreferencedVertices();
+    half_edge_mesh->RemoveDegenerateTriangles();
 
     // If the original mesh is not a manifold, we set HalfEdgeTriangleMesh to
     // be empty. Caller to this constructor is responsible to checking
@@ -303,17 +306,17 @@ void HalfEdgeTriangleMesh::RemoveDuplicatedTriangles() {
     }
 }
 
-void HalfEdgeTriangleMesh::RemoveNonManifoldVertices() {
+void HalfEdgeTriangleMesh::RemoveUnreferencedVertices() {
     size_t before_num = vertices_.size();
-    TriangleMesh::RemoveNonManifoldVertices();
+    TriangleMesh::RemoveUnreferencedVertices();
     if (HasHalfEdges() && vertices_.size() != before_num) {
         ComputeHalfEdges();
     }
 }
 
-void HalfEdgeTriangleMesh::RemoveNonManifoldTriangles() {
+void HalfEdgeTriangleMesh::RemoveDegenerateTriangles() {
     size_t before_num = triangles_.size();
-    TriangleMesh::RemoveNonManifoldTriangles();
+    TriangleMesh::RemoveDegenerateTriangles();
     if (HasHalfEdges() && triangles_.size() != before_num) {
         ComputeHalfEdges();
     }

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
@@ -82,16 +82,17 @@ public:
     /// Clear all data in HalfEdgeTriangleMesh
     void Clear() override;
 
+    void RemoveDuplicatedVertices() override;
+    void RemoveDuplicatedTriangles() override;
+    void RemoveUnreferencedVertices() override;
+    void RemoveDegenerateTriangles() override;
+
     HalfEdgeTriangleMesh &operator+=(const HalfEdgeTriangleMesh &mesh);
 
     HalfEdgeTriangleMesh operator+(const HalfEdgeTriangleMesh &mesh) const;
 
 protected:
     HalfEdgeTriangleMesh(Geometry::GeometryType type) : TriangleMesh(type) {}
-    void RemoveDuplicatedVertices() override;
-    void RemoveDuplicatedTriangles() override;
-    void RemoveNonManifoldVertices() override;
-    void RemoveNonManifoldTriangles() override;
 
 public:
     std::vector<HalfEdge> half_edges_;

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -818,20 +818,29 @@ void TriangleMesh::RemoveNonManifoldEdges() {
 
         for (auto &kv : edges_to_triangles) {
             int n_edge_triangle_refs = kv.second.size();
+            // check if the given edge is manifold
+            // (has exactly 1, or 2 adjacent triangles)
             if (n_edge_triangle_refs == 1 || n_edge_triangle_refs == 2) {
                 continue;
             }
 
+            // There is at least one edge that is non-manifold
+            mesh_is_edge_manifold = false;
+
             // if the edge is non-manifold, then check if a referenced
-            // triangle has already been removed, otherwise remove triangle
+            // triangle has already been removed
+            // (triangle area has been set to < 0), otherwise remove triangle
             // with smallest surface area until number of adjacent triangles
             // is <= 2.
+            // 1) count triangles that are not marked deleted
             int n_triangles = 0;
             for (int tidx : kv.second) {
                 if (triangle_areas[tidx] > 0) {
                     n_triangles++;
                 }
             }
+            // 2) mark smallest triangles as deleted by setting
+            // surface area to -1
             int n_triangles_to_delete = n_triangles - 2;
             while (n_triangles_to_delete > 0) {
                 // find triangle with smallest area

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -240,13 +240,6 @@ void TriangleMesh::ComputeAdjacencyList() {
     }
 }
 
-void TriangleMesh::Purge() {
-    RemoveDuplicatedVertices();
-    RemoveDuplicatedTriangles();
-    RemoveNonManifoldTriangles();
-    RemoveNonManifoldVertices();
-}
-
 std::shared_ptr<PointCloud> SamplePointsUniformly(
         const TriangleMesh &input,
         size_t number_of_points,
@@ -749,9 +742,7 @@ void TriangleMesh::RemoveDuplicatedTriangles() {
             (int)(old_triangle_num - k));
 }
 
-void TriangleMesh::RemoveNonManifoldVertices() {
-    // Non-manifold vertices are vertices without a triangle reference. They
-    // should not exist in a valid triangle mesh.
+void TriangleMesh::RemoveUnreferencedVertices() {
     std::vector<bool> vertex_has_reference(vertices_.size(), false);
     for (const auto &triangle : triangles_) {
         vertex_has_reference[triangle(0)] = true;
@@ -788,14 +779,11 @@ void TriangleMesh::RemoveNonManifoldVertices() {
         }
     }
     utility::PrintDebug(
-            "[RemoveNonManifoldVertices] %d vertices have been removed.\n",
+            "[RemoveUnreferencedVertices] %d vertices have been removed.\n",
             (int)(old_vertex_num - k));
 }
 
-void TriangleMesh::RemoveNonManifoldTriangles() {
-    // Non-manifold triangles are degenerate triangles that have one vertex
-    // as its multiple end-points. They are usually the product of removing
-    // duplicated vertices.
+void TriangleMesh::RemoveDegenerateTriangles() {
     bool has_tri_normal = HasTriangleNormals();
     size_t old_triangle_num = triangles_.size();
     size_t k = 0;
@@ -814,7 +802,7 @@ void TriangleMesh::RemoveNonManifoldTriangles() {
         ComputeAdjacencyList();
     }
     utility::PrintDebug(
-            "[RemoveNonManifoldTriangles] %d triangles have been "
+            "[RemoveDegenerateTriangles] %d triangles have been "
             "removed.\n",
             (int)(old_triangle_num - k));
 }

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -86,8 +86,22 @@ public:
     /// Function to compute adjacency list, call before adjacency list is needed
     void ComputeAdjacencyList();
 
-    /// Function to remove duplicated and non-manifold vertices/triangles
-    void Purge();
+    /// Function that removes duplicated verties, i.e., vertices that have
+    /// identical coordinates.
+    virtual void RemoveDuplicatedVertices();
+
+    /// Function that removes duplicated triangles, i.e., removes triangles
+    /// that reference the same three vertices, independent of their order.
+    virtual void RemoveDuplicatedTriangles();
+
+    /// This function removes vertices from the triangle mesh that are not
+    /// referenced in any triangle of the mesh.
+    virtual void RemoveUnreferencedVertices();
+
+    /// Function that removes degenerate triangles, i.e., triangles that
+    /// references a single vertex multiple times in a single triangle.
+    /// They are usually the product of removing duplicated vertices.
+    virtual void RemoveDegenerateTriangles();
 
     /// Function to sharpen triangle mesh. The output value ($v_o$) is the
     /// input value ($v_i$) plus \param strength times the input value minus
@@ -135,10 +149,6 @@ public:
 protected:
     // Forward child class type to avoid indirect nonvirtual base
     TriangleMesh(Geometry::GeometryType type) : Geometry3D(type) {}
-    virtual void RemoveDuplicatedVertices();
-    virtual void RemoveDuplicatedTriangles();
-    virtual void RemoveNonManifoldVertices();
-    virtual void RemoveNonManifoldTriangles();
 
 public:
     bool HasVertices() const { return vertices_.size() > 0; }

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -103,6 +103,9 @@ public:
     /// They are usually the product of removing duplicated vertices.
     virtual void RemoveDegenerateTriangles();
 
+    /// TODO doc
+    virtual void RemoveNonManifoldTriangles();
+
     /// Function to sharpen triangle mesh. The output value ($v_o$) is the
     /// input value ($v_i$) plus \param strength times the input value minus
     /// the sum of he adjacent values.
@@ -251,12 +254,12 @@ public:
     /// such that all normals point towards the outside/inside.
     bool OrientTriangles();
 
-    /// Function that counts the number of faces an edge belongs to.
-    /// Returns a map of Edge (vertex0, vertex1) to number of faces.
+    /// Function that returns a map from edges (vertex0, vertex1) to the
+    /// triangle indices the given edge belongs to.
     std::unordered_map<Eigen::Vector2i,
-                       int,
+                       std::vector<int>,
                        utility::hash_eigen::hash<Eigen::Vector2i>>
-    GetEdgeTriangleCount() const;
+    GetEdgeToTrianglesMap() const;
 
     /// Function that computes the area of a mesh triangle identified by the
     /// triangle index

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -103,8 +103,10 @@ public:
     /// They are usually the product of removing duplicated vertices.
     virtual void RemoveDegenerateTriangles();
 
-    /// TODO doc
-    virtual void RemoveNonManifoldTriangles();
+    /// Function that removes all non-manifold edges, by successively deleting
+    /// triangles with the smallest surface area adjacent to the non-manifold
+    /// edge until the number of adjacent triangles to the edge is `<= 2`.
+    virtual void RemoveNonManifoldEdges();
 
     /// Function to sharpen triangle mesh. The output value ($v_o$) is the
     /// input value ($v_i$) plus \param strength times the input value minus

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -301,13 +301,13 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
     }
 
     // For boundary edges add perpendicular plane quadric
-    auto edge_triangle_count = input.GetEdgeTriangleCount();
+    auto edge_triangle_count = input.GetEdgeToTrianglesMap();
     auto AddPerpPlaneQuadric = [&](int vidx0, int vidx1, int vidx2,
                                    double area) {
         int min = std::min(vidx0, vidx1);
         int max = std::max(vidx0, vidx1);
         Eigen::Vector2i edge(min, max);
-        if (edge_triangle_count[edge] != 1) {
+        if (edge_triangle_count[edge].size() != 1) {
             return;
         }
         const auto& vert0 = mesh->vertices_[vidx0];

--- a/src/Python/geometry/geometry_trampoline.h
+++ b/src/Python/geometry/geometry_trampoline.h
@@ -83,10 +83,10 @@ public:
     void RemoveDuplicatedTriangles() override {
         PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveDuplicatedTriangles, );
     };
-    void RemoveNonManifoldVertices() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveNonManifoldVertices, );
+    void RemoveUnreferencedVertices() override {
+        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveUnreferencedVertices, );
     };
-    void RemoveNonManifoldTriangles() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveNonManifoldTriangles, );
+    void RemoveDegenerateTriangles() override {
+        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveDegenerateTriangles, );
     };
 };

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -88,9 +88,25 @@ void pybind_trianglemesh(py::module &m) {
                  &geometry::TriangleMesh::ComputeAdjacencyList,
                  "Function to compute adjacency list, call before adjacency "
                  "list is needed")
-            .def("purge", &geometry::TriangleMesh::Purge,
-                 "Function to remove duplicated and non-manifold "
-                 "vertices/triangles")
+            .def("remove_duplicated_vertices",
+                 &geometry::TriangleMesh::RemoveDuplicatedVertices,
+                 "Function that removes duplicated verties, i.e., vertices "
+                 "that have identical coordinates.")
+            .def("remove_duplicated_triangles",
+                 &geometry::TriangleMesh::RemoveDuplicatedTriangles,
+                 "Function that removes duplicated triangles, i.e., removes "
+                 "triangles that reference the same three vertices, "
+                 "independent of their order.")
+            .def("remove_unreferenced_vertices",
+                 &geometry::TriangleMesh::RemoveUnreferencedVertices,
+                 "This function removes vertices from the triangle mesh that "
+                 "are not referenced in any triangle of the mesh.")
+            .def("remove_degenerate_triangles",
+                 &geometry::TriangleMesh::RemoveDegenerateTriangles,
+                 "Function that removes degenerate triangles, i.e., triangles "
+                 "that references a single vertex multiple times in a single "
+                 "triangle. They are usually the product of removing "
+                 "duplicated vertices.")
             .def("filter_sharpen", &geometry::TriangleMesh::FilterSharpen,
                  "Function to sharpen triangle mesh. The output value "
                  "(:math:`v_o`) is the input value (:math:`v_i`) plus strength "
@@ -259,7 +275,14 @@ void pybind_trianglemesh(py::module &m) {
             {{"other", "Other triangle mesh to test intersection with."}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "is_orientable");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "orient_triangles");
-    docstring::ClassMethodDocInject(m, "TriangleMesh", "purge");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "remove_duplicated_vertices");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "remove_duplicated_triangles");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "remove_unreferenced_vertices");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "remove_degenerate_triangles");
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "filter_sharpen",
             {{"number_of_iterations",

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -107,6 +107,12 @@ void pybind_trianglemesh(py::module &m) {
                  "that references a single vertex multiple times in a single "
                  "triangle. They are usually the product of removing "
                  "duplicated vertices.")
+            .def("remove_non_manifold_edges",
+                 &geometry::TriangleMesh::RemoveNonManifoldEdges,
+                 "Function that removes all non-manifold edges, by "
+                 "successively deleting  triangles with the smallest surface "
+                 "area adjacent to the non-manifold edge until the number of "
+                 "adjacent triangles to the edge is `<= 2`.")
             .def("filter_sharpen", &geometry::TriangleMesh::FilterSharpen,
                  "Function to sharpen triangle mesh. The output value "
                  "(:math:`v_o`) is the input value (:math:`v_i`) plus strength "
@@ -283,6 +289,8 @@ void pybind_trianglemesh(py::module &m) {
                                     "remove_unreferenced_vertices");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "remove_degenerate_triangles");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "remove_non_manifold_edges");
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "filter_sharpen",
             {{"number_of_iterations",

--- a/src/Tools/MergeMesh.cpp
+++ b/src/Tools/MergeMesh.cpp
@@ -37,7 +37,7 @@ void PrintHelp() {
     utility::PrintInfo("Options (listed in the order of execution priority):\n");
     utility::PrintInfo("    --help, -h                : Print help information.\n");
     utility::PrintInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::PrintInfo("    --purge                   : Clear duplicated and non-manifold vertices and\n");
+    utility::PrintInfo("    --purge                   : Clear duplicated and unreferenced vertices and\n");
     utility::PrintInfo("                                triangles.\n");
     // clang-format on
 }
@@ -67,7 +67,10 @@ int main(int argc, char **argv) {
     }
 
     if (utility::ProgramOptionExists(argc, argv, "--purge")) {
-        merged_mesh_ptr->Purge();
+        merged_mesh_ptr->RemoveDuplicatedVertices();
+        merged_mesh_ptr->RemoveDuplicatedTriangles();
+        merged_mesh_ptr->RemoveUnreferencedVertices();
+        merged_mesh_ptr->RemoveDegenerateTriangles();
     }
     io::WriteTriangleMesh(argv[2], *merged_mesh_ptr);
 

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -664,7 +664,10 @@ TEST(TriangleMesh, Purge) {
 
     geometry::TriangleMesh tm = tm0 + tm1;
 
-    tm.Purge();
+    tm.RemoveDuplicatedVertices();
+    tm.RemoveDuplicatedTriangles();
+    tm.RemoveUnreferencedVertices();
+    tm.RemoveDegenerateTriangles();
 
     ExpectEQ(ref_vertices, tm.vertices_);
     ExpectEQ(ref_vertex_normals, tm.vertex_normals_);


### PR DESCRIPTION
In this PR I renamed the existing `RemoveNonManifold*` methods in `TriangleMesh` to reflect their actual behavior: `RemoveUnreferencedVertices()` and `RemoveDegenerateTriangles()`. In addition, I moved them to public scope, added doc strings and made them accessible through Python bindings.

The main contribution in this PR is an actual `RemoveNonManifoldEdges()` method. Non manifold edges are edges with more than 2 adjacent triangles. Hence, this method removes the triangle with the smallest surface area from the non-manifold edges until they are manifold.

This method is showcased in the `mesh_properties.py` example. Further, I cleaned up a bit the Python examples by introducing a `meshes.py` file that provides functions to create/load triangle meshes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/985)
<!-- Reviewable:end -->
