### PR TITLE
Added center parameter to rotate method

### DIFF
--- a/examples/Python/Basic/mesh_simplification.py
+++ b/examples/Python/Basic/mesh_simplification.py
@@ -38,6 +38,8 @@ def mesh_generator():
 
     yield meshes.bathtub()
 
+    yield meshes.bunny()
+
 
 if __name__ == "__main__":
     np.random.seed(42)
@@ -54,6 +56,7 @@ if __name__ == "__main__":
 
         voxel_size = max(mesh.get_max_bound() - mesh.get_min_bound()) / 4
         target_number_of_triangles = np.asarray(mesh.triangles).shape[0] // 2
+        print('voxel_size = %f' % voxel_size)
 
         mesh_smp = o3d.geometry.simplify_vertex_clustering(
             mesh,

--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -195,12 +195,9 @@ if __name__ == '__main__':
 
     for scale, aa in zip(scales, axisangles):
         for geom in geoms:
-            vertices = np.asarray(geom.vertices)
-            tc = vertices.mean(axis=0)
-            geom.vertices = o3d.utility.Vector3dVector(vertices - tc)
             geom.scale(scale).rotate(aa,
+                                     center=True,
                                      type=o3d.geometry.RotationType.AxisAngle)
-            geom.vertices = o3d.utility.Vector3dVector(vertices + tc)
         vis.update_geometry()
         vis.poll_events()
         vis.update_renderer()

--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -11,6 +11,7 @@ import urllib.request
 import gzip
 import tarfile
 import shutil
+import time
 
 
 def cat_meshes(mesh0, mesh1):
@@ -34,6 +35,13 @@ def edges_to_lineset(mesh, edges, color):
     return ls
 
 
+def apply_noise(mesh, noise):
+    vertices = np.asarray(mesh.vertices)
+    vertices += np.random.uniform(-noise, noise, size=vertices.shape)
+    mesh.vertices = o3d.utility.Vector3dVector(vertices)
+    return mesh
+
+
 def triangle():
     mesh = o3d.geometry.TriangleMesh()
     mesh.vertices = o3d.utility.Vector3dVector(
@@ -42,6 +50,7 @@ def triangle():
                   (-np.sqrt(2 / 9), -np.sqrt(2 / 3), -1 / 3)],
                  dtype=np.float32))
     mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 1, 2]]))
+    mesh.compute_vertex_normals()
     return mesh
 
 
@@ -52,6 +61,7 @@ def plane():
                  dtype=np.float32))
     mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
                                                                       3]]))
+    mesh.compute_vertex_normals()
     return mesh
 
 
@@ -62,6 +72,7 @@ def non_manifold_edge():
     mesh = o3d.geometry.TriangleMesh()
     mesh.vertices = o3d.utility.Vector3dVector(verts)
     mesh.triangles = o3d.utility.Vector3iVector(triangles)
+    mesh.compute_vertex_normals()
     return mesh
 
 
@@ -74,12 +85,14 @@ def non_manifold_vertex():
     mesh = o3d.geometry.TriangleMesh()
     mesh.vertices = o3d.utility.Vector3dVector(verts)
     mesh.triangles = o3d.utility.Vector3iVector(triangles)
+    mesh.compute_vertex_normals()
     return mesh
 
 
 def open_box():
     mesh = o3d.geometry.create_mesh_box()
     mesh.triangles = o3d.utility.Vector3iVector(np.asarray(mesh.triangles)[:-2])
+    mesh.compute_vertex_normals()
     return mesh
 
 
@@ -90,16 +103,19 @@ def intersecting_boxes():
     mesh1 = o3d.geometry.create_mesh_box()
     mesh1.transform(T)
     mesh = cat_meshes(mesh0, mesh1)
+    mesh.compute_vertex_normals()
     return mesh
 
 
 def knot():
     mesh = o3d.io.read_triangle_mesh('../../TestData/knot.ply')
+    mesh.compute_vertex_normals()
     return mesh
 
 
 def bathtub():
     mesh = o3d.io.read_triangle_mesh("../../TestData/bathtub_0154.ply")
+    mesh.compute_vertex_normals()
     return mesh
 
 
@@ -114,7 +130,9 @@ def armadillo():
             with open(armadillo_path, 'wb') as fout:
                 shutil.copyfileobj(fin, fout)
         os.remove(armadillo_path + '.gz')
-    return o3d.io.read_triangle_mesh(armadillo_path)
+    mesh = o3d.io.read_triangle_mesh(armadillo_path)
+    mesh.compute_vertex_normals()
+    return mesh
 
 
 def bunny():
@@ -131,4 +149,59 @@ def bunny():
                          'bun_zipper.ply'), bunny_path)
         os.remove(bunny_path + '.tar.gz')
         shutil.rmtree(os.path.join(os.path.dirname(bunny_path), 'bunny'))
-    return o3d.io.read_triangle_mesh(bunny_path)
+    mesh = o3d.io.read_triangle_mesh(bunny_path)
+    mesh.compute_vertex_normals()
+    return mesh
+
+
+def center_and_scale(mesh):
+    vertices = np.asarray(mesh.vertices)
+    vertices = vertices / max(vertices.max(axis=0) - vertices.min(axis=0))
+    vertices -= vertices.mean(axis=0)
+    mesh.vertices = o3d.utility.Vector3dVector(vertices)
+    return mesh
+
+
+if __name__ == '__main__':
+
+    def process(mesh):
+        mesh.compute_vertex_normals()
+        mesh = center_and_scale(mesh)
+        return mesh
+
+    print('visualize')
+    print('  tetrahedron, octahedron, icosahedron')
+    print('  torus, moebius strip one twist, moebius strip two twists')
+    d = 1.5
+    geoms = [
+        process(o3d.geometry.create_mesh_tetrahedron()).translate((-d, 0, 0)),
+        process(o3d.geometry.create_mesh_octahedron()).translate((0, 0, 0)),
+        process(o3d.geometry.create_mesh_icosahedron()).translate((d, 0, 0)),
+        process(o3d.geometry.create_mesh_torus()).translate((-d, -d, 0)),
+        process(o3d.geometry.create_mesh_moebius(twists=1)).translate(
+            (0, -d, 0)),
+        process(o3d.geometry.create_mesh_moebius(twists=2)).translate(
+            (d, -d, 0)),
+    ]
+
+    vis = o3d.visualization.Visualizer()
+    vis.create_window()
+    vis.get_render_option().mesh_show_back_face = True
+    for geom in geoms:
+        vis.add_geometry(geom)
+
+    scales = [0.995 for _ in range(100)] + [1 / 0.995 for _ in range(100)]
+    axisangles = [(0.2 / np.sqrt(2), 0.2 / np.sqrt(2), 0) for _ in range(200)]
+
+    for scale, aa in zip(scales, axisangles):
+        for geom in geoms:
+            vertices = np.asarray(geom.vertices)
+            tc = vertices.mean(axis=0)
+            geom.vertices = o3d.utility.Vector3dVector(vertices - tc)
+            geom.scale(scale).rotate(aa,
+                                     type=o3d.geometry.RotationType.AxisAngle)
+            geom.vertices = o3d.utility.Vector3dVector(vertices + tc)
+        vis.update_geometry()
+        vis.poll_events()
+        vis.update_renderer()
+        time.sleep(0.05)

--- a/examples/Python/Basic/transformation.py
+++ b/examples/Python/Basic/transformation.py
@@ -40,7 +40,9 @@ def animate(geom):
          ] + [(-0.1, -0.1, 0.1) for _ in range(30)]
 
     for scale, aa in zip(scales, axisangles):
-        geom.scale(scale).rotate(aa, type=o3d.geometry.RotationType.AxisAngle)
+        geom.scale(scale).rotate(aa,
+                                 center=False,
+                                 type=o3d.geometry.RotationType.AxisAngle)
         vis.update_geometry()
         vis.poll_events()
         vis.update_renderer()

--- a/examples/Python/Basic/transformation.py
+++ b/examples/Python/Basic/transformation.py
@@ -15,7 +15,6 @@ def geometry_generator():
     colors = np.random.uniform(0, 1, size=verts.shape)
     mesh.vertex_colors = o3d.utility.Vector3dVector(colors)
     mesh.compute_vertex_normals()
-    yield mesh
 
     pcl = o3d.geometry.PointCloud()
     pcl.points = mesh.vertices
@@ -23,15 +22,9 @@ def geometry_generator():
     pcl.normals = mesh.vertex_normals
     yield pcl
 
-    ls = o3d.geometry.LineSet()
-    ls.points = o3d.utility.Vector3dVector(
-        np.array([(0, 0, 0), (1, 0, 0), (1, 0, 1), (0, 0, 1), (0, 1, 0),
-                  (1, 1, 0), (1, 1, 1), (0, 1, 1)],
-                 dtype=np.float64))
-    ls.lines = o3d.utility.Vector2iVector(
-        np.array([(0, 1), (0, 4), (0, 3), (2, 3), (2, 1), (2, 6), (5, 1),
-                  (5, 4), (5, 6), (7, 3), (7, 6), (7, 4)]))
-    yield ls
+    yield o3d.geometry.create_line_set_from_triangle_mesh(mesh)
+
+    yield mesh
 
 
 def animate(geom):
@@ -46,7 +39,7 @@ def animate(geom):
     ts = [(0.1, 0.1, -0.1) for _ in range(30)
          ] + [(-0.1, -0.1, 0.1) for _ in range(30)]
 
-    for scale, aa, t in zip(scales, axisangles, ts):
+    for scale, aa in zip(scales, axisangles):
         geom.scale(scale).rotate(aa, type=o3d.geometry.RotationType.AxisAngle)
         vis.update_geometry()
         vis.poll_events()
@@ -55,6 +48,14 @@ def animate(geom):
 
     for t in ts:
         geom.translate(t)
+        vis.update_geometry()
+        vis.poll_events()
+        vis.update_renderer()
+        time.sleep(0.05)
+
+    for scale, aa, t in zip(scales, axisangles, ts):
+        geom.scale(scale).translate(t).rotate(
+            aa, center=True, type=o3d.geometry.RotationType.AxisAngle)
         vis.update_geometry()
         vis.poll_events()
         vis.update_renderer()

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -53,6 +53,7 @@ public:
     virtual Geometry3D& Translate(const Eigen::Vector3d& translation) = 0;
     virtual Geometry3D& Scale(const double scale) = 0;
     virtual Geometry3D& Rotate(const Eigen::Vector3d& rotation,
+                               bool center = false,
                                RotationType type = RotationType::XYZ) = 0;
 
 protected:

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -51,9 +51,9 @@ public:
     virtual Eigen::Vector3d GetMaxBound() const = 0;
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
     virtual Geometry3D& Translate(const Eigen::Vector3d& translation) = 0;
-    virtual Geometry3D& Scale(const double scale) = 0;
+    virtual Geometry3D& Scale(const double scale, bool center = true) = 0;
     virtual Geometry3D& Rotate(const Eigen::Vector3d& rotation,
-                               bool center = false,
+                               bool center = true,
                                RotationType type = RotationType::XYZ) = 0;
 
 protected:

--- a/src/Open3D/Geometry/LineSet.cpp
+++ b/src/Open3D/Geometry/LineSet.cpp
@@ -100,11 +100,13 @@ LineSet &LineSet::Translate(const Eigen::Vector3d &translation) {
     return *this;
 }
 
-LineSet &LineSet::Scale(const double scale) {
+LineSet &LineSet::Scale(const double scale, bool center) {
     Eigen::Vector3d point_center(0, 0, 0);
-    point_center =
-            std::accumulate(points_.begin(), points_.end(), point_center);
-    point_center /= points_.size();
+    if (center && !points_.empty()) {
+        point_center =
+                std::accumulate(points_.begin(), points_.end(), point_center);
+        point_center /= points_.size();
+    }
     for (auto &point : points_) {
         point = (point - point_center) * scale + point_center;
     }
@@ -115,7 +117,7 @@ LineSet &LineSet::Rotate(const Eigen::Vector3d &rotation,
                          bool center,
                          RotationType type) {
     Eigen::Vector3d point_center(0, 0, 0);
-    if (center) {
+    if (center && !points_.empty()) {
         point_center =
                 std::accumulate(points_.begin(), points_.end(), point_center);
         point_center /= points_.size();

--- a/src/Open3D/Geometry/LineSet.cpp
+++ b/src/Open3D/Geometry/LineSet.cpp
@@ -119,18 +119,10 @@ LineSet &LineSet::Rotate(const Eigen::Vector3d &rotation,
         point_center =
                 std::accumulate(points_.begin(), points_.end(), point_center);
         point_center /= points_.size();
-        std::for_each(points_.begin(), points_.end(),
-                      [&](Eigen::Vector3d &v) { v -= point_center; });
     }
-
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto &point : points_) {
-        point = R * point;
-    }
-
-    if (center) {
-        std::for_each(points_.begin(), points_.end(),
-                      [&](Eigen::Vector3d &v) { v += point_center; });
+        point = R * (point - point_center) + point_center;
     }
     return *this;
 }

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -50,9 +50,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     LineSet &Transform(const Eigen::Matrix4d &transformation) override;
     LineSet &Translate(const Eigen::Vector3d &translation) override;
-    LineSet &Scale(const double scale) override;
+    LineSet &Scale(const double scale, bool center = true) override;
     LineSet &Rotate(const Eigen::Vector3d &rotation,
-                    bool center = false,
+                    bool center = true,
                     RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -52,6 +52,7 @@ public:
     LineSet &Translate(const Eigen::Vector3d &translation) override;
     LineSet &Scale(const double scale) override;
     LineSet &Rotate(const Eigen::Vector3d &rotation,
+                    bool center = false,
                     RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -368,7 +368,9 @@ Octree& Octree::Scale(const double scale) {
     return *this;
 }
 
-Octree& Octree::Rotate(const Eigen::Vector3d& rotation, RotationType type) {
+Octree& Octree::Rotate(const Eigen::Vector3d& rotation,
+                       bool center,
+                       RotationType type) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -363,7 +363,7 @@ Octree& Octree::Translate(const Eigen::Vector3d& translation) {
     return *this;
 }
 
-Octree& Octree::Scale(const double scale) {
+Octree& Octree::Scale(const double scale, bool center) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -150,6 +150,7 @@ public:
     Octree& Translate(const Eigen::Vector3d& translation) override;
     Octree& Scale(const double scale) override;
     Octree& Rotate(const Eigen::Vector3d& rotation,
+                   bool center = false,
                    RotationType type = RotationType::XYZ) override;
     bool ConvertToJsonValue(Json::Value& value) const override;
     bool ConvertFromJsonValue(const Json::Value& value) override;

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -148,9 +148,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     Octree& Transform(const Eigen::Matrix4d& transformation) override;
     Octree& Translate(const Eigen::Vector3d& translation) override;
-    Octree& Scale(const double scale) override;
+    Octree& Scale(const double scale, bool center = true) override;
     Octree& Rotate(const Eigen::Vector3d& rotation,
-                   bool center = false,
+                   bool center = true,
                    RotationType type = RotationType::XYZ) override;
     bool ConvertToJsonValue(Json::Value& value) const override;
     bool ConvertFromJsonValue(const Json::Value& value) override;

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -130,21 +130,13 @@ PointCloud &PointCloud::Rotate(const Eigen::Vector3d &rotation,
         point_center =
                 std::accumulate(points_.begin(), points_.end(), point_center);
         point_center /= points_.size();
-        std::for_each(points_.begin(), points_.end(),
-                      [&](Eigen::Vector3d &v) { v -= point_center; });
     }
-
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto &point : points_) {
-        point = R * point;
+        point = R * (point - point_center) + point_center;
     }
     for (auto &normal : normals_) {
         normal = R * normal;
-    }
-
-    if (center) {
-        std::for_each(points_.begin(), points_.end(),
-                      [&](Eigen::Vector3d &v) { v += point_center; });
     }
     return *this;
 }

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -111,11 +111,13 @@ PointCloud &PointCloud::Translate(const Eigen::Vector3d &translation) {
     return *this;
 }
 
-PointCloud &PointCloud::Scale(const double scale) {
+PointCloud &PointCloud::Scale(const double scale, bool center) {
     Eigen::Vector3d point_center(0, 0, 0);
-    point_center =
-            std::accumulate(points_.begin(), points_.end(), point_center);
-    point_center /= points_.size();
+    if (center && !points_.empty()) {
+        point_center =
+                std::accumulate(points_.begin(), points_.end(), point_center);
+        point_center /= points_.size();
+    }
     for (auto &point : points_) {
         point = (point - point_center) * scale + point_center;
     }
@@ -126,7 +128,7 @@ PointCloud &PointCloud::Rotate(const Eigen::Vector3d &rotation,
                                bool center,
                                RotationType type) {
     Eigen::Vector3d point_center(0, 0, 0);
-    if (center) {
+    if (center && !points_.empty()) {
         point_center =
                 std::accumulate(points_.begin(), points_.end(), point_center);
         point_center /= points_.size();

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -60,6 +60,7 @@ public:
     PointCloud &Translate(const Eigen::Vector3d &translation) override;
     PointCloud &Scale(const double scale) override;
     PointCloud &Rotate(const Eigen::Vector3d &rotation,
+                       bool center = false,
                        RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -58,9 +58,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
     PointCloud &Translate(const Eigen::Vector3d &translation) override;
-    PointCloud &Scale(const double scale) override;
+    PointCloud &Scale(const double scale, bool center = true) override;
     PointCloud &Rotate(const Eigen::Vector3d &rotation,
-                       bool center = false,
+                       bool center = true,
                        RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -127,11 +127,13 @@ TriangleMesh &TriangleMesh::Translate(const Eigen::Vector3d &translation) {
     return *this;
 }
 
-TriangleMesh &TriangleMesh::Scale(const double scale) {
+TriangleMesh &TriangleMesh::Scale(const double scale, bool center) {
     Eigen::Vector3d vertex_center(0, 0, 0);
-    vertex_center =
-            std::accumulate(vertices_.begin(), vertices_.end(), vertex_center);
-    vertex_center /= vertices_.size();
+    if (center && !vertices_.empty()) {
+        vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
+                                        vertex_center);
+        vertex_center /= vertices_.size();
+    }
     for (auto &vertex : vertices_) {
         vertex = (vertex - vertex_center) * scale + vertex_center;
     }
@@ -142,7 +144,7 @@ TriangleMesh &TriangleMesh::Rotate(const Eigen::Vector3d &rotation,
                                    bool center,
                                    RotationType type) {
     Eigen::Vector3d vertex_center(0, 0, 0);
-    if (center) {
+    if (center && !vertices_.empty()) {
         vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
                                         vertex_center);
         vertex_center /= vertices_.size();

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -146,24 +146,16 @@ TriangleMesh &TriangleMesh::Rotate(const Eigen::Vector3d &rotation,
         vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
                                         vertex_center);
         vertex_center /= vertices_.size();
-        std::for_each(vertices_.begin(), vertices_.end(),
-                      [&](Eigen::Vector3d &v) { v -= vertex_center; });
     }
-
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto &vertex : vertices_) {
-        vertex = R * vertex;
+        vertex = R * (vertex - vertex_center) + vertex_center;
     }
     for (auto &normal : vertex_normals_) {
         normal = R * normal;
     }
     for (auto &normal : triangle_normals_) {
         normal = R * normal;
-    }
-
-    if (center) {
-        std::for_each(vertices_.begin(), vertices_.end(),
-                      [&](Eigen::Vector3d &v) { v += vertex_center; });
     }
     return *this;
 }

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -69,9 +69,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     TriangleMesh &Transform(const Eigen::Matrix4d &transformation) override;
     TriangleMesh &Translate(const Eigen::Vector3d &translation) override;
-    TriangleMesh &Scale(const double scale) override;
+    TriangleMesh &Scale(const double scale, bool center = true) override;
     TriangleMesh &Rotate(const Eigen::Vector3d &rotation,
-                         bool center = false,
+                         bool center = true,
                          RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -71,6 +71,7 @@ public:
     TriangleMesh &Translate(const Eigen::Vector3d &translation) override;
     TriangleMesh &Scale(const double scale) override;
     TriangleMesh &Rotate(const Eigen::Vector3d &rotation,
+                         bool center = false,
                          RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -89,6 +89,7 @@ VoxelGrid &VoxelGrid::Scale(const double scale) {
 }
 
 VoxelGrid &VoxelGrid::Rotate(const Eigen::Vector3d &rotation,
+                             bool center,
                              RotationType type) {
     throw std::runtime_error("Not implemented");
     return *this;

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -83,7 +83,7 @@ VoxelGrid &VoxelGrid::Translate(const Eigen::Vector3d &translation) {
     return *this;
 }
 
-VoxelGrid &VoxelGrid::Scale(const double scale) {
+VoxelGrid &VoxelGrid::Scale(const double scale, bool center) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -52,9 +52,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override;
     VoxelGrid &Transform(const Eigen::Matrix4d &transformation) override;
     VoxelGrid &Translate(const Eigen::Vector3d &translation) override;
-    VoxelGrid &Scale(const double scale) override;
+    VoxelGrid &Scale(const double scale, bool center = true) override;
     VoxelGrid &Rotate(const Eigen::Vector3d &rotation,
-                      bool center = false,
+                      bool center = true,
                       RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -54,6 +54,7 @@ public:
     VoxelGrid &Translate(const Eigen::Vector3d &translation) override;
     VoxelGrid &Scale(const double scale) override;
     VoxelGrid &Rotate(const Eigen::Vector3d &rotation,
+                      bool center = false,
                       RotationType type = RotationType::XYZ) override;
 
 public:

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
@@ -66,7 +66,7 @@ PointCloudPicker& PointCloudPicker::Translate(
     return *this;
 }
 
-PointCloudPicker& PointCloudPicker::Scale(const double scale) {
+PointCloudPicker& PointCloudPicker::Scale(const double scale, bool center) {
     // Do nothing
     return *this;
 }

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
@@ -72,6 +72,7 @@ PointCloudPicker& PointCloudPicker::Scale(const double scale) {
 }
 
 PointCloudPicker& PointCloudPicker::Rotate(const Eigen::Vector3d& rotation,
+                                           bool center,
                                            RotationType type) {
     // Do nothing
     return *this;

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.h
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.h
@@ -55,6 +55,7 @@ public:
     PointCloudPicker& Translate(const Eigen::Vector3d& translation) override;
     PointCloudPicker& Scale(const double scale) override;
     PointCloudPicker& Rotate(const Eigen::Vector3d& rotation,
+                             bool center = false,
                              RotationType type = RotationType::XYZ) override;
     bool SetPointCloud(std::shared_ptr<const geometry::Geometry> ptr);
 

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.h
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.h
@@ -53,9 +53,9 @@ public:
     Eigen::Vector3d GetMaxBound() const final;
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
     PointCloudPicker& Translate(const Eigen::Vector3d& translation) override;
-    PointCloudPicker& Scale(const double scale) override;
+    PointCloudPicker& Scale(const double scale, bool center = true) override;
     PointCloudPicker& Rotate(const Eigen::Vector3d& rotation,
-                             bool center = false,
+                             bool center = true,
                              RotationType type = RotationType::XYZ) override;
     bool SetPointCloud(std::shared_ptr<const geometry::Geometry> ptr);
 

--- a/src/Python/geometry/geometry.cpp
+++ b/src/Python/geometry/geometry.cpp
@@ -97,15 +97,23 @@ void pybind_geometry_classes(py::module &m) {
             .def("translate", &geometry::Geometry3D::Translate,
                  "Apply translation to the geometry coordinates.")
             .def("scale", &geometry::Geometry3D::Scale,
-                 "Apply scaling to the geometry coordinates.")
+                 "Apply scaling to the geometry coordinates.", "scale"_a,
+                 "center"_a = true)
             .def("rotate", &geometry::Geometry3D::Rotate,
                  "Apply rotation to the geometry coordinates and normals.",
-                 "rotation"_a, "center"_a = false,
+                 "rotation"_a, "center"_a = true,
                  "type"_a = geometry::Geometry3D::RotationType::XYZ);
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_min_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_max_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "transform");
     docstring::ClassMethodDocInject(m, "Geometry3D", "translate");
+    docstring::ClassMethodDocInject(
+            m, "Geometry3D", "scale",
+            {{"scale",
+              "The scale parameter that is multiplied to the points/vertices "
+              "of the geometry"},
+             {"center",
+              "If true, then the scale is applied to the centered geometry"}});
     docstring::ClassMethodDocInject(
             m, "Geometry3D", "rotate",
             {{"rotation",

--- a/src/Python/geometry/geometry.cpp
+++ b/src/Python/geometry/geometry.cpp
@@ -100,7 +100,7 @@ void pybind_geometry_classes(py::module &m) {
                  "Apply scaling to the geometry coordinates.")
             .def("rotate", &geometry::Geometry3D::Rotate,
                  "Apply rotation to the geometry coordinates and normals.",
-                 "rotation"_a,
+                 "rotation"_a, "center"_a = false,
                  "type"_a = geometry::Geometry3D::RotationType::XYZ);
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_min_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_max_bound");
@@ -113,6 +113,8 @@ void pybind_geometry_classes(py::module &m) {
               "Euler rotation, or in the axis-angle representation "
               "the normalized vector defines the axis of rotation and "
               "the norm the angle around this axis."},
+             {"center",
+              "If true, then the rotation is applied to the centered geometry"},
              {"type",
               "Type of rotation, i.e., an Euler format, or "
               "axis-angle."}});


### PR DESCRIPTION
I added a `center` parameter to the `Rotate` methods of the `Geometry3D` classes. If it is set to `true`, then the vertices/points are rotated in the centered 3D space.
In addition, I center the points/vertices in the `Scale` methods, otherwise it would do something different as most users might expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/994)
<!-- Reviewable:end -->
