### PR TITLE
Geometry functions as class methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,12 @@ docs/python_api/
 _vimrc_local.vim
 examples/TestData/Armadillo.ply
 examples/TestData/Bunny.ply
+examples/Python/Basic/voxel_grid_test.ply
+examples/Python/Benchmark/testdata/
+examples/Python/Misc/test.jpg
+examples/TestData/GraphOptimization/pose_graph_example_fragment_optimized.json
+examples/TestData/GraphOptimization/pose_graph_example_global_optimized.json
+examples/TestData/depth/
+examples/TestData/image/
+examples/TestData/sync.ply
+examples/TestData/sync.png

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ examples/TestData/depth/
 examples/TestData/image/
 examples/TestData/sync.ply
 examples/TestData/sync.png
+examples/Python/Advanced/multiway_registration.pcd
+examples/Python/Advanced/test.json
+examples/Python/Advanced/viewpoint.json
+examples/Python/Basic/copy_of_fragment.pcd
+examples/Python/Basic/copy_of_knot.ply
+examples/Python/Basic/copy_of_lena_color.jpg
+

--- a/docs/_static/C++/TestVisualizer.cpp
+++ b/docs/_static/C++/TestVisualizer.cpp
@@ -37,10 +37,10 @@ int main(int argc, char *argv[]) {
     if (argc < 3) {
         // clang-format off
         utility::PrintInfo("Open3D %s\n", OPEN3D_VERSION);
-		utility::PrintInfo("\n");
-		utility::PrintInfo("Usage:\n");
-		utility::PrintInfo("    > TestVisualizer [mesh|spin|slowspin|pointcloud|rainbow|image|depth|editing] [filename]\n");
-		utility::PrintInfo("    > TestVisualizer [animation] [filename] [trajectoryfile]\n");
+        utility::PrintInfo("\n");
+        utility::PrintInfo("Usage:\n");
+        utility::PrintInfo("    > TestVisualizer [mesh|spin|slowspin|pointcloud|rainbow|image|depth|editing] [filename]\n");
+        utility::PrintInfo("    > TestVisualizer [animation] [filename] [trajectoryfile]\n");
         // clang-format on
         // CI will call this file without input files, return 0 to pass
         return 0;
@@ -149,7 +149,7 @@ int main(int argc, char *argv[]) {
         camera::PinholeCameraIntrinsic camera;
         camera.SetIntrinsics(640, 480, 575.0, 575.0, 319.5, 239.5);
         auto pointcloud_ptr =
-                geometry::CreatePointCloudFromDepthImage(*image_ptr, camera);
+                geometry::PointCloud::CreateFromDepthImage(*image_ptr, camera);
         visualization::DrawGeometries(
                 {pointcloud_ptr},
                 "geometry::PointCloud from Depth geometry::Image", 1920, 1080);

--- a/docs/tutorial/Advanced/colored_pointcloud_registration.rst
+++ b/docs/tutorial/Advanced/colored_pointcloud_registration.rst
@@ -90,7 +90,7 @@ To further improve efficiency, [Park2017]_ proposes a multi-scale registration s
 .. literalinclude:: ../../../examples/Python/Advanced/colored_pointcloud_registration.py
    :language: python
    :lineno-start: 40
-   :lines: 40-74
+   :lines: 40-72
    :linenos:
 
 In total, 3 layers of multi-resolution point clouds are created with :ref:`voxel_downsampling`. Normals are computed with :ref:`vertex_normal_estimation`. The core registration function ``registration_colored_icp`` is called for each layer, from coarse to fine.  ``lambda_geometric`` is an optional argument for ``registration_colored_icp`` that determines :math:`\lambda \in [0,1]` in the overall energy :math:`\lambda E_{G} + (1-\lambda) E_{C}`.

--- a/docs/tutorial/Advanced/global_registration.rst
+++ b/docs/tutorial/Advanced/global_registration.rst
@@ -46,7 +46,7 @@ RANSAC
 .. literalinclude:: ../../../examples/Python/Advanced/global_registration.py
    :language: python
    :lineno-start: 53
-   :lines: 53-66
+   :lines: 52-65
    :linenos:
 
 We use RANSAC for global registration. In each RANSAC iteration, ``ransac_n`` random points are picked from the source point cloud. Their corresponding points in the target point cloud are detected by querying the nearest neighbor in the 33-dimensional FPFH feature space. A pruning step takes fast pruning algorithms  to quickly reject false matches early.
@@ -76,7 +76,7 @@ For performance reason, the global registration is only performed on a heavily d
 .. literalinclude:: ../../../examples/Python/Advanced/global_registration.py
    :language: python
    :lineno-start: 69
-   :lines: 69-77
+   :lines: 68-76
    :linenos:
 
 Outputs a tight alignment. This summarizes a complete pairwise registration workflow.

--- a/docs/tutorial/Advanced/multiway_registration.rst
+++ b/docs/tutorial/Advanced/multiway_registration.rst
@@ -106,7 +106,7 @@ Make a combined point cloud
 .. literalinclude:: ../../../examples/Python/Advanced/multiway_registration.py
    :language: python
    :lineno-start: 97
-   :lines: 97-106
+   :lines: 97-105
    :linenos:
 
 .. image:: ../../_static/Advanced/multiway_registration/combined.png

--- a/docs/tutorial/Advanced/pointcloud_outlier_removal.rst
+++ b/docs/tutorial/Advanced/pointcloud_outlier_removal.rst
@@ -57,7 +57,7 @@ Statistical outlier removal
 .. literalinclude:: ../../../examples/Python/Advanced/pointcloud_outlier_removal.py
    :language: python
    :lineno-start: 34
-   :lines: 34-38
+   :lines: 34-37
    :linenos:
 
 ``statistical_outlier_removal`` removes points that are further away from their neighbors compared to the average for the point cloud. It takes two input parameters:
@@ -74,7 +74,7 @@ Radius outlier removal
 .. literalinclude:: ../../../examples/Python/Advanced/pointcloud_outlier_removal.py
    :language: python
    :lineno-start: 40
-   :lines: 40-44
+   :lines: 39-41
    :linenos:
 
 ``radius_outlier_removal`` removes points that have few neighbors in a given sphere around them. Two parameters can be used to tune the filter to your data:

--- a/docs/tutorial/Basic/kdtree.rst
+++ b/docs/tutorial/Basic/kdtree.rst
@@ -19,7 +19,7 @@ Build KDTree from point cloud
 .. literalinclude:: ../../../examples/Python/Basic/kdtree.py
    :language: python
    :lineno-start: 12
-   :lines: 12-17
+   :lines: 12-16
    :linenos:
 
 This script reads a point cloud and builds a KDTree. This is a preprocessing step for the following nearest neighbor queries.
@@ -32,7 +32,7 @@ Find neighboring points
 .. literalinclude:: ../../../examples/Python/Basic/kdtree.py
    :language: python
    :lineno-start: 19
-   :lines: 19-20
+   :lines: 18-19
    :linenos:
 
 We pick the 1500-th point as the anchor point and paint it red.
@@ -43,7 +43,7 @@ Using search_knn_vector_3d
 .. literalinclude:: ../../../examples/Python/Basic/kdtree.py
    :language: python
    :lineno-start: 22
-   :lines: 22-24
+   :lines: 21-23
    :linenos:
 
 Function ``search_knn_vector_3d`` returns a list of indices of the k nearest neighbors of the anchor point. These neighboring points are painted with blue color. Note that we convert ``pcd.colors`` to a numpy array to make batch access to the point colors, and broadcast a blue color [0, 0, 1] to all the selected points. We skip the first index since it is the anchor point itself.
@@ -55,7 +55,7 @@ Using search_radius_vector_3d
 .. literalinclude:: ../../../examples/Python/Basic/kdtree.py
    :language: python
    :lineno-start: 26
-   :lines: 26-28
+   :lines: 25-27
    :linenos:
 
 Similarly, we can use ``search_radius_vector_3d`` to query all points with distances to the anchor point less than a given radius. We paint these points with green color.
@@ -63,7 +63,7 @@ Similarly, we can use ``search_radius_vector_3d`` to query all points with dista
 .. literalinclude:: ../../../examples/Python/Basic/kdtree.py
    :language: python
    :lineno-start: 30
-   :lines: 30-32
+   :lines: 29-31
    :linenos:
 
 The visualization looks like:

--- a/docs/tutorial/Basic/pointcloud.rst
+++ b/docs/tutorial/Basic/pointcloud.rst
@@ -72,7 +72,7 @@ Another basic operation for point cloud is point normal estimation.
 .. literalinclude:: ../../../examples/Python/Basic/pointcloud.py
    :language: python
    :lineno-start: 22
-   :lines: 22-27
+   :lines: 22-25
    :linenos:
 
 ``estimate_normals`` computes normal for every point. The function finds adjacent points and calculate the principal axis of the adjacent points using covariance analysis.
@@ -95,7 +95,7 @@ Estimated normal vectors can be retrieved by ``normals`` variable of ``downpcd``
 .. literalinclude:: ../../../examples/Python/Basic/pointcloud.py
    :language: python
    :lineno-start: 29
-   :lines: 29-30
+   :lines: 27-28
    :linenos:
 
 .. code-block:: sh
@@ -109,7 +109,7 @@ Normal vectors can be transformed as a numpy array using ``np.asarray``.
 .. literalinclude:: ../../../examples/Python/Basic/pointcloud.py
    :language: python
    :lineno-start: 31
-   :lines: 31-32
+   :lines: 29-30
    :linenos:
 
 .. code-block:: sh
@@ -136,7 +136,7 @@ Crop point cloud
 .. literalinclude:: ../../../examples/Python/Basic/pointcloud.py
    :language: python
    :lineno-start: 35
-   :lines: 35-40
+   :lines: 33-38
    :linenos:
 
 ``read_selection_polygon_volume`` reads a json file that specifies polygon selection area.
@@ -153,7 +153,7 @@ Paint point cloud
 .. literalinclude:: ../../../examples/Python/Basic/pointcloud.py
    :language: python
    :lineno-start: 42
-   :lines: 42-45
+   :lines: 40-43
    :linenos:
 
 ``paint_uniform_color`` paints all the points to a uniform color. The color is in RGB space, [0, 1] range.

--- a/docs/tutorial/ReconstructionSystem/refine_registration.rst
+++ b/docs/tutorial/ReconstructionSystem/refine_registration.rst
@@ -17,7 +17,7 @@ Fine-grained registration
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/refine_registration.py
    :language: python
    :lineno-start: 38
-   :lines: 5,39-92
+   :lines: 5,39-90
    :linenos:
 
 Two options are given for the fine-grained registration. The ``color`` option is recommended since it uses color information to prevent drift. See [Park2017]_ for details.
@@ -49,8 +49,8 @@ The function ``make_posegraph_for_refined_scene`` below calls all the functions 
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/refine_registration.py
    :language: python
-   :lineno-start: 131
-   :lines: 5,132-178
+   :lineno-start: 129
+   :lines: 5,130-176
    :linenos:
 
 The main workflow is: pairwise local refinement -> multiway registration.

--- a/docs/tutorial/ReconstructionSystem/register_fragments.rst
+++ b/docs/tutorial/ReconstructionSystem/register_fragments.rst
@@ -19,7 +19,7 @@ Preprocess point cloud
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/register_fragments.py
    :language: python
    :lineno-start: 17
-   :lines: 5,18-29
+   :lines: 5,18-28
    :linenos:
 
 This function downsamples point cloud to make a point cloud sparser and regularly distributed. Normals and FPFH feature are precomputed. See :ref:`voxel_downsampling`, :ref:`vertex_normal_estimation`, and :ref:`extract_geometric_feature` for more details.
@@ -30,8 +30,8 @@ Compute initial registration
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/register_fragments.py
    :language: python
-   :lineno-start: 55
-   :lines: 5,56-82
+   :lineno-start: 54
+   :lines: 5,55-81
    :linenos:
 
 This function computes a rough alignment between two fragments. If the fragments are neighboring fragments, the rough alignment is determined by an aggregating RGBD odometry obtained from :ref:`reconstruction_system_make_fragments`. Otherwise, ``register_point_cloud_fpfh`` is called to perform global registration. Note that global registration is less reliable according to [Choi2015]_.
@@ -44,8 +44,8 @@ Pairwise global registration
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/register_fragments.py
    :language: python
-   :lineno-start: 31
-   :lines: 5,32-53
+   :lineno-start: 30
+   :lines: 5,31-52
    :linenos:
 
 This function uses :ref:`feature_matching` or :ref:`fast_global_registration` for pairwise global registration.
@@ -58,8 +58,8 @@ Multiway registration
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/register_fragments.py
    :language: python
-   :lineno-start: 84
-   :lines: 5,85-104
+   :lineno-start: 83
+   :lines: 5,84-103
    :linenos:
 
 This script uses the technique demonstrated in :ref:`multiway_registration`. Function ``update_posegrph_for_scene`` builds a pose graph for multiway registration of all fragments. Each graph node represents a fragment and its pose which transforms the geometry to the global space.
@@ -79,8 +79,8 @@ The function ``make_posegraph_for_scene`` below calls all the functions introduc
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/register_fragments.py
    :language: python
-   :lineno-start: 136
-   :lines: 5,137-177
+   :lineno-start: 135
+   :lines: 5,136-176
    :linenos:
 
 Results

--- a/examples/Cpp/ColorMapOptimization.cpp
+++ b/examples/Cpp/ColorMapOptimization.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
         auto depth = io::CreateImageFromFile(depth_filenames[i]);
         utility::PrintDebug("reading %s...\n", color_filenames[i].c_str());
         auto color = io::CreateImageFromFile(color_filenames[i]);
-        auto rgbd_image = geometry::CreateRGBDImageFromColorAndDepth(
+        auto rgbd_image = geometry::RGBDImage::CreateFromColorAndDepth(
                 *color, *depth, 1000.0, 3.0, false);
         rgbd_images.push_back(rgbd_image);
     }

--- a/examples/Cpp/DepthCapture.cpp
+++ b/examples/Cpp/DepthCapture.cpp
@@ -57,9 +57,10 @@ protected:
                 camera::PinholeCameraTrajectory camera;
                 io::ReadIJsonConvertible("camera.json", camera);
                 auto image_ptr = io::CreateImageFromFile("depth.png");
-                auto pointcloud_ptr = geometry::CreatePointCloudFromDepthImage(
-                        *image_ptr, camera.parameters_[0].intrinsic_,
-                        camera.parameters_[0].extrinsic_);
+                auto pointcloud_ptr =
+                        geometry::PointCloud::CreateFromDepthImage(
+                                *image_ptr, camera.parameters_[0].intrinsic_,
+                                camera.parameters_[0].extrinsic_);
                 AddGeometry(pointcloud_ptr);
             }
         } else if (key == GLFW_KEY_K) {
@@ -112,7 +113,7 @@ int main(int argc, char *argv[]) {
 
     camera::PinholeCameraTrajectory camera;
     io::ReadIJsonConvertible("camera.json", camera);
-    auto pointcloud_ptr = geometry::CreatePointCloudFromDepthImage(
+    auto pointcloud_ptr = geometry::PointCloud::CreateFromDepthImage(
             *image_ptr, camera.parameters_[0].intrinsic_,
             camera.parameters_[0].extrinsic_);
     VisualizerWithDepthCapture visualizer1;

--- a/examples/Cpp/Image.cpp
+++ b/examples/Cpp/Image.cpp
@@ -56,41 +56,41 @@ int main(int argc, char **argv) {
     if (io::ReadImage(filename_rgb, color_image_8bit)) {
         utility::PrintDebug("RGB image size : %d x %d\n",
                             color_image_8bit.width_, color_image_8bit.height_);
-        auto gray_image = color_image_8bit.CreateFloatImageFromImage();
+        auto gray_image = color_image_8bit.CreateFloatImage();
         io::WriteImage("gray.png",
                        *gray_image->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Gaussian Filtering\n");
         auto gray_image_b3 =
-                gray_image->FilterImage(geometry::Image::FilterType::Gaussian3);
+                gray_image->Filter(geometry::Image::FilterType::Gaussian3);
         io::WriteImage("gray_blur3.png",
                        *gray_image_b3->CreateImageFromFloatImage<uint8_t>());
         auto gray_image_b5 =
-                gray_image->FilterImage(geometry::Image::FilterType::Gaussian5);
+                gray_image->Filter(geometry::Image::FilterType::Gaussian5);
         io::WriteImage("gray_blur5.png",
                        *gray_image_b5->CreateImageFromFloatImage<uint8_t>());
         auto gray_image_b7 =
-                gray_image->FilterImage(geometry::Image::FilterType::Gaussian7);
+                gray_image->Filter(geometry::Image::FilterType::Gaussian7);
         io::WriteImage("gray_blur7.png",
                        *gray_image_b7->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Sobel Filtering\n");
         auto gray_image_dx =
-                gray_image->FilterImage(geometry::Image::FilterType::Sobel3Dx);
+                gray_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-1,1] to [0,1].
         gray_image_dx->LinearTransformImage(0.5, 0.5);
         gray_image_dx->ClipIntensityImage();
         io::WriteImage("gray_sobel_dx.png",
                        *gray_image_dx->CreateImageFromFloatImage<uint8_t>());
         auto gray_image_dy =
-                gray_image->FilterImage(geometry::Image::FilterType::Sobel3Dy);
+                gray_image->Filter(geometry::Image::FilterType::Sobel3Dy);
         gray_image_dy->LinearTransformImage(0.5, 0.5);
         gray_image_dy->ClipIntensityImage();
         io::WriteImage("gray_sobel_dy.png",
                        *gray_image_dy->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Build Pyramid\n");
-        auto pyramid = gray_image->CreateImagePyramid(4);
+        auto pyramid = gray_image->CreatePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
             auto level_8bit = level->CreateImageFromFloatImage<uint8_t>();
@@ -107,41 +107,41 @@ int main(int argc, char **argv) {
         utility::PrintDebug("Depth image size : %d x %d\n",
                             depth_image_16bit.width_,
                             depth_image_16bit.height_);
-        auto depth_image = depth_image_16bit.CreateFloatImageFromImage();
+        auto depth_image = depth_image_16bit.CreateFloatImage();
         io::WriteImage("depth.png",
                        *depth_image->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Gaussian Filtering\n");
-        auto depth_image_b3 = depth_image->FilterImage(
-                geometry::Image::FilterType::Gaussian3);
+        auto depth_image_b3 =
+                depth_image->Filter(geometry::Image::FilterType::Gaussian3);
         io::WriteImage("depth_blur3.png",
                        *depth_image_b3->CreateImageFromFloatImage<uint16_t>());
-        auto depth_image_b5 = depth_image->FilterImage(
-                geometry::Image::FilterType::Gaussian5);
+        auto depth_image_b5 =
+                depth_image->Filter(geometry::Image::FilterType::Gaussian5);
         io::WriteImage("depth_blur5.png",
                        *depth_image_b5->CreateImageFromFloatImage<uint16_t>());
-        auto depth_image_b7 = depth_image->FilterImage(
-                geometry::Image::FilterType::Gaussian7);
+        auto depth_image_b7 =
+                depth_image->Filter(geometry::Image::FilterType::Gaussian7);
         io::WriteImage("depth_blur7.png",
                        *depth_image_b7->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Sobel Filtering\n");
         auto depth_image_dx =
-                depth_image->FilterImage(geometry::Image::FilterType::Sobel3Dx);
+                depth_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-65536,65536] to [0,13107.2]. // todo: need to test this
         depth_image_dx->LinearTransformImage(0.1, 6553.6);
         depth_image_dx->ClipIntensityImage(0.0, 13107.2);
         io::WriteImage("depth_sobel_dx.png",
                        *depth_image_dx->CreateImageFromFloatImage<uint16_t>());
         auto depth_image_dy =
-                depth_image->FilterImage(geometry::Image::FilterType::Sobel3Dy);
+                depth_image->Filter(geometry::Image::FilterType::Sobel3Dy);
         depth_image_dy->LinearTransformImage(0.1, 6553.6);
         depth_image_dx->ClipIntensityImage(0.0, 13107.2);
         io::WriteImage("depth_sobel_dy.png",
                        *depth_image_dy->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Build Pyramid\n");
-        auto pyramid = depth_image->CreateImagePyramid(4);
+        auto pyramid = depth_image->CreatePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
             auto level_16bit = level->CreateImageFromFloatImage<uint16_t>();

--- a/examples/Cpp/Image.cpp
+++ b/examples/Cpp/Image.cpp
@@ -56,51 +56,44 @@ int main(int argc, char **argv) {
     if (io::ReadImage(filename_rgb, color_image_8bit)) {
         utility::PrintDebug("RGB image size : %d x %d\n",
                             color_image_8bit.width_, color_image_8bit.height_);
-        auto gray_image = CreateFloatImageFromImage(color_image_8bit);
-        io::WriteImage(
-                "gray.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image));
+        auto gray_image = color_image_8bit.CreateFloatImageFromImage();
+        io::WriteImage("gray.png",
+                       *gray_image->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Gaussian Filtering\n");
-        auto gray_image_b3 = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Gaussian3);
-        io::WriteImage(
-                "gray_blur3.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image_b3));
-        auto gray_image_b5 = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Gaussian5);
-        io::WriteImage(
-                "gray_blur5.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image_b5));
-        auto gray_image_b7 = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Gaussian7);
-        io::WriteImage(
-                "gray_blur7.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image_b7));
+        auto gray_image_b3 =
+                gray_image->FilterImage(geometry::Image::FilterType::Gaussian3);
+        io::WriteImage("gray_blur3.png",
+                       *gray_image_b3->CreateImageFromFloatImage<uint8_t>());
+        auto gray_image_b5 =
+                gray_image->FilterImage(geometry::Image::FilterType::Gaussian5);
+        io::WriteImage("gray_blur5.png",
+                       *gray_image_b5->CreateImageFromFloatImage<uint8_t>());
+        auto gray_image_b7 =
+                gray_image->FilterImage(geometry::Image::FilterType::Gaussian7);
+        io::WriteImage("gray_blur7.png",
+                       *gray_image_b7->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Sobel Filtering\n");
-        auto gray_image_dx = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Sobel3Dx);
+        auto gray_image_dx =
+                gray_image->FilterImage(geometry::Image::FilterType::Sobel3Dx);
         // make [-1,1] to [0,1].
-        geometry::LinearTransformImage(*gray_image_dx, 0.5, 0.5);
-        geometry::ClipIntensityImage(*gray_image_dx);
-        io::WriteImage(
-                "gray_sobel_dx.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image_dx));
-        auto gray_image_dy = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Sobel3Dy);
-        geometry::LinearTransformImage(*gray_image_dy, 0.5, 0.5);
-        geometry::ClipIntensityImage(*gray_image_dy);
-        io::WriteImage(
-                "gray_sobel_dy.png",
-                *geometry::CreateImageFromFloatImage<uint8_t>(*gray_image_dy));
+        gray_image_dx->LinearTransformImage(0.5, 0.5);
+        gray_image_dx->ClipIntensityImage();
+        io::WriteImage("gray_sobel_dx.png",
+                       *gray_image_dx->CreateImageFromFloatImage<uint8_t>());
+        auto gray_image_dy =
+                gray_image->FilterImage(geometry::Image::FilterType::Sobel3Dy);
+        gray_image_dy->LinearTransformImage(0.5, 0.5);
+        gray_image_dy->ClipIntensityImage();
+        io::WriteImage("gray_sobel_dy.png",
+                       *gray_image_dy->CreateImageFromFloatImage<uint8_t>());
 
         utility::PrintDebug("Build Pyramid\n");
-        auto pyramid = geometry::CreateImagePyramid(*gray_image, 4);
+        auto pyramid = gray_image->CreateImagePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
-            auto level_8bit =
-                    geometry::CreateImageFromFloatImage<uint8_t>(*level);
+            auto level_8bit = level->CreateImageFromFloatImage<uint8_t>();
             std::string outputname =
                     "gray_pyramid_level" + std::to_string(i) + ".png";
             io::WriteImage(outputname, *level_8bit);
@@ -114,51 +107,44 @@ int main(int argc, char **argv) {
         utility::PrintDebug("Depth image size : %d x %d\n",
                             depth_image_16bit.width_,
                             depth_image_16bit.height_);
-        auto depth_image = CreateFloatImageFromImage(depth_image_16bit);
-        io::WriteImage(
-                "depth.png",
-                *geometry::CreateImageFromFloatImage<uint16_t>(*depth_image));
+        auto depth_image = depth_image_16bit.CreateFloatImageFromImage();
+        io::WriteImage("depth.png",
+                       *depth_image->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Gaussian Filtering\n");
-        auto depth_image_b3 = geometry::FilterImage(
-                *depth_image, geometry::Image::FilterType::Gaussian3);
+        auto depth_image_b3 = depth_image->FilterImage(
+                geometry::Image::FilterType::Gaussian3);
         io::WriteImage("depth_blur3.png",
-                       *geometry::CreateImageFromFloatImage<uint16_t>(
-                               *depth_image_b3));
-        auto depth_image_b5 = geometry::FilterImage(
-                *depth_image, geometry::Image::FilterType::Gaussian5);
+                       *depth_image_b3->CreateImageFromFloatImage<uint16_t>());
+        auto depth_image_b5 = depth_image->FilterImage(
+                geometry::Image::FilterType::Gaussian5);
         io::WriteImage("depth_blur5.png",
-                       *geometry::CreateImageFromFloatImage<uint16_t>(
-                               *depth_image_b5));
-        auto depth_image_b7 = geometry::FilterImage(
-                *depth_image, geometry::Image::FilterType::Gaussian7);
+                       *depth_image_b5->CreateImageFromFloatImage<uint16_t>());
+        auto depth_image_b7 = depth_image->FilterImage(
+                geometry::Image::FilterType::Gaussian7);
         io::WriteImage("depth_blur7.png",
-                       *geometry::CreateImageFromFloatImage<uint16_t>(
-                               *depth_image_b7));
+                       *depth_image_b7->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Sobel Filtering\n");
-        auto depth_image_dx = geometry::FilterImage(
-                *depth_image, geometry::Image::FilterType::Sobel3Dx);
+        auto depth_image_dx =
+                depth_image->FilterImage(geometry::Image::FilterType::Sobel3Dx);
         // make [-65536,65536] to [0,13107.2]. // todo: need to test this
-        geometry::LinearTransformImage(*depth_image_dx, 0.1, 6553.6);
-        geometry::ClipIntensityImage(*depth_image_dx, 0.0, 13107.2);
+        depth_image_dx->LinearTransformImage(0.1, 6553.6);
+        depth_image_dx->ClipIntensityImage(0.0, 13107.2);
         io::WriteImage("depth_sobel_dx.png",
-                       *geometry::CreateImageFromFloatImage<uint16_t>(
-                               *depth_image_dx));
-        auto depth_image_dy = geometry::FilterImage(
-                *depth_image, geometry::Image::FilterType::Sobel3Dy);
-        geometry::LinearTransformImage(*depth_image_dy, 0.1, 6553.6);
-        geometry::ClipIntensityImage(*depth_image_dx, 0.0, 13107.2);
+                       *depth_image_dx->CreateImageFromFloatImage<uint16_t>());
+        auto depth_image_dy =
+                depth_image->FilterImage(geometry::Image::FilterType::Sobel3Dy);
+        depth_image_dy->LinearTransformImage(0.1, 6553.6);
+        depth_image_dx->ClipIntensityImage(0.0, 13107.2);
         io::WriteImage("depth_sobel_dy.png",
-                       *geometry::CreateImageFromFloatImage<uint16_t>(
-                               *depth_image_dy));
+                       *depth_image_dy->CreateImageFromFloatImage<uint16_t>());
 
         utility::PrintDebug("Build Pyramid\n");
-        auto pyramid = geometry::CreateImagePyramid(*depth_image, 4);
+        auto pyramid = depth_image->CreateImagePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
-            auto level_16bit =
-                    geometry::CreateImageFromFloatImage<uint16_t>(*level);
+            auto level_16bit = level->CreateImageFromFloatImage<uint16_t>();
             std::string outputname =
                     "depth_pyramid_level" + std::to_string(i) + ".png";
             io::WriteImage(outputname, *level_16bit);

--- a/examples/Cpp/Image.cpp
+++ b/examples/Cpp/Image.cpp
@@ -78,14 +78,14 @@ int main(int argc, char **argv) {
         auto gray_image_dx =
                 gray_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-1,1] to [0,1].
-        gray_image_dx->LinearTransformImage(0.5, 0.5);
-        gray_image_dx->ClipIntensityImage();
+        gray_image_dx->LinearTransform(0.5, 0.5);
+        gray_image_dx->ClipIntensity();
         io::WriteImage("gray_sobel_dx.png",
                        *gray_image_dx->CreateImageFromFloatImage<uint8_t>());
         auto gray_image_dy =
                 gray_image->Filter(geometry::Image::FilterType::Sobel3Dy);
-        gray_image_dy->LinearTransformImage(0.5, 0.5);
-        gray_image_dy->ClipIntensityImage();
+        gray_image_dy->LinearTransform(0.5, 0.5);
+        gray_image_dy->ClipIntensity();
         io::WriteImage("gray_sobel_dy.png",
                        *gray_image_dy->CreateImageFromFloatImage<uint8_t>());
 
@@ -129,14 +129,14 @@ int main(int argc, char **argv) {
         auto depth_image_dx =
                 depth_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-65536,65536] to [0,13107.2]. // todo: need to test this
-        depth_image_dx->LinearTransformImage(0.1, 6553.6);
-        depth_image_dx->ClipIntensityImage(0.0, 13107.2);
+        depth_image_dx->LinearTransform(0.1, 6553.6);
+        depth_image_dx->ClipIntensity(0.0, 13107.2);
         io::WriteImage("depth_sobel_dx.png",
                        *depth_image_dx->CreateImageFromFloatImage<uint16_t>());
         auto depth_image_dy =
                 depth_image->Filter(geometry::Image::FilterType::Sobel3Dy);
-        depth_image_dy->LinearTransformImage(0.1, 6553.6);
-        depth_image_dx->ClipIntensityImage(0.0, 13107.2);
+        depth_image_dy->LinearTransform(0.1, 6553.6);
+        depth_image_dx->ClipIntensity(0.0, 13107.2);
         io::WriteImage("depth_sobel_dy.png",
                        *depth_image_dy->CreateImageFromFloatImage<uint16_t>());
 

--- a/examples/Cpp/IntegrateRGBD.cpp
+++ b/examples/Cpp/IntegrateRGBD.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
             utility::PrintDebug("Processing frame %d ...\n", index);
             io::ReadImage(dir_name + st[0], depth);
             io::ReadImage(dir_name + st[1], color);
-            auto rgbd = geometry::CreateRGBDImageFromColorAndDepth(
+            auto rgbd = geometry::RGBDImage::CreateFromColorAndDepth(
                     color, depth, 1000.0, 4.0, false);
             if (index == 0 ||
                 (every_k_frames > 0 && index % every_k_frames == 0)) {

--- a/examples/Cpp/LineSet.cpp
+++ b/examples/Cpp/LineSet.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < nn; i++) {
         correspondences.push_back(std::make_pair(0, indices_vec[i]));
     }
-    auto lineset_ptr = CreateLineSetFromPointCloudCorrespondences(
+    auto lineset_ptr = geometry::LineSet::CreateFromPointCloudCorrespondences(
             *cloud_ptr, *cloud_ptr, correspondences);
     visualization::DrawGeometries({cloud_ptr, lineset_ptr});
 
@@ -85,8 +85,9 @@ int main(int argc, char **argv) {
         kdtree.SearchKNN(new_cloud_ptr->points_[i], 1, indices_vec, dists_vec);
         correspondences.push_back(std::make_pair(indices_vec[0], (int)i));
     }
-    auto new_lineset_ptr = CreateLineSetFromPointCloudCorrespondences(
-            *cloud_ptr, *new_cloud_ptr, correspondences);
+    auto new_lineset_ptr =
+            geometry::LineSet::CreateFromPointCloudCorrespondences(
+                    *cloud_ptr, *new_cloud_ptr, correspondences);
     new_lineset_ptr->colors_.resize(new_lineset_ptr->lines_.size());
     for (size_t i = 0; i < new_lineset_ptr->lines_.size(); i++) {
         auto point_pair = new_lineset_ptr->GetLineCoordinate(i);

--- a/examples/Cpp/OdometryRGBD.cpp
+++ b/examples/Cpp/OdometryRGBD.cpp
@@ -87,15 +87,15 @@ int main(int argc, char* argv[]) {
     std::shared_ptr<geometry::RGBDImage> (*CreateRGBDImage)(
             const geometry::Image&, const geometry::Image&, bool);
     if (rgbd_type == 0)
-        CreateRGBDImage = &geometry::CreateRGBDImageFromRedwoodFormat;
+        CreateRGBDImage = &geometry::RGBDImage::CreateFromRedwoodFormat;
     else if (rgbd_type == 1)
-        CreateRGBDImage = &geometry::CreateRGBDImageFromTUMFormat;
+        CreateRGBDImage = &geometry::RGBDImage::CreateFromTUMFormat;
     else if (rgbd_type == 2)
-        CreateRGBDImage = &geometry::CreateRGBDImageFromSUNFormat;
+        CreateRGBDImage = &geometry::RGBDImage::CreateFromSUNFormat;
     else if (rgbd_type == 3)
-        CreateRGBDImage = &geometry::CreateRGBDImageFromNYUFormat;
+        CreateRGBDImage = &geometry::RGBDImage::CreateFromNYUFormat;
     else
-        CreateRGBDImage = &geometry::CreateRGBDImageFromRedwoodFormat;
+        CreateRGBDImage = &geometry::RGBDImage::CreateFromRedwoodFormat;
     auto source = CreateRGBDImage(*color_source, *depth_source, true);
     auto target = CreateRGBDImage(*color_target, *depth_target, true);
 

--- a/examples/Cpp/PointCloud.cpp
+++ b/examples/Cpp/PointCloud.cpp
@@ -77,8 +77,7 @@ int main(int argc, char *argv[]) {
     {
         utility::ScopeTimer timer("Normal estimation with KNN20");
         for (int i = 0; i < 20; i++) {
-            geometry::EstimateNormals(
-                    *pcd, open3d::geometry::KDTreeSearchParamKNN(20));
+            pcd->EstimateNormals(open3d::geometry::KDTreeSearchParamKNN(20));
         }
     }
     std::cout << pcd->normals_[0] << std::endl;
@@ -87,8 +86,8 @@ int main(int argc, char *argv[]) {
     {
         utility::ScopeTimer timer("Normal estimation with Radius 0.01666");
         for (int i = 0; i < 20; i++) {
-            geometry::EstimateNormals(
-                    *pcd, open3d::geometry::KDTreeSearchParamRadius(0.01666));
+            pcd->EstimateNormals(
+                    open3d::geometry::KDTreeSearchParamRadius(0.01666));
         }
     }
     std::cout << pcd->normals_[0] << std::endl;
@@ -97,15 +96,14 @@ int main(int argc, char *argv[]) {
     {
         utility::ScopeTimer timer("Normal estimation with Hybrid 0.01666, 60");
         for (int i = 0; i < 20; i++) {
-            geometry::EstimateNormals(
-                    *pcd,
+            pcd->EstimateNormals(
                     open3d::geometry::KDTreeSearchParamHybrid(0.01666, 60));
         }
     }
     std::cout << pcd->normals_[0] << std::endl;
     std::cout << pcd->normals_[10] << std::endl;
 
-    auto downpcd = geometry::VoxelDownSample(*pcd, 0.05);
+    auto downpcd = pcd->VoxelDownSample(0.05);
 
     // 1. test basic pointcloud functions.
 
@@ -179,7 +177,7 @@ int main(int argc, char *argv[]) {
                                   "Combined Pointcloud");
 
     // 5. test downsample
-    auto downsampled = geometry::VoxelDownSample(*pointcloud_ptr, 0.05);
+    auto downsampled = pointcloud_ptr->VoxelDownSample(0.05);
     visualization::DrawGeometries({downsampled}, "Down Sampled Pointcloud");
 
     // 6. test normal estimation
@@ -189,8 +187,7 @@ int main(int argc, char *argv[]) {
               [&](visualization::Visualizer *vis) {
                   // EstimateNormals(*pointcloud_ptr,
                   //        open3d::KDTreeSearchParamKNN(20));
-                  geometry::EstimateNormals(
-                          *pointcloud_ptr,
+                  pointcloud_ptr->EstimateNormals(
                           open3d::geometry::KDTreeSearchParamRadius(0.05));
                   utility::PrintInfo("Done.\n");
                   return true;

--- a/examples/Cpp/RGBDOdometry.cpp
+++ b/examples/Cpp/RGBDOdometry.cpp
@@ -53,12 +53,12 @@ std::shared_ptr<geometry::RGBDImage> ReadRGBDImage(
     double depth_scale = 1000.0, depth_trunc = 3.0;
     bool convert_rgb_to_intensity = true;
     std::shared_ptr<geometry::RGBDImage> rgbd_image =
-            geometry::CreateRGBDImageFromColorAndDepth(
+            geometry::RGBDImage::CreateFromColorAndDepth(
                     color, depth, depth_scale, depth_trunc,
                     convert_rgb_to_intensity);
     if (visualize) {
-        auto pcd =
-                geometry::CreatePointCloudFromRGBDImage(*rgbd_image, intrinsic);
+        auto pcd = geometry::PointCloud::CreateFromRGBDImage(*rgbd_image,
+                                                             intrinsic);
         visualization::DrawGeometries({pcd});
     }
     return rgbd_image;

--- a/examples/Cpp/RegistrationRANSAC.cpp
+++ b/examples/Cpp/RegistrationRANSAC.cpp
@@ -36,9 +36,9 @@ std::tuple<std::shared_ptr<geometry::PointCloud>,
            std::shared_ptr<registration::Feature>>
 PreprocessPointCloud(const char *file_name) {
     auto pcd = open3d::io::CreatePointCloudFromFile(file_name);
-    auto pcd_down = geometry::VoxelDownSample(*pcd, 0.05);
-    geometry::EstimateNormals(
-            *pcd_down, open3d::geometry::KDTreeSearchParamHybrid(0.1, 30));
+    auto pcd_down = pcd->VoxelDownSample(0.05);
+    pcd_down->EstimateNormals(
+            open3d::geometry::KDTreeSearchParamHybrid(0.1, 30));
     auto pcd_fpfh = registration::ComputeFPFHFeature(
             *pcd_down, open3d::geometry::KDTreeSearchParamHybrid(0.25, 100));
     return std::make_tuple(pcd_down, pcd_fpfh);

--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
             char buffer[1024];
             sprintf(buffer, "image/image_%06d.png", (int)i + 1);
             auto image = io::CreateImageFromFile(buffer);
-            auto fimage = image->CreateFloatImageFromImage();
+            auto fimage = image->CreateFloatImage();
             Eigen::Vector4d pt_in_camera =
                     trajectory.parameters_[i].extrinsic_ *
                     Eigen::Vector4d(mesh->vertices_[idx](0),

--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -56,35 +56,35 @@ int main(int argc, char *argv[]) {
 
     std::string option(argv[1]);
     if (option == "sphere") {
-        auto mesh = geometry::CreateMeshSphere(0.05);
+        auto mesh = geometry::TriangleMesh::CreateSphere(0.05);
         mesh->ComputeVertexNormals();
         visualization::DrawGeometries({mesh});
         io::WriteTriangleMesh("sphere.ply", *mesh, true, true);
     } else if (option == "cylinder") {
-        auto mesh = geometry::CreateMeshCylinder(0.5, 2.0);
+        auto mesh = geometry::TriangleMesh::CreateCylinder(0.5, 2.0);
         mesh->ComputeVertexNormals();
         visualization::DrawGeometries({mesh});
         io::WriteTriangleMesh("cylinder.ply", *mesh, true, true);
     } else if (option == "cone") {
-        auto mesh = geometry::CreateMeshCone(0.5, 2.0, 20, 3);
+        auto mesh = geometry::TriangleMesh::CreateCone(0.5, 2.0, 20, 3);
         mesh->ComputeVertexNormals();
         visualization::DrawGeometries({mesh});
         io::WriteTriangleMesh("cone.ply", *mesh, true, true);
     } else if (option == "arrow") {
-        auto mesh = geometry::CreateMeshArrow();
+        auto mesh = geometry::TriangleMesh::CreateArrow();
         mesh->ComputeVertexNormals();
         visualization::DrawGeometries({mesh});
         io::WriteTriangleMesh("arrow.ply", *mesh, true, true);
     } else if (option == "frame") {
         if (argc < 3) {
-            auto mesh = geometry::CreateMeshCoordinateFrame();
+            auto mesh = geometry::TriangleMesh::CreateCoordinateFrame();
             visualization::DrawGeometries({mesh});
             io::WriteTriangleMesh("frame.ply", *mesh, true, true);
         } else {
             auto mesh = io::CreateMeshFromFile(argv[2]);
             mesh->ComputeVertexNormals();
             visualization::BoundingBox boundingbox(*mesh);
-            auto mesh_frame = geometry::CreateMeshCoordinateFrame(
+            auto mesh_frame = geometry::TriangleMesh::CreateCoordinateFrame(
                     boundingbox.GetSize() * 0.2, boundingbox.min_bound_);
             visualization::DrawGeometries({mesh, mesh_frame});
         }
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
         int idx = 3000;
         std::vector<std::shared_ptr<const geometry::Geometry>> ptrs;
         ptrs.push_back(mesh);
-        auto mesh_sphere = geometry::CreateMeshSphere(0.05);
+        auto mesh_sphere = geometry::TriangleMesh::CreateSphere(0.05);
         Eigen::Matrix4d trans;
         trans.setIdentity();
         trans.block<3, 1>(0, 3) = mesh->vertices_[idx];
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
             char buffer[1024];
             sprintf(buffer, "image/image_%06d.png", (int)i + 1);
             auto image = io::CreateImageFromFile(buffer);
-            auto fimage = CreateFloatImageFromImage(*image);
+            auto fimage = image->CreateFloatImageFromImage();
             Eigen::Vector4d pt_in_camera =
                     trajectory.parameters_[i].extrinsic_ *
                     Eigen::Vector4d(mesh->vertices_[idx](0),

--- a/examples/Cpp/ViewDistances.cpp
+++ b/examples/Cpp/ViewDistances.cpp
@@ -66,12 +66,12 @@ int main(int argc, char *argv[]) {
             utility::filesystem::GetFileNameWithoutExtension(argv[1]) + ".bin";
     std::vector<double> distances(pcd->points_.size());
     if (utility::ProgramOptionExists(argc, argv, "--mahalanobis_distance")) {
-        distances = geometry::ComputePointCloudMahalanobisDistance(*pcd);
+        distances = pcd->ComputeMahalanobisDistance();
         FILE *f = fopen(binname.c_str(), "wb");
         fwrite(distances.data(), sizeof(double), distances.size(), f);
         fclose(f);
     } else if (utility::ProgramOptionExists(argc, argv, "--nn_distance")) {
-        distances = geometry::ComputePointCloudNearestNeighborDistance(*pcd);
+        distances = pcd->ComputeNearestNeighborDistance();
         FILE *f = fopen(binname.c_str(), "wb");
         fwrite(distances.data(), sizeof(double), distances.size(), f);
         fclose(f);

--- a/examples/Cpp/Visualizer.cpp
+++ b/examples/Cpp/Visualizer.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
         camera::PinholeCameraIntrinsic camera;
         camera.SetIntrinsics(640, 480, 575.0, 575.0, 319.5, 239.5);
         auto pointcloud_ptr =
-                geometry::CreatePointCloudFromDepthImage(*image_ptr, camera);
+                geometry::PointCloud::CreateFromDepthImage(*image_ptr, camera);
         visualization::DrawGeometries(
                 {pointcloud_ptr},
                 "geometry::PointCloud from Depth geometry::Image", 1920, 1080);

--- a/examples/Cpp/Voxelization.cpp
+++ b/examples/Cpp/Voxelization.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** args) {
     }
 
     auto pcd = io::CreatePointCloudFromFile(args[1]);
-    auto voxel = geometry::CreateSurfaceVoxelGridFromPointCloud(*pcd, 0.05);
+    auto voxel = geometry::VoxelGrid::CreateFromPointCloud(*pcd, 0.05);
     PrintVoxelGridInformation(*voxel);
     visualization::DrawGeometries({pcd, voxel});
     io::WriteVoxelGrid(args[2], *voxel, true);

--- a/examples/Python/Advanced/camera_trajectory.py
+++ b/examples/Python/Advanced/camera_trajectory.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
             "../../TestData/RGBD/color/{:05d}.jpg".format(i))
         im = o3d.geometry.create_rgbd_image_from_color_and_depth(
             im2, im1, 1000.0, 5.0, False)
-        pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+        pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
             im, trajectory.parameters[i].intrinsic,
             trajectory.parameters[i].extrinsic)
         pcds.append(pcd)

--- a/examples/Python/Advanced/camera_trajectory.py
+++ b/examples/Python/Advanced/camera_trajectory.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             "../../TestData/RGBD/depth/{:05d}.png".format(i))
         im2 = o3d.io.read_image(
             "../../TestData/RGBD/color/{:05d}.jpg".format(i))
-        im = o3d.geometry.create_rgbd_image_from_color_and_depth(
+        im = o3d.geometry.RGBDImage.create_from_color_and_depth(
             im2, im1, 1000.0, 5.0, False)
         pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
             im, trajectory.parameters[i].intrinsic,

--- a/examples/Python/Advanced/color_map_optimization.py
+++ b/examples/Python/Advanced/color_map_optimization.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     for i in range(len(depth_image_path)):
         depth = o3d.io.read_image(os.path.join(depth_image_path[i]))
         color = o3d.io.read_image(os.path.join(color_image_path[i]))
-        rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
             color, depth, convert_rgb_to_intensity=False)
         if debug_mode:
             pcd = o3d.geometry.PointCloud.create_from_rgbd_image(

--- a/examples/Python/Advanced/color_map_optimization.py
+++ b/examples/Python/Advanced/color_map_optimization.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
             color, depth, convert_rgb_to_intensity=False)
         if debug_mode:
-            pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+            pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
                 rgbd_image,
                 o3d.camera.PinholeCameraIntrinsic(
                     o3d.camera.PinholeCameraIntrinsicParameters.

--- a/examples/Python/Advanced/colored_pointcloud_registration.py
+++ b/examples/Python/Advanced/colored_pointcloud_registration.py
@@ -51,15 +51,13 @@ if __name__ == "__main__":
         print([iter, radius, scale])
 
         print("3-1. Downsample with a voxel size %.2f" % radius)
-        source_down = o3d.geometry.voxel_down_sample(source, radius)
-        target_down = o3d.geometry.voxel_down_sample(target, radius)
+        source_down = source.voxel_down_sample(radius)
+        target_down = target.voxel_down_sample(radius)
 
         print("3-2. Estimate normal.")
-        o3d.geometry.estimate_normals(
-            source_down,
+        source_down.estimate_normals(
             o3d.geometry.KDTreeSearchParamHybrid(radius=radius * 2, max_nn=30))
-        o3d.geometry.estimate_normals(
-            target_down,
+        target_down.estimate_normals(
             o3d.geometry.KDTreeSearchParamHybrid(radius=radius * 2, max_nn=30))
 
         print("3-3. Applying colored point cloud registration")

--- a/examples/Python/Advanced/downsampling_and_trace.py
+++ b/examples/Python/Advanced/downsampling_and_trace.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     pcd = o3d.io.read_point_cloud("../../TestData/fragment.ply")
     min_cube_size = 0.05
     print("\nOriginal, # of points %d" % (np.asarray(pcd.points).shape[0]))
-    pcd_down = o3d.geometry.voxel_down_sample(pcd, min_cube_size)
+    pcd_down = pcd.voxel_down_sample(min_cube_size)
     print("\nScale %f, # of points %d" % \
             (min_cube_size, np.asarray(pcd_down.points).shape[0]))
     min_bound = pcd_down.get_min_bound() - min_cube_size * 0.5
@@ -20,8 +20,8 @@ if __name__ == "__main__":
     num_scales = 3
     for i in range(1, num_scales):
         multiplier = pow(2, i)
-        pcd_curr_down, cubic_id = o3d.geometry.voxel_down_sample_and_trace(
-            pcd_curr, multiplier * min_cube_size, min_bound, max_bound, False)
+        pcd_curr_down, cubic_id = pcd_curr.voxel_down_sample_and_trace(
+            multiplier * min_cube_size, min_bound, max_bound, False)
         print("\nScale %f, # of points %d" %
               (multiplier * min_cube_size, np.asarray(
                   pcd_curr_down.points).shape[0]))

--- a/examples/Python/Advanced/global_registration.py
+++ b/examples/Python/Advanced/global_registration.py
@@ -20,12 +20,11 @@ def draw_registration_result(source, target, transformation):
 
 def preprocess_point_cloud(pcd, voxel_size):
     print(":: Downsample with a voxel size %.3f." % voxel_size)
-    pcd_down = o3d.geometry.voxel_down_sample(pcd, voxel_size)
+    pcd_down = pcd.voxel_down_sample(voxel_size)
 
     radius_normal = voxel_size * 2
     print(":: Estimate normal with search radius %.3f." % radius_normal)
-    o3d.geometry.estimate_normals(
-        pcd_down,
+    pcd_down.estimate_normals(
         o3d.geometry.KDTreeSearchParamHybrid(radius=radius_normal, max_nn=30))
 
     radius_feature = voxel_size * 5

--- a/examples/Python/Advanced/multiway_registration.py
+++ b/examples/Python/Advanced/multiway_registration.py
@@ -16,7 +16,7 @@ def load_point_clouds(voxel_size=0.0):
     pcds = []
     for i in range(3):
         pcd = o3d.io.read_point_cloud("../../TestData/ICP/cloud_bin_%d.pcd" % i)
-        pcd_down = o3d.geometry.voxel_down_sample(pcd, voxel_size=voxel_size)
+        pcd_down = pcd.voxel_down_sample(voxel_size=voxel_size)
         pcds.append(pcd_down)
     return pcds
 
@@ -100,7 +100,6 @@ if __name__ == "__main__":
     for point_id in range(len(pcds)):
         pcds[point_id].transform(pose_graph.nodes[point_id].pose)
         pcd_combined += pcds[point_id]
-    pcd_combined_down = o3d.geometry.voxel_down_sample(pcd_combined,
-                                                       voxel_size=voxel_size)
+    pcd_combined_down = pcd_combined.voxel_down_sample(voxel_size=voxel_size)
     o3d.io.write_point_cloud("multiway_registration.pcd", pcd_combined_down)
     o3d.visualization.draw_geometries([pcd_combined_down])

--- a/examples/Python/Advanced/non_blocking_visualization.py
+++ b/examples/Python/Advanced/non_blocking_visualization.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
     o3d.utility.set_verbosity_level(o3d.utility.VerbosityLevel.Debug)
     source_raw = o3d.io.read_point_cloud("../../TestData/ICP/cloud_bin_0.pcd")
     target_raw = o3d.io.read_point_cloud("../../TestData/ICP/cloud_bin_1.pcd")
-    source = o3d.geometry.voxel_down_sample(source_raw, voxel_size=0.02)
-    target = o3d.geometry.voxel_down_sample(target_raw, voxel_size=0.02)
+    source = source_raw.voxel_down_sample(voxel_size=0.02)
+    target = target_raw.voxel_down_sample(voxel_size=0.02)
     trans = [[0.862, 0.011, -0.507, 0.0], [-0.139, 0.967, -0.215, 0.7],
              [0.487, 0.255, 0.835, -1.4], [0.0, 0.0, 0.0, 1.0]]
     source.transform(trans)

--- a/examples/Python/Advanced/pointcloud_outlier_removal.py
+++ b/examples/Python/Advanced/pointcloud_outlier_removal.py
@@ -8,8 +8,8 @@ import open3d as o3d
 
 
 def display_inlier_outlier(cloud, ind):
-    inlier_cloud = o3d.geometry.select_down_sample(cloud, ind)
-    outlier_cloud = o3d.geometry.select_down_sample(cloud, ind, invert=True)
+    inlier_cloud = cloud.select_down_sample(ind)
+    outlier_cloud = cloud.select_down_sample(ind, invert=True)
 
     print("Showing outliers (red) and inliers (gray): ")
     outlier_cloud.paint_uniform_color([1, 0, 0])
@@ -24,21 +24,18 @@ if __name__ == "__main__":
     o3d.visualization.draw_geometries([pcd])
 
     print("Downsample the point cloud with a voxel of 0.02")
-    voxel_down_pcd = o3d.geometry.voxel_down_sample(pcd, voxel_size=0.02)
+    voxel_down_pcd = pcd.voxel_down_sample(voxel_size=0.02)
     o3d.visualization.draw_geometries([voxel_down_pcd])
 
     print("Every 5th points are selected")
-    uni_down_pcd = o3d.geometry.uniform_down_sample(pcd, every_k_points=5)
+    uni_down_pcd = pcd.uniform_down_sample(every_k_points=5)
     o3d.visualization.draw_geometries([uni_down_pcd])
 
     print("Statistical oulier removal")
-    cl, ind = o3d.geometry.statistical_outlier_removal(voxel_down_pcd,
-                                                       nb_neighbors=20,
-                                                       std_ratio=2.0)
+    cl, ind = voxel_down_pcd.remove_statistical_outlier(nb_neighbors=20,
+                                                        std_ratio=2.0)
     display_inlier_outlier(voxel_down_pcd, ind)
 
     print("Radius oulier removal")
-    cl, ind = o3d.geometry.radius_outlier_removal(voxel_down_pcd,
-                                                  nb_points=16,
-                                                  radius=0.05)
+    cl, ind = voxel_down_pcd.remove_radius_outlier(nb_points=16, radius=0.05)
     display_inlier_outlier(voxel_down_pcd, ind)

--- a/examples/Python/Advanced/rgbd_integration.py
+++ b/examples/Python/Advanced/rgbd_integration.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
             "../../TestData/RGBD/color/{:05d}.jpg".format(i))
         depth = o3d.io.read_image(
             "../../TestData/RGBD/depth/{:05d}.png".format(i))
-        rgbd = o3d.geometry.create_rgbd_image_from_color_and_depth(
+        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
             color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
         volume.integrate(
             rgbd,

--- a/examples/Python/Advanced/rgbd_integration_uniform.py
+++ b/examples/Python/Advanced/rgbd_integration_uniform.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
             "../../TestData/RGBD/color/{:05d}.jpg".format(i))
         depth = o3d.io.read_image(
             "../../TestData/RGBD/depth/{:05d}.png".format(i))
-        rgbd = o3d.geometry.create_rgbd_image_from_color_and_depth(
+        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
             color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
         volume.integrate(
             rgbd,

--- a/examples/Python/Basic/convex_hull.py
+++ b/examples/Python/Basic/convex_hull.py
@@ -17,8 +17,8 @@ import meshes
 
 
 def mesh_generator():
-    yield o3d.geometry.create_mesh_box()
-    yield o3d.geometry.create_mesh_sphere()
+    yield o3d.geometry.TriangleMesh.create_box()
+    yield o3d.geometry.TriangleMesh.create_sphere()
     yield meshes.knot()
     yield meshes.bunny()
     yield meshes.armadillo()
@@ -27,14 +27,13 @@ def mesh_generator():
 if __name__ == "__main__":
     for mesh in mesh_generator():
         mesh.compute_vertex_normals()
-        hull = o3d.geometry.compute_mesh_convex_hull(mesh)
-        hull_ls = o3d.geometry.create_line_set_from_triangle_mesh(hull)
+        hull = mesh.compute_convex_hull()
+        hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)
         hull_ls.paint_uniform_color((1, 0, 0))
         o3d.visualization.draw_geometries([mesh, hull_ls])
 
-        pcl = o3d.geometry.sample_points_poisson_disk(mesh,
-                                                      number_of_points=2000)
-        hull = o3d.geometry.compute_point_cloud_convex_hull(pcl)
-        hull_ls = o3d.geometry.create_line_set_from_triangle_mesh(hull)
+        pcl = mesh.sample_points_poisson_disk(number_of_points=2000)
+        hull = pcl.compute_convex_hull()
+        hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)
         hull_ls.paint_uniform_color((1, 0, 0))
         o3d.visualization.draw_geometries([pcl, hull_ls])

--- a/examples/Python/Basic/half_edge_mesh.py
+++ b/examples/Python/Basic/half_edge_mesh.py
@@ -21,9 +21,9 @@ def draw_geometries_with_back_face(geometries):
 
 if __name__ == "__main__":
     mesh = o3d.io.read_triangle_mesh("../../TestData/sphere.ply")
-    mesh = o3d.geometry.crop_triangle_mesh(mesh, [-1, -1, -1], [1, 0.6, 1])
-    mesh.purge()
-    mesh = o3d.geometry.create_half_edge_mesh_from_mesh(mesh)
+    mesh = mesh.crop([-1, -1, -1], [1, 0.6, 1])
+    # mesh.purge()
+    mesh = o3d.geometry.HalfEdge.create_from_mesh(mesh)
     mesh.compute_vertex_normals()
     num_vertices = len(mesh.vertices)
     draw_geometries_with_back_face([mesh])

--- a/examples/Python/Basic/half_edge_mesh.py
+++ b/examples/Python/Basic/half_edge_mesh.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     mesh = o3d.io.read_triangle_mesh("../../TestData/sphere.ply")
     mesh = mesh.crop([-1, -1, -1], [1, 0.6, 1])
     # mesh.purge()
-    mesh = o3d.geometry.HalfEdge.create_from_mesh(mesh)
+    mesh = o3d.geometry.HalfEdgeTriangleMesh.create_from_mesh(mesh)
     mesh.compute_vertex_normals()
     num_vertices = len(mesh.vertices)
     draw_geometries_with_back_face([mesh])

--- a/examples/Python/Basic/kdtree.py
+++ b/examples/Python/Basic/kdtree.py
@@ -11,8 +11,7 @@ if __name__ == "__main__":
 
     print("Testing kdtree in open3d ...")
     print("Load a point cloud and paint it gray.")
-    pcd = o3d.io.read_point_cloud(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.pcd")
+    pcd = o3d.io.read_point_cloud("../../TestData/Feature/cloud_bin_0.pcd")
     pcd.paint_uniform_color([0.5, 0.5, 0.5])
     pcd_tree = o3d.geometry.KDTreeFlann(pcd)
 

--- a/examples/Python/Basic/mesh_filter.py
+++ b/examples/Python/Basic/mesh_filter.py
@@ -21,24 +21,22 @@ def test_mesh(noise=0):
 
 
 if __name__ == '__main__':
-    mesh = test_mesh()
+    in_mesh = test_mesh()
+    o3d.visualization.draw_geometries([in_mesh])
+
+    mesh = in_mesh.filter_sharpen(number_of_iterations=1, strength=1)
     o3d.visualization.draw_geometries([mesh])
 
-    mesh = test_mesh()
-    mesh.filter_sharpen(number_of_iterations=1, strength=1)
+    in_mesh = test_mesh(noise=5)
+    o3d.visualization.draw_geometries([in_mesh])
+
+    mesh = in_mesh.filter_smooth_simple(number_of_iterations=1)
     o3d.visualization.draw_geometries([mesh])
 
-    mesh = test_mesh(noise=5)
     o3d.visualization.draw_geometries([mesh])
-    mesh.filter_smooth_simple(number_of_iterations=1)
-    o3d.visualization.draw_geometries([mesh])
-
-    mesh = test_mesh(noise=5)
-    o3d.visualization.draw_geometries([mesh])
-    mesh.filter_smooth_laplacian(number_of_iterations=100)
+    mesh = in_mesh.filter_smooth_laplacian(number_of_iterations=100)
     o3d.visualization.draw_geometries([mesh])
 
-    mesh = test_mesh(noise=5)
     o3d.visualization.draw_geometries([mesh])
-    mesh.filter_smooth_taubin(number_of_iterations=100)
+    mesh = in_mesh.filter_smooth_taubin(number_of_iterations=100)
     o3d.visualization.draw_geometries([mesh])

--- a/examples/Python/Basic/mesh_properties.py
+++ b/examples/Python/Basic/mesh_properties.py
@@ -12,14 +12,17 @@ import meshes
 
 
 def mesh_generator(edge_cases=True):
-    yield 'box', o3d.geometry.create_mesh_box()
-    yield 'sphere', o3d.geometry.create_mesh_sphere()
-    yield 'cone', o3d.geometry.create_mesh_cone()
-    yield 'torus', o3d.geometry.create_mesh_torus(radial_resolution=30,
-                                                  tubular_resolution=20)
-    yield 'moebius (twists=1)', o3d.geometry.create_mesh_moebius(twists=1)
-    yield 'moebius (twists=2)', o3d.geometry.create_mesh_moebius(twists=2)
-    yield 'moebius (twists=3)', o3d.geometry.create_mesh_moebius(twists=3)
+    yield 'box', o3d.geometry.TriangleMesh.create_box()
+    yield 'sphere', o3d.geometry.TriangleMesh.create_sphere()
+    yield 'cone', o3d.geometry.TriangleMesh.create_cone()
+    yield 'torus', o3d.geometry.TriangleMesh.create_torus(radial_resolution=30,
+                                                          tubular_resolution=20)
+    yield 'moebius (twists=1)', o3d.geometry.TriangleMesh.create_moebius(
+        twists=1)
+    yield 'moebius (twists=2)', o3d.geometry.TriangleMesh.create_moebius(
+        twists=2)
+    yield 'moebius (twists=3)', o3d.geometry.TriangleMesh.create_moebius(
+        twists=3)
 
     yield 'knot', meshes.knot()
 
@@ -126,11 +129,12 @@ if __name__ == "__main__":
     print('Intersection tests')
     print('#' * 80)
     np.random.seed(30)
-    bbox = o3d.geometry.create_mesh_box(20, 20, 20).translate((-10, -10, -10))
-    meshes = [o3d.geometry.create_mesh_box() for _ in range(20)]
-    meshes.append(o3d.geometry.create_mesh_sphere())
-    meshes.append(o3d.geometry.create_mesh_cone())
-    meshes.append(o3d.geometry.create_mesh_torus())
+    bbox = o3d.geometry.TriangleMesh.create_box(20, 20, 20).translate(
+        (-10, -10, -10))
+    meshes = [o3d.geometry.TriangleMesh.create_box() for _ in range(20)]
+    meshes.append(o3d.geometry.TriangleMesh.create_sphere())
+    meshes.append(o3d.geometry.TriangleMesh.create_cone())
+    meshes.append(o3d.geometry.TriangleMesh.create_torus())
     dirs = [np.random.uniform(-0.1, 0.1, size=(3,)) for _ in meshes]
     for mesh in meshes:
         mesh.compute_vertex_normals()

--- a/examples/Python/Basic/mesh_sampling.py
+++ b/examples/Python/Basic/mesh_sampling.py
@@ -22,7 +22,7 @@ def time_fcn(fcn, *fcn_args, runs=5):
 
 def mesh_generator():
     yield meshes.plane()
-    yield o3d.geometry.create_mesh_sphere()
+    yield o3d.geometry.TriangleMesh.create_sphere()
     yield meshes.bunny()
     yield meshes.armadillo()
 
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     o3d.visualization.draw_geometries([plane])
 
     print('Uniform sampling can yield clusters of points on the surface')
-    pcd = o3d.geometry.sample_points_uniformly(plane, number_of_points=500)
+    pcd = plane.sample_points_uniformly(number_of_points=500)
     o3d.visualization.draw_geometries([pcd])
 
     print(
@@ -45,9 +45,7 @@ if __name__ == "__main__":
     print('1) Default via the parameter init_factor: The method first samples '
           'uniformly a point cloud from the mesh with '
           'init_factor x number_of_points and uses this for the elimination')
-    pcd = o3d.geometry.sample_points_poisson_disk(plane,
-                                                  number_of_points=500,
-                                                  init_factor=5)
+    pcd = plane.sample_points_poisson_disk(number_of_points=500, init_factor=5)
     o3d.visualization.draw_geometries([pcd])
 
     print(
@@ -55,11 +53,9 @@ if __name__ == "__main__":
         'o3d.geometry.sample_points_poisson_disk method. Then this point cloud is used '
         'for elimination.')
     print('Initial point cloud')
-    pcd = o3d.geometry.sample_points_uniformly(plane, number_of_points=2500)
+    pcd = plane.sample_points_uniformly(number_of_points=2500)
     o3d.visualization.draw_geometries([pcd])
-    pcd = o3d.geometry.sample_points_poisson_disk(plane,
-                                                  number_of_points=500,
-                                                  pcl=pcd)
+    pcd = plane.sample_points_poisson_disk(number_of_points=500, pcl=pcd)
     o3d.visualization.draw_geometries([pcd])
 
     print('Timings')
@@ -67,11 +63,10 @@ if __name__ == "__main__":
         mesh.compute_vertex_normals()
         o3d.visualization.draw_geometries([mesh])
 
-        pcd, times = time_fcn(o3d.geometry.sample_points_uniformly, mesh, 500)
+        pcd, times = time_fcn(mesh.sample_points_uniformly, 500)
         print('sample uniform took on average: %f[s]' % np.mean(times))
         o3d.visualization.draw_geometries([pcd])
 
-        pcd, times = time_fcn(o3d.geometry.sample_points_poisson_disk, mesh,
-                              500, 5)
+        pcd, times = time_fcn(mesh.sample_points_poisson_disk, 500, 5)
         print('sample poisson disk took on average: %f[s]' % np.mean(times))
         o3d.visualization.draw_geometries([pcd])

--- a/examples/Python/Basic/mesh_simplification.py
+++ b/examples/Python/Basic/mesh_simplification.py
@@ -10,31 +10,21 @@ import open3d as o3d
 import meshes
 
 
-def create_mesh_plane():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
-                                                                      3]]))
-    return mesh
-
-
 def mesh_generator():
     mesh = meshes.plane()
-    yield o3d.geometry.subdivide_midpoint(mesh, 2)
+    yield mesh.subdivide_midpoint(2)
 
-    mesh = o3d.geometry.create_mesh_box()
-    yield o3d.geometry.subdivide_midpoint(mesh, 2)
+    mesh = o3d.geometry.TriangleMesh.create_box()
+    yield mesh.subdivide_midpoint(2)
 
-    mesh = o3d.geometry.create_mesh_sphere()
-    yield o3d.geometry.subdivide_midpoint(mesh, 2)
+    mesh = o3d.geometry.TriangleMesh.create_sphere()
+    yield mesh.subdivide_midpoint(2)
 
-    mesh = o3d.geometry.create_mesh_cone()
-    yield o3d.geometry.subdivide_midpoint(mesh, 2)
+    mesh = o3d.geometry.TriangleMesh.create_cone()
+    yield mesh.subdivide_midpoint(2)
 
-    mesh = o3d.geometry.create_mesh_cylinder()
-    yield o3d.geometry.subdivide_midpoint(mesh, 2)
+    mesh = o3d.geometry.TriangleMesh.create_cylinder()
+    yield mesh.subdivide_midpoint(2)
 
     yield meshes.bathtub()
 
@@ -58,8 +48,7 @@ if __name__ == "__main__":
         target_number_of_triangles = np.asarray(mesh.triangles).shape[0] // 2
         print('voxel_size = %f' % voxel_size)
 
-        mesh_smp = o3d.geometry.simplify_vertex_clustering(
-            mesh,
+        mesh_smp = mesh.simplify_vertex_clustering(
             voxel_size=voxel_size,
             contraction=o3d.geometry.SimplificationContraction.Average)
         print(
@@ -68,8 +57,7 @@ if __name__ == "__main__":
              np.asarray(mesh_smp.vertices).shape[0]))
         o3d.visualization.draw_geometries([mesh_smp])
 
-        mesh_smp = o3d.geometry.simplify_vertex_clustering(
-            mesh,
+        mesh_smp = mesh.simplify_vertex_clustering(
             voxel_size=voxel_size,
             contraction=o3d.geometry.SimplificationContraction.Quadric)
         print(
@@ -78,8 +66,8 @@ if __name__ == "__main__":
              np.asarray(mesh_smp.vertices).shape[0]))
         o3d.visualization.draw_geometries([mesh_smp])
 
-        mesh_smp = o3d.geometry.simplify_quadric_decimation(
-            mesh, target_number_of_triangles=target_number_of_triangles)
+        mesh_smp = mesh.simplify_quadric_decimation(
+            target_number_of_triangles=target_number_of_triangles)
         print("quadric decimated mesh has %d triangles and %d vertices" %
               (np.asarray(mesh_smp.triangles).shape[0],
                np.asarray(mesh_smp.vertices).shape[0]))

--- a/examples/Python/Basic/mesh_subdivision.py
+++ b/examples/Python/Basic/mesh_subdivision.py
@@ -13,13 +13,13 @@ import meshes
 def mesh_generator():
     yield meshes.triangle()
     yield meshes.plane()
-    yield o3d.geometry.create_mesh_tetrahedron()
-    yield o3d.geometry.create_mesh_box()
-    yield o3d.geometry.create_mesh_octahedron()
-    yield o3d.geometry.create_mesh_icosahedron()
-    yield o3d.geometry.create_mesh_sphere()
-    yield o3d.geometry.create_mesh_cone()
-    yield o3d.geometry.create_mesh_cylinder()
+    yield o3d.geometry.TriangleMesh.create_tetrahedron()
+    yield o3d.geometry.TriangleMesh.create_box()
+    yield o3d.geometry.TriangleMesh.create_octahedron()
+    yield o3d.geometry.TriangleMesh.create_icosahedron()
+    yield o3d.geometry.TriangleMesh.create_sphere()
+    yield o3d.geometry.TriangleMesh.create_cone()
+    yield o3d.geometry.TriangleMesh.create_cylinder()
     yield meshes.knot()
     yield meshes.bathtub()
 
@@ -39,15 +39,14 @@ if __name__ == "__main__":
             mesh.triangles).shape[0], np.asarray(mesh.vertices).shape[0]))
         o3d.visualization.draw_geometries([mesh])
 
-        mesh_up = o3d.geometry.subdivide_midpoint(
-            mesh, number_of_iterations=number_of_iterations)
+        mesh_up = mesh.subdivide_midpoint(
+            number_of_iterations=number_of_iterations)
         print("midpoint upsampled mesh has %d triangles and %d vertices" %
               (np.asarray(mesh_up.triangles).shape[0],
                np.asarray(mesh_up.vertices).shape[0]))
         o3d.visualization.draw_geometries([mesh_up])
 
-        mesh_up = o3d.geometry.subdivide_loop(
-            mesh, number_of_iterations=number_of_iterations)
+        mesh_up = mesh.subdivide_loop(number_of_iterations=number_of_iterations)
         print("loop upsampled mesh has %d triangles and %d vertices" %
               (np.asarray(mesh_up.triangles).shape[0],
                np.asarray(mesh_up.vertices).shape[0]))

--- a/examples/Python/Basic/mesh_voxelization.py
+++ b/examples/Python/Basic/mesh_voxelization.py
@@ -109,8 +109,7 @@ centers.points = o3d.utility.Vector3dVector(centers_pts)
 o3d.visualization.draw_geometries([centers, model])
 
 print("voxelize dense point cloud")
-voxel = o3d.geometry.create_surface_voxel_grid_from_point_cloud(pcd_agg,
-                                                                voxel_size=0.05)
+voxel = o3d.geometry.VoxelGrid.create_from_point_cloud(pcd_agg, voxel_size=0.05)
 print(voxel)
 o3d.visualization.draw_geometries([voxel])
 

--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -90,17 +90,17 @@ def non_manifold_vertex():
 
 
 def open_box():
-    mesh = o3d.geometry.create_mesh_box()
+    mesh = o3d.geometry.TriangleMesh.create_box()
     mesh.triangles = o3d.utility.Vector3iVector(np.asarray(mesh.triangles)[:-2])
     mesh.compute_vertex_normals()
     return mesh
 
 
 def intersecting_boxes():
-    mesh0 = o3d.geometry.create_mesh_box()
+    mesh0 = o3d.geometry.TriangleMesh.create_box()
     T = np.eye(4)
     T[:, 3] += (0.5, 0.5, 0.5, 0)
-    mesh1 = o3d.geometry.create_mesh_box()
+    mesh1 = o3d.geometry.TriangleMesh.create_box()
     mesh1.transform(T)
     mesh = cat_meshes(mesh0, mesh1)
     mesh.compute_vertex_normals()
@@ -174,13 +174,17 @@ if __name__ == '__main__':
     print('  torus, moebius strip one twist, moebius strip two twists')
     d = 1.5
     geoms = [
-        process(o3d.geometry.create_mesh_tetrahedron()).translate((-d, 0, 0)),
-        process(o3d.geometry.create_mesh_octahedron()).translate((0, 0, 0)),
-        process(o3d.geometry.create_mesh_icosahedron()).translate((d, 0, 0)),
-        process(o3d.geometry.create_mesh_torus()).translate((-d, -d, 0)),
-        process(o3d.geometry.create_mesh_moebius(twists=1)).translate(
+        process(o3d.geometry.TriangleMesh.create_tetrahedron()).translate(
+            (-d, 0, 0)),
+        process(o3d.geometry.TriangleMesh.create_octahedron()).translate(
+            (0, 0, 0)),
+        process(o3d.geometry.TriangleMesh.create_icosahedron()).translate(
+            (d, 0, 0)),
+        process(o3d.geometry.TriangleMesh.create_torus()).translate(
+            (-d, -d, 0)),
+        process(o3d.geometry.TriangleMesh.create_moebius(twists=1)).translate(
             (0, -d, 0)),
-        process(o3d.geometry.create_mesh_moebius(twists=2)).translate(
+        process(o3d.geometry.TriangleMesh.create_moebius(twists=2)).translate(
             (d, -d, 0)),
     ]
 

--- a/examples/Python/Basic/pointcloud.py
+++ b/examples/Python/Basic/pointcloud.py
@@ -16,14 +16,12 @@ if __name__ == "__main__":
     o3d.visualization.draw_geometries([pcd])
 
     print("Downsample the point cloud with a voxel of 0.05")
-    downpcd = o3d.geometry.voxel_down_sample(pcd, voxel_size=0.05)
+    downpcd = pcd.voxel_down_sample(voxel_size=0.05)
     o3d.visualization.draw_geometries([downpcd])
 
     print("Recompute the normal of the downsampled point cloud")
-    o3d.geometry.estimate_normals(
-        downpcd,
-        search_param=o3d.geometry.KDTreeSearchParamHybrid(radius=0.1,
-                                                          max_nn=30))
+    downpcd.estimate_normals(search_param=o3d.geometry.KDTreeSearchParamHybrid(
+        radius=0.1, max_nn=30))
     o3d.visualization.draw_geometries([downpcd])
 
     print("Print a normal vector of the 0th point")

--- a/examples/Python/Basic/rgbd_nyu.py
+++ b/examples/Python/Basic/rgbd_nyu.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     plt.title('NYU depth image')
     plt.imshow(rgbd_image.depth)
     plt.show()
-    pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+    pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         rgbd_image,
         o3d.camera.PinholeCameraIntrinsic(
             o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault))

--- a/examples/Python/Basic/rgbd_nyu.py
+++ b/examples/Python/Basic/rgbd_nyu.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     depth_raw = read_nyu_pgm("../../TestData/RGBD/other_formats/NYU_depth.pgm")
     color = o3d.geometry.Image(color_raw)
     depth = o3d.geometry.Image(depth_raw)
-    rgbd_image = o3d.geometry.create_rgbd_image_from_nyu_format(color, depth)
+    rgbd_image = o3d.geometry.RGBDImage.create_from_nyu_format(color, depth)
     print(rgbd_image)
     plt.subplot(1, 2, 1)
     plt.title('NYU grayscale image')

--- a/examples/Python/Basic/rgbd_odometry.py
+++ b/examples/Python/Basic/rgbd_odometry.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         source_color, source_depth)
     target_rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
         target_color, target_depth)
-    target_pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+    target_pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         target_rgbd_image, pinhole_camera_intrinsic)
 
     option = o3d.odometry.OdometryOption()
@@ -39,14 +39,14 @@ if __name__ == "__main__":
     if success_color_term:
         print("Using RGB-D Odometry")
         print(trans_color_term)
-        source_pcd_color_term = o3d.geometry.create_point_cloud_from_rgbd_image(
+        source_pcd_color_term = o3d.geometry.PointCloud.create_from_rgbd_image(
             source_rgbd_image, pinhole_camera_intrinsic)
         source_pcd_color_term.transform(trans_color_term)
         o3d.visualization.draw_geometries([target_pcd, source_pcd_color_term])
     if success_hybrid_term:
         print("Using Hybrid RGB-D Odometry")
         print(trans_hybrid_term)
-        source_pcd_hybrid_term = o3d.geometry.create_point_cloud_from_rgbd_image(
+        source_pcd_hybrid_term = o3d.geometry.PointCloud.create_from_rgbd_image(
             source_rgbd_image, pinhole_camera_intrinsic)
         source_pcd_hybrid_term.transform(trans_hybrid_term)
         o3d.visualization.draw_geometries([target_pcd, source_pcd_hybrid_term])

--- a/examples/Python/Basic/rgbd_odometry.py
+++ b/examples/Python/Basic/rgbd_odometry.py
@@ -16,9 +16,9 @@ if __name__ == "__main__":
     source_depth = o3d.io.read_image("../../TestData/RGBD/depth/00000.png")
     target_color = o3d.io.read_image("../../TestData/RGBD/color/00001.jpg")
     target_depth = o3d.io.read_image("../../TestData/RGBD/depth/00001.png")
-    source_rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+    source_rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
         source_color, source_depth)
-    target_rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+    target_rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
         target_color, target_depth)
     target_pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         target_rgbd_image, pinhole_camera_intrinsic)

--- a/examples/Python/Basic/rgbd_redwood.py
+++ b/examples/Python/Basic/rgbd_redwood.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     plt.imshow(rgbd_image.depth)
     plt.show()
 
-    pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+    pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         rgbd_image,
         o3d.camera.PinholeCameraIntrinsic(
             o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault))

--- a/examples/Python/Basic/rgbd_redwood.py
+++ b/examples/Python/Basic/rgbd_redwood.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     print("Read Redwood dataset")
     color_raw = o3d.io.read_image("../../TestData/RGBD/color/00000.jpg")
     depth_raw = o3d.io.read_image("../../TestData/RGBD/depth/00000.png")
-    rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+    rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
         color_raw, depth_raw)
     print(rgbd_image)
 

--- a/examples/Python/Basic/rgbd_sun.py
+++ b/examples/Python/Basic/rgbd_sun.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         "../../TestData/RGBD/other_formats/SUN_color.jpg")
     depth_raw = o3d.io.read_image(
         "../../TestData/RGBD/other_formats/SUN_depth.png")
-    rgbd_image = o3d.geometry.create_rgbd_image_from_sun_format(
+    rgbd_image = o3d.geometry.RGBDImage.create_from_sun_format(
         color_raw, depth_raw)
     print(rgbd_image)
     plt.subplot(1, 2, 1)

--- a/examples/Python/Basic/rgbd_sun.py
+++ b/examples/Python/Basic/rgbd_sun.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     plt.title('SUN depth image')
     plt.imshow(rgbd_image.depth)
     plt.show()
-    pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+    pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         rgbd_image,
         o3d.camera.PinholeCameraIntrinsic(
             o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault))

--- a/examples/Python/Basic/rgbd_tum.py
+++ b/examples/Python/Basic/rgbd_tum.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         "../../TestData/RGBD/other_formats/TUM_color.png")
     depth_raw = o3d.io.read_image(
         "../../TestData/RGBD/other_formats/TUM_depth.png")
-    rgbd_image = o3d.geometry.create_rgbd_image_from_tum_format(
+    rgbd_image = o3d.geometry.RGBDImage.create_from_tum_format(
         color_raw, depth_raw)
     print(rgbd_image)
     plt.subplot(1, 2, 1)

--- a/examples/Python/Basic/rgbd_tum.py
+++ b/examples/Python/Basic/rgbd_tum.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     plt.title('TUM depth image')
     plt.imshow(rgbd_image.depth)
     plt.show()
-    pcd = o3d.geometry.create_point_cloud_from_rgbd_image(
+    pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
         rgbd_image,
         o3d.camera.PinholeCameraIntrinsic(
             o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault))

--- a/examples/Python/Basic/transformation.py
+++ b/examples/Python/Basic/transformation.py
@@ -10,7 +10,7 @@ import time
 
 
 def geometry_generator():
-    mesh = o3d.geometry.create_mesh_sphere()
+    mesh = o3d.geometry.TriangleMesh.create_sphere()
     verts = np.asarray(mesh.vertices)
     colors = np.random.uniform(0, 1, size=verts.shape)
     mesh.vertex_colors = o3d.utility.Vector3dVector(colors)
@@ -22,7 +22,7 @@ def geometry_generator():
     pcl.normals = mesh.vertex_normals
     yield pcl
 
-    yield o3d.geometry.create_line_set_from_triangle_mesh(mesh)
+    yield o3d.geometry.LineSet.create_from_triangle_mesh(mesh)
 
     yield mesh
 

--- a/examples/Python/Basic/visualization.py
+++ b/examples/Python/Basic/visualization.py
@@ -14,17 +14,20 @@ if __name__ == "__main__":
     o3d.visualization.draw_geometries([pcd])
 
     print("Let\'s draw some primitives")
-    mesh_box = o3d.geometry.create_mesh_box(width=1.0, height=1.0, depth=1.0)
+    mesh_box = o3d.geometry.TriangleMesh.create_box(width=1.0,
+                                                    height=1.0,
+                                                    depth=1.0)
     mesh_box.compute_vertex_normals()
     mesh_box.paint_uniform_color([0.9, 0.1, 0.1])
-    mesh_sphere = o3d.geometry.create_mesh_sphere(radius=1.0)
+    mesh_sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
     mesh_sphere.compute_vertex_normals()
     mesh_sphere.paint_uniform_color([0.1, 0.1, 0.7])
-    mesh_cylinder = o3d.geometry.create_mesh_cylinder(radius=0.3, height=4.0)
+    mesh_cylinder = o3d.geometry.TriangleMesh.create_cylinder(radius=0.3,
+                                                              height=4.0)
     mesh_cylinder.compute_vertex_normals()
     mesh_cylinder.paint_uniform_color([0.1, 0.9, 0.1])
-    mesh_frame = o3d.geometry.create_mesh_coordinate_frame(size=0.6,
-                                                           origin=[-2, -2, -2])
+    mesh_frame = o3d.geometry.TriangleMesh.create_coordinate_frame(
+        size=0.6, origin=[-2, -2, -2])
 
     print("We draw a few primitives using collection.")
     o3d.visualization.draw_geometries(

--- a/examples/Python/Misc/color_image.py
+++ b/examples/Python/Misc/color_image.py
@@ -44,22 +44,18 @@ if __name__ == "__main__":
     print("Testing basic image processing module.")
     im_raw = mpimg.imread("../../TestData/lena_color.jpg")
     im = o3d.geometry.Image(im_raw)
-    im_g3 = o3d.geometry.filter_image(im,
-                                      o3d.geometry.ImageFilterType.Gaussian3)
-    im_g5 = o3d.geometry.filter_image(im,
-                                      o3d.geometry.ImageFilterType.Gaussian5)
-    im_g7 = o3d.geometry.filter_image(im,
-                                      o3d.geometry.ImageFilterType.Gaussian7)
+    im_g3 = im.filter(o3d.geometry.ImageFilterType.Gaussian3)
+    im_g5 = im.filter(o3d.geometry.ImageFilterType.Gaussian5)
+    im_g7 = im.filter(o3d.geometry.ImageFilterType.Gaussian7)
     im_gaussian = [im, im_g3, im_g5, im_g7]
     pyramid_levels = 4
     pyramid_with_gaussian_filter = True
-    im_pyramid = o3d.geometry.create_image_pyramid(
-        im, pyramid_levels, pyramid_with_gaussian_filter)
-    im_dx = o3d.geometry.filter_image(im, o3d.geometry.ImageFilterType.Sobel3dx)
-    im_dx_pyramid = o3d.geometry.filter_image_pyramid(
+    im_pyramid = im.create_pyramid(pyramid_levels, pyramid_with_gaussian_filter)
+    im_dx = im.filter(o3d.geometry.ImageFilterType.Sobel3dx)
+    im_dx_pyramid = o3d.geometry.Image.filter_pyramid(
         im_pyramid, o3d.geometry.ImageFilterType.Sobel3dx)
-    im_dy = o3d.geometry.filter_image(im, o3d.geometry.ImageFilterType.Sobel3dy)
-    im_dy_pyramid = o3d.geometry.filter_image_pyramid(
+    im_dy = im.filter(o3d.geometry.ImageFilterType.Sobel3dy)
+    im_dy_pyramid = o3d.geometry.Image.filter_pyramid(
         im_pyramid, o3d.geometry.ImageFilterType.Sobel3dy)
     switcher = {
         0: im_gaussian,

--- a/examples/Python/Misc/evaluate_geometric_feature.py
+++ b/examples/Python/Misc/evaluate_geometric_feature.py
@@ -19,13 +19,13 @@ def evaluate(pcd_target, pcd_source, feature_target, feature_source):
 
 if __name__ == "__main__":
     pcd_target = o3d.io.read_point_cloud(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.pcd")
+        "../../TestData/Feature/cloud_bin_0.pcd")
     pcd_source = o3d.io.read_point_cloud(
-        "../../TestData/o3d.registration.Feature/cloud_bin_1.pcd")
+        "../../TestData/Feature/cloud_bin_1.pcd")
     feature_target = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.fpfh.bin")
+        "../../TestData/Feature/cloud_bin_0.fpfh.bin")
     feature_source = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_1.fpfh.bin")
+        "../../TestData/Feature/cloud_bin_1.fpfh.bin")
     pt_dis = evaluate(pcd_target, pcd_source, feature_target, feature_source)
     num_good = sum(pt_dis < 0.075)
     print(

--- a/examples/Python/Misc/feature.py
+++ b/examples/Python/Misc/feature.py
@@ -8,10 +8,8 @@ import open3d as o3d
 if __name__ == "__main__":
 
     print("Load two aligned point clouds.")
-    pcd0 = o3d.io.read_point_cloud(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.pcd")
-    pcd1 = o3d.io.read_point_cloud(
-        "../../TestData/o3d.registration.Feature/cloud_bin_1.pcd")
+    pcd0 = o3d.io.read_point_cloud("../../TestData/Feature/cloud_bin_0.pcd")
+    pcd1 = o3d.io.read_point_cloud("../../TestData/Feature/cloud_bin_1.pcd")
     pcd0.paint_uniform_color([1, 0.706, 0])
     pcd1.paint_uniform_color([0, 0.651, 0.929])
     o3d.visualization.draw_geometries([pcd0, pcd1])
@@ -19,9 +17,9 @@ if __name__ == "__main__":
     print("Black : matching distance > 0.2")
     print("White : matching distance = 0")
     feature0 = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.fpfh.bin")
+        "../../TestData/Feature/cloud_bin_0.fpfh.bin")
     feature1 = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_1.fpfh.bin")
+        "../../TestData/Feature/cloud_bin_1.fpfh.bin")
     fpfh_tree = o3d.geometry.KDTreeFlann(feature1)
     for i in range(len(pcd0.points)):
         [_, idx, _] = fpfh_tree.search_knn_vector_xd(feature0.data[:, i], 1)
@@ -34,10 +32,8 @@ if __name__ == "__main__":
     print("Load their L32D feature and evaluate.")
     print("Black : matching distance > 0.2")
     print("White : matching distance = 0")
-    feature0 = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_0.d32.bin")
-    feature1 = o3d.io.read_feature(
-        "../../TestData/o3d.registration.Feature/cloud_bin_1.d32.bin")
+    feature0 = o3d.io.read_feature("../../TestData/Feature/cloud_bin_0.d32.bin")
+    feature1 = o3d.io.read_feature("../../TestData/Feature/cloud_bin_1.d32.bin")
     fpfh_tree = o3d.geometry.KDTreeFlann(feature1)
     for i in range(len(pcd0.points)):
         [_, idx, _] = fpfh_tree.search_knn_vector_xd(feature0.data[:, i], 1)

--- a/examples/Python/ReconstructionSystem/debug/pairwise_rgbd_alignment.py
+++ b/examples/Python/ReconstructionSystem/debug/pairwise_rgbd_alignment.py
@@ -27,9 +27,9 @@ def test_single_pair(s, t, color_files, depth_files, intrinsic, with_opencv,
                                         config)
     target_rgbd_image = read_rgbd_image(color_files[t], depth_files[t], False,
                                         config)
-    source = o3d.geometry.create_point_cloud_from_rgbd_image(
+    source = o3d.geometry.PointCloud.create_from_rgbd_image(
         source_rgbd_image, intrinsic)
-    target = o3d.geometry.create_point_cloud_from_rgbd_image(
+    target = o3d.geometry.PointCloud.create_from_rgbd_image(
         target_rgbd_image, intrinsic)
     draw_geometries_flip([source, target])
 

--- a/examples/Python/ReconstructionSystem/debug/visualize_alignment.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_alignment.py
@@ -86,10 +86,8 @@ if __name__ == "__main__":
                     ply_file_names[edge.source_node_id])
                 target = o3d.io.read_point_cloud(
                     ply_file_names[edge.target_node_id])
-                source_down = o3d.geometry.voxel_down_sample(
-                    source, config["voxel_size"])
-                target_down = o3d.geometry.voxel_down_sample(
-                    target, config["voxel_size"])
+                source_down = source.voxel_down_sample(config["voxel_size"])
+                target_down = target.voxel_down_sample(config["voxel_size"])
                 print("original registration")
                 draw_registration_result(source_down, target_down,
                                          edge.transformation)

--- a/examples/Python/ReconstructionSystem/debug/visualize_fragments.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_fragments.py
@@ -37,8 +37,7 @@ if __name__ == "__main__":
             print(fragment_files[i])
             pcd = o3d.io.read_point_cloud(fragment_files[i])
             if (args.estimate_normal):
-                o3d.geometry.estimate_normals(
-                    pcd,
+                pcd.estimate_normals(
                     o3d.geometry.KDTreeSearchParamHybrid(
                         radius=config["voxel_size"] * 2.0, max_nn=30))
             draw_geometries_flip([pcd])

--- a/examples/Python/ReconstructionSystem/debug/visualize_pointcloud.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_pointcloud.py
@@ -52,8 +52,7 @@ if __name__ == "__main__":
             pcds = []
             for i in range(len(pose_graph.nodes)):
                 pcd = o3d.io.read_point_cloud(ply_file_names[i])
-                pcd_down = o3d.geometry.voxel_down_sample(
-                    pcd, config["voxel_size"] / 2.0)
+                pcd_down = pcd.voxel_down_sample(config["voxel_size"] / 2.0)
                 pcd_down.transform(pose_graph.nodes[i].pose)
                 print(np.linalg.inv(pose_graph.nodes[i].pose))
                 pcds.append(pcd_down)
@@ -83,10 +82,9 @@ if __name__ == "__main__":
                 print("appending rgbd image %d" % i)
                 rgbd_image = read_rgbd_image(color_files[i], depth_files[i],
                                              False, config)
-                pcd_i = o3d.geometry.create_point_cloud_from_rgbd_image(
+                pcd_i = o3d.geometry.PointCloud.create_from_rgbd_image(
                     rgbd_image, pinhole_camera_intrinsic,
                     np.linalg.inv(pose_graph.nodes[i - sid].pose))
-                pcd_i_down = o3d.geometry.voxel_down_sample(
-                    pcd_i, config["voxel_size"])
+                pcd_i_down = pcd_i.voxel_down_sample(config["voxel_size"])
                 pcds.append(pcd_i_down)
             draw_geometries_flip(pcds)

--- a/examples/Python/ReconstructionSystem/make_fragments.py
+++ b/examples/Python/ReconstructionSystem/make_fragments.py
@@ -24,7 +24,7 @@ def read_rgbd_image(color_file, depth_file, convert_rgb_to_intensity, config):
     color = o3d.io.read_image(color_file)
     depth = o3d.io.read_image(depth_file)
     if config["depth_map_type"] == "redwood":
-        rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
             color,
             depth,
             depth_trunc=config["max_depth"],

--- a/examples/Python/ReconstructionSystem/refine_registration.py
+++ b/examples/Python/ReconstructionSystem/refine_registration.py
@@ -47,8 +47,8 @@ def multiscale_icp(source,
         iter = max_iter[scale]
         distance_threshold = config["voxel_size"] * 1.4
         print("voxel_size %f" % voxel_size[scale])
-        source_down = o3d.geometry.voxel_down_sample(source, voxel_size[scale])
-        target_down = o3d.geometry.voxel_down_sample(target, voxel_size[scale])
+        source_down = source.voxel_down_sample(voxel_size[scale])
+        target_down = target.voxel_down_sample(voxel_size[scale])
         if config["icp_method"] == "point_to_point":
             result_icp = o3d.registration.registration_icp(
                 source_down, target_down, distance_threshold,
@@ -56,13 +56,11 @@ def multiscale_icp(source,
                 o3d.registration.TransformationEstimationPointToPoint(),
                 o3d.registration.ICPConvergenceCriteria(max_iteration=iter))
         else:
-            o3d.geometry.estimate_normals(
-                source_down,
+            source_down.estimate_normals(
                 o3d.geometry.KDTreeSearchParamHybrid(radius=voxel_size[scale] *
                                                      2.0,
                                                      max_nn=30))
-            o3d.geometry.estimate_normals(
-                target_down,
+            target_down.estimate_normals(
                 o3d.geometry.KDTreeSearchParamHybrid(radius=voxel_size[scale] *
                                                      2.0,
                                                      max_nn=30))

--- a/examples/Python/ReconstructionSystem/register_fragments.py
+++ b/examples/Python/ReconstructionSystem/register_fragments.py
@@ -17,9 +17,8 @@ from refine_registration import multiscale_icp
 
 def preprocess_point_cloud(pcd, config):
     voxel_size = config["voxel_size"]
-    pcd_down = o3d.geometry.voxel_down_sample(pcd, voxel_size)
-    o3d.geometry.estimate_normals(
-        pcd_down,
+    pcd_down = pcd.voxel_down_sample(voxel_size)
+    pcd_down.estimate_normals(
         o3d.geometry.KDTreeSearchParamHybrid(radius=voxel_size * 2.0,
                                              max_nn=30))
     pcd_fpfh = o3d.registration.compute_fpfh_feature(

--- a/examples/Python/ReconstructionSystem/sensors/realsense_pcd_visualizer.py
+++ b/examples/Python/ReconstructionSystem/sensors/realsense_pcd_visualizer.py
@@ -93,13 +93,13 @@ if __name__ == "__main__":
             color_temp = np.asarray(color_frame.get_data())
             color_image = o3d.geometry.Image(color_temp)
 
-            rgbd_image = o3d.geometry.create_rgbd_image_from_color_and_depth(
+            rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
                 color_image,
                 depth_image,
                 depth_scale=1.0 / depth_scale,
                 depth_trunc=clipping_distance_in_meters,
                 convert_rgb_to_intensity=False)
-            temp = o3d.geometry.create_point_cloud_from_rgbd_image(
+            temp = o3d.geometry.PointCloud.create_from_rgbd_image(
                 rgbd_image, intrinsic)
             temp.transform(flip_transform)
             pcd.points = temp.points

--- a/src/Open3D/ColorMap/ColorMapOptimization.cpp
+++ b/src/Open3D/ColorMap/ColorMapOptimization.cpp
@@ -226,13 +226,13 @@ CreateGradientImages(
     std::vector<std::shared_ptr<geometry::Image>> images_color;
     std::vector<std::shared_ptr<geometry::Image>> images_depth;
     for (auto i = 0; i < images_rgbd.size(); i++) {
-        auto gray_image = images_rgbd[i]->color_.CreateFloatImageFromImage();
+        auto gray_image = images_rgbd[i]->color_.CreateFloatImage();
         auto gray_image_filtered =
-                gray_image->FilterImage(geometry::Image::FilterType::Gaussian3);
+                gray_image->Filter(geometry::Image::FilterType::Gaussian3);
         images_gray.push_back(gray_image_filtered);
-        images_dx.push_back(gray_image_filtered->FilterImage(
+        images_dx.push_back(gray_image_filtered->Filter(
                 geometry::Image::FilterType::Sobel3Dx));
-        images_dy.push_back(gray_image_filtered->FilterImage(
+        images_dy.push_back(gray_image_filtered->Filter(
                 geometry::Image::FilterType::Sobel3Dy));
         auto color = std::make_shared<geometry::Image>(images_rgbd[i]->color_);
         auto depth = std::make_shared<geometry::Image>(images_rgbd[i]->depth_);

--- a/src/Open3D/ColorMap/ColorMapOptimization.cpp
+++ b/src/Open3D/ColorMap/ColorMapOptimization.cpp
@@ -226,14 +226,14 @@ CreateGradientImages(
     std::vector<std::shared_ptr<geometry::Image>> images_color;
     std::vector<std::shared_ptr<geometry::Image>> images_depth;
     for (auto i = 0; i < images_rgbd.size(); i++) {
-        auto gray_image = CreateFloatImageFromImage(images_rgbd[i]->color_);
-        auto gray_image_filtered = geometry::FilterImage(
-                *gray_image, geometry::Image::FilterType::Gaussian3);
+        auto gray_image = images_rgbd[i]->color_.CreateFloatImageFromImage();
+        auto gray_image_filtered =
+                gray_image->FilterImage(geometry::Image::FilterType::Gaussian3);
         images_gray.push_back(gray_image_filtered);
-        images_dx.push_back(geometry::FilterImage(
-                *gray_image_filtered, geometry::Image::FilterType::Sobel3Dx));
-        images_dy.push_back(geometry::FilterImage(
-                *gray_image_filtered, geometry::Image::FilterType::Sobel3Dy));
+        images_dx.push_back(gray_image_filtered->FilterImage(
+                geometry::Image::FilterType::Sobel3Dx));
+        images_dy.push_back(gray_image_filtered->FilterImage(
+                geometry::Image::FilterType::Sobel3Dy));
         auto color = std::make_shared<geometry::Image>(images_rgbd[i]->color_);
         auto depth = std::make_shared<geometry::Image>(images_rgbd[i]->depth_);
         images_color.push_back(color);
@@ -251,8 +251,7 @@ std::vector<std::shared_ptr<geometry::Image>> CreateDepthBoundaryMasks(
     for (auto i = 0; i < n_images; i++) {
         utility::PrintDebug("[MakeDepthMasks] geometry::Image %d/%d\n", i,
                             n_images);
-        masks.push_back(geometry::CreateDepthBoundaryMask(
-                *images_depth[i],
+        masks.push_back(images_depth[i]->CreateDepthBoundaryMask(
                 option.depth_threshold_for_discontinuity_check_,
                 option.half_dilation_kernel_size_for_discontinuity_map_));
     }

--- a/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.cpp
+++ b/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.cpp
@@ -76,11 +76,9 @@ CreateVertexAndImageVisibility(
             int u_d = int(round(u)), v_d = int(round(v));
             if (d < 0.0 || !images_depth[c]->TestImageBoundary(u_d, v_d))
                 continue;
-            float d_sensor =
-                    *geometry::PointerAt<float>(*images_depth[c], u_d, v_d);
+            float d_sensor = *images_depth[c]->PointerAt<float>(u_d, v_d);
             if (d_sensor > maximum_allowable_depth) continue;
-            if (*geometry::PointerAt<unsigned char>(*images_mask[c], u_d,
-                                                    v_d) == 255)
+            if (*images_mask[c]->PointerAt<unsigned char>(u_d, v_d) == 255)
                 continue;
             if (std::fabs(d - d_sensor) < depth_threshold_for_visiblity_check) {
 #ifdef _OPENMP
@@ -115,11 +113,10 @@ std::tuple<bool, T> QueryImageIntensity(
         int u_round = int(round(u));
         int v_round = int(round(v));
         if (ch == -1) {
-            return std::make_tuple(
-                    true, *geometry::PointerAt<T>(img, u_round, v_round));
+            return std::make_tuple(true, *img.PointerAt<T>(u_round, v_round));
         } else {
-            return std::make_tuple(
-                    true, *geometry::PointerAt<T>(img, u_round, v_round, ch));
+            return std::make_tuple(true,
+                                   *img.PointerAt<T>(u_round, v_round, ch));
         }
     } else {
         return std::make_tuple(false, 0);
@@ -144,12 +141,11 @@ std::tuple<bool, T> QueryImageIntensity(
             int u_shift = int(round(uv_shift(0)));
             int v_shift = int(round(uv_shift(1)));
             if (ch == -1) {
-                return std::make_tuple(
-                        true, *geometry::PointerAt<T>(img, u_shift, v_shift));
+                return std::make_tuple(true,
+                                       *img.PointerAt<T>(u_shift, v_shift));
             } else {
-                return std::make_tuple(
-                        true,
-                        *geometry::PointerAt<T>(img, u_shift, v_shift, ch));
+                return std::make_tuple(true,
+                                       *img.PointerAt<T>(u_shift, v_shift, ch));
             }
         }
     }

--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -141,54 +141,52 @@ private:
 }  // unnamed namespace
 
 namespace geometry {
-std::shared_ptr<PointCloud> SelectDownSample(const PointCloud &input,
-                                             const std::vector<size_t> &indices,
-                                             bool invert /* = false */) {
+std::shared_ptr<PointCloud> PointCloud::SelectDownSample(
+        const std::vector<size_t> &indices, bool invert /* = false */) const {
     auto output = std::make_shared<PointCloud>();
-    bool has_normals = input.HasNormals();
-    bool has_colors = input.HasColors();
+    bool has_normals = HasNormals();
+    bool has_colors = HasColors();
 
-    std::vector<bool> mask = std::vector<bool>(input.points_.size(), invert);
+    std::vector<bool> mask = std::vector<bool>(points_.size(), invert);
     for (size_t i : indices) {
         mask[i] = !invert;
     }
 
-    for (size_t i = 0; i < input.points_.size(); i++) {
+    for (size_t i = 0; i < points_.size(); i++) {
         if (mask[i]) {
-            output->points_.push_back(input.points_[i]);
-            if (has_normals) output->normals_.push_back(input.normals_[i]);
-            if (has_colors) output->colors_.push_back(input.colors_[i]);
+            output->points_.push_back(points_[i]);
+            if (has_normals) output->normals_.push_back(normals_[i]);
+            if (has_colors) output->colors_.push_back(colors_[i]);
         }
     }
     utility::PrintDebug(
             "Pointcloud down sampled from %d points to %d points.\n",
-            (int)input.points_.size(), (int)output->points_.size());
+            (int)points_.size(), (int)output->points_.size());
     return output;
 }
 
-std::shared_ptr<TriangleMesh> SelectDownSample(
-        const TriangleMesh &input, const std::vector<size_t> &indices) {
+std::shared_ptr<TriangleMesh> TriangleMesh::SelectDownSample(
+        const std::vector<size_t> &indices) const {
     auto output = std::make_shared<TriangleMesh>();
-    bool has_triangle_normals = input.HasTriangleNormals();
-    bool has_vertex_normals = input.HasVertexNormals();
-    bool has_vertex_colors = input.HasVertexColors();
+    bool has_triangle_normals = HasTriangleNormals();
+    bool has_vertex_normals = HasVertexNormals();
+    bool has_vertex_colors = HasVertexColors();
     // For each vertex, list face indices.
-    std::vector<std::vector<int>> vertex_to_triangle_temp(
-            input.vertices_.size());
+    std::vector<std::vector<int>> vertex_to_triangle_temp(vertices_.size());
     int triangle_id = 0;
-    for (auto trangle : input.triangles_) {
+    for (auto trangle : triangles_) {
         for (int i = 0; i < 3; i++)
             vertex_to_triangle_temp[trangle(i)].push_back(triangle_id);
         triangle_id++;
     }
     // Remove face indices of vertex_to_triangle_temp
     // if it does not correspond to selected vertices
-    std::vector<std::vector<int>> vertex_to_triangle(input.vertices_.size());
+    std::vector<std::vector<int>> vertex_to_triangle(vertices_.size());
     for (auto vertex_id : indices) {
         vertex_to_triangle[vertex_id] = vertex_to_triangle_temp[vertex_id];
     }
     // Make a triangle_to_vertex using vertex_to_triangle
-    std::vector<std::vector<int>> triangle_to_vertex(input.triangles_.size());
+    std::vector<std::vector<int>> triangle_to_vertex(triangles_.size());
     int vertex_id = 0;
     for (auto face_ids : vertex_to_triangle) {
         for (auto face_id : face_ids)
@@ -197,14 +195,14 @@ std::shared_ptr<TriangleMesh> SelectDownSample(
     }
     // Only a face with three selected points contributes to mark
     // mask_observed_vertex.
-    std::vector<bool> mask_observed_vertex(input.vertices_.size());
+    std::vector<bool> mask_observed_vertex(vertices_.size());
     for (auto vertex_ids : triangle_to_vertex) {
         if ((int)vertex_ids.size() == 3)
             for (int i = 0; i < 3; i++)
                 mask_observed_vertex[vertex_ids[i]] = true;
     }
     // Rename vertex id based on selected points
-    std::vector<int> new_vertex_id(input.vertices_.size());
+    std::vector<int> new_vertex_id(vertices_.size());
     for (auto i = 0, cnt = 0; i < mask_observed_vertex.size(); i++) {
         if (mask_observed_vertex[i]) new_vertex_id[i] = cnt++;
     }
@@ -214,22 +212,22 @@ std::shared_ptr<TriangleMesh> SelectDownSample(
         if ((int)vertex_ids.size() == 3) {
             Eigen::Vector3i new_face;
             for (int i = 0; i < 3; i++)
-                new_face(i) = new_vertex_id[input.triangles_[triangle_id][i]];
+                new_face(i) = new_vertex_id[triangles_[triangle_id][i]];
             output->triangles_.push_back(new_face);
             if (has_triangle_normals)
                 output->triangle_normals_.push_back(
-                        input.triangle_normals_[triangle_id]);
+                        triangle_normals_[triangle_id]);
         }
         triangle_id++;
     }
     // Push marked vertex.
     for (auto i = 0; i < mask_observed_vertex.size(); i++) {
         if (mask_observed_vertex[i]) {
-            output->vertices_.push_back(input.vertices_[i]);
+            output->vertices_.push_back(vertices_[i]);
             if (has_vertex_normals)
-                output->vertex_normals_.push_back(input.vertex_normals_[i]);
+                output->vertex_normals_.push_back(vertex_normals_[i]);
             if (has_vertex_colors)
-                output->vertex_colors_.push_back(input.vertex_colors_[i]);
+                output->vertex_colors_.push_back(vertex_colors_[i]);
         }
     }
     output->RemoveDuplicatedVertices();
@@ -239,13 +237,13 @@ std::shared_ptr<TriangleMesh> SelectDownSample(
     utility::PrintDebug(
             "Triangle mesh sampled from %d vertices and %d triangles to %d "
             "vertices and %d triangles.\n",
-            (int)input.vertices_.size(), (int)input.triangles_.size(),
+            (int)vertices_.size(), (int)triangles_.size(),
             (int)output->vertices_.size(), (int)output->triangles_.size());
     return output;
 }
 
-std::shared_ptr<PointCloud> VoxelDownSample(const PointCloud &input,
-                                            double voxel_size) {
+std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
+        double voxel_size) const {
     auto output = std::make_shared<PointCloud>();
     if (voxel_size <= 0.0) {
         utility::PrintDebug("[VoxelDownSample] voxel_size <= 0.\n");
@@ -253,8 +251,8 @@ std::shared_ptr<PointCloud> VoxelDownSample(const PointCloud &input,
     }
     Eigen::Vector3d voxel_size3 =
             Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
-    Eigen::Vector3d voxel_min_bound = input.GetMinBound() - voxel_size3 * 0.5;
-    Eigen::Vector3d voxel_max_bound = input.GetMaxBound() + voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_min_bound = GetMinBound() - voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
         utility::PrintDebug("[VoxelDownSample] voxel_size is too small.\n");
@@ -266,14 +264,14 @@ std::shared_ptr<PointCloud> VoxelDownSample(const PointCloud &input,
 
     Eigen::Vector3d ref_coord;
     Eigen::Vector3i voxel_index;
-    for (int i = 0; i < (int)input.points_.size(); i++) {
-        ref_coord = (input.points_[i] - voxel_min_bound) / voxel_size;
+    for (int i = 0; i < (int)points_.size(); i++) {
+        ref_coord = (points_[i] - voxel_min_bound) / voxel_size;
         voxel_index << int(floor(ref_coord(0))), int(floor(ref_coord(1))),
                 int(floor(ref_coord(2)));
-        voxelindex_to_accpoint[voxel_index].AddPoint(input, i);
+        voxelindex_to_accpoint[voxel_index].AddPoint(*this, i);
     }
-    bool has_normals = input.HasNormals();
-    bool has_colors = input.HasColors();
+    bool has_normals = HasNormals();
+    bool has_colors = HasColors();
     for (auto accpoint : voxelindex_to_accpoint) {
         output->points_.push_back(accpoint.second.GetAveragePoint());
         if (has_normals) {
@@ -285,16 +283,15 @@ std::shared_ptr<PointCloud> VoxelDownSample(const PointCloud &input,
     }
     utility::PrintDebug(
             "Pointcloud down sampled from %d points to %d points.\n",
-            (int)input.points_.size(), (int)output->points_.size());
+            (int)points_.size(), (int)output->points_.size());
     return output;
 }
 
 std::tuple<std::shared_ptr<PointCloud>, Eigen::MatrixXi>
-VoxelDownSampleAndTrace(const PointCloud &input,
-                        double voxel_size,
-                        const Eigen::Vector3d &min_bound,
-                        const Eigen::Vector3d &max_bound,
-                        bool approximate_class) {
+PointCloud::VoxelDownSampleAndTrace(double voxel_size,
+                                    const Eigen::Vector3d &min_bound,
+                                    const Eigen::Vector3d &max_bound,
+                                    bool approximate_class) const {
     auto output = std::make_shared<PointCloud>();
     Eigen::MatrixXi cubic_id;
     if (voxel_size <= 0.0) {
@@ -314,8 +311,8 @@ VoxelDownSampleAndTrace(const PointCloud &input,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
             voxelindex_to_accpoint;
     int cid_temp[3] = {1, 2, 4};
-    for (size_t i = 0; i < input.points_.size(); i++) {
-        auto ref_coord = (input.points_[i] - voxel_min_bound) / voxel_size;
+    for (size_t i = 0; i < points_.size(); i++) {
+        auto ref_coord = (points_[i] - voxel_min_bound) / voxel_size;
         auto voxel_index = Eigen::Vector3i(int(floor(ref_coord(0))),
                                            int(floor(ref_coord(1))),
                                            int(floor(ref_coord(2))));
@@ -325,11 +322,11 @@ VoxelDownSampleAndTrace(const PointCloud &input,
                 cid += cid_temp[c];
             }
         }
-        voxelindex_to_accpoint[voxel_index].AddPoint(input, i, cid,
+        voxelindex_to_accpoint[voxel_index].AddPoint(*this, i, cid,
                                                      approximate_class);
     }
-    bool has_normals = input.HasNormals();
-    bool has_colors = input.HasColors();
+    bool has_normals = HasNormals();
+    bool has_colors = HasColors();
     int cnt = 0;
     cubic_id.resize(voxelindex_to_accpoint.size(), 8);
     cubic_id.setConstant(-1);
@@ -355,26 +352,26 @@ VoxelDownSampleAndTrace(const PointCloud &input,
     }
     utility::PrintDebug(
             "Pointcloud down sampled from %d points to %d points.\n",
-            (int)input.points_.size(), (int)output->points_.size());
+            (int)points_.size(), (int)output->points_.size());
     return std::make_tuple(output, cubic_id);
 }
 
-std::shared_ptr<PointCloud> UniformDownSample(const PointCloud &input,
-                                              size_t every_k_points) {
+std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
+        size_t every_k_points) const {
     if (every_k_points == 0) {
         utility::PrintDebug("[UniformDownSample] Illegal sample rate.\n");
         return std::make_shared<PointCloud>();
     }
     std::vector<size_t> indices;
-    for (size_t i = 0; i < input.points_.size(); i += every_k_points) {
+    for (size_t i = 0; i < points_.size(); i += every_k_points) {
         indices.push_back(i);
     }
-    return SelectDownSample(input, indices);
+    return SelectDownSample(indices);
 }
 
-std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input,
-                                           const Eigen::Vector3d &min_bound,
-                                           const Eigen::Vector3d &max_bound) {
+std::shared_ptr<PointCloud> PointCloud::Crop(
+        const Eigen::Vector3d &min_bound,
+        const Eigen::Vector3d &max_bound) const {
     if (min_bound(0) > max_bound(0) || min_bound(1) > max_bound(1) ||
         min_bound(2) > max_bound(2)) {
         utility::PrintDebug(
@@ -382,21 +379,19 @@ std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input,
         return std::make_shared<PointCloud>();
     }
     std::vector<size_t> indices;
-    for (size_t i = 0; i < input.points_.size(); i++) {
-        const auto &point = input.points_[i];
+    for (size_t i = 0; i < points_.size(); i++) {
+        const auto &point = points_[i];
         if (point(0) >= min_bound(0) && point(0) <= max_bound(0) &&
             point(1) >= min_bound(1) && point(1) <= max_bound(1) &&
             point(2) >= min_bound(2) && point(2) <= max_bound(2)) {
             indices.push_back(i);
         }
     }
-    return SelectDownSample(input, indices);
+    return SelectDownSample(indices);
 }
 
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
-RemoveRadiusOutliers(const PointCloud &input,
-                     size_t nb_points,
-                     double search_radius) {
+PointCloud::RemoveRadiusOutliers(size_t nb_points, double search_radius) const {
     if (nb_points < 1 || search_radius <= 0) {
         utility::PrintDebug(
                 "[RemoveRadiusOutliers] Illegal input parameters,"
@@ -405,15 +400,15 @@ RemoveRadiusOutliers(const PointCloud &input,
                                std::vector<size_t>());
     }
     KDTreeFlann kdtree;
-    kdtree.SetGeometry(input);
-    std::vector<bool> mask = std::vector<bool>(input.points_.size());
+    kdtree.SetGeometry(*this);
+    std::vector<bool> mask = std::vector<bool>(points_.size());
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (auto i = 0; i < input.points_.size(); i++) {
+    for (auto i = 0; i < points_.size(); i++) {
         std::vector<int> tmp_indices;
         std::vector<double> dist;
-        int nb_neighbors = kdtree.SearchRadius(input.points_[i], search_radius,
+        int nb_neighbors = kdtree.SearchRadius(points_[i], search_radius,
                                                tmp_indices, dist);
         mask[i] = (nb_neighbors > nb_points);
     }
@@ -423,13 +418,12 @@ RemoveRadiusOutliers(const PointCloud &input,
             indices.push_back(i);
         }
     }
-    return std::make_tuple(SelectDownSample(input, indices), indices);
+    return std::make_tuple(SelectDownSample(indices), indices);
 }
 
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
-RemoveStatisticalOutliers(const PointCloud &input,
-                          size_t nb_neighbors,
-                          double std_ratio) {
+PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
+                                      double std_ratio) const {
     if (nb_neighbors < 1 || std_ratio <= 0) {
         utility::PrintDebug(
                 "[RemoveStatisticalOutliers] Illegal input parameters, number "
@@ -438,23 +432,22 @@ RemoveStatisticalOutliers(const PointCloud &input,
         return std::make_tuple(std::make_shared<PointCloud>(),
                                std::vector<size_t>());
     }
-    if (input.points_.size() == 0) {
+    if (points_.size() == 0) {
         return std::make_tuple(std::make_shared<PointCloud>(),
                                std::vector<size_t>());
     }
     KDTreeFlann kdtree;
-    kdtree.SetGeometry(input);
-    std::vector<double> avg_distances =
-            std::vector<double>(input.points_.size());
+    kdtree.SetGeometry(*this);
+    std::vector<double> avg_distances = std::vector<double>(points_.size());
     std::vector<size_t> indices;
     size_t valid_distances = 0;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (auto i = 0; i < input.points_.size(); i++) {
+    for (auto i = 0; i < points_.size(); i++) {
         std::vector<int> tmp_indices;
         std::vector<double> dist;
-        kdtree.SearchKNN(input.points_[i], nb_neighbors, tmp_indices, dist);
+        kdtree.SearchKNN(points_[i], nb_neighbors, tmp_indices, dist);
         double mean = -1;
         if (dist.size() > 0) {
             valid_distances++;
@@ -484,13 +477,12 @@ RemoveStatisticalOutliers(const PointCloud &input,
             indices.push_back(i);
         }
     }
-    return std::make_tuple(SelectDownSample(input, indices), indices);
+    return std::make_tuple(SelectDownSample(indices), indices);
 }
 
-std::shared_ptr<TriangleMesh> CropTriangleMesh(
-        const TriangleMesh &input,
+std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
         const Eigen::Vector3d &min_bound,
-        const Eigen::Vector3d &max_bound) {
+        const Eigen::Vector3d &max_bound) const {
     if (min_bound(0) > max_bound(0) || min_bound(1) > max_bound(1) ||
         min_bound(2) > max_bound(2)) {
         utility::PrintDebug(
@@ -498,15 +490,15 @@ std::shared_ptr<TriangleMesh> CropTriangleMesh(
         return std::make_shared<TriangleMesh>();
     }
     std::vector<size_t> indices;
-    for (size_t i = 0; i < input.vertices_.size(); i++) {
-        const auto &point = input.vertices_[i];
+    for (size_t i = 0; i < vertices_.size(); i++) {
+        const auto &point = vertices_[i];
         if (point(0) >= min_bound(0) && point(0) <= max_bound(0) &&
             point(1) >= min_bound(1) && point(1) <= max_bound(1) &&
             point(2) >= min_bound(2) && point(2) <= max_bound(2)) {
             indices.push_back(i);
         }
     }
-    return SelectDownSample(input, indices);
+    return SelectDownSample(indices);
 }
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/Geometry.h
+++ b/src/Open3D/Geometry/Geometry.h
@@ -50,7 +50,7 @@ protected:
         : geometry_type_(type), dimension_(dimension) {}
 
 public:
-    virtual void Clear() = 0;
+    virtual Geometry& Clear() = 0;
     virtual bool IsEmpty() const = 0;
     GeometryType GetGeometryType() const { return geometry_type_; }
     int Dimension() const { return dimension_; }

--- a/src/Open3D/Geometry/Geometry2D.h
+++ b/src/Open3D/Geometry/Geometry2D.h
@@ -41,7 +41,7 @@ protected:
     Geometry2D(GeometryType type) : Geometry(type, 2) {}
 
 public:
-    void Clear() override = 0;
+    Geometry& Clear() override = 0;
     bool IsEmpty() const override = 0;
     virtual Eigen::Vector2d GetMinBound() const = 0;
     virtual Eigen::Vector2d GetMaxBound() const = 0;

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -45,7 +45,7 @@ protected:
     Geometry3D(GeometryType type) : Geometry(type, 3) {}
 
 public:
-    void Clear() override = 0;
+    Geometry3D& Clear() override = 0;
     bool IsEmpty() const override = 0;
     virtual Eigen::Vector3d GetMinBound() const = 0;
     virtual Eigen::Vector3d GetMaxBound() const = 0;

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -26,13 +26,15 @@
 
 #include "Open3D/Geometry/HalfEdgeTriangleMesh.h"
 
+#include <numeric>
+
 #include "Open3D/Utility/Console.h"
 #include "Open3D/Utility/Helper.h"
 
 namespace open3d {
 namespace geometry {
 
-HalfEdgeTriangleMesh::HalfEdge::HalfEdge(const Eigen::Vector2i& vertex_indices,
+HalfEdgeTriangleMesh::HalfEdge::HalfEdge(const Eigen::Vector2i &vertex_indices,
                                          int triangle_index,
                                          int next,
                                          int twin)
@@ -41,10 +43,11 @@ HalfEdgeTriangleMesh::HalfEdge::HalfEdge(const Eigen::Vector2i& vertex_indices,
       next_(next),
       twin_(twin) {}
 
-void HalfEdgeTriangleMesh::Clear() {
-    TriangleMesh::Clear();
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Clear() {
+    // TriangleMesh::Clear();
     half_edges_.clear();
     ordered_half_edge_from_vertex_.clear();
+    return *this;
 }
 
 bool HalfEdgeTriangleMesh::ComputeHalfEdges() {
@@ -60,7 +63,7 @@ bool HalfEdgeTriangleMesh::ComputeHalfEdges() {
 
     for (size_t triangle_index = 0; triangle_index < triangles_.size();
          triangle_index++) {
-        const Eigen::Vector3i& triangle = triangles_[triangle_index];
+        const Eigen::Vector3i &triangle = triangles_[triangle_index];
         size_t num_half_edges = half_edges_.size();
 
         size_t he_0_index = num_half_edges;
@@ -96,7 +99,7 @@ bool HalfEdgeTriangleMesh::ComputeHalfEdges() {
     // each half-edge can have at most one twin half-edge.
     for (size_t this_he_index = 0; this_he_index < half_edges_.size();
          this_he_index++) {
-        HalfEdge& this_he = half_edges_[this_he_index];
+        HalfEdge &this_he = half_edges_[this_he_index];
         Eigen::Vector2i twin_end_points(this_he.vertex_indices_(1),
                                         this_he.vertex_indices_(0));
         if (this_he.twin_ == -1 &&
@@ -104,7 +107,7 @@ bool HalfEdgeTriangleMesh::ComputeHalfEdges() {
                     vertex_indices_to_half_edge_index.end()) {
             size_t twin_he_index =
                     vertex_indices_to_half_edge_index[twin_end_points];
-            HalfEdge& twin_he = half_edges_[twin_he_index];
+            HalfEdge &twin_he = half_edges_[twin_he_index];
             this_he.twin_ = int(twin_he_index);
             twin_he.twin_ = int(this_he_index);
         }
@@ -127,7 +130,7 @@ bool HalfEdgeTriangleMesh::ComputeHalfEdges() {
          vertex_index++) {
         size_t num_boundaries = 0;
         int init_half_edge_index = 0;
-        for (const int& half_edge_index :
+        for (const int &half_edge_index :
              half_edges_from_vertex[vertex_index]) {
             if (bool is_boundary = half_edges_[half_edge_index].IsBoundary()) {
                 num_boundaries++;
@@ -165,11 +168,11 @@ bool HalfEdgeTriangleMesh::HasHalfEdges() const {
 }
 
 int HalfEdgeTriangleMesh::NextHalfEdgeFromVertex(int half_edge_index) const {
-    const HalfEdge& curr_he = half_edges_[half_edge_index];
+    const HalfEdge &curr_he = half_edges_[half_edge_index];
     int next_he_index = curr_he.next_;
-    const HalfEdge& next_he = half_edges_[next_he_index];
+    const HalfEdge &next_he = half_edges_[next_he_index];
     int next_next_he_index = next_he.next_;
-    const HalfEdge& next_next_he = half_edges_[next_next_he_index];
+    const HalfEdge &next_next_he = half_edges_[next_next_he_index];
     int next_next_twin_he_index = next_next_he.twin_;
     return next_next_twin_he_index;
 }
@@ -177,7 +180,7 @@ int HalfEdgeTriangleMesh::NextHalfEdgeFromVertex(int half_edge_index) const {
 std::vector<int> HalfEdgeTriangleMesh::BoundaryHalfEdgesFromVertex(
         int vertex_index) const {
     int init_he_index = ordered_half_edge_from_vertex_[vertex_index][0];
-    const HalfEdge& init_he = half_edges_[init_he_index];
+    const HalfEdge &init_he = half_edges_[init_he_index];
 
     if (!init_he.IsBoundary()) {
         utility::PrintWarning("The vertex %d is not on boundary.\n",
@@ -201,7 +204,7 @@ std::vector<int> HalfEdgeTriangleMesh::BoundaryVerticesFromVertex(
     std::vector<int> boundary_half_edges =
             BoundaryHalfEdgesFromVertex(vertex_index);
     std::vector<int> boundary_vertices;
-    for (const int& half_edge_idx : boundary_half_edges) {
+    for (const int &half_edge_idx : boundary_half_edges) {
         boundary_vertices.push_back(
                 half_edges_[half_edge_idx].vertex_indices_(0));
     }
@@ -230,6 +233,120 @@ std::vector<std::vector<int>> HalfEdgeTriangleMesh::GetBoundaries() const {
         visited.insert(vertex_ind);
     }
     return boundaries;
+}
+
+bool HalfEdgeTriangleMesh::IsEmpty() const { return !HasVertices(); }
+
+Eigen::Vector3d HalfEdgeTriangleMesh::GetMinBound() const {
+    if (!HasVertices()) {
+        return Eigen::Vector3d(0.0, 0.0, 0.0);
+    }
+    auto itr_x = std::min_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(0) < b(0);
+            });
+    auto itr_y = std::min_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(1) < b(1);
+            });
+    auto itr_z = std::min_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(2) < b(2);
+            });
+    return Eigen::Vector3d((*itr_x)(0), (*itr_y)(1), (*itr_z)(2));
+}
+
+Eigen::Vector3d HalfEdgeTriangleMesh::GetMaxBound() const {
+    if (!HasVertices()) {
+        return Eigen::Vector3d(0.0, 0.0, 0.0);
+    }
+    auto itr_x = std::max_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(0) < b(0);
+            });
+    auto itr_y = std::max_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(1) < b(1);
+            });
+    auto itr_z = std::max_element(
+            vertices_.begin(), vertices_.end(),
+            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
+                return a(2) < b(2);
+            });
+    return Eigen::Vector3d((*itr_x)(0), (*itr_y)(1), (*itr_z)(2));
+}
+
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Transform(
+        const Eigen::Matrix4d &transformation) {
+    for (auto &vertex : vertices_) {
+        Eigen::Vector4d new_point =
+                transformation *
+                Eigen::Vector4d(vertex(0), vertex(1), vertex(2), 1.0);
+        vertex = new_point.block<3, 1>(0, 0);
+    }
+    for (auto &vertex_normal : vertex_normals_) {
+        Eigen::Vector4d new_normal =
+                transformation * Eigen::Vector4d(vertex_normal(0),
+                                                 vertex_normal(1),
+                                                 vertex_normal(2), 0.0);
+        vertex_normal = new_normal.block<3, 1>(0, 0);
+    }
+    for (auto &triangle_normal : triangle_normals_) {
+        Eigen::Vector4d new_normal =
+                transformation * Eigen::Vector4d(triangle_normal(0),
+                                                 triangle_normal(1),
+                                                 triangle_normal(2), 0.0);
+        triangle_normal = new_normal.block<3, 1>(0, 0);
+    }
+    return *this;
+}
+
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Translate(
+        const Eigen::Vector3d &translation) {
+    for (auto &vertex : vertices_) {
+        vertex += translation;
+    }
+    return *this;
+}
+
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Scale(const double scale,
+                                                  bool center) {
+    Eigen::Vector3d vertex_center(0, 0, 0);
+    if (center && !vertices_.empty()) {
+        vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
+                                        vertex_center);
+        vertex_center /= vertices_.size();
+    }
+    for (auto &vertex : vertices_) {
+        vertex = (vertex - vertex_center) * scale + vertex_center;
+    }
+    return *this;
+}
+
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Rotate(
+        const Eigen::Vector3d &rotation, bool center, RotationType type) {
+    Eigen::Vector3d vertex_center(0, 0, 0);
+    if (center && !vertices_.empty()) {
+        vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
+                                        vertex_center);
+        vertex_center /= vertices_.size();
+    }
+    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
+    for (auto &vertex : vertices_) {
+        vertex = R * (vertex - vertex_center) + vertex_center;
+    }
+    for (auto &normal : vertex_normals_) {
+        normal = R * normal;
+    }
+    for (auto &normal : triangle_normals_) {
+        normal = R * normal;
+    }
+    return *this;
 }
 
 int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
@@ -263,7 +380,7 @@ int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
 }
 
 std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(
-        const TriangleMesh& mesh) {
+        const TriangleMesh &mesh) {
     auto half_edge_mesh = std::make_shared<HalfEdgeTriangleMesh>();
 
     // Copy
@@ -290,41 +407,45 @@ std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(
     return half_edge_mesh;
 }
 
-void HalfEdgeTriangleMesh::RemoveDuplicatedVertices() {
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::RemoveDuplicatedVertices() {
     size_t before_num = vertices_.size();
-    TriangleMesh::RemoveDuplicatedVertices();
+    // TriangleMesh::RemoveDuplicatedVertices();
     if (HasHalfEdges() && vertices_.size() != before_num) {
         ComputeHalfEdges();
     }
+    return *this;
 }
 
-void HalfEdgeTriangleMesh::RemoveDuplicatedTriangles() {
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::RemoveDuplicatedTriangles() {
     size_t before_num = triangles_.size();
-    TriangleMesh::RemoveDuplicatedTriangles();
+    // TriangleMesh::RemoveDuplicatedTriangles();
     if (HasHalfEdges() && triangles_.size() != before_num) {
         ComputeHalfEdges();
     }
+    return *this;
 }
 
-void HalfEdgeTriangleMesh::RemoveUnreferencedVertices() {
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::RemoveUnreferencedVertices() {
     size_t before_num = vertices_.size();
-    TriangleMesh::RemoveUnreferencedVertices();
+    // TriangleMesh::RemoveUnreferencedVertices();
     if (HasHalfEdges() && vertices_.size() != before_num) {
         ComputeHalfEdges();
     }
+    return *this;
 }
 
-void HalfEdgeTriangleMesh::RemoveDegenerateTriangles() {
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::RemoveDegenerateTriangles() {
     size_t before_num = triangles_.size();
-    TriangleMesh::RemoveDegenerateTriangles();
+    // TriangleMesh::RemoveDegenerateTriangles();
     if (HasHalfEdges() && triangles_.size() != before_num) {
         ComputeHalfEdges();
     }
+    return *this;
 }
 
-HalfEdgeTriangleMesh& HalfEdgeTriangleMesh::operator+=(
-        const HalfEdgeTriangleMesh& mesh) {
-    TriangleMesh::operator+=(mesh);
+HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::operator+=(
+        const HalfEdgeTriangleMesh &mesh) {
+    // TriangleMesh::operator+=(mesh);
     if (HasHalfEdges()) {
         ComputeHalfEdges();
     }
@@ -332,7 +453,7 @@ HalfEdgeTriangleMesh& HalfEdgeTriangleMesh::operator+=(
 }
 
 HalfEdgeTriangleMesh HalfEdgeTriangleMesh::operator+(
-        const HalfEdgeTriangleMesh& mesh) const {
+        const HalfEdgeTriangleMesh &mesh) const {
     return (HalfEdgeTriangleMesh(*this) += mesh);
 }
 

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -379,7 +379,7 @@ int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
     return next_half_edge_index;
 }
 
-std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(
+std::shared_ptr<HalfEdgeTriangleMesh> HalfEdgeTriangleMesh::CreateFromMesh(
         const TriangleMesh &mesh) {
     auto half_edge_mesh = std::make_shared<HalfEdgeTriangleMesh>();
 

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
@@ -107,6 +107,9 @@ public:
 
     HalfEdgeTriangleMesh operator+(const HalfEdgeTriangleMesh &mesh) const;
 
+    static std::shared_ptr<HalfEdgeTriangleMesh> CreateFromMesh(
+            const TriangleMesh &mesh);
+
 protected:
     HalfEdgeTriangleMesh(Geometry::GeometryType type) : Geometry3D(type) {}
 
@@ -130,9 +133,6 @@ public:
     /// If the vertex is on boundary, the starting edge must be on boundary too
     std::vector<std::vector<int>> ordered_half_edge_from_vertex_;
 };
-
-std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(
-        const TriangleMesh &mesh);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
@@ -35,7 +35,8 @@
 namespace open3d {
 namespace geometry {
 
-class HalfEdgeTriangleMesh : public TriangleMesh {
+// TODO likely broken
+class HalfEdgeTriangleMesh : public Geometry3D {
 public:
     class HalfEdge {
     public:
@@ -59,11 +60,29 @@ public:
 
 public:
     HalfEdgeTriangleMesh()
-        : TriangleMesh(Geometry::GeometryType::HalfEdgeTriangleMesh) {}
+        : Geometry3D(Geometry::GeometryType::HalfEdgeTriangleMesh) {}
+
+    /// Clear all data in HalfEdgeTriangleMesh
+    HalfEdgeTriangleMesh &Clear() override;
+    bool IsEmpty() const override;
+    Eigen::Vector3d GetMinBound() const override;
+    Eigen::Vector3d GetMaxBound() const override;
+    HalfEdgeTriangleMesh &Transform(
+            const Eigen::Matrix4d &transformation) override;
+    HalfEdgeTriangleMesh &Translate(
+            const Eigen::Vector3d &translation) override;
+    HalfEdgeTriangleMesh &Scale(const double scale,
+                                bool center = true) override;
+    HalfEdgeTriangleMesh &Rotate(
+            const Eigen::Vector3d &rotation,
+            bool center = true,
+            RotationType type = RotationType::XYZ) override;
 
     /// Compute and update half edges, half edge can only be computed if the
     /// mesh is a manifold. Returns true if half edges are computed.
     bool ComputeHalfEdges();
+
+    bool HasVertices() const { return vertices_.size() > 0; }
 
     /// True if half-edges have already been computed
     bool HasHalfEdges() const;
@@ -79,34 +98,37 @@ public:
     /// Returns a vector of boundaries. A boundary is a vector of vertices.
     std::vector<std::vector<int>> GetBoundaries() const;
 
-    /// Clear all data in HalfEdgeTriangleMesh
-    void Clear() override;
-
-    void RemoveDuplicatedVertices() override;
-    void RemoveDuplicatedTriangles() override;
-    void RemoveUnreferencedVertices() override;
-    void RemoveDegenerateTriangles() override;
+    HalfEdgeTriangleMesh &RemoveDuplicatedVertices();
+    HalfEdgeTriangleMesh &RemoveDuplicatedTriangles();
+    HalfEdgeTriangleMesh &RemoveUnreferencedVertices();
+    HalfEdgeTriangleMesh &RemoveDegenerateTriangles();
 
     HalfEdgeTriangleMesh &operator+=(const HalfEdgeTriangleMesh &mesh);
 
     HalfEdgeTriangleMesh operator+(const HalfEdgeTriangleMesh &mesh) const;
 
 protected:
-    HalfEdgeTriangleMesh(Geometry::GeometryType type) : TriangleMesh(type) {}
+    HalfEdgeTriangleMesh(Geometry::GeometryType type) : Geometry3D(type) {}
 
-public:
-    std::vector<HalfEdge> half_edges_;
-
-    /// Counter-clockwise ordered half-edges started from each vertex
-    /// If the vertex is on boundary, the starting edge must be on boundary too
-    std::vector<std::vector<int>> ordered_half_edge_from_vertex_;
-
-protected:
     /// Returns the next half edge from starting vertex of the input half edge,
     /// in a counterclock wise manner. Returns -1 if when hitting a boundary.
     /// This is done by traversing to the next, next and twin half edge.
     int NextHalfEdgeFromVertex(int init_half_edge_index) const;
     int NextHalfEdgeOnBoundary(int curr_half_edge_index) const;
+
+public:
+    std::vector<Eigen::Vector3d> vertices_;
+    std::vector<Eigen::Vector3d> vertex_normals_;
+    std::vector<Eigen::Vector3d> vertex_colors_;
+    std::vector<Eigen::Vector3i> triangles_;
+    std::vector<Eigen::Vector3d> triangle_normals_;
+    std::vector<std::unordered_set<int>> adjacency_list_;
+
+    std::vector<HalfEdge> half_edges_;
+
+    /// Counter-clockwise ordered half-edges started from each vertex
+    /// If the vertex is on boundary, the starting edge must be on boundary too
+    std::vector<std::vector<int>> ordered_half_edge_from_vertex_;
 };
 
 std::shared_ptr<HalfEdgeTriangleMesh> CreateHalfEdgeMeshFromMesh(

--- a/src/Open3D/Geometry/Image.cpp
+++ b/src/Open3D/Geometry/Image.cpp
@@ -118,10 +118,9 @@ std::shared_ptr<Image> Image::ConvertDepthToFloatImage(
     return output;
 }
 
-Image &Image::ClipIntensityImage(double min /* = 0.0*/, double max /* = 1.0*/) {
+Image &Image::ClipIntensity(double min /* = 0.0*/, double max /* = 1.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::PrintWarning(
-                "[ClipIntensityImage] Unsupported image format.\n");
+        utility::PrintWarning("[ClipIntensity] Unsupported image format.\n");
         return *this;
     }
     for (int y = 0; y < height_; y++) {
@@ -134,10 +133,9 @@ Image &Image::ClipIntensityImage(double min /* = 0.0*/, double max /* = 1.0*/) {
     return *this;
 }
 
-Image &Image::LinearTransformImage(double scale, double offset /* = 0.0*/) {
+Image &Image::LinearTransform(double scale, double offset /* = 0.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::PrintWarning(
-                "[LinearTransformImage] Unsupported image format.\n");
+        utility::PrintWarning("[LinearTransform] Unsupported image format.\n");
         return *this;
     }
     for (int y = 0; y < height_; y++) {
@@ -149,15 +147,15 @@ Image &Image::LinearTransformImage(double scale, double offset /* = 0.0*/) {
     return *this;
 }
 
-std::shared_ptr<Image> Image::DownsampleImage() const {
+std::shared_ptr<Image> Image::Downsample() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::PrintWarning("[DownsampleImage] Unsupported image format.\n");
+        utility::PrintWarning("[Downsample] Unsupported image format.\n");
         return output;
     }
     int half_width = (int)floor((double)width_ / 2.0);
     int half_height = (int)floor((double)height_ / 2.0);
-    output->PrepareImage(half_width, half_height, 1, 4);
+    output->Prepare(half_width, half_height, 1, 4);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -185,7 +183,7 @@ std::shared_ptr<Image> Image::FilterHorizontal(
                 "size.\n");
         return output;
     }
-    output->PrepareImage(width_, height_, 1, 4);
+    output->Prepare(width_, height_, 1, 4);
 
     const int half_kernel_size = (int)(floor((double)kernel.size() / 2.0));
 #ifdef _OPENMP
@@ -257,19 +255,19 @@ std::shared_ptr<Image> Image::Filter(const std::vector<double> &dx,
     }
 
     auto temp1 = FilterHorizontal(dx);
-    auto temp2 = temp1->FlipImage();
+    auto temp2 = temp1->Flip();
     auto temp3 = temp2->FilterHorizontal(dy);
-    auto temp4 = temp3->FlipImage();
+    auto temp4 = temp3->Flip();
     return temp4;
 }
 
-std::shared_ptr<Image> Image::FlipImage() const {
+std::shared_ptr<Image> Image::Flip() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
         utility::PrintWarning("[FilpImage] Unsupported image format.\n");
         return output;
     }
-    output->PrepareImage(height_, width_, 1, 4);
+    output->Prepare(height_, width_, 1, 4);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -284,14 +282,13 @@ std::shared_ptr<Image> Image::FlipImage() const {
     return output;
 }
 
-std::shared_ptr<Image> Image::DilateImage(
-        int half_kernel_size /* = 1 */) const {
+std::shared_ptr<Image> Image::Dilate(int half_kernel_size /* = 1 */) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 1) {
-        utility::PrintWarning("[DilateImage] Unsupported image format.\n");
+        utility::PrintWarning("[Dilate] Unsupported image format.\n");
         return output;
     }
-    output->PrepareImage(width_, height_, 1, 1);
+    output->Prepare(width_, height_, 1, 1);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -327,7 +324,7 @@ std::shared_ptr<Image> Image::CreateDepthBoundaryMask(
     auto depth_image_gradient_dy =
             depth_image->Filter(Image::FilterType::Sobel3Dy);
     auto mask = std::make_shared<Image>();
-    mask->PrepareImage(width, height, 1, 1);
+    mask->Prepare(width, height, 1, 1);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -345,8 +342,8 @@ std::shared_ptr<Image> Image::CreateDepthBoundaryMask(
         }
     }
     if (half_dilation_kernel_size_for_discontinuity_map >= 1) {
-        auto mask_dilated = mask->DilateImage(
-                half_dilation_kernel_size_for_discontinuity_map);
+        auto mask_dilated =
+                mask->Dilate(half_dilation_kernel_size_for_discontinuity_map);
         return mask_dilated;
     } else {
         return mask;

--- a/src/Open3D/Geometry/Image.h
+++ b/src/Open3D/Geometry/Image.h
@@ -110,7 +110,7 @@ public:
             const camera::PinholeCameraIntrinsic &intrinsic);
 
     /// Return a gray scaled float type image.
-    std::shared_ptr<Image> CreateFloatImageFromImage(
+    std::shared_ptr<Image> CreateFloatImage(
             Image::ColorToIntensityConversionType type =
                     Image::ColorToIntensityConversionType::Weighted) const;
 
@@ -128,13 +128,13 @@ public:
     std::shared_ptr<Image> FlipImage() const;
 
     /// Function to filter image with pre-defined filtering type
-    std::shared_ptr<Image> FilterImage(Image::FilterType type) const;
+    std::shared_ptr<Image> Filter(Image::FilterType type) const;
 
     /// Function to filter image with arbitrary dx, dy separable filters
-    std::shared_ptr<Image> FilterImage(const std::vector<double> &dx,
-                                       const std::vector<double> &dy) const;
+    std::shared_ptr<Image> Filter(const std::vector<double> &dx,
+                                  const std::vector<double> &dy) const;
 
-    std::shared_ptr<Image> FilterHorizontalImage(
+    std::shared_ptr<Image> FilterHorizontal(
             const std::vector<double> &kernel) const;
 
     /// Function to 2x image downsample using simple 2x2 averaging
@@ -159,12 +159,12 @@ public:
     std::shared_ptr<Image> CreateImageFromFloatImage() const;
 
     /// Function to filter image pyramid
-    static ImagePyramid FilterImagePyramid(const ImagePyramid &input,
-                                           Image::FilterType type);
+    static ImagePyramid FilterPyramid(const ImagePyramid &input,
+                                      Image::FilterType type);
 
     /// Function to create image pyramid
-    ImagePyramid CreateImagePyramid(size_t num_of_levels,
-                                    bool with_gaussian_filter = true) const;
+    ImagePyramid CreatePyramid(size_t num_of_levels,
+                               bool with_gaussian_filter = true) const;
 
     /// Function to create a depthmap boundary mask from depth image
     std::shared_ptr<Image> CreateDepthBoundaryMask(

--- a/src/Open3D/Geometry/Image.h
+++ b/src/Open3D/Geometry/Image.h
@@ -78,10 +78,10 @@ public:
                data_.size() == height_ * BytesPerLine();
     }
 
-    Image &PrepareImage(int width,
-                        int height,
-                        int num_of_channels,
-                        int bytes_per_channel) {
+    Image &Prepare(int width,
+                   int height,
+                   int num_of_channels,
+                   int bytes_per_channel) {
         width_ = width;
         height_ = height;
         num_of_channels_ = num_of_channels;
@@ -125,7 +125,7 @@ public:
     std::shared_ptr<Image> ConvertDepthToFloatImage(
             double depth_scale = 1000.0, double depth_trunc = 3.0) const;
 
-    std::shared_ptr<Image> FlipImage() const;
+    std::shared_ptr<Image> Flip() const;
 
     /// Function to filter image with pre-defined filtering type
     std::shared_ptr<Image> Filter(Image::FilterType type) const;
@@ -138,19 +138,19 @@ public:
             const std::vector<double> &kernel) const;
 
     /// Function to 2x image downsample using simple 2x2 averaging
-    std::shared_ptr<Image> DownsampleImage() const;
+    std::shared_ptr<Image> Downsample() const;
 
     /// Function to dilate 8bit mask map
-    std::shared_ptr<Image> DilateImage(int half_kernel_size = 1) const;
+    std::shared_ptr<Image> Dilate(int half_kernel_size = 1) const;
 
     /// Function to linearly transform pixel intensities
     /// image_new = scale * image + offset
-    Image &LinearTransformImage(double scale = 1.0, double offset = 0.0);
+    Image &LinearTransform(double scale = 1.0, double offset = 0.0);
 
     /// Function to clipping pixel intensities
     /// min is lower bound
     /// max is upper bound
-    Image &ClipIntensityImage(double min = 0.0, double max = 1.0);
+    Image &ClipIntensity(double min = 0.0, double max = 1.0);
 
     /// Function to change data types of image
     /// crafted for specific usage such as

--- a/src/Open3D/Geometry/Image.h
+++ b/src/Open3D/Geometry/Image.h
@@ -41,6 +41,11 @@ class PinholeCameraIntrinsic;
 
 namespace geometry {
 
+class Image;
+
+/// Typedef and functions for ImagePyramid
+typedef std::vector<std::shared_ptr<Image>> ImagePyramid;
+
 class Image : public Geometry2D {
 public:
     enum class ColorToIntensityConversionType {
@@ -61,7 +66,7 @@ public:
     ~Image() override {}
 
 public:
-    void Clear() override;
+    Image &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector2d GetMinBound() const override;
     Eigen::Vector2d GetMaxBound() const override;
@@ -73,15 +78,16 @@ public:
                data_.size() == height_ * BytesPerLine();
     }
 
-    void PrepareImage(int width,
-                      int height,
-                      int num_of_channels,
-                      int bytes_per_channel) {
+    Image &PrepareImage(int width,
+                        int height,
+                        int num_of_channels,
+                        int bytes_per_channel) {
         width_ = width;
         height_ = height;
         num_of_channels_ = num_of_channels;
         bytes_per_channel_ = bytes_per_channel;
         AllocateDataBuffer();
+        return *this;
     }
 
     int BytesPerLine() const {
@@ -91,6 +97,79 @@ public:
     /// Function to access the bilinear interpolated float value of a
     /// (single-channel) float image
     std::pair<bool, double> FloatValueAt(double u, double v) const;
+
+    /// Factory function to create a float image composed of multipliers that
+    /// convert depth values into camera distances (ImageFactory.cpp)
+    /// The multiplier function M(u,v) is defined as:
+    /// M(u, v) = sqrt(1 + ((u - cx) / fx) ^ 2 + ((v - cy) / fy) ^ 2)
+    /// This function is used as a convenient function for performance
+    /// optimization in volumetric integration (see
+    /// Core/Integration/TSDFVolume.h).
+    static std::shared_ptr<Image>
+    CreateDepthToCameraDistanceMultiplierFloatImage(
+            const camera::PinholeCameraIntrinsic &intrinsic);
+
+    /// Return a gray scaled float type image.
+    std::shared_ptr<Image> CreateFloatImageFromImage(
+            Image::ColorToIntensityConversionType type =
+                    Image::ColorToIntensityConversionType::Weighted) const;
+
+    /// Function to access the raw data of a single-channel Image
+    template <typename T>
+    T *PointerAt(int u, int v) const;
+
+    /// Function to access the raw data of a multi-channel Image
+    template <typename T>
+    T *PointerAt(int u, int v, int ch) const;
+
+    std::shared_ptr<Image> ConvertDepthToFloatImage(
+            double depth_scale = 1000.0, double depth_trunc = 3.0) const;
+
+    std::shared_ptr<Image> FlipImage() const;
+
+    /// Function to filter image with pre-defined filtering type
+    std::shared_ptr<Image> FilterImage(Image::FilterType type) const;
+
+    /// Function to filter image with arbitrary dx, dy separable filters
+    std::shared_ptr<Image> FilterImage(const std::vector<double> &dx,
+                                       const std::vector<double> &dy) const;
+
+    std::shared_ptr<Image> FilterHorizontalImage(
+            const std::vector<double> &kernel) const;
+
+    /// Function to 2x image downsample using simple 2x2 averaging
+    std::shared_ptr<Image> DownsampleImage() const;
+
+    /// Function to dilate 8bit mask map
+    std::shared_ptr<Image> DilateImage(int half_kernel_size = 1) const;
+
+    /// Function to linearly transform pixel intensities
+    /// image_new = scale * image + offset
+    Image &LinearTransformImage(double scale = 1.0, double offset = 0.0);
+
+    /// Function to clipping pixel intensities
+    /// min is lower bound
+    /// max is upper bound
+    Image &ClipIntensityImage(double min = 0.0, double max = 1.0);
+
+    /// Function to change data types of image
+    /// crafted for specific usage such as
+    /// single channel float image -> 8-bit RGB or 16-bit depth image
+    template <typename T>
+    std::shared_ptr<Image> CreateImageFromFloatImage() const;
+
+    /// Function to filter image pyramid
+    static ImagePyramid FilterImagePyramid(const ImagePyramid &input,
+                                           Image::FilterType type);
+
+    /// Function to create image pyramid
+    ImagePyramid CreateImagePyramid(size_t num_of_levels,
+                                    bool with_gaussian_filter = true) const;
+
+    /// Function to create a depthmap boundary mask from depth image
+    std::shared_ptr<Image> CreateDepthBoundaryMask(
+            double depth_threshold_for_discontinuity_check = 0.1,
+            int half_dilation_kernel_size_for_discontinuity_map = 3) const;
 
 protected:
     void AllocateDataBuffer() {
@@ -104,88 +183,6 @@ public:
     int bytes_per_channel_ = 0;
     std::vector<uint8_t> data_;
 };
-
-/// Factory function to create a float image composed of multipliers that
-/// convert depth values into camera distances (ImageFactory.cpp)
-/// The multiplier function M(u,v) is defined as:
-/// M(u, v) = sqrt(1 + ((u - cx) / fx) ^ 2 + ((v - cy) / fy) ^ 2)
-/// This function is used as a convenient function for performance optimization
-/// in volumetric integration (see Core/Integration/TSDFVolume.h).
-std::shared_ptr<Image> CreateDepthToCameraDistanceMultiplierFloatImage(
-        const camera::PinholeCameraIntrinsic &intrinsic);
-
-/// Return a gray scaled float type image.
-std::shared_ptr<Image> CreateFloatImageFromImage(
-        const Image &image,
-        Image::ColorToIntensityConversionType type =
-                Image::ColorToIntensityConversionType::Weighted);
-
-/// Function to access the raw data of a single-channel Image
-template <typename T>
-T *PointerAt(const Image &image, int u, int v);
-
-/// Function to access the raw data of a multi-channel Image
-template <typename T>
-T *PointerAt(const Image &image, int u, int v, int ch);
-
-std::shared_ptr<Image> ConvertDepthToFloatImage(const Image &depth,
-                                                double depth_scale = 1000.0,
-                                                double depth_trunc = 3.0);
-
-std::shared_ptr<Image> FlipImage(const Image &input);
-
-/// Function to filter image with pre-defined filtering type
-std::shared_ptr<Image> FilterImage(const Image &input, Image::FilterType type);
-
-/// Function to filter image with arbitrary dx, dy separable filters
-std::shared_ptr<Image> FilterImage(const Image &input,
-                                   const std::vector<double> &dx,
-                                   const std::vector<double> &dy);
-
-std::shared_ptr<Image> FilterHorizontalImage(const Image &input,
-                                             const std::vector<double> &kernel);
-
-/// Function to 2x image downsample using simple 2x2 averaging
-std::shared_ptr<Image> DownsampleImage(const Image &input);
-
-/// Function to dilate 8bit mask map
-std::shared_ptr<Image> DilateImage(const Image &input,
-                                   int half_kernel_size = 1);
-
-/// Function to linearly transform pixel intensities
-/// image_new = scale * image + offset
-void LinearTransformImage(Image &input,
-                          double scale = 1.0,
-                          double offset = 0.0);
-
-/// Function to clipping pixel intensities
-/// min is lower bound
-/// max is upper bound
-void ClipIntensityImage(Image &input, double min = 0.0, double max = 1.0);
-
-/// Function to change data types of image
-/// crafted for specific usage such as
-/// single channel float image -> 8-bit RGB or 16-bit depth image
-template <typename T>
-std::shared_ptr<Image> CreateImageFromFloatImage(const Image &input);
-
-/// Typedef and functions for ImagePyramid
-typedef std::vector<std::shared_ptr<Image>> ImagePyramid;
-
-/// Function to filter image pyramid
-ImagePyramid FilterImagePyramid(const ImagePyramid &input,
-                                Image::FilterType type);
-
-/// Function to create image pyramid
-ImagePyramid CreateImagePyramid(const Image &image,
-                                size_t num_of_levels,
-                                bool with_gaussian_filter = true);
-
-/// Function to create a depthmap boundary mask from depth image
-std::shared_ptr<Image> CreateDepthBoundaryMask(
-        const Image &depth_image_input,
-        double depth_threshold_for_discontinuity_check = 0.1,
-        int half_dilation_kernel_size_for_discontinuity_map = 3);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/ImageFactory.cpp
+++ b/src/Open3D/Geometry/ImageFactory.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<Image> Image::CreateDepthToCameraDistanceMultiplierFloatImage(
     return fimage;
 }
 
-std::shared_ptr<Image> Image::CreateFloatImageFromImage(
+std::shared_ptr<Image> Image::CreateFloatImage(
         Image::ColorToIntensityConversionType type /* = WEIGHTED*/) const {
     auto fimage = std::make_shared<Image>();
     if (IsEmpty()) {
@@ -143,8 +143,8 @@ template std::shared_ptr<Image> Image::CreateImageFromFloatImage<uint8_t>()
 template std::shared_ptr<Image> Image::CreateImageFromFloatImage<uint16_t>()
         const;
 
-ImagePyramid Image::CreateImagePyramid(
-        size_t num_of_levels, bool with_gaussian_filter /*= true*/) const {
+ImagePyramid Image::CreatePyramid(size_t num_of_levels,
+                                  bool with_gaussian_filter /*= true*/) const {
     std::vector<std::shared_ptr<Image>> pyramid_image;
     pyramid_image.clear();
     if ((num_of_channels_ != 1) || (bytes_per_channel_ != 4)) {
@@ -161,7 +161,7 @@ ImagePyramid Image::CreateImagePyramid(
         } else {
             if (with_gaussian_filter) {
                 // https://en.wikipedia.org/wiki/Pyramid_(image_processing)
-                auto level_b = pyramid_image[i - 1]->FilterImage(
+                auto level_b = pyramid_image[i - 1]->Filter(
                         Image::FilterType::Gaussian3);
                 auto level_bd = level_b->DownsampleImage();
                 pyramid_image.push_back(level_bd);

--- a/src/Open3D/Geometry/ImageFactory.cpp
+++ b/src/Open3D/Geometry/ImageFactory.cpp
@@ -33,7 +33,7 @@ namespace geometry {
 std::shared_ptr<Image> Image::CreateDepthToCameraDistanceMultiplierFloatImage(
         const camera::PinholeCameraIntrinsic &intrinsic) {
     auto fimage = std::make_shared<Image>();
-    fimage->PrepareImage(intrinsic.width_, intrinsic.height_, 1, 4);
+    fimage->Prepare(intrinsic.width_, intrinsic.height_, 1, 4);
     float ffl_inv[2] = {
             1.0f / (float)intrinsic.GetFocalLength().first,
             1.0f / (float)intrinsic.GetFocalLength().second,
@@ -66,7 +66,7 @@ std::shared_ptr<Image> Image::CreateFloatImage(
     if (IsEmpty()) {
         return fimage;
     }
-    fimage->PrepareImage(width_, height_, 1, 4);
+    fimage->Prepare(width_, height_, 1, 4);
     for (int i = 0; i < height_ * width_; i++) {
         float *p = (float *)(fimage->data_.data() + i * 4);
         const uint8_t *pi =
@@ -128,7 +128,7 @@ std::shared_ptr<Image> Image::CreateImageFromFloatImage() const {
         return output;
     }
 
-    output->PrepareImage(width_, height_, num_of_channels_, sizeof(T));
+    output->Prepare(width_, height_, num_of_channels_, sizeof(T));
     const float *pi = (const float *)data_.data();
     T *p = (T *)output->data_.data();
     for (int i = 0; i < height_ * width_; i++, p++, pi++) {
@@ -163,10 +163,10 @@ ImagePyramid Image::CreatePyramid(size_t num_of_levels,
                 // https://en.wikipedia.org/wiki/Pyramid_(image_processing)
                 auto level_b = pyramid_image[i - 1]->Filter(
                         Image::FilterType::Gaussian3);
-                auto level_bd = level_b->DownsampleImage();
+                auto level_bd = level_b->Downsample();
                 pyramid_image.push_back(level_bd);
             } else {
-                auto level_d = pyramid_image[i - 1]->DownsampleImage();
+                auto level_d = pyramid_image[i - 1]->Downsample();
                 pyramid_image.push_back(level_d);
             }
         }

--- a/src/Open3D/Geometry/IntersectionTest.cpp
+++ b/src/Open3D/Geometry/IntersectionTest.cpp
@@ -31,10 +31,10 @@
 namespace open3d {
 namespace geometry {
 
-bool IntersectingAABBAABB(const Eigen::Vector3d& min0,
-                          const Eigen::Vector3d& max0,
-                          const Eigen::Vector3d& min1,
-                          const Eigen::Vector3d& max1) {
+bool IntersectionTest::AABBAABB(const Eigen::Vector3d& min0,
+                                const Eigen::Vector3d& max0,
+                                const Eigen::Vector3d& min1,
+                                const Eigen::Vector3d& max1) {
     if (max0(0) < min1(0) || min0(0) > max1(0)) {
         return false;
     }
@@ -47,12 +47,12 @@ bool IntersectingAABBAABB(const Eigen::Vector3d& min0,
     return true;
 }
 
-bool IntersectingTriangleTriangle3d(const Eigen::Vector3d& p0,
-                                    const Eigen::Vector3d& p1,
-                                    const Eigen::Vector3d& p2,
-                                    const Eigen::Vector3d& q0,
-                                    const Eigen::Vector3d& q1,
-                                    const Eigen::Vector3d& q2) {
+bool IntersectionTest::TriangleTriangle3d(const Eigen::Vector3d& p0,
+                                          const Eigen::Vector3d& p1,
+                                          const Eigen::Vector3d& p2,
+                                          const Eigen::Vector3d& q0,
+                                          const Eigen::Vector3d& q1,
+                                          const Eigen::Vector3d& q2) {
     return NoDivTriTriIsect(
             const_cast<double*>(p0.data()), const_cast<double*>(p1.data()),
             const_cast<double*>(p2.data()), const_cast<double*>(q0.data()),

--- a/src/Open3D/Geometry/IntersectionTest.h
+++ b/src/Open3D/Geometry/IntersectionTest.h
@@ -31,17 +31,20 @@
 namespace open3d {
 namespace geometry {
 
-bool IntersectingAABBAABB(const Eigen::Vector3d& min0,
-                          const Eigen::Vector3d& max0,
-                          const Eigen::Vector3d& min1,
-                          const Eigen::Vector3d& max1);
+class IntersectionTest {
+public:
+    static bool AABBAABB(const Eigen::Vector3d& min0,
+                         const Eigen::Vector3d& max0,
+                         const Eigen::Vector3d& min1,
+                         const Eigen::Vector3d& max1);
 
-bool IntersectingTriangleTriangle3d(const Eigen::Vector3d& p0,
-                                    const Eigen::Vector3d& p1,
-                                    const Eigen::Vector3d& p2,
-                                    const Eigen::Vector3d& q0,
-                                    const Eigen::Vector3d& q1,
-                                    const Eigen::Vector3d& q2);
+    static bool TriangleTriangle3d(const Eigen::Vector3d& p0,
+                                   const Eigen::Vector3d& p1,
+                                   const Eigen::Vector3d& p2,
+                                   const Eigen::Vector3d& q0,
+                                   const Eigen::Vector3d& q1,
+                                   const Eigen::Vector3d& q2);
+};
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/LineSet.cpp
+++ b/src/Open3D/Geometry/LineSet.cpp
@@ -31,10 +31,11 @@
 namespace open3d {
 namespace geometry {
 
-void LineSet::Clear() {
+LineSet &LineSet::Clear() {
     points_.clear();
     lines_.clear();
     colors_.clear();
+    return *this;
 }
 
 bool LineSet::IsEmpty() const { return !HasPoints(); }

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -44,7 +44,7 @@ public:
     ~LineSet() override {}
 
 public:
-    void Clear() override;
+    LineSet &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
@@ -55,11 +55,9 @@ public:
                     bool center = true,
                     RotationType type = RotationType::XYZ) override;
 
-public:
     LineSet &operator+=(const LineSet &lineset);
     LineSet operator+(const LineSet &lineset) const;
 
-public:
     bool HasPoints() const { return points_.size() > 0; }
 
     bool HasLines() const { return HasPoints() && lines_.size() > 0; }
@@ -75,31 +73,32 @@ public:
     }
 
     /// Assigns each line in the LineSet the same color \param color.
-    void PaintUniformColor(const Eigen::Vector3d &color) {
+    LineSet &PaintUniformColor(const Eigen::Vector3d &color) {
         colors_.resize(lines_.size());
         for (size_t i = 0; i < lines_.size(); i++) {
             colors_[i] = color;
         }
+        return *this;
     }
+
+    /// Factory function to create a LineSet from two PointClouds
+    /// (\param cloud0, \param cloud1) and a correspondence set
+    /// \param correspondences.
+    static std::shared_ptr<LineSet> CreateFromPointCloudCorrespondences(
+            const PointCloud &cloud0,
+            const PointCloud &cloud1,
+            const std::vector<std::pair<int, int>> &correspondences);
+
+    /// Factory function to create a LineSet from edges of a triangle mesh
+    /// \param mesh.
+    static std::shared_ptr<LineSet> CreateFromTriangleMesh(
+            const TriangleMesh &mesh);
 
 public:
     std::vector<Eigen::Vector3d> points_;
     std::vector<Eigen::Vector2i> lines_;
     std::vector<Eigen::Vector3d> colors_;
 };
-
-/// Factory function to create a LineSet from two PointClouds
-/// (\param cloud0, \param cloud1) and a correspondence set
-/// \param correspondences.
-std::shared_ptr<LineSet> CreateLineSetFromPointCloudCorrespondences(
-        const PointCloud &cloud0,
-        const PointCloud &cloud1,
-        const std::vector<std::pair<int, int>> &correspondences);
-
-/// Factory function to create a LineSet from edges of a triangle mesh
-/// \param mesh.
-std::shared_ptr<LineSet> CreateLineSetFromTriangleMesh(
-        const TriangleMesh &mesh);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/LineSetFactory.cpp
+++ b/src/Open3D/Geometry/LineSetFactory.cpp
@@ -33,7 +33,7 @@
 namespace open3d {
 namespace geometry {
 
-std::shared_ptr<LineSet> CreateLineSetFromPointCloudCorrespondences(
+std::shared_ptr<LineSet> LineSet::CreateFromPointCloudCorrespondences(
         const PointCloud &cloud0,
         const PointCloud &cloud1,
         const std::vector<std::pair<int, int>> &correspondences) {
@@ -55,7 +55,7 @@ std::shared_ptr<LineSet> CreateLineSetFromPointCloudCorrespondences(
     return lineset_ptr;
 }
 
-std::shared_ptr<LineSet> CreateLineSetFromTriangleMesh(
+std::shared_ptr<LineSet> LineSet::CreateFromTriangleMesh(
         const TriangleMesh &mesh) {
     auto line_set = std::make_shared<LineSet>();
     line_set->points_ = mesh.vertices_;

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -328,11 +328,12 @@ bool Octree::operator==(const Octree& that) const {
     return rc;
 }
 
-void Octree::Clear() {
+Octree& Octree::Clear() {
     // Inherited Clear function
     root_node_ = nullptr;
     origin_.setZero();
     size_ = 0;
+    return *this;
 }
 
 bool Octree::IsEmpty() const { return root_node_ == nullptr; }

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -142,7 +142,7 @@ public:
     ~Octree() override {}
 
 public:
-    void Clear() override;
+    Octree& Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -92,29 +92,6 @@ public:
         return *this;
     }
 
-    /// Factory function to create a pointcloud from a depth image and a camera
-    /// model (PointCloudFactory.cpp)
-    /// The input depth image can be either a float image, or a uint16_t image.
-    /// In the latter case, the depth is scaled by 1 / depth_scale, and
-    /// truncated at depth_trunc distance. The depth image is also sampled with
-    /// stride, in order to support (fast) coarse point cloud extraction. Return
-    /// an empty pointcloud if the conversion fails.
-    static std::shared_ptr<PointCloud> CreateFromDepthImage(
-            const Image &depth,
-            const camera::PinholeCameraIntrinsic &intrinsic,
-            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
-            double depth_scale = 1000.0,
-            double depth_trunc = 1000.0,
-            int stride = 1);
-
-    /// Factory function to create a pointcloud from an RGB-D image and a camera
-    /// model (PointCloudFactory.cpp)
-    /// Return an empty pointcloud if the conversion fails.
-    static std::shared_ptr<PointCloud> CreateFromRGBDImage(
-            const RGBDImage &image,
-            const camera::PinholeCameraIntrinsic &intrinsic,
-            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity());
-
     /// Function to select points from \param input pointcloud into
     /// \return output pointcloud
     /// Points with indices in \param indices are selected.
@@ -199,6 +176,29 @@ public:
 
     /// Function that computes the convex hull of the point cloud using qhull
     std::shared_ptr<TriangleMesh> ComputeConvexHull() const;
+
+    /// Factory function to create a pointcloud from a depth image and a camera
+    /// model (PointCloudFactory.cpp)
+    /// The input depth image can be either a float image, or a uint16_t image.
+    /// In the latter case, the depth is scaled by 1 / depth_scale, and
+    /// truncated at depth_trunc distance. The depth image is also sampled with
+    /// stride, in order to support (fast) coarse point cloud extraction. Return
+    /// an empty pointcloud if the conversion fails.
+    static std::shared_ptr<PointCloud> CreateFromDepthImage(
+            const Image &depth,
+            const camera::PinholeCameraIntrinsic &intrinsic,
+            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
+            double depth_scale = 1000.0,
+            double depth_trunc = 1000.0,
+            int stride = 1);
+
+    /// Factory function to create a pointcloud from an RGB-D image and a camera
+    /// model (PointCloudFactory.cpp)
+    /// Return an empty pointcloud if the conversion fails.
+    static std::shared_ptr<PointCloud> CreateFromRGBDImage(
+            const RGBDImage &image,
+            const camera::PinholeCameraIntrinsic &intrinsic,
+            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity());
 
 public:
     std::vector<Eigen::Vector3d> points_;

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -52,7 +52,7 @@ public:
     ~PointCloud() override {}
 
 public:
-    void Clear() override;
+    PointCloud &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
@@ -63,11 +63,9 @@ public:
                        bool center = true,
                        RotationType type = RotationType::XYZ) override;
 
-public:
     PointCloud &operator+=(const PointCloud &cloud);
     PointCloud operator+(const PointCloud &cloud) const;
 
-public:
     bool HasPoints() const { return points_.size() > 0; }
 
     bool HasNormals() const {
@@ -78,150 +76,135 @@ public:
         return points_.size() > 0 && colors_.size() == points_.size();
     }
 
-    void NormalizeNormals() {
+    PointCloud &NormalizeNormals() {
         for (size_t i = 0; i < normals_.size(); i++) {
             normals_[i].normalize();
         }
+        return *this;
     }
 
     /// Assigns each point in the PointCloud the same color \param color.
-    void PaintUniformColor(const Eigen::Vector3d &color) {
+    PointCloud &PaintUniformColor(const Eigen::Vector3d &color) {
         colors_.resize(points_.size());
         for (size_t i = 0; i < points_.size(); i++) {
             colors_[i] = color;
         }
+        return *this;
     }
+
+    /// Factory function to create a pointcloud from a depth image and a camera
+    /// model (PointCloudFactory.cpp)
+    /// The input depth image can be either a float image, or a uint16_t image.
+    /// In the latter case, the depth is scaled by 1 / depth_scale, and
+    /// truncated at depth_trunc distance. The depth image is also sampled with
+    /// stride, in order to support (fast) coarse point cloud extraction. Return
+    /// an empty pointcloud if the conversion fails.
+    static std::shared_ptr<PointCloud> CreateFromDepthImage(
+            const Image &depth,
+            const camera::PinholeCameraIntrinsic &intrinsic,
+            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
+            double depth_scale = 1000.0,
+            double depth_trunc = 1000.0,
+            int stride = 1);
+
+    /// Factory function to create a pointcloud from an RGB-D image and a camera
+    /// model (PointCloudFactory.cpp)
+    /// Return an empty pointcloud if the conversion fails.
+    static std::shared_ptr<PointCloud> CreateFromRGBDImage(
+            const RGBDImage &image,
+            const camera::PinholeCameraIntrinsic &intrinsic,
+            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity());
+
+    /// Function to select points from \param input pointcloud into
+    /// \return output pointcloud
+    /// Points with indices in \param indices are selected.
+    std::shared_ptr<PointCloud> SelectDownSample(
+            const std::vector<size_t> &indices, bool invert = false) const;
+
+    /// Function to downsample \param input pointcloud into output pointcloud
+    /// with a voxel \param voxel_size defines the resolution of the voxel grid,
+    /// smaller value leads to denser output point cloud. Normals and colors are
+    /// averaged if they exist.
+    std::shared_ptr<PointCloud> VoxelDownSample(double voxel_size) const;
+
+    /// Function to downsample using VoxelDownSample, but specialized for
+    /// Surface convolution project. Experimental function.
+    std::tuple<std::shared_ptr<PointCloud>, Eigen::MatrixXi>
+    VoxelDownSampleAndTrace(double voxel_size,
+                            const Eigen::Vector3d &min_bound,
+                            const Eigen::Vector3d &max_bound,
+                            bool approximate_class = false) const;
+
+    /// Function to downsample \param input pointcloud into output pointcloud
+    /// uniformly \param every_k_points indicates the sample rate.
+    std::shared_ptr<PointCloud> UniformDownSample(size_t every_k_points) const;
+
+    /// Function to crop \param input pointcloud into output pointcloud
+    /// All points with coordinates less than \param min_bound or larger than
+    /// \param max_bound are clipped.
+    std::shared_ptr<PointCloud> Crop(const Eigen::Vector3d &min_bound,
+                                     const Eigen::Vector3d &max_bound) const;
+
+    /// Function to remove points that have less than \param nb_points in a
+    /// sphere of radius \param search_radius
+    std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
+    RemoveRadiusOutliers(size_t nb_points, double search_radius) const;
+
+    /// Function to remove points that are further away from their
+    /// \param nb_neighbor neighbors in average.
+    std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
+    RemoveStatisticalOutliers(size_t nb_neighbors, double std_ratio) const;
+
+    /// Function to compute the normals of a point cloud
+    /// \param cloud is the input point cloud. It also stores the output
+    /// normals. Normals are oriented with respect to the input point cloud if
+    /// normals exist in the input. \param search_param The KDTree search
+    /// parameters
+    bool EstimateNormals(
+            const KDTreeSearchParam &search_param = KDTreeSearchParamKNN());
+
+    /// Function to orient the normals of a point cloud
+    /// \param cloud is the input point cloud. It must have normals.
+    /// Normals are oriented with respect to \param orientation_reference
+    bool OrientNormalsToAlignWithDirection(
+            const Eigen::Vector3d &orientation_reference =
+                    Eigen::Vector3d(0.0, 0.0, 1.0));
+
+    /// Function to orient the normals of a point cloud
+    /// \param cloud is the input point cloud. It also stores the output
+    /// normals. Normals are oriented with towards \param camera_location
+    bool OrientNormalsTowardsCameraLocation(
+            const Eigen::Vector3d &camera_location = Eigen::Vector3d::Zero());
+
+    /// Function to compute the point to point distances between point clouds
+    /// \param source is the first point cloud.
+    /// \param target is the second point cloud.
+    /// \return the output distance. It has the same size as the number
+    /// of points in \param source
+    std::vector<double> ComputePointCloudDistance(const PointCloud &target);
+
+    /// Function to compute the mean and covariance matrix
+    /// of an \param input point cloud
+    std::tuple<Eigen::Vector3d, Eigen::Matrix3d> ComputeMeanAndCovariance()
+            const;
+
+    /// Function to compute the Mahalanobis distance for points
+    /// in an \param input point cloud
+    /// https://en.wikipedia.org/wiki/Mahalanobis_distance
+    std::vector<double> ComputeMahalanobisDistance() const;
+
+    /// Function to compute the distance from a point to its nearest neighbor in
+    /// the \param input point cloud
+    std::vector<double> ComputeNearestNeighborDistance() const;
+
+    /// Function that computes the convex hull of the point cloud using qhull
+    std::shared_ptr<TriangleMesh> ComputeConvexHull() const;
 
 public:
     std::vector<Eigen::Vector3d> points_;
     std::vector<Eigen::Vector3d> normals_;
     std::vector<Eigen::Vector3d> colors_;
 };
-
-/// Factory function to create a pointcloud from a depth image and a camera
-/// model (PointCloudFactory.cpp)
-/// The input depth image can be either a float image, or a uint16_t image. In
-/// the latter case, the depth is scaled by 1 / depth_scale, and truncated at
-/// depth_trunc distance. The depth image is also sampled with stride, in order
-/// to support (fast) coarse point cloud extraction.
-/// Return an empty pointcloud if the conversion fails.
-std::shared_ptr<PointCloud> CreatePointCloudFromDepthImage(
-        const Image &depth,
-        const camera::PinholeCameraIntrinsic &intrinsic,
-        const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
-        double depth_scale = 1000.0,
-        double depth_trunc = 1000.0,
-        int stride = 1);
-
-/// Factory function to create a pointcloud from an RGB-D image and a camera
-/// model (PointCloudFactory.cpp)
-/// Return an empty pointcloud if the conversion fails.
-std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImage(
-        const RGBDImage &image,
-        const camera::PinholeCameraIntrinsic &intrinsic,
-        const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity());
-
-/// Function to select points from \param input pointcloud into
-/// \return output pointcloud
-/// Points with indices in \param indices are selected.
-std::shared_ptr<PointCloud> SelectDownSample(const PointCloud &input,
-                                             const std::vector<size_t> &indices,
-                                             bool invert = false);
-
-/// Function to downsample \param input pointcloud into output pointcloud with a
-/// voxel \param voxel_size defines the resolution of the voxel grid, smaller
-/// value leads to denser output point cloud. Normals and colors are averaged if
-/// they exist.
-std::shared_ptr<PointCloud> VoxelDownSample(const PointCloud &input,
-                                            double voxel_size);
-
-/// Function to downsample using VoxelDownSample, but specialized for
-/// Surface convolution project. Experimental function.
-std::tuple<std::shared_ptr<PointCloud>, Eigen::MatrixXi>
-VoxelDownSampleAndTrace(const PointCloud &input,
-                        double voxel_size,
-                        const Eigen::Vector3d &min_bound,
-                        const Eigen::Vector3d &max_bound,
-                        bool approximate_class = false);
-
-/// Function to downsample \param input pointcloud into output pointcloud
-/// uniformly \param every_k_points indicates the sample rate.
-std::shared_ptr<PointCloud> UniformDownSample(const PointCloud &input,
-                                              size_t every_k_points);
-
-/// Function to crop \param input pointcloud into output pointcloud
-/// All points with coordinates less than \param min_bound or larger than
-/// \param max_bound are clipped.
-std::shared_ptr<PointCloud> CropPointCloud(const PointCloud &input,
-                                           const Eigen::Vector3d &min_bound,
-                                           const Eigen::Vector3d &max_bound);
-
-/// Function to remove points that have less than \param nb_points in a sphere
-/// of radius \param search_radius
-std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
-RemoveRadiusOutliers(const PointCloud &input,
-                     size_t nb_points,
-                     double search_radius);
-
-/// Function to remove points that are further away from their
-/// \param nb_neighbor neighbors in average.
-std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
-RemoveStatisticalOutliers(const PointCloud &input,
-                          size_t nb_neighbors,
-                          double std_ratio);
-
-/// Function to compute the normals of a point cloud
-/// \param cloud is the input point cloud. It also stores the output normals.
-/// Normals are oriented with respect to the input point cloud if normals exist
-/// in the input.
-/// \param search_param The KDTree search parameters
-bool EstimateNormals(
-        PointCloud &cloud,
-        const KDTreeSearchParam &search_param = KDTreeSearchParamKNN());
-
-/// Function to orient the normals of a point cloud
-/// \param cloud is the input point cloud. It must have normals.
-/// Normals are oriented with respect to \param orientation_reference
-bool OrientNormalsToAlignWithDirection(
-        PointCloud &cloud,
-        const Eigen::Vector3d &orientation_reference = Eigen::Vector3d(0.0,
-                                                                       0.0,
-                                                                       1.0));
-
-/// Function to orient the normals of a point cloud
-/// \param cloud is the input point cloud. It also stores the output normals.
-/// Normals are oriented with towards \param camera_location
-bool OrientNormalsTowardsCameraLocation(
-        PointCloud &cloud,
-        const Eigen::Vector3d &camera_location = Eigen::Vector3d::Zero());
-
-/// Function to compute the point to point distances between point clouds
-/// \param source is the first point cloud.
-/// \param target is the second point cloud.
-/// \return the output distance. It has the same size as the number
-/// of points in \param source
-std::vector<double> ComputePointCloudToPointCloudDistance(
-        const PointCloud &source, const PointCloud &target);
-
-/// Function to compute the mean and covariance matrix
-/// of an \param input point cloud
-std::tuple<Eigen::Vector3d, Eigen::Matrix3d> ComputePointCloudMeanAndCovariance(
-        const PointCloud &input);
-
-/// Function to compute the Mahalanobis distance for points
-/// in an \param input point cloud
-/// https://en.wikipedia.org/wiki/Mahalanobis_distance
-std::vector<double> ComputePointCloudMahalanobisDistance(
-        const PointCloud &input);
-
-/// Function to compute the distance from a point to its nearest neighbor in the
-/// \param input point cloud
-std::vector<double> ComputePointCloudNearestNeighborDistance(
-        const PointCloud &input);
-
-/// Function that computes the convex hull of the point cloud using qhull
-std::shared_ptr<TriangleMesh> ComputePointCloudConvexHull(
-        const PointCloud &input);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -41,7 +41,7 @@ int CountValidDepthPixels(const Image &depth, int stride) {
     int num_valid_pixels = 0;
     for (int i = 0; i < depth.height_; i += stride) {
         for (int j = 0; j < depth.width_; j += stride) {
-            const float *p = PointerAt<float>(depth, j, i);
+            const float *p = depth.PointerAt<float>(j, i);
             if (*p > 0) num_valid_pixels += 1;
         }
     }
@@ -62,7 +62,7 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
     int cnt = 0;
     for (int i = 0; i < depth.height_; i += stride) {
         for (int j = 0; j < depth.width_; j += stride) {
-            const float *p = PointerAt<float>(depth, j, i);
+            const float *p = depth.PointerAt<float>(j, i);
             if (*p > 0) {
                 double z = (double)(*p);
                 double x = (j - principal_point.first) * z / focal_length.first;
@@ -117,7 +117,7 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
 }  // unnamed namespace
 
 namespace geometry {
-std::shared_ptr<PointCloud> CreatePointCloudFromDepthImage(
+std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
         const Image &depth,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic /* = Eigen::Matrix4d::Identity()*/,
@@ -127,7 +127,7 @@ std::shared_ptr<PointCloud> CreatePointCloudFromDepthImage(
     if (depth.num_of_channels_ == 1) {
         if (depth.bytes_per_channel_ == 2) {
             auto float_depth =
-                    ConvertDepthToFloatImage(depth, depth_scale, depth_trunc);
+                    depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
             return CreatePointCloudFromFloatDepthImage(*float_depth, intrinsic,
                                                        extrinsic, stride);
         } else if (depth.bytes_per_channel_ == 4) {
@@ -140,7 +140,7 @@ std::shared_ptr<PointCloud> CreatePointCloudFromDepthImage(
     return std::make_shared<PointCloud>();
 }
 
-std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImage(
+std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
         const RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic /* = Eigen::Matrix4d::Identity()*/) {

--- a/src/Open3D/Geometry/Qhull.cpp
+++ b/src/Open3D/Geometry/Qhull.cpp
@@ -36,7 +36,7 @@
 namespace open3d {
 namespace geometry {
 
-std::shared_ptr<TriangleMesh> ComputeConvexHull(
+std::shared_ptr<TriangleMesh> Qhull::ComputeConvexHull(
         const std::vector<Eigen::Vector3d>& points) {
     auto convex_hull = std::make_shared<TriangleMesh>();
 

--- a/src/Open3D/Geometry/Qhull.h
+++ b/src/Open3D/Geometry/Qhull.h
@@ -35,8 +35,11 @@ namespace geometry {
 
 class TriangleMesh;
 
-std::shared_ptr<TriangleMesh> ComputeConvexHull(
-        const std::vector<Eigen::Vector3d>& points);
+class Qhull {
+public:
+    static std::shared_ptr<TriangleMesh> ComputeConvexHull(
+            const std::vector<Eigen::Vector3d>& points);
+};
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/RGBDImage.cpp
+++ b/src/Open3D/Geometry/RGBDImage.cpp
@@ -29,7 +29,7 @@
 namespace open3d {
 namespace geometry {
 
-RGBDImagePyramid RGBDImage::FilterRGBDImagePyramid(
+RGBDImagePyramid RGBDImage::FilterPyramid(
         const RGBDImagePyramid& rgbd_image_pyramid, Image::FilterType type) {
     RGBDImagePyramid rgbd_image_pyramid_filtered;
     rgbd_image_pyramid_filtered.clear();
@@ -37,8 +37,8 @@ RGBDImagePyramid RGBDImage::FilterRGBDImagePyramid(
     for (int level = 0; level < num_of_levels; level++) {
         auto color_level = rgbd_image_pyramid[level]->color_;
         auto depth_level = rgbd_image_pyramid[level]->depth_;
-        auto color_level_filtered = color_level.FilterImage(type);
-        auto depth_level_filtered = depth_level.FilterImage(type);
+        auto color_level_filtered = color_level.Filter(type);
+        auto depth_level_filtered = depth_level.Filter(type);
         auto rgbd_image_level_filtered = std::make_shared<RGBDImage>(
                 RGBDImage(*color_level_filtered, *depth_level_filtered));
         rgbd_image_pyramid_filtered.push_back(rgbd_image_level_filtered);
@@ -46,14 +46,14 @@ RGBDImagePyramid RGBDImage::FilterRGBDImagePyramid(
     return rgbd_image_pyramid_filtered;
 }
 
-RGBDImagePyramid RGBDImage::CreateRGBDImagePyramid(
+RGBDImagePyramid RGBDImage::CreatePyramid(
         size_t num_of_levels,
         bool with_gaussian_filter_for_color /* = true */,
         bool with_gaussian_filter_for_depth /* = false */) const {
-    ImagePyramid color_pyramid = color_.CreateImagePyramid(
-            num_of_levels, with_gaussian_filter_for_color);
-    ImagePyramid depth_pyramid = depth_.CreateImagePyramid(
-            num_of_levels, with_gaussian_filter_for_depth);
+    ImagePyramid color_pyramid =
+            color_.CreatePyramid(num_of_levels, with_gaussian_filter_for_color);
+    ImagePyramid depth_pyramid =
+            depth_.CreatePyramid(num_of_levels, with_gaussian_filter_for_depth);
     RGBDImagePyramid rgbd_image_pyramid;
     rgbd_image_pyramid.clear();
     for (size_t level = 0; level < num_of_levels; level++) {

--- a/src/Open3D/Geometry/RGBDImage.cpp
+++ b/src/Open3D/Geometry/RGBDImage.cpp
@@ -29,7 +29,7 @@
 namespace open3d {
 namespace geometry {
 
-RGBDImagePyramid FilterRGBDImagePyramid(
+RGBDImagePyramid RGBDImage::FilterRGBDImagePyramid(
         const RGBDImagePyramid& rgbd_image_pyramid, Image::FilterType type) {
     RGBDImagePyramid rgbd_image_pyramid_filtered;
     rgbd_image_pyramid_filtered.clear();
@@ -37,8 +37,8 @@ RGBDImagePyramid FilterRGBDImagePyramid(
     for (int level = 0; level < num_of_levels; level++) {
         auto color_level = rgbd_image_pyramid[level]->color_;
         auto depth_level = rgbd_image_pyramid[level]->depth_;
-        auto color_level_filtered = FilterImage(color_level, type);
-        auto depth_level_filtered = FilterImage(depth_level, type);
+        auto color_level_filtered = color_level.FilterImage(type);
+        auto depth_level_filtered = depth_level.FilterImage(type);
         auto rgbd_image_level_filtered = std::make_shared<RGBDImage>(
                 RGBDImage(*color_level_filtered, *depth_level_filtered));
         rgbd_image_pyramid_filtered.push_back(rgbd_image_level_filtered);
@@ -46,15 +46,14 @@ RGBDImagePyramid FilterRGBDImagePyramid(
     return rgbd_image_pyramid_filtered;
 }
 
-RGBDImagePyramid CreateRGBDImagePyramid(
-        const RGBDImage& rgbd_image,
+RGBDImagePyramid RGBDImage::CreateRGBDImagePyramid(
         size_t num_of_levels,
         bool with_gaussian_filter_for_color /* = true */,
-        bool with_gaussian_filter_for_depth /* = false */) {
-    ImagePyramid color_pyramid = CreateImagePyramid(
-            rgbd_image.color_, num_of_levels, with_gaussian_filter_for_color);
-    ImagePyramid depth_pyramid = CreateImagePyramid(
-            rgbd_image.depth_, num_of_levels, with_gaussian_filter_for_depth);
+        bool with_gaussian_filter_for_depth /* = false */) const {
+    ImagePyramid color_pyramid = color_.CreateImagePyramid(
+            num_of_levels, with_gaussian_filter_for_color);
+    ImagePyramid depth_pyramid = depth_.CreateImagePyramid(
+            num_of_levels, with_gaussian_filter_for_depth);
     RGBDImagePyramid rgbd_image_pyramid;
     rgbd_image_pyramid.clear();
     for (size_t level = 0; level < num_of_levels; level++) {

--- a/src/Open3D/Geometry/RGBDImage.h
+++ b/src/Open3D/Geometry/RGBDImage.h
@@ -82,10 +82,10 @@ public:
             const Image &depth,
             bool convert_rgb_to_intensity = true);
 
-    static RGBDImagePyramid FilterRGBDImagePyramid(
+    static RGBDImagePyramid FilterPyramid(
             const RGBDImagePyramid &rgbd_image_pyramid, Image::FilterType type);
 
-    RGBDImagePyramid CreateRGBDImagePyramid(
+    RGBDImagePyramid CreatePyramid(
             size_t num_of_levels,
             bool with_gaussian_filter_for_color = true,
             bool with_gaussian_filter_for_depth = false) const;

--- a/src/Open3D/Geometry/RGBDImage.h
+++ b/src/Open3D/Geometry/RGBDImage.h
@@ -32,6 +32,11 @@
 namespace open3d {
 namespace geometry {
 
+class RGBDImage;
+
+/// Typedef and functions for RGBDImagePyramid
+typedef std::vector<std::shared_ptr<RGBDImage>> RGBDImagePyramid;
+
 /// RGBDImage is for a pair of registered color and depth images,
 /// viewed from the same view, of the same resolution.
 /// If you have other format, convert it first.
@@ -45,54 +50,50 @@ public:
         depth_.Clear();
     };
 
+    /// Factory function to create an RGBD Image from color and depth Images
+    static std::shared_ptr<RGBDImage> CreateFromColorAndDepth(
+            const Image &color,
+            const Image &depth,
+            double depth_scale = 1000.0,
+            double depth_trunc = 3.0,
+            bool convert_rgb_to_intensity = true);
+
+    /// Factory function to create an RGBD Image from Redwood dataset
+    static std::shared_ptr<RGBDImage> CreateFromRedwoodFormat(
+            const Image &color,
+            const Image &depth,
+            bool convert_rgb_to_intensity = true);
+
+    /// Factory function to create an RGBD Image from TUM dataset
+    static std::shared_ptr<RGBDImage> CreateFromTUMFormat(
+            const Image &color,
+            const Image &depth,
+            bool convert_rgb_to_intensity = true);
+
+    /// Factory function to create an RGBD Image from SUN3D dataset
+    static std::shared_ptr<RGBDImage> CreateFromSUNFormat(
+            const Image &color,
+            const Image &depth,
+            bool convert_rgb_to_intensity = true);
+
+    /// Factory function to create an RGBD Image from NYU dataset
+    static std::shared_ptr<RGBDImage> CreateFromNYUFormat(
+            const Image &color,
+            const Image &depth,
+            bool convert_rgb_to_intensity = true);
+
+    static RGBDImagePyramid FilterRGBDImagePyramid(
+            const RGBDImagePyramid &rgbd_image_pyramid, Image::FilterType type);
+
+    RGBDImagePyramid CreateRGBDImagePyramid(
+            size_t num_of_levels,
+            bool with_gaussian_filter_for_color = true,
+            bool with_gaussian_filter_for_depth = false) const;
+
 public:
     Image color_;
     Image depth_;
 };
-
-/// Factory function to create an RGBD Image from color and depth Images
-std::shared_ptr<RGBDImage> CreateRGBDImageFromColorAndDepth(
-        const Image &color,
-        const Image &depth,
-        double depth_scale = 1000.0,
-        double depth_trunc = 3.0,
-        bool convert_rgb_to_intensity = true);
-
-/// Factory function to create an RGBD Image from Redwood dataset
-std::shared_ptr<RGBDImage> CreateRGBDImageFromRedwoodFormat(
-        const Image &color,
-        const Image &depth,
-        bool convert_rgb_to_intensity = true);
-
-/// Factory function to create an RGBD Image from TUM dataset
-std::shared_ptr<RGBDImage> CreateRGBDImageFromTUMFormat(
-        const Image &color,
-        const Image &depth,
-        bool convert_rgb_to_intensity = true);
-
-/// Factory function to create an RGBD Image from SUN3D dataset
-std::shared_ptr<RGBDImage> CreateRGBDImageFromSUNFormat(
-        const Image &color,
-        const Image &depth,
-        bool convert_rgb_to_intensity = true);
-
-/// Factory function to create an RGBD Image from NYU dataset
-std::shared_ptr<RGBDImage> CreateRGBDImageFromNYUFormat(
-        const Image &color,
-        const Image &depth,
-        bool convert_rgb_to_intensity = true);
-
-/// Typedef and functions for RGBDImagePyramid
-typedef std::vector<std::shared_ptr<RGBDImage>> RGBDImagePyramid;
-
-RGBDImagePyramid FilterRGBDImagePyramid(
-        const RGBDImagePyramid &rgbd_image_pyramid, Image::FilterType type);
-
-RGBDImagePyramid CreateRGBDImagePyramid(
-        const RGBDImage &rgbd_image,
-        size_t num_of_levels,
-        bool with_gaussian_filter_for_color = true,
-        bool with_gaussian_filter_for_depth = false);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/RGBDImageFactory.cpp
+++ b/src/Open3D/Geometry/RGBDImageFactory.cpp
@@ -29,7 +29,7 @@
 namespace open3d {
 namespace geometry {
 
-std::shared_ptr<RGBDImage> CreateRGBDImageFromColorAndDepth(
+std::shared_ptr<RGBDImage> RGBDImage::CreateFromColorAndDepth(
         const Image &color,
         const Image &depth,
         double depth_scale /* = 1000.0*/,
@@ -38,41 +38,41 @@ std::shared_ptr<RGBDImage> CreateRGBDImageFromColorAndDepth(
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
         utility::PrintWarning(
-                "[CreateRGBDImageFromColorAndDepth] Unsupported image "
+                "[CreateFromColorAndDepth] Unsupported image "
                 "format.\n");
         return rgbd_image;
     }
     rgbd_image->depth_ =
-            *ConvertDepthToFloatImage(depth, depth_scale, depth_trunc);
+            *depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
     rgbd_image->color_ = convert_rgb_to_intensity
-                                 ? *CreateFloatImageFromImage(color)
+                                 ? *color.CreateFloatImageFromImage()
                                  : color;
     return rgbd_image;
 }
 
 /// Reference: http://redwood-data.org/indoor/
 /// File format: http://redwood-data.org/indoor/dataset.html
-std::shared_ptr<RGBDImage> CreateRGBDImageFromRedwoodFormat(
+std::shared_ptr<RGBDImage> RGBDImage::CreateFromRedwoodFormat(
         const Image &color,
         const Image &depth,
         bool convert_rgb_to_intensity /* = true*/) {
-    return CreateRGBDImageFromColorAndDepth(color, depth, 1000.0, 4.0,
-                                            convert_rgb_to_intensity);
+    return CreateFromColorAndDepth(color, depth, 1000.0, 4.0,
+                                   convert_rgb_to_intensity);
 }
 
 /// Reference: http://vision.in.tum.de/data/datasets/rgbd-dataset
 /// File format: http://vision.in.tum.de/data/datasets/rgbd-dataset/file_formats
-std::shared_ptr<RGBDImage> CreateRGBDImageFromTUMFormat(
+std::shared_ptr<RGBDImage> RGBDImage::CreateFromTUMFormat(
         const Image &color,
         const Image &depth,
         bool convert_rgb_to_intensity /* = true*/) {
-    return CreateRGBDImageFromColorAndDepth(color, depth, 5000.0, 4.0,
-                                            convert_rgb_to_intensity);
+    return CreateFromColorAndDepth(color, depth, 5000.0, 4.0,
+                                   convert_rgb_to_intensity);
 }
 
 /// Reference: http://sun3d.cs.princeton.edu/
 /// File format: https://github.com/PrincetonVision/SUN3DCppReader
-std::shared_ptr<RGBDImage> CreateRGBDImageFromSUNFormat(
+std::shared_ptr<RGBDImage> RGBDImage::CreateFromSUNFormat(
         const Image &color,
         const Image &depth,
         bool convert_rgb_to_intensity /* = true*/) {
@@ -84,17 +84,17 @@ std::shared_ptr<RGBDImage> CreateRGBDImageFromSUNFormat(
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {
-            uint16_t &d = *PointerAt<uint16_t>(depth, u, v);
+            uint16_t &d = *depth.PointerAt<uint16_t>(u, v);
             d = (d >> 3) | (d << 13);
         }
     }
     // SUN depth map has long range depth. We set depth_trunc as 7.0
-    return CreateRGBDImageFromColorAndDepth(color, depth, 1000.0, 7.0,
-                                            convert_rgb_to_intensity);
+    return CreateFromColorAndDepth(color, depth, 1000.0, 7.0,
+                                   convert_rgb_to_intensity);
 }
 
 /// Reference: http://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html
-std::shared_ptr<RGBDImage> CreateRGBDImageFromNYUFormat(
+std::shared_ptr<RGBDImage> RGBDImage::CreateFromNYUFormat(
         const Image &color,
         const Image &depth,
         bool convert_rgb_to_intensity /* = true*/) {
@@ -106,7 +106,7 @@ std::shared_ptr<RGBDImage> CreateRGBDImageFromNYUFormat(
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {
-            uint16_t *d = PointerAt<uint16_t>(depth, u, v);
+            uint16_t *d = depth.PointerAt<uint16_t>(u, v);
             uint8_t *p = (uint8_t *)d;
             uint8_t x = *p;
             *p = *(p + 1);
@@ -120,8 +120,8 @@ std::shared_ptr<RGBDImage> CreateRGBDImageFromNYUFormat(
         }
     }
     // NYU depth map has long range depth. We set depth_trunc as 7.0
-    return CreateRGBDImageFromColorAndDepth(color, depth, 1000.0, 7.0,
-                                            convert_rgb_to_intensity);
+    return CreateFromColorAndDepth(color, depth, 1000.0, 7.0,
+                                   convert_rgb_to_intensity);
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/RGBDImageFactory.cpp
+++ b/src/Open3D/Geometry/RGBDImageFactory.cpp
@@ -44,9 +44,8 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromColorAndDepth(
     }
     rgbd_image->depth_ =
             *depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
-    rgbd_image->color_ = convert_rgb_to_intensity
-                                 ? *color.CreateFloatImageFromImage()
-                                 : color;
+    rgbd_image->color_ =
+            convert_rgb_to_intensity ? *color.CreateFloatImage() : color;
     return rgbd_image;
 }
 

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -477,7 +477,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothTaubin(
     return mesh;
 }
 
-std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
+std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
         size_t number_of_points,
         std::vector<double> &triangle_areas,
         double surface_area) const {
@@ -550,8 +550,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
     std::vector<double> triangle_areas;
     double surface_area = GetSurfaceArea(triangle_areas);
 
-    return SamplePointsUniformly(number_of_points, triangle_areas,
-                                 surface_area);
+    return SamplePointsUniformlyImpl(number_of_points, triangle_areas,
+                                     surface_area);
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
@@ -559,24 +559,25 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
         double init_factor /* = 5 */,
         const std::shared_ptr<PointCloud> pcl_init /* = nullptr */) const {
     if (number_of_points <= 0) {
-        utility::PrintWarning("[SamplePointsUniformly] number_of_points <= 0");
+        utility::PrintWarning(
+                "[SamplePointsPoissonDisk] number_of_points <= 0");
         return std::make_shared<PointCloud>();
     }
     if (triangles_.size() == 0) {
         utility::PrintWarning(
-                "[SamplePointsUniformly] input mesh has no triangles");
+                "[SamplePointsPoissonDisk] input mesh has no triangles");
         return std::make_shared<PointCloud>();
     }
     if (pcl_init == nullptr && init_factor < 1) {
         utility::PrintWarning(
-                "[SamplePointsUniformly] either pass pcl_init with #points "
+                "[SamplePointsPoissonDisk] either pass pcl_init with #points "
                 "> "
                 "number_of_points or init_factor > 1");
         return std::make_shared<PointCloud>();
     }
     if (pcl_init != nullptr && pcl_init->points_.size() < number_of_points) {
         utility::PrintWarning(
-                "[SamplePointsUniformly] either pass pcl_init with #points "
+                "[SamplePointsPoissonDisk] either pass pcl_init with #points "
                 "> "
                 "number_of_points, or init_factor > 1");
         return std::make_shared<PointCloud>();
@@ -589,8 +590,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
     // Compute init points using uniform sampling
     std::shared_ptr<PointCloud> pcl;
     if (pcl_init == nullptr) {
-        pcl = SamplePointsUniformly(init_factor * number_of_points,
-                                    triangle_areas, surface_area);
+        pcl = SamplePointsUniformlyImpl(init_factor * number_of_points,
+                                        triangle_areas, surface_area);
     } else {
         pcl = std::make_shared<PointCloud>();
         pcl->points_ = pcl_init->points_;

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -41,13 +41,14 @@
 namespace open3d {
 namespace geometry {
 
-void TriangleMesh::Clear() {
+TriangleMesh &TriangleMesh::Clear() {
     vertices_.clear();
     vertex_normals_.clear();
     vertex_colors_.clear();
     triangles_.clear();
     triangle_normals_.clear();
     adjacency_list_.clear();
+    return *this;
 }
 
 bool TriangleMesh::IsEmpty() const { return !HasVertices(); }
@@ -212,7 +213,8 @@ TriangleMesh TriangleMesh::operator+(const TriangleMesh &mesh) const {
     return (TriangleMesh(*this) += mesh);
 }
 
-void TriangleMesh::ComputeTriangleNormals(bool normalized /* = true*/) {
+TriangleMesh &TriangleMesh::ComputeTriangleNormals(
+        bool normalized /* = true*/) {
     triangle_normals_.resize(triangles_.size());
     for (size_t i = 0; i < triangles_.size(); i++) {
         auto &triangle = triangles_[i];
@@ -223,9 +225,10 @@ void TriangleMesh::ComputeTriangleNormals(bool normalized /* = true*/) {
     if (normalized) {
         NormalizeNormals();
     }
+    return *this;
 }
 
-void TriangleMesh::ComputeVertexNormals(bool normalized /* = true*/) {
+TriangleMesh &TriangleMesh::ComputeVertexNormals(bool normalized /* = true*/) {
     if (HasTriangleNormals() == false) {
         ComputeTriangleNormals(false);
     }
@@ -239,9 +242,10 @@ void TriangleMesh::ComputeVertexNormals(bool normalized /* = true*/) {
     if (normalized) {
         NormalizeNormals();
     }
+    return *this;
 }
 
-void TriangleMesh::ComputeAdjacencyList() {
+TriangleMesh &TriangleMesh::ComputeAdjacencyList() {
     adjacency_list_.clear();
     adjacency_list_.resize(vertices_.size());
     for (const auto &triangle : triangles_) {
@@ -252,73 +256,19 @@ void TriangleMesh::ComputeAdjacencyList() {
         adjacency_list_[triangle(2)].insert(triangle(0));
         adjacency_list_[triangle(2)].insert(triangle(1));
     }
+    return *this;
 }
 
-std::shared_ptr<PointCloud> SamplePointsUniformly(
-        const TriangleMesh &input,
-        size_t number_of_points,
-        std::vector<double> &triangle_areas,
-        double surface_area) {
-    // triangle areas to cdf
-    triangle_areas[0] /= surface_area;
-    for (size_t tidx = 1; tidx < input.triangles_.size(); ++tidx) {
-        triangle_areas[tidx] =
-                triangle_areas[tidx] / surface_area + triangle_areas[tidx - 1];
-    }
-
-    // sample point cloud
-    bool has_vert_normal = input.HasVertexNormals();
-    bool has_vert_color = input.HasVertexColors();
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_real_distribution<double> dist(0.0, 1.0);
-    auto pcd = std::make_shared<PointCloud>();
-    pcd->points_.resize(number_of_points);
-    if (has_vert_normal) {
-        pcd->normals_.resize(number_of_points);
-    }
-    if (has_vert_color) {
-        pcd->colors_.resize(number_of_points);
-    }
-    size_t point_idx = 0;
-    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
-        size_t n = std::round(triangle_areas[tidx] * number_of_points);
-        while (point_idx < n) {
-            double r1 = dist(mt);
-            double r2 = dist(mt);
-            double a = (1 - std::sqrt(r1));
-            double b = std::sqrt(r1) * (1 - r2);
-            double c = std::sqrt(r1) * r2;
-
-            const Eigen::Vector3i &triangle = input.triangles_[tidx];
-            pcd->points_[point_idx] = a * input.vertices_[triangle(0)] +
-                                      b * input.vertices_[triangle(1)] +
-                                      c * input.vertices_[triangle(2)];
-            if (has_vert_normal) {
-                pcd->normals_[point_idx] =
-                        a * input.vertex_normals_[triangle(0)] +
-                        b * input.vertex_normals_[triangle(1)] +
-                        c * input.vertex_normals_[triangle(2)];
-            }
-            if (has_vert_color) {
-                pcd->colors_[point_idx] =
-                        a * input.vertex_colors_[triangle(0)] +
-                        b * input.vertex_colors_[triangle(1)] +
-                        c * input.vertex_colors_[triangle(2)];
-            }
-
-            point_idx++;
-        }
-    }
-
-    return pcd;
-}
-
-void TriangleMesh::FilterSharpen(int number_of_iterations,
-                                 double strength,
-                                 FilterScope scope) {
-    if (!HasAdjacencyList()) {
-        ComputeAdjacencyList();
+std::shared_ptr<TriangleMesh> TriangleMesh::FilterSharpen(
+        int number_of_iterations, double strength, FilterScope scope) const {
+    std::shared_ptr<TriangleMesh> mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = vertices_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->triangles_ = triangles_;
+    mesh->adjacency_list_ = adjacency_list_;
+    if (!mesh->HasAdjacencyList()) {
+        mesh->ComputeAdjacencyList();
     }
 
     bool filter_vertex =
@@ -331,15 +281,16 @@ void TriangleMesh::FilterSharpen(int number_of_iterations,
             HasVertexColors();
 
     for (int iter = 0; iter < number_of_iterations; ++iter) {
-        std::vector<Eigen::Vector3d> prev_vertices = vertices_;
-        std::vector<Eigen::Vector3d> prev_vertex_normals = vertex_normals_;
-        std::vector<Eigen::Vector3d> prev_vertex_colors = vertex_colors_;
+        std::vector<Eigen::Vector3d> prev_vertices = mesh->vertices_;
+        std::vector<Eigen::Vector3d> prev_vertex_normals =
+                mesh->vertex_normals_;
+        std::vector<Eigen::Vector3d> prev_vertex_colors = mesh->vertex_colors_;
 
-        for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        for (size_t vidx = 0; vidx < mesh->vertices_.size(); ++vidx) {
             Eigen::Vector3d vertex_sum(0, 0, 0);
             Eigen::Vector3d normal_sum(0, 0, 0);
             Eigen::Vector3d color_sum(0, 0, 0);
-            for (int nbidx : adjacency_list_[vidx]) {
+            for (int nbidx : mesh->adjacency_list_[vidx]) {
                 if (filter_vertex) {
                     vertex_sum += prev_vertices[nbidx];
                 }
@@ -351,32 +302,40 @@ void TriangleMesh::FilterSharpen(int number_of_iterations,
                 }
             }
 
-            size_t nb_size = adjacency_list_[vidx].size();
+            size_t nb_size = mesh->adjacency_list_[vidx].size();
             if (filter_vertex) {
-                vertices_[vidx] =
+                mesh->vertices_[vidx] =
                         prev_vertices[vidx] +
                         strength * (prev_vertices[vidx] * nb_size - vertex_sum);
             }
             if (filter_normal) {
-                vertex_normals_[vidx] =
+                mesh->vertex_normals_[vidx] =
                         prev_vertex_normals[vidx] +
                         strength * (prev_vertex_normals[vidx] * nb_size -
                                     normal_sum);
             }
             if (filter_color) {
-                vertex_colors_[vidx] =
+                mesh->vertex_colors_[vidx] =
                         prev_vertex_colors[vidx] +
                         strength * (prev_vertex_colors[vidx] * nb_size -
                                     color_sum);
             }
         }
     }
+
+    return mesh;
 }
 
-void TriangleMesh::FilterSmoothSimple(int number_of_iterations,
-                                      FilterScope scope) {
-    if (!HasAdjacencyList()) {
-        ComputeAdjacencyList();
+std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothSimple(
+        int number_of_iterations, FilterScope scope) const {
+    std::shared_ptr<TriangleMesh> mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = vertices_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->triangles_ = triangles_;
+    mesh->adjacency_list_ = adjacency_list_;
+    if (!mesh->HasAdjacencyList()) {
+        mesh->ComputeAdjacencyList();
     }
 
     bool filter_vertex =
@@ -389,15 +348,16 @@ void TriangleMesh::FilterSmoothSimple(int number_of_iterations,
             HasVertexColors();
 
     for (int iter = 0; iter < number_of_iterations; ++iter) {
-        std::vector<Eigen::Vector3d> prev_vertices = vertices_;
-        std::vector<Eigen::Vector3d> prev_vertex_normals = vertex_normals_;
-        std::vector<Eigen::Vector3d> prev_vertex_colors = vertex_colors_;
+        std::vector<Eigen::Vector3d> prev_vertices = mesh->vertices_;
+        std::vector<Eigen::Vector3d> prev_vertex_normals =
+                mesh->vertex_normals_;
+        std::vector<Eigen::Vector3d> prev_vertex_colors = mesh->vertex_colors_;
 
-        for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        for (size_t vidx = 0; vidx < mesh->vertices_.size(); ++vidx) {
             Eigen::Vector3d vertex_sum(0, 0, 0);
             Eigen::Vector3d normal_sum(0, 0, 0);
             Eigen::Vector3d color_sum(0, 0, 0);
-            for (int nbidx : adjacency_list_[vidx]) {
+            for (int nbidx : mesh->adjacency_list_[vidx]) {
                 if (filter_vertex) {
                     vertex_sum += prev_vertices[nbidx];
                 }
@@ -409,29 +369,35 @@ void TriangleMesh::FilterSmoothSimple(int number_of_iterations,
                 }
             }
 
-            size_t nb_size = adjacency_list_[vidx].size();
+            size_t nb_size = mesh->adjacency_list_[vidx].size();
             if (filter_vertex) {
-                vertices_[vidx] =
+                mesh->vertices_[vidx] =
                         (prev_vertices[vidx] + vertex_sum) / (1 + nb_size);
             }
             if (filter_normal) {
-                vertex_normals_[vidx] =
+                mesh->vertex_normals_[vidx] =
                         (prev_vertex_normals[vidx] + normal_sum) /
                         (1 + nb_size);
             }
             if (filter_color) {
-                vertex_colors_[vidx] =
+                mesh->vertex_colors_[vidx] =
                         (prev_vertex_colors[vidx] + color_sum) / (1 + nb_size);
             }
         }
     }
+    return mesh;
 }
 
-void TriangleMesh::FilterSmoothLaplacian(int number_of_iterations,
-                                         double lambda,
-                                         FilterScope scope) {
-    if (!HasAdjacencyList()) {
-        ComputeAdjacencyList();
+std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothLaplacian(
+        int number_of_iterations, double lambda, FilterScope scope) const {
+    std::shared_ptr<TriangleMesh> mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = vertices_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->triangles_ = triangles_;
+    mesh->adjacency_list_ = adjacency_list_;
+    if (!mesh->HasAdjacencyList()) {
+        mesh->ComputeAdjacencyList();
     }
 
     bool filter_vertex =
@@ -444,16 +410,17 @@ void TriangleMesh::FilterSmoothLaplacian(int number_of_iterations,
             HasVertexColors();
 
     for (int iter = 0; iter < number_of_iterations; ++iter) {
-        std::vector<Eigen::Vector3d> prev_vertices = vertices_;
-        std::vector<Eigen::Vector3d> prev_vertex_normals = vertex_normals_;
-        std::vector<Eigen::Vector3d> prev_vertex_colors = vertex_colors_;
+        std::vector<Eigen::Vector3d> prev_vertices = mesh->vertices_;
+        std::vector<Eigen::Vector3d> prev_vertex_normals =
+                mesh->vertex_normals_;
+        std::vector<Eigen::Vector3d> prev_vertex_colors = mesh->vertex_colors_;
 
-        for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        for (size_t vidx = 0; vidx < mesh->vertices_.size(); ++vidx) {
             Eigen::Vector3d vertex_sum(0, 0, 0);
             Eigen::Vector3d normal_sum(0, 0, 0);
             Eigen::Vector3d color_sum(0, 0, 0);
             double total_weight = 0;
-            for (int nbidx : adjacency_list_[vidx]) {
+            for (int nbidx : mesh->adjacency_list_[vidx]) {
                 auto diff = prev_vertices[vidx] - prev_vertices[nbidx];
                 double dist = diff.norm();
                 double weight = 1. / (dist + 1e-12);
@@ -471,41 +438,109 @@ void TriangleMesh::FilterSmoothLaplacian(int number_of_iterations,
             }
 
             if (filter_vertex) {
-                vertices_[vidx] = prev_vertices[vidx] +
-                                  lambda * (vertex_sum / total_weight -
-                                            prev_vertices[vidx]);
+                mesh->vertices_[vidx] = prev_vertices[vidx] +
+                                        lambda * (vertex_sum / total_weight -
+                                                  prev_vertices[vidx]);
             }
             if (filter_normal) {
-                vertex_normals_[vidx] = prev_vertex_normals[vidx] +
-                                        lambda * (normal_sum / total_weight -
-                                                  prev_vertex_normals[vidx]);
+                mesh->vertex_normals_[vidx] =
+                        prev_vertex_normals[vidx] +
+                        lambda * (normal_sum / total_weight -
+                                  prev_vertex_normals[vidx]);
             }
             if (filter_color) {
-                vertex_colors_[vidx] = prev_vertex_colors[vidx] +
-                                       lambda * (color_sum / total_weight -
-                                                 prev_vertex_colors[vidx]);
+                mesh->vertex_colors_[vidx] =
+                        prev_vertex_colors[vidx] +
+                        lambda * (color_sum / total_weight -
+                                  prev_vertex_colors[vidx]);
             }
         }
     }
+    return mesh;
 }
 
-void TriangleMesh::FilterSmoothTaubin(int number_of_iterations,
-                                      double lambda,
-                                      double mu,
-                                      FilterScope scope) {
+std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothTaubin(
+        int number_of_iterations,
+        double lambda,
+        double mu,
+        FilterScope scope) const {
+    std::shared_ptr<TriangleMesh> mesh = std::make_shared<TriangleMesh>();
+    mesh->vertices_ = vertices_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->triangles_ = triangles_;
+    mesh->adjacency_list_ = adjacency_list_;
     for (int iter = 0; iter < number_of_iterations; ++iter) {
-        FilterSmoothLaplacian(1, lambda, scope);
-        FilterSmoothLaplacian(1, mu, scope);
+        mesh = mesh->FilterSmoothLaplacian(1, lambda, scope);
+        mesh = mesh->FilterSmoothLaplacian(1, mu, scope);
     }
+    return mesh;
 }
 
-std::shared_ptr<PointCloud> SamplePointsUniformly(const TriangleMesh &input,
-                                                  size_t number_of_points) {
+std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
+        size_t number_of_points,
+        std::vector<double> &triangle_areas,
+        double surface_area) const {
+    // triangle areas to cdf
+    triangle_areas[0] /= surface_area;
+    for (size_t tidx = 1; tidx < triangles_.size(); ++tidx) {
+        triangle_areas[tidx] =
+                triangle_areas[tidx] / surface_area + triangle_areas[tidx - 1];
+    }
+
+    // sample point cloud
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    auto pcd = std::make_shared<PointCloud>();
+    pcd->points_.resize(number_of_points);
+    if (has_vert_normal) {
+        pcd->normals_.resize(number_of_points);
+    }
+    if (has_vert_color) {
+        pcd->colors_.resize(number_of_points);
+    }
+    size_t point_idx = 0;
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        size_t n = std::round(triangle_areas[tidx] * number_of_points);
+        while (point_idx < n) {
+            double r1 = dist(mt);
+            double r2 = dist(mt);
+            double a = (1 - std::sqrt(r1));
+            double b = std::sqrt(r1) * (1 - r2);
+            double c = std::sqrt(r1) * r2;
+
+            const Eigen::Vector3i &triangle = triangles_[tidx];
+            pcd->points_[point_idx] = a * vertices_[triangle(0)] +
+                                      b * vertices_[triangle(1)] +
+                                      c * vertices_[triangle(2)];
+            if (has_vert_normal) {
+                pcd->normals_[point_idx] = a * vertex_normals_[triangle(0)] +
+                                           b * vertex_normals_[triangle(1)] +
+                                           c * vertex_normals_[triangle(2)];
+            }
+            if (has_vert_color) {
+                pcd->colors_[point_idx] = a * vertex_colors_[triangle(0)] +
+                                          b * vertex_colors_[triangle(1)] +
+                                          c * vertex_colors_[triangle(2)];
+            }
+
+            point_idx++;
+        }
+    }
+
+    return pcd;
+}
+
+std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
+        size_t number_of_points) const {
     if (number_of_points <= 0) {
         utility::PrintWarning("[SamplePointsUniformly] number_of_points <= 0");
         return std::make_shared<PointCloud>();
     }
-    if (input.triangles_.size() == 0) {
+    if (triangles_.size() == 0) {
         utility::PrintWarning(
                 "[SamplePointsUniformly] input mesh has no triangles");
         return std::make_shared<PointCloud>();
@@ -513,22 +548,21 @@ std::shared_ptr<PointCloud> SamplePointsUniformly(const TriangleMesh &input,
 
     // Compute area of each triangle and sum surface area
     std::vector<double> triangle_areas;
-    double surface_area = input.GetSurfaceArea(triangle_areas);
+    double surface_area = GetSurfaceArea(triangle_areas);
 
-    return SamplePointsUniformly(input, number_of_points, triangle_areas,
+    return SamplePointsUniformly(number_of_points, triangle_areas,
                                  surface_area);
 }
 
-std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
-        const TriangleMesh &input,
+std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
         size_t number_of_points,
         double init_factor /* = 5 */,
-        const std::shared_ptr<PointCloud> pcl_init /* = nullptr */) {
+        const std::shared_ptr<PointCloud> pcl_init /* = nullptr */) const {
     if (number_of_points <= 0) {
         utility::PrintWarning("[SamplePointsUniformly] number_of_points <= 0");
         return std::make_shared<PointCloud>();
     }
-    if (input.triangles_.size() == 0) {
+    if (triangles_.size() == 0) {
         utility::PrintWarning(
                 "[SamplePointsUniformly] input mesh has no triangles");
         return std::make_shared<PointCloud>();
@@ -550,12 +584,12 @@ std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
 
     // Compute area of each triangle and sum surface area
     std::vector<double> triangle_areas;
-    double surface_area = input.GetSurfaceArea(triangle_areas);
+    double surface_area = GetSurfaceArea(triangle_areas);
 
     // Compute init points using uniform sampling
     std::shared_ptr<PointCloud> pcl;
     if (pcl_init == nullptr) {
-        pcl = SamplePointsUniformly(input, init_factor * number_of_points,
+        pcl = SamplePointsUniformly(init_factor * number_of_points,
                                     triangle_areas, surface_area);
     } else {
         pcl = std::make_shared<PointCloud>();
@@ -669,7 +703,7 @@ std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
     return pcl;
 }
 
-void TriangleMesh::RemoveDuplicatedVertices() {
+TriangleMesh &TriangleMesh::RemoveDuplicatedVertices() {
     typedef std::tuple<double, double, double> Coordinate3;
     std::unordered_map<Coordinate3, size_t,
                        utility::hash_tuple::hash<Coordinate3>>
@@ -709,9 +743,11 @@ void TriangleMesh::RemoveDuplicatedVertices() {
     utility::PrintDebug(
             "[RemoveDuplicatedVertices] %d vertices have been removed.\n",
             (int)(old_vertex_num - k));
+
+    return *this;
 }
 
-void TriangleMesh::RemoveDuplicatedTriangles() {
+TriangleMesh &TriangleMesh::RemoveDuplicatedTriangles() {
     typedef std::tuple<int, int, int> Index3;
     std::unordered_map<Index3, size_t, utility::hash_tuple::hash<Index3>>
             triangle_to_old_index;
@@ -754,9 +790,11 @@ void TriangleMesh::RemoveDuplicatedTriangles() {
     utility::PrintDebug(
             "[RemoveDuplicatedTriangles] %d triangles have been removed.\n",
             (int)(old_triangle_num - k));
+
+    return *this;
 }
 
-void TriangleMesh::RemoveUnreferencedVertices() {
+TriangleMesh &TriangleMesh::RemoveUnreferencedVertices() {
     std::vector<bool> vertex_has_reference(vertices_.size(), false);
     for (const auto &triangle : triangles_) {
         vertex_has_reference[triangle(0)] = true;
@@ -795,9 +833,11 @@ void TriangleMesh::RemoveUnreferencedVertices() {
     utility::PrintDebug(
             "[RemoveUnreferencedVertices] %d vertices have been removed.\n",
             (int)(old_vertex_num - k));
+
+    return *this;
 }
 
-void TriangleMesh::RemoveDegenerateTriangles() {
+TriangleMesh &TriangleMesh::RemoveDegenerateTriangles() {
     bool has_tri_normal = HasTriangleNormals();
     size_t old_triangle_num = triangles_.size();
     size_t k = 0;
@@ -819,9 +859,10 @@ void TriangleMesh::RemoveDegenerateTriangles() {
             "[RemoveDegenerateTriangles] %d triangles have been "
             "removed.\n",
             (int)(old_triangle_num - k));
+    return *this;
 }
 
-void TriangleMesh::RemoveNonManifoldEdges() {
+TriangleMesh &TriangleMesh::RemoveNonManifoldEdges() {
     std::vector<double> triangle_areas;
     GetSurfaceArea(triangle_areas);
 
@@ -893,6 +934,7 @@ void TriangleMesh::RemoveNonManifoldEdges() {
             triangle_normals_.resize(to_tidx);
         }
     }
+    return *this;
 }
 
 template <typename F>
@@ -1034,9 +1076,9 @@ TriangleMesh::GetEdgeToTrianglesMap() const {
     return trias_per_edge;
 }
 
-double ComputeTriangleArea(const Eigen::Vector3d &p0,
-                           const Eigen::Vector3d &p1,
-                           const Eigen::Vector3d &p2) {
+double TriangleMesh::ComputeTriangleArea(const Eigen::Vector3d &p0,
+                                         const Eigen::Vector3d &p1,
+                                         const Eigen::Vector3d &p2) {
     const Eigen::Vector3d x = p0 - p1;
     const Eigen::Vector3d y = p0 - p2;
     double area = 0.5 * x.cross(y).norm();
@@ -1071,9 +1113,9 @@ double TriangleMesh::GetSurfaceArea(std::vector<double> &triangle_areas) const {
     return surface_area;
 }
 
-Eigen::Vector4d ComputeTrianglePlane(const Eigen::Vector3d &p0,
-                                     const Eigen::Vector3d &p1,
-                                     const Eigen::Vector3d &p2) {
+Eigen::Vector4d TriangleMesh::ComputeTrianglePlane(const Eigen::Vector3d &p0,
+                                                   const Eigen::Vector3d &p1,
+                                                   const Eigen::Vector3d &p2) {
     const Eigen::Vector3d e0 = p1 - p0;
     const Eigen::Vector3d e1 = p2 - p0;
     Eigen::Vector3d abc = e0.cross(e1);
@@ -1230,7 +1272,7 @@ std::vector<Eigen::Vector2i> TriangleMesh::GetSelfIntersectingTriangles()
             const Eigen::Vector3d &q0 = vertices_[tria_q(0)];
             const Eigen::Vector3d &q1 = vertices_[tria_q(1)];
             const Eigen::Vector3d &q2 = vertices_[tria_q(2)];
-            if (IntersectingTriangleTriangle3d(p0, p1, p2, q0, q1, q2)) {
+            if (IntersectionTest::TriangleTriangle3d(p0, p1, p2, q0, q1, q2)) {
                 self_intersecting_triangles.push_back(
                         Eigen::Vector2i(tidx0, tidx1));
             }
@@ -1244,8 +1286,8 @@ bool TriangleMesh::IsSelfIntersecting() const {
 }
 
 bool TriangleMesh::IsBoundingBoxIntersecting(const TriangleMesh &other) const {
-    return IntersectingAABBAABB(GetMinBound(), GetMaxBound(),
-                                other.GetMinBound(), other.GetMaxBound());
+    return IntersectionTest::AABBAABB(GetMinBound(), GetMaxBound(),
+                                      other.GetMinBound(), other.GetMaxBound());
 }
 
 bool TriangleMesh::IsIntersecting(const TriangleMesh &other) const {
@@ -1262,7 +1304,7 @@ bool TriangleMesh::IsIntersecting(const TriangleMesh &other) const {
             const Eigen::Vector3d &q0 = other.vertices_[tria_q(0)];
             const Eigen::Vector3d &q1 = other.vertices_[tria_q(1)];
             const Eigen::Vector3d &q2 = other.vertices_[tria_q(2)];
-            if (IntersectingTriangleTriangle3d(p0, p1, p2, q0, q1, q2)) {
+            if (IntersectionTest::TriangleTriangle3d(p0, p1, p2, q0, q1, q2)) {
                 return true;
             }
         }
@@ -1270,8 +1312,8 @@ bool TriangleMesh::IsIntersecting(const TriangleMesh &other) const {
     return false;
 }
 
-std::shared_ptr<TriangleMesh> ComputeMeshConvexHull(const TriangleMesh &mesh) {
-    return ComputeConvexHull(mesh.vertices_);
+std::shared_ptr<TriangleMesh> TriangleMesh::ComputeConvexHull() const {
+    return Qhull::ComputeConvexHull(vertices_);
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -298,7 +298,7 @@ public:
 
     /// Function to sample \param number_of_points points uniformly from the
     /// mesh
-    std::shared_ptr<PointCloud> SamplePointsUniformly(
+    std::shared_ptr<PointCloud> SamplePointsUniformlyImpl(
             size_t number_of_points,
             std::vector<double> &triangle_areas,
             double surface_area) const;

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -63,7 +63,7 @@ public:
     ~TriangleMesh() override {}
 
 public:
-    void Clear() override;
+    TriangleMesh &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
@@ -79,35 +79,35 @@ public:
     TriangleMesh operator+(const TriangleMesh &mesh) const;
 
     /// Function to compute triangle normals, usually called before rendering
-    void ComputeTriangleNormals(bool normalized = true);
+    TriangleMesh &ComputeTriangleNormals(bool normalized = true);
 
     /// Function to compute vertex normals, usually called before rendering
-    void ComputeVertexNormals(bool normalized = true);
+    TriangleMesh &ComputeVertexNormals(bool normalized = true);
 
     /// Function to compute adjacency list, call before adjacency list is needed
-    void ComputeAdjacencyList();
+    TriangleMesh &ComputeAdjacencyList();
 
     /// Function that removes duplicated verties, i.e., vertices that have
     /// identical coordinates.
-    virtual void RemoveDuplicatedVertices();
+    TriangleMesh &RemoveDuplicatedVertices();
 
     /// Function that removes duplicated triangles, i.e., removes triangles
     /// that reference the same three vertices, independent of their order.
-    virtual void RemoveDuplicatedTriangles();
+    TriangleMesh &RemoveDuplicatedTriangles();
 
     /// This function removes vertices from the triangle mesh that are not
     /// referenced in any triangle of the mesh.
-    virtual void RemoveUnreferencedVertices();
+    TriangleMesh &RemoveUnreferencedVertices();
 
     /// Function that removes degenerate triangles, i.e., triangles that
     /// references a single vertex multiple times in a single triangle.
     /// They are usually the product of removing duplicated vertices.
-    virtual void RemoveDegenerateTriangles();
+    TriangleMesh &RemoveDegenerateTriangles();
 
     /// Function that removes all non-manifold edges, by successively deleting
     /// triangles with the smallest surface area adjacent to the non-manifold
     /// edge until the number of adjacent triangles to the edge is `<= 2`.
-    virtual void RemoveNonManifoldEdges();
+    TriangleMesh &RemoveNonManifoldEdges();
 
     /// Function to sharpen triangle mesh. The output value ($v_o$) is the
     /// input value ($v_i$) plus \param strength times the input value minus
@@ -115,9 +115,10 @@ public:
     /// $v_o = v_i x strength (v_i * |N| - \sum_{n \in N} v_n)$.
     /// \param number_of_iterations defines the number of repetitions
     /// of this operation.
-    void FilterSharpen(int number_of_iterations,
-                       double strength,
-                       FilterScope scope = FilterScope::All);
+    std::shared_ptr<TriangleMesh> FilterSharpen(
+            int number_of_iterations,
+            double strength,
+            FilterScope scope = FilterScope::All) const;
 
     /// Function to smooth triangle mesh with simple neighbour average.
     /// $v_o = \frac{v_i + \sum_{n \in N} v_n)}{|N| + 1}$, with $v_i$
@@ -125,8 +126,9 @@ public:
     /// set of adjacent neighbours.
     /// \param number_of_iterations defines the number of repetitions
     /// of this operation.
-    void FilterSmoothSimple(int number_of_iterations,
-                            FilterScope scope = FilterScope::All);
+    std::shared_ptr<TriangleMesh> FilterSmoothSimple(
+            int number_of_iterations,
+            FilterScope scope = FilterScope::All) const;
 
     /// Function to smooth triangle mesh using Laplacian.
     /// $v_o = v_i \cdot \lambda (sum_{n \in N} w_n v_n - v_i)$,
@@ -136,9 +138,10 @@ public:
     /// and \param lambda is the smoothing parameter.
     /// \param number_of_iterations defines the number of repetitions
     /// of this operation.
-    void FilterSmoothLaplacian(int number_of_iterations,
-                               double lambda,
-                               FilterScope scope = FilterScope::All);
+    std::shared_ptr<TriangleMesh> FilterSmoothLaplacian(
+            int number_of_iterations,
+            double lambda,
+            FilterScope scope = FilterScope::All) const;
 
     /// Function to smooth triangle mesh using method of Taubin,
     /// "Curve and Surface Smoothing Without Shrinkage", 1995.
@@ -147,16 +150,12 @@ public:
     /// This method avoids shrinkage of the triangle mesh.
     /// \param number_of_iterations defines the number of repetitions
     /// of this operation.
-    void FilterSmoothTaubin(int number_of_iterations,
-                            double lambda = 0.5,
-                            double mu = -0.53,
-                            FilterScope scope = FilterScope::All);
+    std::shared_ptr<TriangleMesh> FilterSmoothTaubin(
+            int number_of_iterations,
+            double lambda = 0.5,
+            double mu = -0.53,
+            FilterScope scope = FilterScope::All) const;
 
-protected:
-    // Forward child class type to avoid indirect nonvirtual base
-    TriangleMesh(Geometry::GeometryType type) : Geometry3D(type) {}
-
-public:
     bool HasVertices() const { return vertices_.size() > 0; }
 
     bool HasTriangles() const {
@@ -182,7 +181,7 @@ public:
                adjacency_list_.size() == vertices_.size();
     }
 
-    void NormalizeNormals() {
+    TriangleMesh &NormalizeNormals() {
         for (size_t i = 0; i < vertex_normals_.size(); i++) {
             vertex_normals_[i].normalize();
             if (std::isnan(vertex_normals_[i](0))) {
@@ -195,14 +194,16 @@ public:
                 triangle_normals_[i] = Eigen::Vector3d(0.0, 0.0, 1.0);
             }
         }
+        return *this;
     }
 
     /// Assigns each vertex in the TriangleMesh the same color \param color.
-    void PaintUniformColor(const Eigen::Vector3d &color) {
+    TriangleMesh &PaintUniformColor(const Eigen::Vector3d &color) {
         vertex_colors_.resize(vertices_.size());
         for (size_t i = 0; i < vertices_.size(); i++) {
             vertex_colors_[i] = color;
         }
+        return *this;
     }
 
     /// Function that computes the Euler-Poincaré characteristic, i.e.,
@@ -264,6 +265,11 @@ public:
                        utility::hash_eigen::hash<Eigen::Vector2i>>
     GetEdgeToTrianglesMap() const;
 
+    /// Function that computes the area of a mesh triangle
+    static double ComputeTriangleArea(const Eigen::Vector3d &p0,
+                                      const Eigen::Vector3d &p1,
+                                      const Eigen::Vector3d &p2);
+
     /// Function that computes the area of a mesh triangle identified by the
     /// triangle index
     double GetTriangleArea(size_t triangle_idx) const;
@@ -276,9 +282,185 @@ public:
     /// the individual triangle surfaces.
     double GetSurfaceArea(std::vector<double> &triangle_areas) const;
 
+    /// Function that computes the plane equation from the three points.
+    /// If the three points are co-linear, then this function returns the
+    /// invalid plane (0, 0, 0, 0).
+    static Eigen::Vector4d ComputeTrianglePlane(const Eigen::Vector3d &p0,
+                                                const Eigen::Vector3d &p1,
+                                                const Eigen::Vector3d &p2);
+
     /// Function that computes the plane equation of a mesh triangle identified
     /// by the triangle index.
     Eigen::Vector4d GetTrianglePlane(size_t triangle_idx) const;
+
+    /// Function that computes the convex hull of the triangle mesh using qhull
+    std::shared_ptr<TriangleMesh> ComputeConvexHull() const;
+
+    /// Function to sample \param number_of_points points uniformly from the
+    /// mesh
+    std::shared_ptr<PointCloud> SamplePointsUniformly(
+            size_t number_of_points,
+            std::vector<double> &triangle_areas,
+            double surface_area) const;
+
+    /// Function to sample \param number_of_points points uniformly from the
+    /// mesh
+    std::shared_ptr<PointCloud> SamplePointsUniformly(
+            size_t number_of_points) const;
+
+    /// Function to sample \param number_of_points points (blue noise).
+    /// Based on the method presented in Yuksel, "Sample Elimination for
+    /// Generating Poisson Disk Sample Sets", EUROGRAPHICS, 2015 The PointCloud
+    /// \param pcl_init is used for sample elimination if given, otherwise a
+    /// PointCloud is first uniformly sampled with \param init_number_of_points
+    /// x \param number_of_points number of points.
+    std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
+            size_t number_of_points,
+            double init_factor = 5,
+            const std::shared_ptr<PointCloud> pcl_init = nullptr) const;
+
+    /// Function to subdivide triangle mesh using the simple midpoint algorithm.
+    /// Each triangle is subdivided into four triangles per iteration and the
+    /// new vertices lie on the midpoint of the triangle edges.
+    std::shared_ptr<TriangleMesh> SubdivideMidpoint(
+            int number_of_iterations) const;
+
+    /// Function to subdivide triangle mesh using Loop's scheme.
+    /// Cf. Charles T. Loop, "Smooth subdivision surfaces based on triangles",
+    /// 1987. Each triangle is subdivided into four triangles per iteration.
+    std::shared_ptr<TriangleMesh> SubdivideLoop(int number_of_iterations) const;
+
+    /// Function to simplify mesh using Vertex Clustering.
+    /// The result can be a non-manifold mesh.
+    std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
+            double voxel_size,
+            TriangleMesh::SimplificationContraction contraction =
+                    TriangleMesh::SimplificationContraction::Average) const;
+
+    /// Function to simplify mesh using Quadric Error Metric Decimation by
+    /// Garland and Heckbert.
+    std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
+            int target_number_of_triangles) const;
+
+    /// Function to select points from \param input TriangleMesh into
+    /// \return output TriangleMesh
+    /// Vertices with indices in \param indices are selected.
+    std::shared_ptr<TriangleMesh> SelectDownSample(
+            const std::vector<size_t> &indices) const;
+
+    /// Function to crop \param input tringlemesh into output tringlemesh
+    /// All points with coordinates less than \param min_bound or larger than
+    /// \param max_bound are clipped.
+    std::shared_ptr<TriangleMesh> Crop(const Eigen::Vector3d &min_bound,
+                                       const Eigen::Vector3d &max_bound) const;
+
+    /// Factory function to create a tetrahedron mesh (trianglemeshfactory.cpp).
+    /// the mesh centroid will be at (0,0,0) and \param radius defines the
+    /// distance from the center to the mesh vertices.
+    static std::shared_ptr<TriangleMesh> CreateTetrahedron(double radius = 1.0);
+
+    /// Factory function to create a octahedron mesh (trianglemeshfactory.cpp).
+    /// the mesh centroid will be at (0,0,0) and \param radius defines the
+    /// distance from the center to the mesh vertices.
+    static std::shared_ptr<TriangleMesh> CreateOctahedron(double radius = 1.0);
+
+    /// Factory function to create a icosahedron mesh (trianglemeshfactory.cpp).
+    /// the mesh centroid will be at (0,0,0) and \param radius defines the
+    /// distance from the center to the mesh vertices.
+    static std::shared_ptr<TriangleMesh> CreateIcosahedron(double radius = 1.0);
+
+    /// Factory function to create a box mesh (TriangleMeshFactory.cpp)
+    /// The left bottom corner on the front will be placed at (0, 0, 0).
+    /// The \param width is x-directional length, and \param height and \param
+    /// depth are y- and z-directional lengths respectively.
+    static std::shared_ptr<TriangleMesh> CreateBox(double width = 1.0,
+                                                   double height = 1.0,
+                                                   double depth = 1.0);
+
+    /// Factory function to create a sphere mesh (TriangleMeshFactory.cpp)
+    /// The sphere with \param radius will be centered at (0, 0, 0).
+    /// Its axis is aligned with z-axis.
+    /// The longitudes will be split into \param resolution segments.
+    /// The latitudes will be split into \param resolution * 2 segments.
+    static std::shared_ptr<TriangleMesh> CreateSphere(double radius = 1.0,
+                                                      int resolution = 20);
+
+    /// Factory function to create a cylinder mesh (TriangleMeshFactory.cpp)
+    /// The axis of the cylinder will be from (0, 0, -height/2) to (0, 0,
+    /// height/2). The circle with \param radius will be split into \param
+    /// resolution segments. The \param height will be split into \param split
+    /// segments.
+    static std::shared_ptr<TriangleMesh> CreateCylinder(double radius = 1.0,
+                                                        double height = 2.0,
+                                                        int resolution = 20,
+                                                        int split = 4);
+
+    /// Factory function to create a cone mesh (TriangleMeshFactory.cpp)
+    /// The axis of the cone will be from (0, 0, 0) to (0, 0, \param height).
+    /// The circle with \param radius will be split into \param resolution
+    /// segments. The height will be split into \param split segments.
+    static std::shared_ptr<TriangleMesh> CreateCone(double radius = 1.0,
+                                                    double height = 2.0,
+                                                    int resolution = 20,
+                                                    int split = 1);
+
+    /// Factory function to create a torus mesh (TriangleMeshFactory.cpp)
+    /// The torus will be centered at (0, 0, 0) and a radius of \param
+    /// torus_radius. The tube of the torus will have a radius of \param
+    /// tube_radius. The number of segments in radial and tubular direction are
+    /// \param radial_resolution and \param tubular_resolution respectively.
+    static std::shared_ptr<TriangleMesh> CreateTorus(
+            double torus_radius = 1.0,
+            double tube_radius = 0.5,
+            int radial_resolution = 30,
+            int tubular_resolution = 20);
+
+    /// Factory function to create an arrow mesh (TriangleMeshFactory.cpp)
+    /// The axis of the cone with \param cone_radius will be along the z-axis.
+    /// The cylinder with \param cylinder_radius is from
+    /// (0, 0, 0) to (0, 0, cylinder_height), and
+    /// the cone is from (0, 0, cylinder_height)
+    /// to (0, 0, cylinder_height + cone_height).
+    /// The cone will be split into \param resolution segments.
+    /// The \param cylinder_height will be split into \param cylinder_split
+    /// segments. The \param cone_height will be split into \param cone_split
+    /// segments.
+    static std::shared_ptr<TriangleMesh> CreateArrow(
+            double cylinder_radius = 1.0,
+            double cone_radius = 1.5,
+            double cylinder_height = 5.0,
+            double cone_height = 4.0,
+            int resolution = 20,
+            int cylinder_split = 4,
+            int cone_split = 1);
+
+    /// Factory function to create a coordinate frame mesh
+    /// (TriangleMeshFactory.cpp) The coordinate frame will be centered at
+    /// \param origin The x, y, z axis will be rendered as red, green, and blue
+    /// arrows respectively. \param size is the length of the axes.
+    static std::shared_ptr<TriangleMesh> CreateCoordinateFrame(
+            double size = 1.0,
+            const Eigen::Vector3d &origin = Eigen::Vector3d(0.0, 0.0, 0.0));
+
+    /// Factory function to create a Moebius strip. \param length_split
+    /// defines the number of segments along the Moebius strip, \param
+    /// width_split defines the number of segments along the width of
+    /// the Moebius strip, \param twists defines the number of twists of the
+    /// strip, \param radius defines the radius of the Moebius strip,
+    /// \param flatness controls the height of the strip, \param width
+    /// controls the width of the Moebius strip and \param scale is used
+    /// to scale the entire Moebius strip.
+    static std::shared_ptr<TriangleMesh> CreateMoebius(int length_split = 70,
+                                                       int width_split = 15,
+                                                       int twists = 1,
+                                                       double radius = 1,
+                                                       double flatness = 1,
+                                                       double width = 1,
+                                                       double scale = 1);
+
+protected:
+    // Forward child class type to avoid indirect nonvirtual base
+    TriangleMesh(Geometry::GeometryType type) : Geometry3D(type) {}
 
 public:
     std::vector<Eigen::Vector3d> vertices_;
@@ -288,177 +470,6 @@ public:
     std::vector<Eigen::Vector3d> triangle_normals_;
     std::vector<std::unordered_set<int>> adjacency_list_;
 };
-
-/// Function that computes the area of a mesh triangle
-double ComputeTriangleArea(const Eigen::Vector3d &p0,
-                           const Eigen::Vector3d &p1,
-                           const Eigen::Vector3d &p2);
-
-/// Function that computes the plane equation from the three points.
-/// If the three points are co-linear, then this function returns the invalid
-/// plane (0, 0, 0, 0).
-Eigen::Vector4d ComputeTrianglePlane(const Eigen::Vector3d &p0,
-                                     const Eigen::Vector3d &p1,
-                                     const Eigen::Vector3d &p2);
-
-/// Function that computes the convex hull of the triangle mesh using qhull
-std::shared_ptr<TriangleMesh> ComputeMeshConvexHull(const TriangleMesh &mesh);
-
-/// Function to sample \param number_of_points points uniformly from the mesh
-std::shared_ptr<PointCloud> SamplePointsUniformly(const TriangleMesh &input,
-                                                  size_t number_of_points);
-
-/// Function to sample \param number_of_points points (blue noise).
-/// Based on the method presented in Yuksel, "Sample Elimination for Generating
-/// Poisson Disk Sample Sets", EUROGRAPHICS, 2015
-/// The PointCloud \param pcl_init is used for sample elimination if given,
-/// otherwise a PointCloud is first uniformly sampled with
-/// \param init_number_of_points x \param number_of_points number of points.
-std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
-        const TriangleMesh &input,
-        size_t number_of_points,
-        double init_factor = 5,
-        const std::shared_ptr<PointCloud> pcl_init = nullptr);
-
-/// Function to subdivide triangle mesh using the simple midpoint algorithm.
-/// Each triangle is subdivided into four triangles per iteration and the
-/// new vertices lie on the midpoint of the triangle edges.
-std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh &input,
-                                                int number_of_iterations);
-
-/// Function to subdivide triangle mesh using Loop's scheme.
-/// Cf. Charles T. Loop, "Smooth subdivision surfaces based on triangles", 1987.
-/// Each triangle is subdivided into four triangles per iteration.
-std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh &input,
-                                            int number_of_iterations);
-
-/// Function to simplify mesh using Vertex Clustering.
-/// The result can be a non-manifold mesh.
-std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
-        const TriangleMesh &input,
-        double voxel_size,
-        TriangleMesh::SimplificationContraction contraction =
-                TriangleMesh::SimplificationContraction::Average);
-
-/// Function to simplify mesh using Quadric Error Metric Decimation by
-/// Garland and Heckbert.
-std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-        const TriangleMesh &input, int target_number_of_triangles);
-
-/// Function to select points from \param input TriangleMesh into
-/// \return output TriangleMesh
-/// Vertices with indices in \param indices are selected.
-std::shared_ptr<TriangleMesh> SelectDownSample(
-        const TriangleMesh &input, const std::vector<size_t> &indices);
-
-/// Function to crop \param input tringlemesh into output tringlemesh
-/// All points with coordinates less than \param min_bound or larger than
-/// \param max_bound are clipped.
-std::shared_ptr<TriangleMesh> CropTriangleMesh(
-        const TriangleMesh &input,
-        const Eigen::Vector3d &min_bound,
-        const Eigen::Vector3d &max_bound);
-
-/// Factory function to create a tetrahedron mesh (trianglemeshfactory.cpp).
-/// the mesh centroid will be at (0,0,0) and \param radius defines the distance
-/// from the center to the mesh vertices.
-std::shared_ptr<TriangleMesh> CreateMeshTetrahedron(double radius = 1.0);
-
-/// Factory function to create a octahedron mesh (trianglemeshfactory.cpp).
-/// the mesh centroid will be at (0,0,0) and \param radius defines the distance
-/// from the center to the mesh vertices.
-std::shared_ptr<TriangleMesh> CreateMeshOctahedron(double radius = 1.0);
-
-/// Factory function to create a icosahedron mesh (trianglemeshfactory.cpp).
-/// the mesh centroid will be at (0,0,0) and \param radius defines the distance
-/// from the center to the mesh vertices.
-std::shared_ptr<TriangleMesh> CreateMeshIcosahedron(double radius = 1.0);
-
-/// Factory function to create a box mesh (TriangleMeshFactory.cpp)
-/// The left bottom corner on the front will be placed at (0, 0, 0).
-/// The \param width is x-directional length, and \param height and \param depth
-/// are y- and z-directional lengths respectively.
-std::shared_ptr<TriangleMesh> CreateMeshBox(double width = 1.0,
-                                            double height = 1.0,
-                                            double depth = 1.0);
-
-/// Factory function to create a sphere mesh (TriangleMeshFactory.cpp)
-/// The sphere with \param radius will be centered at (0, 0, 0).
-/// Its axis is aligned with z-axis.
-/// The longitudes will be split into \param resolution segments.
-/// The latitudes will be split into \param resolution * 2 segments.
-std::shared_ptr<TriangleMesh> CreateMeshSphere(double radius = 1.0,
-                                               int resolution = 20);
-
-/// Factory function to create a cylinder mesh (TriangleMeshFactory.cpp)
-/// The axis of the cylinder will be from (0, 0, -height/2) to (0, 0, height/2).
-/// The circle with \param radius will be split into \param resolution segments.
-/// The \param height will be split into \param split segments.
-std::shared_ptr<TriangleMesh> CreateMeshCylinder(double radius = 1.0,
-                                                 double height = 2.0,
-                                                 int resolution = 20,
-                                                 int split = 4);
-
-/// Factory function to create a cone mesh (TriangleMeshFactory.cpp)
-/// The axis of the cone will be from (0, 0, 0) to (0, 0, \param height).
-/// The circle with \param radius will be split into \param resolution segments.
-/// The height will be split into \param split segments.
-std::shared_ptr<TriangleMesh> CreateMeshCone(double radius = 1.0,
-                                             double height = 2.0,
-                                             int resolution = 20,
-                                             int split = 1);
-
-/// Factory function to create a torus mesh (TriangleMeshFactory.cpp)
-/// The torus will be centered at (0, 0, 0) and a radius of \param torus_radius.
-/// The tube of the torus will have a radius of \param tube_radius.
-/// The number of segments in radial and tubular direction are \param
-/// radial_resolution and \param tubular_resolution respectively.
-std::shared_ptr<TriangleMesh> CreateMeshTorus(double torus_radius = 1.0,
-                                              double tube_radius = 0.5,
-                                              int radial_resolution = 30,
-                                              int tubular_resolution = 20);
-
-/// Factory function to create an arrow mesh (TriangleMeshFactory.cpp)
-/// The axis of the cone with \param cone_radius will be along the z-axis.
-/// The cylinder with \param cylinder_radius is from
-/// (0, 0, 0) to (0, 0, cylinder_height), and
-/// the cone is from (0, 0, cylinder_height)
-/// to (0, 0, cylinder_height + cone_height).
-/// The cone will be split into \param resolution segments.
-/// The \param cylinder_height will be split into \param cylinder_split
-/// segments. The \param cone_height will be split into \param cone_split
-/// segments.
-std::shared_ptr<TriangleMesh> CreateMeshArrow(double cylinder_radius = 1.0,
-                                              double cone_radius = 1.5,
-                                              double cylinder_height = 5.0,
-                                              double cone_height = 4.0,
-                                              int resolution = 20,
-                                              int cylinder_split = 4,
-                                              int cone_split = 1);
-
-/// Factory function to create a coordinate frame mesh (TriangleMeshFactory.cpp)
-/// The coordinate frame will be centered at \param origin
-/// The x, y, z axis will be rendered as red, green, and blue arrows
-/// respectively. \param size is the length of the axes.
-std::shared_ptr<TriangleMesh> CreateMeshCoordinateFrame(
-        double size = 1.0,
-        const Eigen::Vector3d &origin = Eigen::Vector3d(0.0, 0.0, 0.0));
-
-/// Factory function to create a Moebius strip. \param length_split
-/// defines the number of segments along the Moebius strip, \param
-/// width_split defines the number of segments along the width of
-/// the Moebius strip, \param twists defines the number of twists of the
-/// strip, \param radius defines the radius of the Moebius strip,
-/// \param flatness controls the height of the strip, \param width
-/// controls the width of the Moebius strip and \param scale is used
-/// to scale the entire Moebius strip.
-std::shared_ptr<TriangleMesh> CreateMeshMoebius(int length_split = 70,
-                                                int width_split = 15,
-                                                int twists = 1,
-                                                double radius = 1,
-                                                double flatness = 1,
-                                                double width = 1,
-                                                double scale = 1);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/TriangleMeshFactory.cpp
+++ b/src/Open3D/Geometry/TriangleMeshFactory.cpp
@@ -30,10 +30,11 @@
 namespace open3d {
 namespace geometry {
 
-std::shared_ptr<TriangleMesh> CreateMeshTetrahedron(double radius /* = 1.0*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateTetrahedron(
+        double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshTetrahedron] radius <= 0");
+        utility::PrintWarning("[CreateTetrahedron] radius <= 0");
         return mesh;
     }
     mesh->vertices_.push_back(radius *
@@ -52,10 +53,11 @@ std::shared_ptr<TriangleMesh> CreateMeshTetrahedron(double radius /* = 1.0*/) {
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshOctahedron(double radius /* = 1.0*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateOctahedron(
+        double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshOctahedron] radius <= 0");
+        utility::PrintWarning("[CreateOctahedron] radius <= 0");
         return mesh;
     }
     mesh->vertices_.push_back(radius * Eigen::Vector3d(1, 0, 0));
@@ -75,10 +77,11 @@ std::shared_ptr<TriangleMesh> CreateMeshOctahedron(double radius /* = 1.0*/) {
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshIcosahedron(double radius /* = 1.0*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateIcosahedron(
+        double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshIcosahedron] radius <= 0");
+        utility::PrintWarning("[CreateIcosahedron] radius <= 0");
         return mesh;
     }
     const double p = (1. + std::sqrt(5.)) / 2.;
@@ -117,20 +120,20 @@ std::shared_ptr<TriangleMesh> CreateMeshIcosahedron(double radius /* = 1.0*/) {
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshBox(double width /* = 1.0*/,
-                                            double height /* = 1.0*/,
-                                            double depth /* = 1.0*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateBox(double width /* = 1.0*/,
+                                                      double height /* = 1.0*/,
+                                                      double depth /* = 1.0*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (width <= 0) {
-        utility::PrintWarning("[CreateMeshBox] width <= 0");
+        utility::PrintWarning("[CreateBox] width <= 0");
         return mesh_ptr;
     }
     if (height <= 0) {
-        utility::PrintWarning("[CreateMeshBox] height <= 0");
+        utility::PrintWarning("[CreateBox] height <= 0");
         return mesh_ptr;
     }
     if (depth <= 0) {
-        utility::PrintWarning("[CreateMeshBox] depth <= 0");
+        utility::PrintWarning("[CreateBox] depth <= 0");
         return mesh_ptr;
     }
     mesh_ptr->vertices_.resize(8);
@@ -157,15 +160,15 @@ std::shared_ptr<TriangleMesh> CreateMeshBox(double width /* = 1.0*/,
     return mesh_ptr;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshSphere(double radius /* = 1.0*/,
-                                               int resolution /* = 20*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateSphere(
+        double radius /* = 1.0*/, int resolution /* = 20*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshSphere] radius <= 0");
+        utility::PrintWarning("[CreateSphere] radius <= 0");
         return mesh_ptr;
     }
     if (resolution <= 0) {
-        utility::PrintWarning("[CreateMeshSphere] resolution <= 0");
+        utility::PrintWarning("[CreateSphere] resolution <= 0");
         return mesh_ptr;
     }
     mesh_ptr->vertices_.resize(2 * resolution * (resolution - 1) + 2);
@@ -204,25 +207,26 @@ std::shared_ptr<TriangleMesh> CreateMeshSphere(double radius /* = 1.0*/,
     return mesh_ptr;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshCylinder(double radius /* = 1.0*/,
-                                                 double height /* = 2.0*/,
-                                                 int resolution /* = 20*/,
-                                                 int split /* = 4*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateCylinder(
+        double radius /* = 1.0*/,
+        double height /* = 2.0*/,
+        int resolution /* = 20*/,
+        int split /* = 4*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshCylinder] radius <= 0");
+        utility::PrintWarning("[CreateCylinder] radius <= 0");
         return mesh_ptr;
     }
     if (height <= 0) {
-        utility::PrintWarning("[CreateMeshCylinder] height <= 0");
+        utility::PrintWarning("[CreateCylinder] height <= 0");
         return mesh_ptr;
     }
     if (resolution <= 0) {
-        utility::PrintWarning("[CreateMeshCylinder] resolution <= 0");
+        utility::PrintWarning("[CreateCylinder] resolution <= 0");
         return mesh_ptr;
     }
     if (split <= 0) {
-        utility::PrintWarning("[CreateMeshCylinder] split <= 0");
+        utility::PrintWarning("[CreateCylinder] split <= 0");
         return mesh_ptr;
     }
     mesh_ptr->vertices_.resize(resolution * (split + 1) + 2);
@@ -259,25 +263,25 @@ std::shared_ptr<TriangleMesh> CreateMeshCylinder(double radius /* = 1.0*/,
     return mesh_ptr;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshCone(double radius /* = 1.0*/,
-                                             double height /* = 2.0*/,
-                                             int resolution /* = 20*/,
-                                             int split /* = 4*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateCone(double radius /* = 1.0*/,
+                                                       double height /* = 2.0*/,
+                                                       int resolution /* = 20*/,
+                                                       int split /* = 4*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshCone] radius <= 0");
+        utility::PrintWarning("[CreateCone] radius <= 0");
         return mesh_ptr;
     }
     if (height <= 0) {
-        utility::PrintWarning("[CreateMeshCone] height <= 0");
+        utility::PrintWarning("[CreateCone] height <= 0");
         return mesh_ptr;
     }
     if (resolution <= 0) {
-        utility::PrintWarning("[CreateMeshCone] resolution <= 0");
+        utility::PrintWarning("[CreateCone] resolution <= 0");
         return mesh_ptr;
     }
     if (split <= 0) {
-        utility::PrintWarning("[CreateMeshCone] split <= 0");
+        utility::PrintWarning("[CreateCone] split <= 0");
         return mesh_ptr;
     }
     mesh_ptr->vertices_.resize(resolution * split + 2);
@@ -316,26 +320,26 @@ std::shared_ptr<TriangleMesh> CreateMeshCone(double radius /* = 1.0*/,
     return mesh_ptr;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshTorus(
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateTorus(
         double torus_radius /* = 1.0 */,
         double tube_radius /* = 0.5 */,
         int radial_resolution /* = 20 */,
         int tubular_resolution /* = 20 */) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (torus_radius <= 0) {
-        utility::PrintWarning("[CreateMeshTorus] torus_radius <= 0");
+        utility::PrintWarning("[CreateTorus] torus_radius <= 0");
         return mesh;
     }
     if (tube_radius <= 0) {
-        utility::PrintWarning("[CreateMeshTorus] tube_radius <= 0");
+        utility::PrintWarning("[CreateTorus] tube_radius <= 0");
         return mesh;
     }
     if (radial_resolution <= 0) {
-        utility::PrintWarning("[CreateMeshTorus] radial_resolution <= 0");
+        utility::PrintWarning("[CreateTorus] radial_resolution <= 0");
         return mesh;
     }
     if (tubular_resolution <= 0) {
-        utility::PrintWarning("[CreateMeshTorus] tubular_resolution <= 0");
+        utility::PrintWarning("[CreateTorus] tubular_resolution <= 0");
         return mesh;
     }
 
@@ -372,48 +376,49 @@ std::shared_ptr<TriangleMesh> CreateMeshTorus(
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshArrow(double cylinder_radius /* = 1.0*/,
-                                              double cone_radius /* = 1.5*/,
-                                              double cylinder_height /* = 5.0*/,
-                                              double cone_height /* = 4.0*/,
-                                              int resolution /* = 20*/,
-                                              int cylinder_split /* = 4*/,
-                                              int cone_split /* = 1*/) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateArrow(
+        double cylinder_radius /* = 1.0*/,
+        double cone_radius /* = 1.5*/,
+        double cylinder_height /* = 5.0*/,
+        double cone_height /* = 4.0*/,
+        int resolution /* = 20*/,
+        int cylinder_split /* = 4*/,
+        int cone_split /* = 1*/) {
     if (cylinder_radius <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cylinder_radius <= 0");
+        utility::PrintWarning("[CreateArrow] cylinder_radius <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (cone_radius <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cone_radius <= 0");
+        utility::PrintWarning("[CreateArrow] cone_radius <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (cylinder_height <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cylinder_height <= 0");
+        utility::PrintWarning("[CreateArrow] cylinder_height <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (cone_height <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cone_height <= 0");
+        utility::PrintWarning("[CreateArrow] cone_height <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (resolution <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] resolution <= 0");
+        utility::PrintWarning("[CreateArrow] resolution <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (cylinder_split <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cylinder_split <= 0");
+        utility::PrintWarning("[CreateArrow] cylinder_split <= 0");
         return std::make_shared<TriangleMesh>();
     }
     if (cone_split <= 0) {
-        utility::PrintWarning("[CreateMeshArrow] cone_split <= 0");
+        utility::PrintWarning("[CreateArrow] cone_split <= 0");
         return std::make_shared<TriangleMesh>();
     }
     Eigen::Matrix4d transformation = Eigen::Matrix4d::Identity();
-    auto mesh_cylinder = CreateMeshCylinder(cylinder_radius, cylinder_height,
-                                            resolution, cylinder_split);
+    auto mesh_cylinder = CreateCylinder(cylinder_radius, cylinder_height,
+                                        resolution, cylinder_split);
     transformation(2, 3) = cylinder_height * 0.5;
     mesh_cylinder->Transform(transformation);
     auto mesh_cone =
-            CreateMeshCone(cone_radius, cone_height, resolution, cone_split);
+            CreateCone(cone_radius, cone_height, resolution, cone_split);
     transformation(2, 3) = cylinder_height;
     mesh_cone->Transform(transformation);
     auto mesh_arrow = mesh_cylinder;
@@ -421,38 +426,35 @@ std::shared_ptr<TriangleMesh> CreateMeshArrow(double cylinder_radius /* = 1.0*/,
     return mesh_arrow;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshCoordinateFrame(
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateCoordinateFrame(
         double size /* = 1.0*/,
         const Eigen::Vector3d &origin /* = Eigen::Vector3d(0.0, 0.0, 0.0)*/) {
     if (size <= 0) {
-        utility::PrintWarning("[CreateMeshCoordinateFrame] size <= 0");
+        utility::PrintWarning("[CreateCoordinateFrame] size <= 0");
         return std::make_shared<TriangleMesh>();
     }
-    auto mesh_frame = CreateMeshSphere(0.06 * size);
+    auto mesh_frame = CreateSphere(0.06 * size);
     mesh_frame->ComputeVertexNormals();
     mesh_frame->PaintUniformColor(Eigen::Vector3d(0.5, 0.5, 0.5));
 
     std::shared_ptr<TriangleMesh> mesh_arrow;
     Eigen::Matrix4d transformation;
 
-    mesh_arrow =
-            CreateMeshArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
+    mesh_arrow = CreateArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
     mesh_arrow->ComputeVertexNormals();
     mesh_arrow->PaintUniformColor(Eigen::Vector3d(1.0, 0.0, 0.0));
     transformation << 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1;
     mesh_arrow->Transform(transformation);
     *mesh_frame += *mesh_arrow;
 
-    mesh_arrow =
-            CreateMeshArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
+    mesh_arrow = CreateArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
     mesh_arrow->ComputeVertexNormals();
     mesh_arrow->PaintUniformColor(Eigen::Vector3d(0.0, 1.0, 0.0));
     transformation << 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1;
     mesh_arrow->Transform(transformation);
     *mesh_frame += *mesh_arrow;
 
-    mesh_arrow =
-            CreateMeshArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
+    mesh_arrow = CreateArrow(0.035 * size, 0.06 * size, 0.8 * size, 0.2 * size);
     mesh_arrow->ComputeVertexNormals();
     mesh_arrow->PaintUniformColor(Eigen::Vector3d(0.0, 0.0, 1.0));
     transformation << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1;
@@ -466,40 +468,41 @@ std::shared_ptr<TriangleMesh> CreateMeshCoordinateFrame(
     return mesh_frame;
 }
 
-std::shared_ptr<TriangleMesh> CreateMeshMoebius(int length_split /* = 70 */,
-                                                int width_split /* = 15 */,
-                                                int twists /* = 1 */,
-                                                double radius /* = 1 */,
-                                                double flatness /* = 1 */,
-                                                double width /* = 1 */,
-                                                double scale /* = 1 */) {
+std::shared_ptr<TriangleMesh> TriangleMesh::CreateMoebius(
+        int length_split /* = 70 */,
+        int width_split /* = 15 */,
+        int twists /* = 1 */,
+        double radius /* = 1 */,
+        double flatness /* = 1 */,
+        double width /* = 1 */,
+        double scale /* = 1 */) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (length_split <= 0) {
-        utility::PrintWarning("[CreateMeshMoebius] length_split <= 0");
+        utility::PrintWarning("[CreateMoebius] length_split <= 0");
         return mesh;
     }
     if (width_split <= 0) {
-        utility::PrintWarning("[CreateMeshMoebius] width_split <= 0");
+        utility::PrintWarning("[CreateMoebius] width_split <= 0");
         return mesh;
     }
     if (twists < 0) {
-        utility::PrintWarning("[CreateMeshMoebius] twists < 0");
+        utility::PrintWarning("[CreateMoebius] twists < 0");
         return mesh;
     }
     if (radius <= 0) {
-        utility::PrintWarning("[CreateMeshMoebius] radius <= 0");
+        utility::PrintWarning("[CreateMoebius] radius <= 0");
         return mesh;
     }
     if (flatness == 0) {
-        utility::PrintWarning("[CreateMeshMoebius] flatness == 0");
+        utility::PrintWarning("[CreateMoebius] flatness == 0");
         return mesh;
     }
     if (width <= 0) {
-        utility::PrintWarning("[CreateMeshMoebius] width <= 0");
+        utility::PrintWarning("[CreateMoebius] width <= 0");
         return mesh;
     }
     if (scale <= 0) {
-        utility::PrintWarning("[CreateMeshMoebius] scale <= 0");
+        utility::PrintWarning("[CreateMoebius] scale <= 0");
         return mesh;
     }
 

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -89,11 +89,10 @@ public:
     double c_;
 };
 
-std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
-        const TriangleMesh& input,
+std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
         double voxel_size,
         TriangleMesh::SimplificationContraction
-                contraction /* = SimplificationContraction::Average */) {
+                contraction /* = SimplificationContraction::Average */) const {
     auto mesh = std::make_shared<TriangleMesh>();
     if (voxel_size <= 0.0) {
         utility::PrintWarning("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
@@ -102,8 +101,8 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
 
     Eigen::Vector3d voxel_size3 =
             Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
-    Eigen::Vector3d voxel_min_bound = input.GetMinBound() - voxel_size3 * 0.5;
-    Eigen::Vector3d voxel_max_bound = input.GetMaxBound() + voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_min_bound = GetMinBound() - voxel_size3 * 0.5;
+    Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
         utility::PrintWarning(
@@ -125,8 +124,8 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
                        utility::hash_eigen::hash<Eigen::Vector3i>>
             voxel_vert_ind;
     int new_vidx = 0;
-    for (size_t vidx = 0; vidx < input.vertices_.size(); ++vidx) {
-        const Eigen::Vector3i vox_idx = GetVoxelIdx(input.vertices_[vidx]);
+    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
+        const Eigen::Vector3i vox_idx = GetVoxelIdx(vertices_[vidx]);
         voxel_vertices[vox_idx].insert(vidx);
 
         if (voxel_vert_ind.count(vox_idx) == 0) {
@@ -136,8 +135,8 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
     }
 
     // aggregate vertex info
-    bool has_vert_normal = input.HasVertexNormals();
-    bool has_vert_color = input.HasVertexColors();
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
     mesh->vertices_.resize(voxel_vertices.size());
     if (has_vert_normal) {
         mesh->vertex_normals_.resize(voxel_vertices.size());
@@ -149,7 +148,7 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
     auto AvgVertex = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += input.vertices_[vidx];
+            aggr += vertices_[vidx];
         }
         aggr /= ind.size();
         return aggr;
@@ -157,7 +156,7 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
     auto AvgNormal = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += input.vertex_normals_[vidx];
+            aggr += vertex_normals_[vidx];
         }
         aggr /= ind.size();
         return aggr;
@@ -165,7 +164,7 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
     auto AvgColor = [&](const std::unordered_set<int> ind) {
         Eigen::Vector3d aggr(0, 0, 0);
         for (int vidx : ind) {
-            aggr += input.vertex_colors_[vidx];
+            aggr += vertex_colors_[vidx];
         }
         aggr /= ind.size();
         return aggr;
@@ -187,10 +186,10 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
         // Map triangles
         std::unordered_map<int, std::unordered_set<int>> vert_to_triangles;
         int next_tidx = 0;
-        for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
-            vert_to_triangles[input.triangles_[tidx](0)].emplace(tidx);
-            vert_to_triangles[input.triangles_[tidx](1)].emplace(tidx);
-            vert_to_triangles[input.triangles_[tidx](2)].emplace(tidx);
+        for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+            vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
+            vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
+            vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
         }
 
         for (const auto& voxel : voxel_vertices) {
@@ -199,8 +198,8 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
             Quadric q;
             for (int vidx : voxel.second) {
                 for (int tidx : vert_to_triangles[vidx]) {
-                    Eigen::Vector4d p = input.GetTrianglePlane(tidx);
-                    double area = input.GetTriangleArea(tidx);
+                    Eigen::Vector4d p = GetTrianglePlane(tidx);
+                    double area = GetTriangleArea(tidx);
                     q += Quadric(p, area);
                 }
             }
@@ -224,10 +223,10 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
     std::unordered_set<Eigen::Vector3i,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
             triangles;
-    for (const auto& triangle : input.triangles_) {
-        int vidx0 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(0)])];
-        int vidx1 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(1)])];
-        int vidx2 = voxel_vert_ind[GetVoxelIdx(input.vertices_[triangle(2)])];
+    for (const auto& triangle : triangles_) {
+        int vidx0 = voxel_vert_ind[GetVoxelIdx(vertices_[triangle(0)])];
+        int vidx1 = voxel_vert_ind[GetVoxelIdx(vertices_[triangle(1)])];
+        int vidx2 = voxel_vert_ind[GetVoxelIdx(vertices_[triangle(2)])];
 
         // only connect if in different voxels
         if (vidx0 == vidx1 || vidx0 == vidx2 || vidx1 == vidx2) {
@@ -258,50 +257,49 @@ std::shared_ptr<TriangleMesh> SimplifyVertexClustering(
         tidx++;
     }
 
-    if (input.HasTriangleNormals()) {
+    if (HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-        const TriangleMesh& input, int target_number_of_triangles) {
+std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
+        int target_number_of_triangles) const {
     typedef std::tuple<double, int, int> CostEdge;
 
     auto mesh = std::make_shared<TriangleMesh>();
-    mesh->vertices_ = input.vertices_;
-    mesh->vertex_normals_ = input.vertex_normals_;
-    mesh->vertex_colors_ = input.vertex_colors_;
-    mesh->triangles_ = input.triangles_;
+    mesh->vertices_ = vertices_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->triangles_ = triangles_;
 
-    std::vector<bool> vertices_deleted(input.vertices_.size(), false);
-    std::vector<bool> triangles_deleted(input.triangles_.size(), false);
+    std::vector<bool> vertices_deleted(vertices_.size(), false);
+    std::vector<bool> triangles_deleted(triangles_.size(), false);
 
     // Map vertices to triangles and compute triangle planes and areas
-    std::vector<std::unordered_set<int>> vert_to_triangles(
-            input.vertices_.size());
-    std::vector<Eigen::Vector4d> triangle_planes(input.triangles_.size());
-    std::vector<double> triangle_areas(input.triangles_.size());
-    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
-        vert_to_triangles[input.triangles_[tidx](0)].emplace(tidx);
-        vert_to_triangles[input.triangles_[tidx](1)].emplace(tidx);
-        vert_to_triangles[input.triangles_[tidx](2)].emplace(tidx);
+    std::vector<std::unordered_set<int>> vert_to_triangles(vertices_.size());
+    std::vector<Eigen::Vector4d> triangle_planes(triangles_.size());
+    std::vector<double> triangle_areas(triangles_.size());
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        vert_to_triangles[triangles_[tidx](0)].emplace(tidx);
+        vert_to_triangles[triangles_[tidx](1)].emplace(tidx);
+        vert_to_triangles[triangles_[tidx](2)].emplace(tidx);
 
-        triangle_planes[tidx] = input.GetTrianglePlane(tidx);
-        triangle_areas[tidx] = input.GetTriangleArea(tidx);
+        triangle_planes[tidx] = GetTrianglePlane(tidx);
+        triangle_areas[tidx] = GetTriangleArea(tidx);
     }
 
     // Compute the error metric per vertex
-    std::vector<Quadric> Qs(input.vertices_.size());
-    for (size_t vidx = 0; vidx < input.vertices_.size(); ++vidx) {
+    std::vector<Quadric> Qs(vertices_.size());
+    for (size_t vidx = 0; vidx < vertices_.size(); ++vidx) {
         for (int tidx : vert_to_triangles[vidx]) {
             Qs[vidx] += Quadric(triangle_planes[tidx], triangle_areas[tidx]);
         }
     }
 
     // For boundary edges add perpendicular plane quadric
-    auto edge_triangle_count = input.GetEdgeToTrianglesMap();
+    auto edge_triangle_count = GetEdgeToTrianglesMap();
     auto AddPerpPlaneQuadric = [&](int vidx0, int vidx1, int vidx2,
                                    double area) {
         int min = std::min(vidx0, vidx1);
@@ -319,8 +317,8 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
         Qs[vidx0] += quad;
         Qs[vidx1] += quad;
     };
-    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
-        const auto& tria = input.triangles_[tidx];
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        const auto& tria = triangles_[tidx];
         double area = triangle_areas[tidx];
         AddPerpPlaneQuadric(tria(0), tria(1), tria(2), area);
         AddPerpPlaneQuadric(tria(1), tria(2), tria(0), area);
@@ -377,16 +375,16 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
     };
 
     // add all edges to priority queue
-    for (const auto& triangle : input.triangles_) {
+    for (const auto& triangle : triangles_) {
         AddEdge(triangle(0), triangle(1), false);
         AddEdge(triangle(1), triangle(2), false);
         AddEdge(triangle(2), triangle(0), false);
     }
 
     // perform incremental edge collapse
-    bool has_vert_normal = input.HasVertexNormals();
-    bool has_vert_color = input.HasVertexColors();
-    int n_triangles = input.triangles_.size();
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    int n_triangles = triangles_.size();
     while (n_triangles > target_number_of_triangles && !queue.empty()) {
         // retrieve edge from queue
         double cost;
@@ -538,7 +536,7 @@ std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
     }
     mesh->triangles_.resize(next_free);
 
-    if (input.HasTriangleNormals()) {
+    if (HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -35,17 +35,17 @@
 namespace open3d {
 namespace geometry {
 
-std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
-                                                int number_of_iterations) {
+std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideMidpoint(
+        int number_of_iterations) const {
     auto mesh = std::make_shared<TriangleMesh>();
-    mesh->vertices_ = input.vertices_;
-    mesh->vertex_colors_ = input.vertex_colors_;
-    mesh->vertex_normals_ = input.vertex_normals_;
-    mesh->triangles_ = input.triangles_;
+    mesh->vertices_ = vertices_;
+    mesh->vertex_colors_ = vertex_colors_;
+    mesh->vertex_normals_ = vertex_normals_;
+    mesh->triangles_ = triangles_;
 
-    bool has_vert_normal = input.HasVertexNormals();
-    bool has_vert_color = input.HasVertexColors();
-    bool has_tria_normal = input.HasTriangleNormals();
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    bool has_tria_normal = HasTriangleNormals();
 
     // Compute and return midpoint.
     // Also adds edge - new vertex refrence to new_verts map.
@@ -102,15 +102,15 @@ std::shared_ptr<TriangleMesh> SubdivideMidpoint(const TriangleMesh& input,
         mesh->triangles_ = new_triangles;
     }
 
-    if (input.HasTriangleNormals()) {
+    if (HasTriangleNormals()) {
         mesh->ComputeTriangleNormals();
     }
 
     return mesh;
 }
 
-std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh& input,
-                                            int number_of_iterations) {
+std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideLoop(
+        int number_of_iterations) const {
     typedef std::unordered_map<Eigen::Vector2i, int,
                                utility::hash_eigen::hash<Eigen::Vector2i>>
             EdgeNewVertMap;
@@ -123,9 +123,9 @@ std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh& input,
         return Eigen::Vector2i(std::min(vidx0, vidx1), std::max(vidx0, vidx1));
     };
 
-    bool has_vert_normal = input.HasVertexNormals();
-    bool has_vert_color = input.HasVertexColors();
-    bool has_tria_normal = input.HasTriangleNormals();
+    bool has_vert_normal = HasVertexNormals();
+    bool has_vert_color = HasVertexColors();
+    bool has_tria_normal = HasTriangleNormals();
 
     auto UpdateVertex = [&](int vidx,
                             const std::shared_ptr<TriangleMesh>& old_mesh,
@@ -284,9 +284,9 @@ std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh& input,
     };
 
     EdgeTrianglesMap edge_to_triangles;
-    VertexNeighbours vertex_neighbours(input.vertices_.size());
-    for (size_t tidx = 0; tidx < input.triangles_.size(); ++tidx) {
-        const auto& tria = input.triangles_[tidx];
+    VertexNeighbours vertex_neighbours(vertices_.size());
+    for (size_t tidx = 0; tidx < triangles_.size(); ++tidx) {
+        const auto& tria = triangles_[tidx];
         Eigen::Vector2i e0 = CreateEdge(tria(0), tria(1));
         edge_to_triangles[e0].insert(tidx);
         Eigen::Vector2i e1 = CreateEdge(tria(1), tria(2));
@@ -309,10 +309,10 @@ std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh& input,
     }
 
     auto old_mesh = std::make_shared<TriangleMesh>();
-    old_mesh->vertices_ = input.vertices_;
-    old_mesh->vertex_colors_ = input.vertex_colors_;
-    old_mesh->vertex_normals_ = input.vertex_normals_;
-    old_mesh->triangles_ = input.triangles_;
+    old_mesh->vertices_ = vertices_;
+    old_mesh->vertex_colors_ = vertex_colors_;
+    old_mesh->vertex_normals_ = vertex_normals_;
+    old_mesh->triangles_ = triangles_;
 
     for (int iter = 0; iter < number_of_iterations; ++iter) {
         int n_new_vertices =
@@ -365,7 +365,7 @@ std::shared_ptr<TriangleMesh> SubdivideLoop(const TriangleMesh& input,
         vertex_neighbours = std::move(new_vertex_neighbours);
     }
 
-    if (input.HasTriangleNormals()) {
+    if (HasTriangleNormals()) {
         old_mesh->ComputeTriangleNormals();
     }
 

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -39,10 +39,11 @@ VoxelGrid::VoxelGrid(const VoxelGrid &src_voxel_grid)
       origin_(src_voxel_grid.origin_),
       voxels_(src_voxel_grid.voxels_) {}
 
-void VoxelGrid::Clear() {
+VoxelGrid &VoxelGrid::Clear() {
     voxel_size_ = 0.0;
     origin_ = Eigen::Vector3d::Zero();
     voxels_.clear();
+    return *this;
 }
 
 bool VoxelGrid::IsEmpty() const { return !HasVoxels(); }

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -58,8 +58,7 @@ public:
     VoxelGrid(const VoxelGrid &src_voxel_grid);
     ~VoxelGrid() override {}
 
-public:
-    void Clear() override;
+    VoxelGrid &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
@@ -70,11 +69,9 @@ public:
                       bool center = true,
                       RotationType type = RotationType::XYZ) override;
 
-public:
     VoxelGrid &operator+=(const VoxelGrid &voxelgrid);
     VoxelGrid operator+(const VoxelGrid &voxelgrid) const;
 
-public:
     bool HasVoxels() const { return voxels_.size() > 0; }
     bool HasColors() const {
         return true;  // By default, the colors are (0, 0, 0)
@@ -85,14 +82,14 @@ public:
 
     std::shared_ptr<geometry::Octree> ToOctree(const size_t &max_depth) const;
 
+    static std::shared_ptr<VoxelGrid> CreateFromPointCloud(
+            const PointCloud &input, double voxel_size);
+
 public:
     double voxel_size_;
     Eigen::Vector3d origin_;
     std::vector<Voxel> voxels_;
 };
-
-std::shared_ptr<VoxelGrid> CreateSurfaceVoxelGridFromPointCloud(
-        const PointCloud &input, double voxel_size);
 
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/VoxelGridFactory.cpp
+++ b/src/Open3D/Geometry/VoxelGridFactory.cpp
@@ -68,7 +68,7 @@ public:
 
 namespace geometry {
 
-std::shared_ptr<VoxelGrid> CreateSurfaceVoxelGridFromPointCloud(
+std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloud(
         const PointCloud &input, double voxel_size) {
     auto output = std::make_shared<VoxelGrid>();
     if (voxel_size <= 0.0) {

--- a/src/Open3D/IO/FileFormat/FileJPG.cpp
+++ b/src/Open3D/IO/FileFormat/FileJPG.cpp
@@ -77,8 +77,8 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
             return false;
     }
     jpeg_start_decompress(&cinfo);
-    image.PrepareImage(cinfo.output_width, cinfo.output_height, num_of_channels,
-                       bytes_per_channel);
+    image.Prepare(cinfo.output_width, cinfo.output_height, num_of_channels,
+                  bytes_per_channel);
     int row_stride = cinfo.output_width * cinfo.output_components;
     buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE,
                                         row_stride, 1);

--- a/src/Open3D/IO/FileFormat/FilePNG.cpp
+++ b/src/Open3D/IO/FileFormat/FilePNG.cpp
@@ -62,9 +62,9 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     // We only support two channel types: gray, and RGB.
     // There is no alpha channel.
     // bytes_per_channel is determined by PNG_FORMAT_FLAG_LINEAR flag.
-    image.PrepareImage(pngimage.width, pngimage.height,
-                       (pngimage.format & PNG_FORMAT_FLAG_COLOR) ? 3 : 1,
-                       (pngimage.format & PNG_FORMAT_FLAG_LINEAR) ? 2 : 1);
+    image.Prepare(pngimage.width, pngimage.height,
+                  (pngimage.format & PNG_FORMAT_FLAG_COLOR) ? 3 : 1,
+                  (pngimage.format & PNG_FORMAT_FLAG_LINEAR) ? 2 : 1);
     SetPNGImageFromImage(image, pngimage);
     if (png_image_finish_read(&pngimage, NULL, image.data_.data(), 0, NULL) ==
         0) {

--- a/src/Open3D/Integration/ScalableTSDFVolume.cpp
+++ b/src/Open3D/Integration/ScalableTSDFVolume.cpp
@@ -75,9 +75,9 @@ void ScalableTSDFVolume::Integrate(
         return;
     }
     auto depth2cameradistance =
-            geometry::CreateDepthToCameraDistanceMultiplierFloatImage(
+            geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(
                     intrinsic);
-    auto pointcloud = geometry::CreatePointCloudFromDepthImage(
+    auto pointcloud = geometry::PointCloud::CreateFromDepthImage(
             image.depth_, intrinsic, extrinsic, 1000.0, 1000.0,
             depth_sampling_stride_);
     std::unordered_set<Eigen::Vector3i,

--- a/src/Open3D/Integration/UniformTSDFVolume.cpp
+++ b/src/Open3D/Integration/UniformTSDFVolume.cpp
@@ -90,7 +90,7 @@ void UniformTSDFVolume::Integrate(
         return;
     }
     auto depth2cameradistance =
-            geometry::CreateDepthToCameraDistanceMultiplierFloatImage(
+            geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(
                     intrinsic);
     IntegrateWithDepthToCameraDistanceMultiplier(image, intrinsic, extrinsic,
                                                  *depth2cameradistance);
@@ -338,15 +338,16 @@ void UniformTSDFVolume::IntegrateWithDepthToCameraDistanceMultiplier(
                 // Skip if negative depth in depth image
                 int u = (int)u_f;
                 int v = (int)v_f;
-                float d = *geometry::PointerAt<float>(image.depth_, u, v);
+                float d = *image.depth_.PointerAt<float>(u, v);
                 if (d <= 0.0f) {
                     continue;
                 }
 
                 int v_ind = IndexOf(x, y, z);
-                float sdf = (d - pt_camera(2)) *
-                            (*geometry::PointerAt<float>(
-                                    depth_to_camera_distance_multiplier, u, v));
+                float sdf =
+                        (d - pt_camera(2)) *
+                        (*depth_to_camera_distance_multiplier.PointerAt<float>(
+                                u, v));
                 if (sdf > -sdf_trunc_f) {
                     // integrate
                     float tsdf = std::min(1.0f, sdf * sdf_trunc_inv_f);
@@ -356,8 +357,8 @@ void UniformTSDFVolume::IntegrateWithDepthToCameraDistanceMultiplier(
                              tsdf) /
                             (voxel_grid_.voxels_[v_ind].weight_ + 1.0f);
                     if (color_type_ == TSDFVolumeColorType::RGB8) {
-                        const uint8_t *rgb = geometry::PointerAt<uint8_t>(
-                                image.color_, u, v, 0);
+                        const uint8_t *rgb =
+                                image.color_.PointerAt<uint8_t>(u, v, 0);
                         Eigen::Vector3d rgb_f(rgb[0], rgb[1], rgb[2]);
                         voxel_grid_.voxels_[v_ind].color_ =
                                 (voxel_grid_.voxels_[v_ind].color_ *
@@ -365,8 +366,8 @@ void UniformTSDFVolume::IntegrateWithDepthToCameraDistanceMultiplier(
                                  rgb_f) /
                                 (voxel_grid_.voxels_[v_ind].weight_ + 1.0f);
                     } else if (color_type_ == TSDFVolumeColorType::Gray32) {
-                        const float *intensity = geometry::PointerAt<float>(
-                                image.color_, u, v, 0);
+                        const float *intensity =
+                                image.color_.PointerAt<float>(u, v, 0);
                         voxel_grid_.voxels_[v_ind].color_ =
                                 (voxel_grid_.voxels_[v_ind].color_.array() *
                                          voxel_grid_.voxels_[v_ind].weight_ +

--- a/src/Open3D/Odometry/Odometry.cpp
+++ b/src/Open3D/Odometry/Odometry.cpp
@@ -44,8 +44,8 @@ InitializeCorrespondenceMap(int width, int height) {
     // initialization: filling with any (u,v) to (-1,-1)
     auto correspondence_map = std::make_shared<geometry::Image>();
     auto depth_buffer = std::make_shared<geometry::Image>();
-    correspondence_map->PrepareImage(width, height, 2, 4);
-    depth_buffer->PrepareImage(width, height, 1, 4);
+    correspondence_map->Prepare(width, height, 2, 4);
+    depth_buffer->Prepare(width, height, 1, 4);
     for (int v = 0; v < correspondence_map->height_; v++) {
         for (int u = 0; u < correspondence_map->width_; u++) {
             *correspondence_map->PointerAt<int>(u, v, 0) = -1;
@@ -209,7 +209,7 @@ std::shared_ptr<geometry::Image> ConvertDepthImageToXYZImage(
     const double inv_fy = 1.0 / intrinsic_matrix(1, 1);
     const double ox = intrinsic_matrix(0, 2);
     const double oy = intrinsic_matrix(1, 2);
-    image_xyz->PrepareImage(depth.width_, depth.height_, 3, 4);
+    image_xyz->Prepare(depth.width_, depth.height_, 3, 4);
 
     for (int y = 0; y < image_xyz->height_; y++) {
         for (int x = 0; x < image_xyz->width_; x++) {
@@ -321,8 +321,8 @@ void NormalizeIntensity(geometry::Image &image_s,
     }
     mean_s /= (double)correspondence.size();
     mean_t /= (double)correspondence.size();
-    image_s.LinearTransformImage(0.5 / mean_s, 0.0);
-    image_t.LinearTransformImage(0.5 / mean_t, 0.0);
+    image_s.LinearTransform(0.5 / mean_s, 0.0);
+    image_t.LinearTransform(0.5 / mean_t, 0.0);
 }
 
 inline std::shared_ptr<geometry::RGBDImage> PackRGBDImage(

--- a/src/Open3D/Odometry/Odometry.cpp
+++ b/src/Open3D/Odometry/Odometry.cpp
@@ -378,14 +378,14 @@ InitializeRGBDOdometry(
         const Eigen::Matrix4d &odo_init,
         const OdometryOption &option) {
     auto source_gray =
-            source.color_.FilterImage(geometry::Image::FilterType::Gaussian3);
+            source.color_.Filter(geometry::Image::FilterType::Gaussian3);
     auto target_gray =
-            target.color_.FilterImage(geometry::Image::FilterType::Gaussian3);
+            target.color_.Filter(geometry::Image::FilterType::Gaussian3);
     auto source_depth_preprocessed = PreprocessDepth(source.depth_, option);
     auto target_depth_preprocessed = PreprocessDepth(target.depth_, option);
-    auto source_depth = source_depth_preprocessed->FilterImage(
+    auto source_depth = source_depth_preprocessed->Filter(
             geometry::Image::FilterType::Gaussian3);
-    auto target_depth = target_depth_preprocessed->FilterImage(
+    auto target_depth = target_depth_preprocessed->Filter(
             geometry::Image::FilterType::Gaussian3);
 
     auto correspondence = ComputeCorrespondence(
@@ -453,11 +453,11 @@ std::tuple<bool, Eigen::Matrix4d> ComputeMultiscale(
     std::vector<int> iter_counts = option.iteration_number_per_pyramid_level_;
     int num_levels = (int)iter_counts.size();
 
-    auto source_pyramid = source.CreateRGBDImagePyramid(num_levels);
-    auto target_pyramid = target.CreateRGBDImagePyramid(num_levels);
-    auto target_pyramid_dx = geometry::RGBDImage::FilterRGBDImagePyramid(
+    auto source_pyramid = source.CreatePyramid(num_levels);
+    auto target_pyramid = target.CreatePyramid(num_levels);
+    auto target_pyramid_dx = geometry::RGBDImage::FilterPyramid(
             target_pyramid, geometry::Image::FilterType::Sobel3Dx);
-    auto target_pyramid_dy = geometry::RGBDImage::FilterRGBDImagePyramid(
+    auto target_pyramid_dy = geometry::RGBDImage::FilterPyramid(
             target_pyramid, geometry::Image::FilterType::Sobel3Dy);
 
     Eigen::Matrix4d result_odo = extrinsic_initial.isZero()

--- a/src/Open3D/Odometry/Odometry.cpp
+++ b/src/Open3D/Odometry/Odometry.cpp
@@ -48,9 +48,9 @@ InitializeCorrespondenceMap(int width, int height) {
     depth_buffer->PrepareImage(width, height, 1, 4);
     for (int v = 0; v < correspondence_map->height_; v++) {
         for (int u = 0; u < correspondence_map->width_; u++) {
-            *geometry::PointerAt<int>(*correspondence_map, u, v, 0) = -1;
-            *geometry::PointerAt<int>(*correspondence_map, u, v, 1) = -1;
-            *geometry::PointerAt<float>(*depth_buffer, u, v, 0) = -1.0f;
+            *correspondence_map->PointerAt<int>(u, v, 0) = -1;
+            *correspondence_map->PointerAt<int>(u, v, 1) = -1;
+            *depth_buffer->PointerAt<float>(u, v, 0) = -1.0f;
         }
     }
     return std::make_tuple(correspondence_map, depth_buffer);
@@ -65,21 +65,20 @@ inline void AddElementToCorrespondenceMap(geometry::Image &correspondence_map,
                                           float transformed_d_t) {
     int exist_u_t, exist_v_t;
     double exist_d_t;
-    exist_u_t = *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 0);
-    exist_v_t = *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 1);
+    exist_u_t = *correspondence_map.PointerAt<int>(u_s, v_s, 0);
+    exist_v_t = *correspondence_map.PointerAt<int>(u_s, v_s, 1);
     if (exist_u_t != -1 && exist_v_t != -1) {
-        exist_d_t = *geometry::PointerAt<float>(depth_buffer, u_s, v_s);
+        exist_d_t = *depth_buffer.PointerAt<float>(u_s, v_s);
         if (transformed_d_t <
             exist_d_t) {  // update nearer point as correspondence
-            *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 0) = u_t;
-            *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 1) = v_t;
-            *geometry::PointerAt<float>(depth_buffer, u_s, v_s) =
-                    transformed_d_t;
+            *correspondence_map.PointerAt<int>(u_s, v_s, 0) = u_t;
+            *correspondence_map.PointerAt<int>(u_s, v_s, 1) = v_t;
+            *depth_buffer.PointerAt<float>(u_s, v_s) = transformed_d_t;
         }
     } else {  // register correspondence
-        *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 0) = u_t;
-        *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 1) = v_t;
-        *geometry::PointerAt<float>(depth_buffer, u_s, v_s) = transformed_d_t;
+        *correspondence_map.PointerAt<int>(u_s, v_s, 0) = u_t;
+        *correspondence_map.PointerAt<int>(u_s, v_s, 1) = v_t;
+        *depth_buffer.PointerAt<float>(u_s, v_s) = transformed_d_t;
     }
 }
 
@@ -89,13 +88,11 @@ void MergeCorrespondenceMaps(geometry::Image &correspondence_map,
                              geometry::Image &depth_buffer_part) {
     for (int v_s = 0; v_s < correspondence_map.height_; v_s++) {
         for (int u_s = 0; u_s < correspondence_map.width_; u_s++) {
-            int u_t = *geometry::PointerAt<int>(correspondence_map_part, u_s,
-                                                v_s, 0);
-            int v_t = *geometry::PointerAt<int>(correspondence_map_part, u_s,
-                                                v_s, 1);
+            int u_t = *correspondence_map_part.PointerAt<int>(u_s, v_s, 0);
+            int v_t = *correspondence_map_part.PointerAt<int>(u_s, v_s, 1);
             if (u_t != -1 && v_t != -1) {
-                float transformed_d_t = *geometry::PointerAt<float>(
-                        depth_buffer_part, u_s, v_s);
+                float transformed_d_t =
+                        *depth_buffer_part.PointerAt<float>(u_s, v_s);
                 AddElementToCorrespondenceMap(correspondence_map, depth_buffer,
                                               u_s, v_s, u_t, v_t,
                                               transformed_d_t);
@@ -108,10 +105,8 @@ int CountCorrespondence(const geometry::Image &correspondence_map) {
     int correspondence_count = 0;
     for (int v_s = 0; v_s < correspondence_map.height_; v_s++) {
         for (int u_s = 0; u_s < correspondence_map.width_; u_s++) {
-            int u_t =
-                    *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 0);
-            int v_t =
-                    *geometry::PointerAt<int>(correspondence_map, u_s, v_s, 1);
+            int u_t = *correspondence_map.PointerAt<int>(u_s, v_s, 0);
+            int v_t = *correspondence_map.PointerAt<int>(u_s, v_s, 1);
             if (u_t != -1 && v_t != -1) {
                 correspondence_count++;
             }
@@ -150,7 +145,7 @@ std::shared_ptr<CorrespondenceSetPixelWise> ComputeCorrespondence(
 #endif
         for (int v_s = 0; v_s < depth_s.height_; v_s++) {
             for (int u_s = 0; u_s < depth_s.width_; u_s++) {
-                double d_s = *geometry::PointerAt<float>(depth_s, u_s, v_s);
+                double d_s = *depth_s.PointerAt<float>(u_s, v_s);
                 if (!std::isnan(d_s)) {
                     Eigen::Vector3d uv_in_s =
                             d_s * KRK_inv * Eigen::Vector3d(u_s, v_s, 1.0) + Kt;
@@ -159,8 +154,7 @@ std::shared_ptr<CorrespondenceSetPixelWise> ComputeCorrespondence(
                     int v_t = (int)(uv_in_s(1) / transformed_d_s + 0.5);
                     if (u_t >= 0 && u_t < depth_t.width_ && v_t >= 0 &&
                         v_t < depth_t.height_) {
-                        double d_t =
-                                *geometry::PointerAt<float>(depth_t, u_t, v_t);
+                        double d_t = *depth_t.PointerAt<float>(u_t, v_t);
                         if (!std::isnan(d_t) &&
                             std::abs(transformed_d_s - d_t) <=
                                     option.max_depth_diff_) {
@@ -191,10 +185,8 @@ std::shared_ptr<CorrespondenceSetPixelWise> ComputeCorrespondence(
     int cnt = 0;
     for (int v_s = 0; v_s < correspondence_map->height_; v_s++) {
         for (int u_s = 0; u_s < correspondence_map->width_; u_s++) {
-            int u_t =
-                    *geometry::PointerAt<int>(*correspondence_map, u_s, v_s, 0);
-            int v_t =
-                    *geometry::PointerAt<int>(*correspondence_map, u_s, v_s, 1);
+            int u_t = *correspondence_map->PointerAt<int>(u_s, v_s, 0);
+            int v_t = *correspondence_map->PointerAt<int>(u_s, v_s, 1);
             if (u_t != -1 && v_t != -1) {
                 Eigen::Vector4i pixel_correspondence(u_s, v_s, u_t, v_t);
                 (*correspondence)[cnt] = pixel_correspondence;
@@ -221,10 +213,10 @@ std::shared_ptr<geometry::Image> ConvertDepthImageToXYZImage(
 
     for (int y = 0; y < image_xyz->height_; y++) {
         for (int x = 0; x < image_xyz->width_; x++) {
-            float *px = geometry::PointerAt<float>(*image_xyz, x, y, 0);
-            float *py = geometry::PointerAt<float>(*image_xyz, x, y, 1);
-            float *pz = geometry::PointerAt<float>(*image_xyz, x, y, 2);
-            float z = *geometry::PointerAt<float>(depth, x, y);
+            float *px = image_xyz->PointerAt<float>(x, y, 0);
+            float *py = image_xyz->PointerAt<float>(x, y, 1);
+            float *pz = image_xyz->PointerAt<float>(x, y, 2);
+            float z = *depth.PointerAt<float>(x, y);
             *px = (float)((x - ox) * z * inv_fx);
             *py = (float)((y - oy) * z * inv_fy);
             *pz = z;
@@ -279,9 +271,9 @@ Eigen::Matrix6d CreateInformationMatrix(
         for (auto row = 0; row < correspondence->size(); row++) {
             int u_t = (*correspondence)[row](2);
             int v_t = (*correspondence)[row](3);
-            double x = *geometry::PointerAt<float>(*xyz_t, u_t, v_t, 0);
-            double y = *geometry::PointerAt<float>(*xyz_t, u_t, v_t, 1);
-            double z = *geometry::PointerAt<float>(*xyz_t, u_t, v_t, 2);
+            double x = *xyz_t->PointerAt<float>(u_t, v_t, 0);
+            double y = *xyz_t->PointerAt<float>(u_t, v_t, 1);
+            double z = *xyz_t->PointerAt<float>(u_t, v_t, 2);
             G_r_private.setZero();
             G_r_private(1) = z;
             G_r_private(2) = -y;
@@ -324,13 +316,13 @@ void NormalizeIntensity(geometry::Image &image_s,
         int v_s = correspondence[row](1);
         int u_t = correspondence[row](2);
         int v_t = correspondence[row](3);
-        mean_s += *geometry::PointerAt<float>(image_s, u_s, v_s);
-        mean_t += *geometry::PointerAt<float>(image_t, u_t, v_t);
+        mean_s += *image_s.PointerAt<float>(u_s, v_s);
+        mean_t += *image_t.PointerAt<float>(u_t, v_t);
     }
     mean_s /= (double)correspondence.size();
     mean_t /= (double)correspondence.size();
-    geometry::LinearTransformImage(image_s, 0.5 / mean_s, 0.0);
-    geometry::LinearTransformImage(image_t, 0.5 / mean_t, 0.0);
+    image_s.LinearTransformImage(0.5 / mean_s, 0.0);
+    image_t.LinearTransformImage(0.5 / mean_t, 0.0);
 }
 
 inline std::shared_ptr<geometry::RGBDImage> PackRGBDImage(
@@ -346,7 +338,7 @@ std::shared_ptr<geometry::Image> PreprocessDepth(
     *depth_processed = depth_orig;
     for (int y = 0; y < depth_processed->height_; y++) {
         for (int x = 0; x < depth_processed->width_; x++) {
-            float *p = geometry::PointerAt<float>(*depth_processed, x, y);
+            float *p = depth_processed->PointerAt<float>(x, y);
             if ((*p < option.min_depth_ || *p > option.max_depth_ || *p <= 0))
                 *p = std::numeric_limits<float>::quiet_NaN();
         }
@@ -385,16 +377,16 @@ InitializeRGBDOdometry(
         const camera::PinholeCameraIntrinsic &pinhole_camera_intrinsic,
         const Eigen::Matrix4d &odo_init,
         const OdometryOption &option) {
-    auto source_gray = geometry::FilterImage(
-            source.color_, geometry::Image::FilterType::Gaussian3);
-    auto target_gray = geometry::FilterImage(
-            target.color_, geometry::Image::FilterType::Gaussian3);
+    auto source_gray =
+            source.color_.FilterImage(geometry::Image::FilterType::Gaussian3);
+    auto target_gray =
+            target.color_.FilterImage(geometry::Image::FilterType::Gaussian3);
     auto source_depth_preprocessed = PreprocessDepth(source.depth_, option);
     auto target_depth_preprocessed = PreprocessDepth(target.depth_, option);
-    auto source_depth = geometry::FilterImage(
-            *source_depth_preprocessed, geometry::Image::FilterType::Gaussian3);
-    auto target_depth = geometry::FilterImage(
-            *target_depth_preprocessed, geometry::Image::FilterType::Gaussian3);
+    auto source_depth = source_depth_preprocessed->FilterImage(
+            geometry::Image::FilterType::Gaussian3);
+    auto target_depth = target_depth_preprocessed->FilterImage(
+            geometry::Image::FilterType::Gaussian3);
 
     auto correspondence = ComputeCorrespondence(
             pinhole_camera_intrinsic.intrinsic_matrix_, odo_init, *source_depth,
@@ -461,11 +453,11 @@ std::tuple<bool, Eigen::Matrix4d> ComputeMultiscale(
     std::vector<int> iter_counts = option.iteration_number_per_pyramid_level_;
     int num_levels = (int)iter_counts.size();
 
-    auto source_pyramid = geometry::CreateRGBDImagePyramid(source, num_levels);
-    auto target_pyramid = geometry::CreateRGBDImagePyramid(target, num_levels);
-    auto target_pyramid_dx = geometry::FilterRGBDImagePyramid(
+    auto source_pyramid = source.CreateRGBDImagePyramid(num_levels);
+    auto target_pyramid = target.CreateRGBDImagePyramid(num_levels);
+    auto target_pyramid_dx = geometry::RGBDImage::FilterRGBDImagePyramid(
             target_pyramid, geometry::Image::FilterType::Sobel3Dx);
-    auto target_pyramid_dy = geometry::FilterRGBDImagePyramid(
+    auto target_pyramid_dy = geometry::RGBDImage::FilterRGBDImagePyramid(
             target_pyramid, geometry::Image::FilterType::Sobel3Dy);
 
     Eigen::Matrix4d result_odo = extrinsic_initial.isZero()

--- a/src/Open3D/Odometry/RGBDOdometryJacobian.cpp
+++ b/src/Open3D/Odometry/RGBDOdometryJacobian.cpp
@@ -59,16 +59,13 @@ void RGBDOdometryJacobianFromColorTerm::ComputeJacobianAndResidual(
     int v_s = corresps[row](1);
     int u_t = corresps[row](2);
     int v_t = corresps[row](3);
-    double diff = *geometry::PointerAt<float>(target.color_, u_t, v_t) -
-                  *geometry::PointerAt<float>(source.color_, u_s, v_s);
-    double dIdx = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dx.color_, u_t, v_t));
-    double dIdy = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dy.color_, u_t, v_t));
-    Eigen::Vector3d p3d_mat(
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 0),
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 1),
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 2));
+    double diff = *target.color_.PointerAt<float>(u_t, v_t) -
+                  *source.color_.PointerAt<float>(u_s, v_s);
+    double dIdx = SOBEL_SCALE * (*target_dx.color_.PointerAt<float>(u_t, v_t));
+    double dIdy = SOBEL_SCALE * (*target_dy.color_.PointerAt<float>(u_t, v_t));
+    Eigen::Vector3d p3d_mat(*source_xyz.PointerAt<float>(u_s, v_s, 0),
+                            *source_xyz.PointerAt<float>(u_s, v_s, 1),
+                            *source_xyz.PointerAt<float>(u_s, v_s, 2));
     Eigen::Vector3d p3d_trans = R * p3d_mat + t;
     double invz = 1. / p3d_trans(2);
     double c0 = dIdx * intrinsic(0, 0) * invz;
@@ -111,26 +108,20 @@ void RGBDOdometryJacobianFromHybridTerm::ComputeJacobianAndResidual(
     int v_s = corresps[row](1);
     int u_t = corresps[row](2);
     int v_t = corresps[row](3);
-    double diff_photo = (*geometry::PointerAt<float>(target.color_, u_t, v_t) -
-                         *geometry::PointerAt<float>(source.color_, u_s, v_s));
-    double dIdx = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dx.color_, u_t, v_t));
-    double dIdy = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dy.color_, u_t, v_t));
-    double dDdx = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dx.depth_, u_t, v_t));
-    double dDdy = SOBEL_SCALE *
-                  (*geometry::PointerAt<float>(target_dy.depth_, u_t, v_t));
+    double diff_photo = (*target.color_.PointerAt<float>(u_t, v_t) -
+                         *source.color_.PointerAt<float>(u_s, v_s));
+    double dIdx = SOBEL_SCALE * (*target_dx.color_.PointerAt<float>(u_t, v_t));
+    double dIdy = SOBEL_SCALE * (*target_dy.color_.PointerAt<float>(u_t, v_t));
+    double dDdx = SOBEL_SCALE * (*target_dx.depth_.PointerAt<float>(u_t, v_t));
+    double dDdy = SOBEL_SCALE * (*target_dy.depth_.PointerAt<float>(u_t, v_t));
     if (std::isnan(dDdx)) dDdx = 0;
     if (std::isnan(dDdy)) dDdy = 0;
-    Eigen::Vector3d p3d_mat(
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 0),
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 1),
-            *geometry::PointerAt<float>(source_xyz, u_s, v_s, 2));
+    Eigen::Vector3d p3d_mat(*source_xyz.PointerAt<float>(u_s, v_s, 0),
+                            *source_xyz.PointerAt<float>(u_s, v_s, 1),
+                            *source_xyz.PointerAt<float>(u_s, v_s, 2));
     Eigen::Vector3d p3d_trans = R * p3d_mat + t;
 
-    double diff_geo =
-            *geometry::PointerAt<float>(target.depth_, u_t, v_t) - p3d_trans(2);
+    double diff_geo = *target.depth_.PointerAt<float>(u_t, v_t) - p3d_trans(2);
     double invz = 1. / p3d_trans(2);
     double c0 = dIdx * fx * invz;
     double c1 = dIdy * fy * invz;

--- a/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
+++ b/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
@@ -313,7 +313,7 @@ bool PointCloudPickerRenderer::Render(const RenderOption &option,
     for (size_t i = 0; i < picker.picked_indices_.size(); i++) {
         size_t index = picker.picked_indices_[i];
         if (index < pointcloud.points_.size()) {
-            auto sphere = geometry::CreateMeshSphere(
+            auto sphere = geometry::TriangleMesh::CreateSphere(
                     view.GetBoundingBox().GetSize() *
                     _option.pointcloud_picker_sphere_size_);
             sphere->ComputeVertexNormals();

--- a/src/Open3D/Visualization/Shader/ImageMaskShader.cpp
+++ b/src/Open3D/Visualization/Shader/ImageMaskShader.cpp
@@ -190,7 +190,7 @@ bool ImageMaskShaderForImage::PrepareBinding(const geometry::Geometry &geometry,
         PrintShaderWarning("Mask image does not match framebuffer size.");
         return false;
     }
-    render_image.PrepareImage(image.width_, image.height_, 1, 1);
+    render_image.Prepare(image.width_, image.height_, 1, 1);
     for (int i = 0; i < image.height_ * image.width_; i++) {
         render_image.data_[i] = (image.data_[i] != 0) * 255;
     }

--- a/src/Open3D/Visualization/Shader/ImageShader.cpp
+++ b/src/Open3D/Visualization/Shader/ImageShader.cpp
@@ -214,7 +214,7 @@ bool ImageShaderForImage::PrepareBinding(const geometry::Geometry &geometry,
     if (image.num_of_channels_ == 3 && image.bytes_per_channel_ == 1) {
         render_image = image;
     } else {
-        render_image.PrepareImage(image.width_, image.height_, 3, 1);
+        render_image.Prepare(image.width_, image.height_, 3, 1);
         if (image.num_of_channels_ == 1 && image.bytes_per_channel_ == 1) {
             // grayscale image
             for (int i = 0; i < image.height_ * image.width_; i++) {

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
@@ -32,7 +32,10 @@
 namespace open3d {
 namespace visualization {
 
-void PointCloudPicker::Clear() { picked_indices_.clear(); }
+PointCloudPicker& PointCloudPicker::Clear() {
+    picked_indices_.clear();
+    return *this;
+}
 
 bool PointCloudPicker::IsEmpty() const {
     return (!pointcloud_ptr_ || picked_indices_.empty());

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.h
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.h
@@ -47,7 +47,7 @@ public:
     ~PointCloudPicker() override {}
 
 public:
-    void Clear() override;
+    PointCloudPicker& Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const final;
     Eigen::Vector3d GetMaxBound() const final;

--- a/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
+++ b/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
@@ -37,11 +37,12 @@
 namespace open3d {
 namespace visualization {
 
-void SelectionPolygon::Clear() {
+SelectionPolygon &SelectionPolygon::Clear() {
     polygon_.clear();
     is_closed_ = false;
     polygon_interior_mask_.Clear();
     polygon_type_ = SectionPolygonType::Unfilled;
+    return *this;
 }
 
 bool SelectionPolygon::IsEmpty() const {
@@ -206,28 +207,24 @@ SelectionPolygon::CreateSelectionPolygonVolume(const ViewControl &view) {
 std::shared_ptr<geometry::PointCloud>
 SelectionPolygon::CropPointCloudInRectangle(const geometry::PointCloud &input,
                                             const ViewControl &view) {
-    return geometry::SelectDownSample(input,
-                                      CropInRectangle(input.points_, view));
+    return input.SelectDownSample(CropInRectangle(input.points_, view));
 }
 
 std::shared_ptr<geometry::PointCloud> SelectionPolygon::CropPointCloudInPolygon(
         const geometry::PointCloud &input, const ViewControl &view) {
-    return geometry::SelectDownSample(input,
-                                      CropInPolygon(input.points_, view));
+    return input.SelectDownSample(CropInPolygon(input.points_, view));
 }
 
 std::shared_ptr<geometry::TriangleMesh>
 SelectionPolygon::CropTriangleMeshInRectangle(
         const geometry::TriangleMesh &input, const ViewControl &view) {
-    return geometry::SelectDownSample(input,
-                                      CropInRectangle(input.vertices_, view));
+    return input.SelectDownSample(CropInRectangle(input.vertices_, view));
 }
 
 std::shared_ptr<geometry::TriangleMesh>
 SelectionPolygon::CropTriangleMeshInPolygon(const geometry::TriangleMesh &input,
                                             const ViewControl &view) {
-    return geometry::SelectDownSample(input,
-                                      CropInPolygon(input.vertices_, view));
+    return input.SelectDownSample(CropInPolygon(input.vertices_, view));
 }
 
 std::vector<size_t> SelectionPolygon::CropInRectangle(

--- a/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
+++ b/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
@@ -89,7 +89,7 @@ void SelectionPolygon::FillPolygon(int width, int height) {
     // http://alienryderflex.com/polygon_fill/
     if (IsEmpty()) return;
     is_closed_ = true;
-    polygon_interior_mask_.PrepareImage(width, height, 1, 1);
+    polygon_interior_mask_.Prepare(width, height, 1, 1);
     std::fill(polygon_interior_mask_.data_.begin(),
               polygon_interior_mask_.data_.end(), 0);
     std::vector<int> nodes;

--- a/src/Open3D/Visualization/Utility/SelectionPolygon.h
+++ b/src/Open3D/Visualization/Utility/SelectionPolygon.h
@@ -62,7 +62,7 @@ public:
     ~SelectionPolygon() override {}
 
 public:
-    void Clear() override;
+    SelectionPolygon &Clear() override;
     bool IsEmpty() const override;
     Eigen::Vector2d GetMinBound() const final;
     Eigen::Vector2d GetMaxBound() const final;

--- a/src/Open3D/Visualization/Utility/SelectionPolygonVolume.cpp
+++ b/src/Open3D/Visualization/Utility/SelectionPolygonVolume.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<geometry::PointCloud> SelectionPolygonVolume::CropPointCloud(
 std::shared_ptr<geometry::PointCloud>
 SelectionPolygonVolume::CropPointCloudInPolygon(
         const geometry::PointCloud &input) const {
-    return geometry::SelectDownSample(input, CropInPolygon(input.points_));
+    return input.SelectDownSample(CropInPolygon(input.points_));
 }
 
 std::shared_ptr<geometry::TriangleMesh>
@@ -120,7 +120,7 @@ SelectionPolygonVolume::CropTriangleMesh(
 std::shared_ptr<geometry::TriangleMesh>
 SelectionPolygonVolume::CropTriangleMeshInPolygon(
         const geometry::TriangleMesh &input) const {
-    return geometry::SelectDownSample(input, CropInPolygon(input.vertices_));
+    return input.SelectDownSample(CropInPolygon(input.vertices_));
 }
 
 std::vector<size_t> SelectionPolygonVolume::CropInPolygon(

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -234,7 +234,7 @@ void Visualizer::BuildUtilities() {
 
     // 0. Build coordinate frame
     const auto boundingbox = GetViewControl().GetBoundingBox();
-    coordinate_frame_mesh_ptr_ = geometry::CreateMeshCoordinateFrame(
+    coordinate_frame_mesh_ptr_ = geometry::TriangleMesh::CreateCoordinateFrame(
             boundingbox.GetSize() * 0.2, boundingbox.min_bound_);
     coordinate_frame_mesh_renderer_ptr_ =
             std::make_shared<glsl::CoordinateFrameRenderer>();

--- a/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
@@ -95,8 +95,10 @@ void Visualizer::ResetViewPoint(bool reset_bounding_box /* = false*/) {
         }
         if (coordinate_frame_mesh_ptr_ && coordinate_frame_mesh_renderer_ptr_) {
             const auto &boundingbox = view_control_ptr_->GetBoundingBox();
-            *coordinate_frame_mesh_ptr_ = *geometry::CreateMeshCoordinateFrame(
-                    boundingbox.GetSize() * 0.2, boundingbox.min_bound_);
+            *coordinate_frame_mesh_ptr_ =
+                    *geometry::TriangleMesh::CreateCoordinateFrame(
+                            boundingbox.GetSize() * 0.2,
+                            boundingbox.min_bound_);
             coordinate_frame_mesh_renderer_ptr_->UpdateGeometry();
         }
     }

--- a/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
@@ -145,8 +145,8 @@ void Visualizer::CopyViewStatusFromClipboard() {
 std::shared_ptr<geometry::Image> Visualizer::CaptureScreenFloatBuffer(
         bool do_render /* = true*/) {
     geometry::Image screen_image;
-    screen_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                              view_control_ptr_->GetWindowHeight(), 3, 4);
+    screen_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                         view_control_ptr_->GetWindowHeight(), 3, 4);
     if (do_render) {
         Render();
         is_redraw_required_ = false;
@@ -159,8 +159,8 @@ std::shared_ptr<geometry::Image> Visualizer::CaptureScreenFloatBuffer(
     // glReadPixels get the screen in a vertically flipped manner
     // Thus we should flip it back.
     auto image_ptr = std::make_shared<geometry::Image>();
-    image_ptr->PrepareImage(view_control_ptr_->GetWindowWidth(),
-                            view_control_ptr_->GetWindowHeight(), 3, 4);
+    image_ptr->Prepare(view_control_ptr_->GetWindowWidth(),
+                       view_control_ptr_->GetWindowHeight(), 3, 4);
     int bytes_per_line = screen_image.BytesPerLine();
     for (int i = 0; i < screen_image.height_; i++) {
         memcpy(image_ptr->data_.data() + bytes_per_line * i,
@@ -181,8 +181,8 @@ void Visualizer::CaptureScreenImage(const std::string &filename /* = ""*/,
         camera_filename = "ScreenCamera_" + timestamp + ".json";
     }
     geometry::Image screen_image;
-    screen_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                              view_control_ptr_->GetWindowHeight(), 3, 1);
+    screen_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                         view_control_ptr_->GetWindowHeight(), 3, 1);
     if (do_render) {
         Render();
         is_redraw_required_ = false;
@@ -195,8 +195,8 @@ void Visualizer::CaptureScreenImage(const std::string &filename /* = ""*/,
     // glReadPixels get the screen in a vertically flipped manner
     // Thus we should flip it back.
     geometry::Image png_image;
-    png_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                           view_control_ptr_->GetWindowHeight(), 3, 1);
+    png_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                      view_control_ptr_->GetWindowHeight(), 3, 1);
     int bytes_per_line = screen_image.BytesPerLine();
     for (int i = 0; i < screen_image.height_; i++) {
         memcpy(png_image.data_.data() + bytes_per_line * i,
@@ -220,8 +220,8 @@ void Visualizer::CaptureScreenImage(const std::string &filename /* = ""*/,
 std::shared_ptr<geometry::Image> Visualizer::CaptureDepthFloatBuffer(
         bool do_render /* = true*/) {
     geometry::Image depth_image;
-    depth_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                             view_control_ptr_->GetWindowHeight(), 1, 4);
+    depth_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                        view_control_ptr_->GetWindowHeight(), 1, 4);
     if (do_render) {
         Render();
         is_redraw_required_ = false;
@@ -259,8 +259,8 @@ std::shared_ptr<geometry::Image> Visualizer::CaptureDepthFloatBuffer(
     double z_near = view_control_ptr_->GetZNear();
     double z_far = view_control_ptr_->GetZFar();
 
-    image_ptr->PrepareImage(view_control_ptr_->GetWindowWidth(),
-                            view_control_ptr_->GetWindowHeight(), 1, 4);
+    image_ptr->Prepare(view_control_ptr_->GetWindowWidth(),
+                       view_control_ptr_->GetWindowHeight(), 1, 4);
     for (int i = 0; i < depth_image.height_; i++) {
         float *p_depth = (float *)(depth_image.data_.data() +
                                    depth_image.BytesPerLine() *
@@ -292,8 +292,8 @@ void Visualizer::CaptureDepthImage(const std::string &filename /* = ""*/,
         camera_filename = "DepthCamera_" + timestamp + ".json";
     }
     geometry::Image depth_image;
-    depth_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                             view_control_ptr_->GetWindowHeight(), 1, 4);
+    depth_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                        view_control_ptr_->GetWindowHeight(), 1, 4);
 
     if (do_render) {
         Render();
@@ -332,8 +332,8 @@ void Visualizer::CaptureDepthImage(const std::string &filename /* = ""*/,
     double z_near = view_control_ptr_->GetZNear();
     double z_far = view_control_ptr_->GetZFar();
 
-    png_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                           view_control_ptr_->GetWindowHeight(), 1, 2);
+    png_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                      view_control_ptr_->GetWindowHeight(), 1, 2);
     for (int i = 0; i < depth_image.height_; i++) {
         float *p_depth = (float *)(depth_image.data_.data() +
                                    depth_image.BytesPerLine() *
@@ -377,8 +377,8 @@ void Visualizer::CaptureDepthPointCloud(
         camera_filename = "DepthCamera_" + timestamp + ".json";
     }
     geometry::Image depth_image;
-    depth_image.PrepareImage(view_control_ptr_->GetWindowWidth(),
-                             view_control_ptr_->GetWindowHeight(), 1, 4);
+    depth_image.Prepare(view_control_ptr_->GetWindowWidth(),
+                        view_control_ptr_->GetWindowHeight(), 1, 4);
 
     if (do_render) {
         Render();

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -364,7 +364,7 @@ void VisualizerWithEditing::KeyPressCallback(
                             voxel_size_);
                     geometry::PointCloud &pcd =
                             (geometry::PointCloud &)*editing_geometry_ptr_;
-                    pcd = *geometry::VoxelDownSample(pcd, voxel_size_);
+                    pcd = *pcd.VoxelDownSample(voxel_size_);
                     UpdateGeometry();
                 } else {
                     utility::PrintInfo(

--- a/src/Python/geometry/geometry.cpp
+++ b/src/Python/geometry/geometry.cpp
@@ -144,13 +144,13 @@ void pybind_geometry_classes(py::module &m) {
 void pybind_geometry(py::module &m) {
     py::module m_submodule = m.def_submodule("geometry");
     pybind_geometry_classes(m_submodule);
+    pybind_kdtreeflann(m_submodule);
     pybind_pointcloud(m_submodule);
     pybind_voxelgrid(m_submodule);
     pybind_lineset(m_submodule);
     pybind_trianglemesh(m_submodule);
     pybind_halfedgetrianglemesh(m_submodule);
     pybind_image(m_submodule);
-    pybind_kdtreeflann(m_submodule);
     pybind_pointcloud_methods(m_submodule);
     pybind_voxelgrid_methods(m_submodule);
     pybind_trianglemesh_methods(m_submodule);

--- a/src/Python/geometry/geometry_trampoline.h
+++ b/src/Python/geometry/geometry_trampoline.h
@@ -41,7 +41,7 @@ class PyGeometry : public GeometryBase {
 public:
     using GeometryBase::GeometryBase;
     GeometryBase& Clear() override {
-        PYBIND11_OVERLOAD_PURE(void, GeometryBase, );
+        PYBIND11_OVERLOAD_PURE(GeometryBase&, GeometryBase, );
     }
     bool IsEmpty() const override {
         PYBIND11_OVERLOAD_PURE(bool, GeometryBase, );

--- a/src/Python/geometry/geometry_trampoline.h
+++ b/src/Python/geometry/geometry_trampoline.h
@@ -40,7 +40,9 @@ template <class GeometryBase = geometry::Geometry>
 class PyGeometry : public GeometryBase {
 public:
     using GeometryBase::GeometryBase;
-    GeometryBase& Clear() override { PYBIND11_OVERLOAD_PURE(void, GeometryBase, ); }
+    GeometryBase& Clear() override {
+        PYBIND11_OVERLOAD_PURE(void, GeometryBase, );
+    }
     bool IsEmpty() const override {
         PYBIND11_OVERLOAD_PURE(bool, GeometryBase, );
     }
@@ -72,4 +74,3 @@ public:
         PYBIND11_OVERLOAD_PURE(Eigen::Vector2d, Geometry2DBase, );
     }
 };
-

--- a/src/Python/geometry/geometry_trampoline.h
+++ b/src/Python/geometry/geometry_trampoline.h
@@ -40,7 +40,7 @@ template <class GeometryBase = geometry::Geometry>
 class PyGeometry : public GeometryBase {
 public:
     using GeometryBase::GeometryBase;
-    void Clear() override { PYBIND11_OVERLOAD_PURE(void, GeometryBase, ); }
+    GeometryBase& Clear() override { PYBIND11_OVERLOAD_PURE(void, GeometryBase, ); }
     bool IsEmpty() const override {
         PYBIND11_OVERLOAD_PURE(bool, GeometryBase, );
     }
@@ -73,20 +73,3 @@ public:
     }
 };
 
-template <class TriangleMeshBase = geometry::TriangleMesh>
-class PyTriangleMesh : public PyGeometry3D<TriangleMeshBase> {
-public:
-    using PyGeometry3D<TriangleMeshBase>::PyGeometry3D;
-    void RemoveDuplicatedVertices() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveDuplicatedVertices, );
-    };
-    void RemoveDuplicatedTriangles() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveDuplicatedTriangles, );
-    };
-    void RemoveUnreferencedVertices() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveUnreferencedVertices, );
-    };
-    void RemoveDegenerateTriangles() override {
-        PYBIND11_OVERLOAD(void, TriangleMeshBase, RemoveDegenerateTriangles, );
-    };
-};

--- a/src/Python/geometry/halfedgetrianglemesh.cpp
+++ b/src/Python/geometry/halfedgetrianglemesh.cpp
@@ -78,8 +78,10 @@ void pybind_halfedgetrianglemesh(py::module &m) {
     pybind_half_edge(m);
 
     // open3d.geometry.HalfEdgeTriangleMesh
-    py::class_<geometry::HalfEdgeTriangleMesh, PyGeometry3D<geometry::HalfEdgeTriangleMesh>,
-               std::shared_ptr<geometry::HalfEdgeTriangleMesh>, geometry::Geometry3D>
+    py::class_<geometry::HalfEdgeTriangleMesh,
+               PyGeometry3D<geometry::HalfEdgeTriangleMesh>,
+               std::shared_ptr<geometry::HalfEdgeTriangleMesh>,
+               geometry::Geometry3D>
             half_edge_triangle_mesh(
                     m, "HalfEdgeTriangleMesh",
                     "HalfEdgeTriangleMesh inherits TriangleMesh class with the "

--- a/src/Python/geometry/halfedgetrianglemesh.cpp
+++ b/src/Python/geometry/halfedgetrianglemesh.cpp
@@ -125,6 +125,12 @@ void pybind_halfedgetrianglemesh(py::module &m) {
                  &geometry::HalfEdgeTriangleMesh::GetBoundaries,
                  "Returns a vector of boundaries. A boundary is a vector of "
                  "vertices.")
+            .def_static("create_from_mesh",
+                        &geometry::HalfEdgeTriangleMesh::CreateFromMesh,
+                        "mesh"_a,
+                        "Convert HalfEdgeTriangleMesh from TriangleMesh. "
+                        "Throws exception if "
+                        "the input mesh is not manifolds")
             .def_readwrite("half_edges",
                            &geometry::HalfEdgeTriangleMesh::half_edges_,
                            "List of HalfEdge in the mesh")
@@ -143,11 +149,7 @@ void pybind_halfedgetrianglemesh(py::module &m) {
                                     "get_boundaries");
     docstring::ClassMethodDocInject(m, "HalfEdgeTriangleMesh",
                                     "has_half_edges");
-
-    m.def("create_half_edge_mesh_from_mesh",
-          &geometry::CreateHalfEdgeMeshFromMesh, "mesh"_a,
-          "Convert HalfEdgeTriangleMesh from TriangleMesh. Throws exception if "
-          "the input mesh is not manifolds");
-    docstring::FunctionDocInject(m, "create_half_edge_mesh_from_mesh",
-                                 {{"mesh", "The input TriangleMesh"}});
+    docstring::ClassMethodDocInject(m, "HalfEdgeTriangleMesh",
+                                    "create_from_mesh",
+                                    {{"mesh", "The input TriangleMesh"}});
 }

--- a/src/Python/geometry/halfedgetrianglemesh.cpp
+++ b/src/Python/geometry/halfedgetrianglemesh.cpp
@@ -78,10 +78,8 @@ void pybind_halfedgetrianglemesh(py::module &m) {
     pybind_half_edge(m);
 
     // open3d.geometry.HalfEdgeTriangleMesh
-    py::class_<geometry::HalfEdgeTriangleMesh,
-               PyTriangleMesh<geometry::HalfEdgeTriangleMesh>,
-               std::shared_ptr<geometry::HalfEdgeTriangleMesh>,
-               geometry::TriangleMesh>
+    py::class_<geometry::HalfEdgeTriangleMesh, PyGeometry3D<geometry::HalfEdgeTriangleMesh>,
+               std::shared_ptr<geometry::HalfEdgeTriangleMesh>, geometry::Geometry3D>
             half_edge_triangle_mesh(
                     m, "HalfEdgeTriangleMesh",
                     "HalfEdgeTriangleMesh inherits TriangleMesh class with the "

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -106,8 +106,7 @@ void pybind_image(py::module &m) {
              height = (int)info.shape[0];
              width = (int)info.shape[1];
              auto img = new geometry::Image();
-             img->PrepareImage(width, height, num_of_channels,
-                               bytes_per_channel);
+             img->Prepare(width, height, num_of_channels, bytes_per_channel);
              memcpy(img->data_.data(), info.ptr, img->data_.size());
              return img;
          }))

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -218,10 +218,12 @@ void pybind_image_methods(py::module &m) {
               if (input.num_of_channels_ != 1 ||
                   input.bytes_per_channel_ != 4) {
                   auto input_f = input.CreateFloatImageFromImage();
-                  auto output = input_f->CreateImagePyramid(num_of_levels, with_gaussian_filter);
+                  auto output = input_f->CreateImagePyramid(
+                          num_of_levels, with_gaussian_filter);
                   return output;
               } else {
-                  auto output = input.CreateImagePyramid(num_of_levels, with_gaussian_filter);
+                  auto output = input.CreateImagePyramid(num_of_levels,
+                                                         with_gaussian_filter);
                   return output;
               }
           },
@@ -233,7 +235,8 @@ void pybind_image_methods(py::module &m) {
     m.def("filter_image_pyramid",
           [](const geometry::ImagePyramid &input,
              geometry::Image::FilterType filter_type) {
-              auto output = geometry::Image::FilterImagePyramid(input, filter_type);
+              auto output =
+                      geometry::Image::FilterImagePyramid(input, filter_type);
               return output;
           },
           "Function to filter ImagePyramid", "image_pyramid"_a,

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -200,11 +200,11 @@ void pybind_image_methods(py::module &m) {
              geometry::Image::FilterType filter_type) {
               if (input.num_of_channels_ != 1 ||
                   input.bytes_per_channel_ != 4) {
-                  auto input_f = CreateFloatImageFromImage(input);
-                  auto output = geometry::FilterImage(*input_f, filter_type);
+                  auto input_f = input.CreateFloatImageFromImage();
+                  auto output = input_f->FilterImage(filter_type);
                   return *output;
               } else {
-                  auto output = geometry::FilterImage(input, filter_type);
+                  auto output = input.FilterImage(filter_type);
                   return *output;
               }
           },
@@ -217,13 +217,11 @@ void pybind_image_methods(py::module &m) {
              bool with_gaussian_filter) {
               if (input.num_of_channels_ != 1 ||
                   input.bytes_per_channel_ != 4) {
-                  auto input_f = CreateFloatImageFromImage(input);
-                  auto output = geometry::CreateImagePyramid(
-                          *input_f, num_of_levels, with_gaussian_filter);
+                  auto input_f = input.CreateFloatImageFromImage();
+                  auto output = input_f->CreateImagePyramid(num_of_levels, with_gaussian_filter);
                   return output;
               } else {
-                  auto output = geometry::CreateImagePyramid(
-                          input, num_of_levels, with_gaussian_filter);
+                  auto output = input.CreateImagePyramid(num_of_levels, with_gaussian_filter);
                   return output;
               }
           },
@@ -235,7 +233,7 @@ void pybind_image_methods(py::module &m) {
     m.def("filter_image_pyramid",
           [](const geometry::ImagePyramid &input,
              geometry::Image::FilterType filter_type) {
-              auto output = geometry::FilterImagePyramid(input, filter_type);
+              auto output = geometry::Image::FilterImagePyramid(input, filter_type);
               return output;
           },
           "Function to filter ImagePyramid", "image_pyramid"_a,
@@ -244,7 +242,7 @@ void pybind_image_methods(py::module &m) {
                                  map_shared_argument_docstrings);
 
     m.def("create_rgbd_image_from_color_and_depth",
-          &geometry::CreateRGBDImageFromColorAndDepth,
+          &geometry::RGBDImage::CreateFromColorAndDepth,
           "Function to make RGBDImage from color and depth image", "color"_a,
           "depth"_a, "depth_scale"_a = 1000.0, "depth_trunc"_a = 3.0,
           "convert_rgb_to_intensity"_a = true);
@@ -252,28 +250,28 @@ void pybind_image_methods(py::module &m) {
                                  map_shared_argument_docstrings);
 
     m.def("create_rgbd_image_from_redwood_format",
-          &geometry::CreateRGBDImageFromRedwoodFormat,
+          &geometry::RGBDImage::CreateFromRedwoodFormat,
           "Function to make RGBDImage (for Redwood format)", "color"_a,
           "depth"_a, "convert_rgb_to_intensity"_a = true);
     docstring::FunctionDocInject(m, "create_rgbd_image_from_redwood_format",
                                  map_shared_argument_docstrings);
 
     m.def("create_rgbd_image_from_tum_format",
-          &geometry::CreateRGBDImageFromTUMFormat,
+          &geometry::RGBDImage::CreateFromTUMFormat,
           "Function to make RGBDImage (for TUM format)", "color"_a, "depth"_a,
           "convert_rgb_to_intensity"_a = true);
     docstring::FunctionDocInject(m, "create_rgbd_image_from_tum_format",
                                  map_shared_argument_docstrings);
 
     m.def("create_rgbd_image_from_sun_format",
-          &geometry::CreateRGBDImageFromSUNFormat,
+          &geometry::RGBDImage::CreateFromSUNFormat,
           "Function to make RGBDImage (for SUN format)", "color"_a, "depth"_a,
           "convert_rgb_to_intensity"_a = true);
     docstring::FunctionDocInject(m, "create_rgbd_image_from_sun_format",
                                  map_shared_argument_docstrings);
 
     m.def("create_rgbd_image_from_nyu_format",
-          &geometry::CreateRGBDImageFromNYUFormat,
+          &geometry::RGBDImage::CreateFromNYUFormat,
           "Function to make RGBDImage (for NYU format)", "color"_a, "depth"_a,
           "convert_rgb_to_intensity"_a = true);
     docstring::FunctionDocInject(m, "create_rgbd_image_from_nyu_format",

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -55,6 +55,20 @@ static const std::unordered_map<std::string, std::string>
                  "by a 3x3 Gaussian kernel before downsampling."}};
 
 void pybind_image(py::module &m) {
+    py::enum_<geometry::Image::FilterType> image_filter_type(m,
+                                                             "ImageFilterType");
+    image_filter_type.value("Gaussian3", geometry::Image::FilterType::Gaussian3)
+            .value("Gaussian5", geometry::Image::FilterType::Gaussian5)
+            .value("Gaussian7", geometry::Image::FilterType::Gaussian7)
+            .value("Sobel3dx", geometry::Image::FilterType::Sobel3Dx)
+            .value("Sobel3dy", geometry::Image::FilterType::Sobel3Dy)
+            .export_values();
+    image_filter_type.attr("__doc__") = docstring::static_property(
+            py::cpp_function([](py::handle arg) -> std::string {
+                return "Enum class for Image filter types.";
+            }),
+            py::none(), py::none(), "");
+
     py::class_<geometry::Image, PyGeometry2D<geometry::Image>,
                std::shared_ptr<geometry::Image>, geometry::Geometry2D>
             image(m, "Image", py::buffer_protocol(),
@@ -139,15 +153,64 @@ void pybind_image(py::module &m) {
                                      img.bytes_per_channel_)});
                 }
             })
-            .def("__repr__", [](const geometry::Image &img) {
-                return std::string("Image of size ") +
-                       std::to_string(img.width_) + std::string("x") +
-                       std::to_string(img.height_) + ", with " +
-                       std::to_string(img.num_of_channels_) +
-                       std::string(
-                               " channels.\nUse numpy.asarray to access buffer "
-                               "data.");
-            });
+            .def("__repr__",
+                 [](const geometry::Image &img) {
+                     return std::string("Image of size ") +
+                            std::to_string(img.width_) + std::string("x") +
+                            std::to_string(img.height_) + ", with " +
+                            std::to_string(img.num_of_channels_) +
+                            std::string(
+                                    " channels.\nUse numpy.asarray to access "
+                                    "buffer "
+                                    "data.");
+                 })
+            .def("filter",
+                 [](const geometry::Image &input,
+                    geometry::Image::FilterType filter_type) {
+                     if (input.num_of_channels_ != 1 ||
+                         input.bytes_per_channel_ != 4) {
+                         auto input_f = input.CreateFloatImage();
+                         auto output = input_f->Filter(filter_type);
+                         return *output;
+                     } else {
+                         auto output = input.Filter(filter_type);
+                         return *output;
+                     }
+                 },
+                 "Function to filter Image", "filter_type"_a)
+            .def("create_pyramid",
+                 [](const geometry::Image &input, size_t num_of_levels,
+                    bool with_gaussian_filter) {
+                     if (input.num_of_channels_ != 1 ||
+                         input.bytes_per_channel_ != 4) {
+                         auto input_f = input.CreateFloatImage();
+                         auto output = input_f->CreatePyramid(
+                                 num_of_levels, with_gaussian_filter);
+                         return output;
+                     } else {
+                         auto output = input.CreatePyramid(
+                                 num_of_levels, with_gaussian_filter);
+                         return output;
+                     }
+                 },
+                 "Function to create ImagePyramid", "num_of_levels"_a,
+                 "with_gaussian_filter"_a)
+            .def_static("filter_pyramid",
+                        [](const geometry::ImagePyramid &input,
+                           geometry::Image::FilterType filter_type) {
+                            auto output = geometry::Image::FilterPyramid(
+                                    input, filter_type);
+                            return output;
+                        },
+                        "Function to filter ImagePyramid", "image_pyramid"_a,
+                        "filter_type"_a);
+
+    docstring::ClassMethodDocInject(m, "Image", "filter",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "Image", "create_pyramid",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "Image", "filter_pyramid",
+                                    map_shared_argument_docstrings);
 
     py::class_<geometry::RGBDImage, std::shared_ptr<geometry::RGBDImage>>
             rgbd_image(m, "RGBDImage",
@@ -161,122 +224,65 @@ void pybind_image(py::module &m) {
                            "open3d.geometry.Image: The color image.")
             .def_readwrite("depth", &geometry::RGBDImage::depth_,
                            "open3d.geometry.Image: The depth image.")
-            .def("__repr__", [](const geometry::RGBDImage &rgbd_image) {
-                return std::string("RGBDImage of size \n") +
-                       std::string("Color image : ") +
-                       std::to_string(rgbd_image.color_.width_) +
-                       std::string("x") +
-                       std::to_string(rgbd_image.color_.height_) + ", with " +
-                       std::to_string(rgbd_image.color_.num_of_channels_) +
-                       std::string(" channels.\n") +
-                       std::string("Depth image : ") +
-                       std::to_string(rgbd_image.depth_.width_) +
-                       std::string("x") +
-                       std::to_string(rgbd_image.depth_.height_) + ", with " +
-                       std::to_string(rgbd_image.depth_.num_of_channels_) +
-                       std::string(" channels.\n") +
-                       std::string("Use numpy.asarray to access buffer data.");
-            });
+            .def("__repr__",
+                 [](const geometry::RGBDImage &rgbd_image) {
+                     return std::string("RGBDImage of size \n") +
+                            std::string("Color image : ") +
+                            std::to_string(rgbd_image.color_.width_) +
+                            std::string("x") +
+                            std::to_string(rgbd_image.color_.height_) +
+                            ", with " +
+                            std::to_string(rgbd_image.color_.num_of_channels_) +
+                            std::string(" channels.\n") +
+                            std::string("Depth image : ") +
+                            std::to_string(rgbd_image.depth_.width_) +
+                            std::string("x") +
+                            std::to_string(rgbd_image.depth_.height_) +
+                            ", with " +
+                            std::to_string(rgbd_image.depth_.num_of_channels_) +
+                            std::string(" channels.\n") +
+                            std::string(
+                                    "Use numpy.asarray to access buffer data.");
+                 })
+            .def_static("create_from_color_and_depth",
+                        &geometry::RGBDImage::CreateFromColorAndDepth,
+                        "Function to make RGBDImage from color and depth image",
+                        "color"_a, "depth"_a, "depth_scale"_a = 1000.0,
+                        "depth_trunc"_a = 3.0,
+                        "convert_rgb_to_intensity"_a = true)
+            .def_static("create_from_redwood_format",
+                        &geometry::RGBDImage::CreateFromRedwoodFormat,
+                        "Function to make RGBDImage (for Redwood format)",
+                        "color"_a, "depth"_a,
+                        "convert_rgb_to_intensity"_a = true)
+            .def_static("create_from_tum_format",
+                        &geometry::RGBDImage::CreateFromTUMFormat,
+                        "Function to make RGBDImage (for TUM format)",
+                        "color"_a, "depth"_a,
+                        "convert_rgb_to_intensity"_a = true)
+            .def_static("create_from_sun_format",
+                        &geometry::RGBDImage::CreateFromSUNFormat,
+                        "Function to make RGBDImage (for SUN format)",
+                        "color"_a, "depth"_a,
+                        "convert_rgb_to_intensity"_a = true)
+            .def_static("create_from_nyu_format",
+                        &geometry::RGBDImage::CreateFromNYUFormat,
+                        "Function to make RGBDImage (for NYU format)",
+                        "color"_a, "depth"_a,
+                        "convert_rgb_to_intensity"_a = true);
+
+    docstring::ClassMethodDocInject(m, "RGBDImage",
+                                    "create_from_color_and_depth",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "RGBDImage",
+                                    "create_from_redwood_format",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "RGBDImage", "create_from_tum_format",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "RGBDImage", "create_from_sun_format",
+                                    map_shared_argument_docstrings);
+    docstring::ClassMethodDocInject(m, "RGBDImage", "create_from_nyu_format",
+                                    map_shared_argument_docstrings);
 }
 
-void pybind_image_methods(py::module &m) {
-    py::enum_<geometry::Image::FilterType> image_filter_type(m,
-                                                             "ImageFilterType");
-    image_filter_type.value("Gaussian3", geometry::Image::FilterType::Gaussian3)
-            .value("Gaussian5", geometry::Image::FilterType::Gaussian5)
-            .value("Gaussian7", geometry::Image::FilterType::Gaussian7)
-            .value("Sobel3dx", geometry::Image::FilterType::Sobel3Dx)
-            .value("Sobel3dy", geometry::Image::FilterType::Sobel3Dy)
-            .export_values();
-    // Trick to write docs without listing the members in the enum class again.
-    image_filter_type.attr("__doc__") = docstring::static_property(
-            py::cpp_function([](py::handle arg) -> std::string {
-                return "Enum class for Image filter types.";
-            }),
-            py::none(), py::none(), "");
-
-    m.def("filter_image",
-          [](const geometry::Image &input,
-             geometry::Image::FilterType filter_type) {
-              if (input.num_of_channels_ != 1 ||
-                  input.bytes_per_channel_ != 4) {
-                  auto input_f = input.CreateFloatImageFromImage();
-                  auto output = input_f->FilterImage(filter_type);
-                  return *output;
-              } else {
-                  auto output = input.FilterImage(filter_type);
-                  return *output;
-              }
-          },
-          "Function to filter Image", "image"_a, "filter_type"_a);
-    docstring::FunctionDocInject(m, "filter_image",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_image_pyramid",
-          [](const geometry::Image &input, size_t num_of_levels,
-             bool with_gaussian_filter) {
-              if (input.num_of_channels_ != 1 ||
-                  input.bytes_per_channel_ != 4) {
-                  auto input_f = input.CreateFloatImageFromImage();
-                  auto output = input_f->CreateImagePyramid(
-                          num_of_levels, with_gaussian_filter);
-                  return output;
-              } else {
-                  auto output = input.CreateImagePyramid(num_of_levels,
-                                                         with_gaussian_filter);
-                  return output;
-              }
-          },
-          "Function to create ImagePyramid", "image"_a, "num_of_levels"_a,
-          "with_gaussian_filter"_a);
-    docstring::FunctionDocInject(m, "create_image_pyramid",
-                                 map_shared_argument_docstrings);
-
-    m.def("filter_image_pyramid",
-          [](const geometry::ImagePyramid &input,
-             geometry::Image::FilterType filter_type) {
-              auto output =
-                      geometry::Image::FilterImagePyramid(input, filter_type);
-              return output;
-          },
-          "Function to filter ImagePyramid", "image_pyramid"_a,
-          "filter_type"_a);
-    docstring::FunctionDocInject(m, "filter_image_pyramid",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_rgbd_image_from_color_and_depth",
-          &geometry::RGBDImage::CreateFromColorAndDepth,
-          "Function to make RGBDImage from color and depth image", "color"_a,
-          "depth"_a, "depth_scale"_a = 1000.0, "depth_trunc"_a = 3.0,
-          "convert_rgb_to_intensity"_a = true);
-    docstring::FunctionDocInject(m, "create_rgbd_image_from_color_and_depth",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_rgbd_image_from_redwood_format",
-          &geometry::RGBDImage::CreateFromRedwoodFormat,
-          "Function to make RGBDImage (for Redwood format)", "color"_a,
-          "depth"_a, "convert_rgb_to_intensity"_a = true);
-    docstring::FunctionDocInject(m, "create_rgbd_image_from_redwood_format",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_rgbd_image_from_tum_format",
-          &geometry::RGBDImage::CreateFromTUMFormat,
-          "Function to make RGBDImage (for TUM format)", "color"_a, "depth"_a,
-          "convert_rgb_to_intensity"_a = true);
-    docstring::FunctionDocInject(m, "create_rgbd_image_from_tum_format",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_rgbd_image_from_sun_format",
-          &geometry::RGBDImage::CreateFromSUNFormat,
-          "Function to make RGBDImage (for SUN format)", "color"_a, "depth"_a,
-          "convert_rgb_to_intensity"_a = true);
-    docstring::FunctionDocInject(m, "create_rgbd_image_from_sun_format",
-                                 map_shared_argument_docstrings);
-
-    m.def("create_rgbd_image_from_nyu_format",
-          &geometry::RGBDImage::CreateFromNYUFormat,
-          "Function to make RGBDImage (for NYU format)", "color"_a, "depth"_a,
-          "convert_rgb_to_intensity"_a = true);
-    docstring::FunctionDocInject(m, "create_rgbd_image_from_nyu_format",
-                                 map_shared_argument_docstrings);
-}
+void pybind_image_methods(py::module &m) {}

--- a/src/Python/geometry/lineset.cpp
+++ b/src/Python/geometry/lineset.cpp
@@ -60,13 +60,15 @@ void pybind_lineset(py::module &m) {
             .def("paint_uniform_color", &geometry::LineSet::PaintUniformColor,
                  "Assigns each line in the line set the same color.")
             .def_static("create_from_point_cloud_correspondences",
-                  &geometry::LineSet::CreateFromPointCloudCorrespondences,
-                  "Factory function to create a LineSet from two pointclouds and a correspondence set.",
-                  "cloud0"_a, "cloud1"_a, "correspondences"_a)
+                        &geometry::LineSet::CreateFromPointCloudCorrespondences,
+                        "Factory function to create a LineSet from two "
+                        "pointclouds and a correspondence set.",
+                        "cloud0"_a, "cloud1"_a, "correspondences"_a)
             .def_static("create_from_triangle_mesh",
-                  &geometry::LineSet::CreateFromTriangleMesh,
-                  "Factory function to create a LineSet from edges of a triangle mesh.",
-                  "mesh"_a)
+                        &geometry::LineSet::CreateFromTriangleMesh,
+                        "Factory function to create a LineSet from edges of a "
+                        "triangle mesh.",
+                        "mesh"_a)
             .def_readwrite("points", &geometry::LineSet::points_,
                            "``float64`` array of shape ``(num_points, 3)``, "
                            "use ``numpy.asarray()`` to access data: Points "
@@ -93,8 +95,7 @@ void pybind_lineset(py::module &m) {
              {"cloud1", "Second point cloud."},
              {"correspondences", "Set of correspondences."}});
     docstring::ClassMethodDocInject(m, "LineSet", "create_from_triangle_mesh",
-                                 {{"mesh", "The input triangle mesh."}});
+                                    {{"mesh", "The input triangle mesh."}});
 }
 
-void pybind_lineset_methods(py::module &m) {
-}
+void pybind_lineset_methods(py::module &m) {}

--- a/src/Python/geometry/lineset.cpp
+++ b/src/Python/geometry/lineset.cpp
@@ -59,6 +59,14 @@ void pybind_lineset(py::module &m) {
                  "line_index"_a)
             .def("paint_uniform_color", &geometry::LineSet::PaintUniformColor,
                  "Assigns each line in the line set the same color.")
+            .def_static("create_from_point_cloud_correspondences",
+                  &geometry::LineSet::CreateFromPointCloudCorrespondences,
+                  "Factory function to create a LineSet from two pointclouds and a correspondence set.",
+                  "cloud0"_a, "cloud1"_a, "correspondences"_a)
+            .def_static("create_from_triangle_mesh",
+                  &geometry::LineSet::CreateFromTriangleMesh,
+                  "Factory function to create a LineSet from edges of a triangle mesh.",
+                  "mesh"_a)
             .def_readwrite("points", &geometry::LineSet::points_,
                            "``float64`` array of shape ``(num_points, 3)``, "
                            "use ``numpy.asarray()`` to access data: Points "
@@ -79,24 +87,14 @@ void pybind_lineset(py::module &m) {
                                     {{"line_index", "Index of the line."}});
     docstring::ClassMethodDocInject(m, "LineSet", "paint_uniform_color",
                                     {{"color", "Color for the LineSet."}});
-}
-
-void pybind_lineset_methods(py::module &m) {
-    m.def("create_line_set_from_point_cloud_correspondences",
-          &geometry::CreateLineSetFromPointCloudCorrespondences,
-          "Factory function to create a LineSet from two pointclouds and a "
-          "correspondence set.",
-          "cloud0"_a, "cloud1"_a, "correspondences"_a);
-    docstring::FunctionDocInject(
-            m, "create_line_set_from_point_cloud_correspondences",
+    docstring::ClassMethodDocInject(
+            m, "LineSet", "create_from_point_cloud_correspondences",
             {{"cloud0", "First point cloud."},
              {"cloud1", "Second point cloud."},
              {"correspondences", "Set of correspondences."}});
-
-    m.def("create_line_set_from_triangle_mesh",
-          &geometry::CreateLineSetFromTriangleMesh,
-          "Factory function to create a LineSet from edges of a triangle mesh.",
-          "mesh"_a);
-    docstring::FunctionDocInject(m, "create_line_set_from_triangle_mesh",
+    docstring::ClassMethodDocInject(m, "LineSet", "create_from_triangle_mesh",
                                  {{"mesh", "The input triangle mesh."}});
+}
+
+void pybind_lineset_methods(py::module &m) {
 }

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -104,9 +104,8 @@ void pybind_pointcloud(py::module &m) {
                  "nb_neighbors"_a, "std_ratio"_a)
             .def("estimate_normals", &geometry::PointCloud::EstimateNormals,
                  "Function to compute the normals of a point cloud. Normals "
-                 "are "
-                 "oriented with respect to the input point cloud if normals "
-                 "exist",
+                 "are oriented with respect to the input point cloud if "
+                 "normals exist",
                  "search_param"_a = geometry::KDTreeSearchParamKNN())
             .def("orient_normals_to_align_with_direction",
                  &geometry::PointCloud::OrientNormalsToAlignWithDirection,
@@ -237,8 +236,8 @@ void pybind_pointcloud(py::module &m) {
                                     "compute_mean_and_covariance");
     docstring::ClassMethodDocInject(m, "PointCloud",
                                     "compute_mahalanobis_distance");
-    docstring::ClassMethodDocInject(
-            m, "PointCloud", "compute_point_cloud_nearest_neighbor_distance");
+    docstring::ClassMethodDocInject(m, "PointCloud",
+                                    "compute_nearest_neighbor_distance");
     docstring::ClassMethodDocInject(m, "PointCloud", "compute_convex_hull",
                                     {{"input", "The input point cloud."}});
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_depth_image");

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -473,8 +473,7 @@ void pybind_trianglemesh(py::module &m) {
             {{"target_number_of_triangles",
               "The number of triangles that the simplified mesh should have. "
               "It is not guranteed that this number will be reached."}});
-    docstring::ClassMethodDocInject(m, "TriangleMesh",
-                                    "compute_mesh_convex_hull");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "create_box",
                                     {{"width", "x-directional length."},
                                      {"height", "y-directional length."},

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -206,6 +206,121 @@ void pybind_trianglemesh(py::module &m) {
                  "If the mesh is orientable this function orients all "
                  "triangles such that all normals point towards the same "
                  "direction.")
+            .def("select_down_sample",
+                 &geometry::TriangleMesh::SelectDownSample,
+                 "Function to select mesh from input triangle mesh into output "
+                 "triangle mesh. ``input``: The input triangle mesh. "
+                 "``indices``: "
+                 "Indices of vertices to be selected.",
+                 "indices"_a)
+            .def("crop", &geometry::TriangleMesh::Crop,
+                 "Function to crop input triangle mesh into output triangle "
+                 "mesh",
+                 "min_bound"_a, "max_bound"_a)
+            .def("sample_points_uniformly",
+                 &geometry::TriangleMesh::SamplePointsUniformly,
+                 "Function to uniformly sample points from the mesh.",
+                 "number_of_points"_a = 100)
+            .def("sample_points_poisson_disk",
+                 &geometry::TriangleMesh::SamplePointsPoissonDisk,
+                 "Function to sample points from the mesh, where each point "
+                 "has "
+                 "approximately the same distance to the neighbouring points "
+                 "(blue "
+                 "noise). Method is based on Yuksel, \"Sample Elimination for "
+                 "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
+                 "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr)
+            .def("subdivide_midpoint",
+                 &geometry::TriangleMesh::SubdivideMidpoint,
+                 "Function subdivide mesh using midpoint algorithm.",
+                 "number_of_iterations"_a = 1)
+            .def("subdivide_loop", &geometry::TriangleMesh::SubdivideLoop,
+                 "Function subdivide mesh using Loop's algorithm. Loop, "
+                 "\"Smooth "
+                 "subdivision surfaces based on triangles\", 1987.",
+                 "number_of_iterations"_a = 1)
+            .def("simplify_vertex_clustering",
+                 &geometry::TriangleMesh::SimplifyVertexClustering,
+                 "Function to simplify mesh using vertex clustering.",
+                 "voxel_size"_a,
+                 "contraction"_a = geometry::TriangleMesh::
+                         SimplificationContraction::Average)
+            .def("simplify_quadric_decimation",
+                 &geometry::TriangleMesh::SimplifyQuadricDecimation,
+                 "Function to simplify mesh using Quadric Error Metric "
+                 "Decimation by "
+                 "Garland and Heckbert",
+                 "target_number_of_triangles"_a)
+            .def("compute_convex_hull",
+                 &geometry::TriangleMesh::ComputeConvexHull,
+                 "Computes the convex hull of the triangle mesh.")
+            .def_static("create_box", &geometry::TriangleMesh::CreateBox,
+                        "Factory function to create a box. The left bottom "
+                        "corner on the "
+                        "front will be placed at (0, 0, 0).",
+                        "width"_a = 1.0, "height"_a = 1.0, "depth"_a = 1.0)
+            .def_static("create_tetrahedron",
+                        &geometry::TriangleMesh::CreateTetrahedron,
+                        "Factory function to create a tetrahedron. The "
+                        "centroid of the mesh "
+                        "will be placed at (0, 0, 0) and the vertices have a "
+                        "distance of "
+                        "radius to the center.",
+                        "radius"_a = 1.0)
+            .def_static("create_octahedron",
+                        &geometry::TriangleMesh::CreateOctahedron,
+                        "Factory function to create a octahedron. The centroid "
+                        "of the mesh "
+                        "will be placed at (0, 0, 0) and the vertices have a "
+                        "distance of "
+                        "radius to the center.",
+                        "radius"_a = 1.0)
+            .def_static("create_icosahedron",
+                        &geometry::TriangleMesh::CreateIcosahedron,
+                        "Factory function to create a icosahedron. The "
+                        "centroid of the mesh "
+                        "will be placed at (0, 0, 0) and the vertices have a "
+                        "distance of "
+                        "radius to the center.",
+                        "radius"_a = 1.0)
+            .def_static("create_sphere", &geometry::TriangleMesh::CreateSphere,
+                        "Factory function to create a sphere mesh centered at "
+                        "(0, 0, 0).",
+                        "radius"_a = 1.0, "resolution"_a = 20)
+            .def_static("create_cylinder",
+                        &geometry::TriangleMesh::CreateCylinder,
+                        "Factory function to create a cylinder mesh.",
+                        "radius"_a = 1.0, "height"_a = 2.0, "resolution"_a = 20,
+                        "split"_a = 4)
+            .def_static("create_cone", &geometry::TriangleMesh::CreateCone,
+                        "Factory function to create a cone mesh.",
+                        "radius"_a = 1.0, "height"_a = 2.0, "resolution"_a = 20,
+                        "split"_a = 1)
+            .def_static("create_torus", &geometry::TriangleMesh::CreateTorus,
+                        "Factory function to create a torus mesh.",
+                        "torus_radius"_a = 1.0, "tube_radius"_a = 0.5,
+                        "radial_resolution"_a = 30, "tubular_resolution"_a = 20)
+            .def_static("create_arrow", &geometry::TriangleMesh::CreateArrow,
+                        "Factory function to create an arrow mesh",
+                        "cylinder_radius"_a = 1.0, "cone_radius"_a = 1.5,
+                        "cylinder_height"_a = 5.0, "cone_height"_a = 4.0,
+                        "resolution"_a = 20, "cylinder_split"_a = 4,
+                        "cone_split"_a = 1)
+            .def_static("create_coordinate_frame",
+                        &geometry::TriangleMesh::CreateCoordinateFrame,
+                        "Factory function to create a coordinate frame mesh. "
+                        "The coordinate "
+                        "frame will be centered at ``origin``. The x, y, z "
+                        "axis will be "
+                        "rendered as red, green, and blue arrows respectively.",
+                        "size"_a = 1.0,
+                        "origin"_a = Eigen::Vector3d(0.0, 0.0, 0.0))
+            .def_static("create_moebius",
+                        &geometry::TriangleMesh::CreateMoebius,
+                        "Factory function to create a Moebius strip.",
+                        "length_split"_a = 70, "width_split"_a = 15,
+                        "twists"_a = 1, "raidus"_a = 1, "flatness"_a = 1,
+                        "width"_a = 1, "scale"_a = 1)
             .def_readwrite("vertices", &geometry::TriangleMesh::vertices_,
                            "``float64`` array of shape ``(num_vertices, 3)``, "
                            "use ``numpy.asarray()`` to access data: Vertex "
@@ -315,152 +430,66 @@ void pybind_trianglemesh(py::module &m) {
              {"lambda", "Filter parameter."},
              {"mu", "Filter parameter."},
              {"scope", "Mesh property that should be filtered."}});
-}
-
-void pybind_trianglemesh_methods(py::module &m) {
-    // Overloaded function, do not inject docs. Keep commented out for future.
-    m.def("select_down_sample",
-          (std::shared_ptr<geometry::TriangleMesh>(*)(
-                  const geometry::TriangleMesh &,
-                  const std::vector<size_t> &)) &
-                  geometry::SelectDownSample,
-          "Function to select mesh from input triangle mesh into output "
-          "triangle mesh. ``input``: The input triangle mesh. ``indices``: "
-          "Indices of vertices to be selected.",
-          "input"_a, "indices"_a);
-    // docstring::FunctionDocInject(
-    //         m, "select_down_sample",
-    //         {{"input", "The input triangle mesh."},
-    //          {"indices", "Indices of vertices to be selected."}});
-
-    m.def("crop_triangle_mesh", &geometry::CropTriangleMesh,
-          "Function to crop input triangle mesh into output triangle mesh",
-          "input"_a, "min_bound"_a, "max_bound"_a);
-    docstring::FunctionDocInject(
-            m, "crop_triangle_mesh",
-            {{"input", "The input triangle mesh."},
-             {"min_bound", "Minimum bound for vertex coordinate."},
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "select_down_sample",
+            {{"indices", "Indices of vertices to be selected."}});
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "crop",
+            {{"min_bound", "Minimum bound for vertex coordinate."},
              {"max_bound", "Maximum bound for vertex coordinate."}});
-
-    m.def("sample_points_uniformly", &geometry::SamplePointsUniformly,
-          "Function to uniformly sample points from the mesh.", "input"_a,
-          "number_of_points"_a = 100);
-    docstring::FunctionDocInject(
-            m, "sample_points_uniformly",
-            {{"input", "The input triangle mesh."},
-             {"number_of_points",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "sample_points_uniformly",
+            {{"number_of_points",
               "Number of points that should be uniformly sampled."}});
-
-    m.def("sample_points_poisson_disk", &geometry::SamplePointsPoissonDisk,
-          "Function to sample points from the mesh, where each point has "
-          "approximately the same distance to the neighbouring points (blue "
-          "noise). Method is based on Yuksel, \"Sample Elimination for "
-          "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
-          "input"_a, "number_of_points"_a, "init_factor"_a = 5,
-          "pcl"_a = nullptr);
-    docstring::FunctionDocInject(
-            m, "sample_points_poisson_disk",
-            {{"input", "The input triangle mesh."},
-             {"number_of_points", "Number of points that should be sampled."},
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "sample_points_poisson_disk",
+            {{"number_of_points", "Number of points that should be sampled."},
              {"init_factor",
               "Factor for the initial uniformly sampled PointCloud. This init "
               "PointCloud is used for sample elimination."},
              {"pcl",
               "Initial PointCloud that is used for sample elimination. If this "
               "parameter is provided the init_factor is ignored."}});
-
-    m.def("subdivide_midpoint", &geometry::SubdivideMidpoint,
-          "Function subdivide mesh using midpoint algorithm.", "input"_a,
-          "number_of_iterations"_a = 1);
-    docstring::FunctionDocInject(
-            m, "subdivide_midpoint",
-            {{"input", "The input triangle mesh."},
-             {"number_of_iterations",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "subdivide_midpoint",
+            {{"number_of_iterations",
               "Number of iterations. A single iteration splits each triangle "
               "into four triangles that cover the same surface."}});
-
-    m.def("subdivide_loop", &geometry::SubdivideLoop,
-          "Function subdivide mesh using Loop's algorithm. Loop, \"Smooth "
-          "subdivision surfaces based on triangles\", 1987.",
-          "input"_a, "number_of_iterations"_a = 1);
-    docstring::FunctionDocInject(
-            m, "subdivide_loop",
-            {{"input", "The input triangle mesh."},
-             {"number_of_iterations",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "subdivide_loop",
+            {{"number_of_iterations",
               "Number of iterations. A single iteration splits each triangle "
               "into four triangles."}});
-
-    m.def("simplify_vertex_clustering", &geometry::SimplifyVertexClustering,
-          "Function to simplify mesh using vertex clustering.", "input"_a,
-          "voxel_size"_a,
-          "contraction"_a =
-                  geometry::TriangleMesh::SimplificationContraction::Average);
-    docstring::FunctionDocInject(
-            m, "simplify_vertex_clustering",
-            {{"input", "The input triangle mesh."},
-             {"voxel_size",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "simplify_vertex_clustering",
+            {{"voxel_size",
               "The size of the voxel within vertices are pooled."},
              {"contraction",
               "Method to aggregate vertex information. Average computes a "
               "simple average, Quadric minimizes the distance to the adjacent "
               "planes."}});
-    m.def("simplify_quadric_decimation", &geometry::SimplifyQuadricDecimation,
-          "Function to simplify mesh using Quadric Error Metric Decimation by "
-          "Garland and Heckbert",
-          "input"_a, "target_number_of_triangles"_a);
-    docstring::FunctionDocInject(
-            m, "simplify_quadric_decimation",
-            {{"input", "The input triangle mesh."},
-             {"target_number_of_triangles",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "simplify_quadric_decimation",
+            {{"target_number_of_triangles",
               "The number of triangles that the simplified mesh should have. "
               "It is not guranteed that this number will be reached."}});
-
-    m.def("compute_mesh_convex_hull", &geometry::ComputeMeshConvexHull,
-          "Computes the convex hull of the triangle mesh.", "input"_a);
-    docstring::FunctionDocInject(m, "compute_mesh_convex_hull",
-                                 {{"input", "The input triangle mesh."}});
-
-    m.def("create_mesh_box", &geometry::CreateMeshBox,
-          "Factory function to create a box. The left bottom corner on the "
-          "front will be placed at (0, 0, 0).",
-          "width"_a = 1.0, "height"_a = 1.0, "depth"_a = 1.0);
-    docstring::FunctionDocInject(m, "create_mesh_box",
-                                 {{"width", "x-directional length."},
-                                  {"height", "y-directional length."},
-                                  {"depth", "z-directional length."}});
-
-    m.def("create_mesh_tetrahedron", &geometry::CreateMeshTetrahedron,
-          "Factory function to create a tetrahedron. The centroid of the mesh "
-          "will be placed at (0, 0, 0) and the vertices have a distance of "
-          "radius to the center.",
-          "radius"_a = 1.0);
-    docstring::FunctionDocInject(
-            m, "create_mesh_tetrahedron",
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "compute_mesh_convex_hull");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "create_box",
+                                    {{"width", "x-directional length."},
+                                     {"height", "y-directional length."},
+                                     {"depth", "z-directional length."}});
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_tetrahedron",
             {{"radius", "Distance from centroid to mesh vetices."}});
-
-    m.def("create_mesh_octahedron", &geometry::CreateMeshOctahedron,
-          "Factory function to create a octahedron. The centroid of the mesh "
-          "will be placed at (0, 0, 0) and the vertices have a distance of "
-          "radius to the center.",
-          "radius"_a = 1.0);
-    docstring::FunctionDocInject(
-            m, "create_mesh_octahedron",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_octahedron",
             {{"radius", "Distance from centroid to mesh vetices."}});
-
-    m.def("create_mesh_icosahedron", &geometry::CreateMeshIcosahedron,
-          "Factory function to create a icosahedron. The centroid of the mesh "
-          "will be placed at (0, 0, 0) and the vertices have a distance of "
-          "radius to the center.",
-          "radius"_a = 1.0);
-    docstring::FunctionDocInject(
-            m, "create_mesh_icosahedron",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_icosahedron",
             {{"radius", "Distance from centroid to mesh vetices."}});
-
-    m.def("create_mesh_sphere", &geometry::CreateMeshSphere,
-          "Factory function to create a sphere mesh centered at (0, 0, 0).",
-          "radius"_a = 1.0, "resolution"_a = 20);
-    docstring::FunctionDocInject(
-            m, "create_mesh_sphere",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_sphere",
             {{"radius", "The radius of the sphere."},
              {"resolution",
               "The resolution of the sphere. The longitues will be split into "
@@ -468,12 +497,8 @@ void pybind_trianglemesh_methods(py::module &m) {
               "latitude lines including the north and south pole). The "
               "latitudes will be split into ```2 * resolution`` segments (i.e. "
               "there are ``2 * resolution`` longitude lines.)"}});
-
-    m.def("create_mesh_cylinder", &geometry::CreateMeshCylinder,
-          "Factory function to create a cylinder mesh.", "radius"_a = 1.0,
-          "height"_a = 2.0, "resolution"_a = 20, "split"_a = 4);
-    docstring::FunctionDocInject(
-            m, "create_mesh_cylinder",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_cylinder",
             {{"radius", "The radius of the cylinder."},
              {"height",
               "The height of the cylinder. The axis of the cylinder will be "
@@ -482,12 +507,8 @@ void pybind_trianglemesh_methods(py::module &m) {
               " The circle will be split into ``resolution`` segments"},
              {"split",
               "The ``height`` will be split into ``split`` segments."}});
-
-    m.def("create_mesh_cone", &geometry::CreateMeshCone,
-          "Factory function to create a cone mesh.", "radius"_a = 1.0,
-          "height"_a = 2.0, "resolution"_a = 20, "split"_a = 1);
-    docstring::FunctionDocInject(
-            m, "create_mesh_cone",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_cone",
             {{"radius", "The radius of the cone."},
              {"height",
               "The height of the cone. The axis of the cone will be from (0, "
@@ -496,13 +517,8 @@ void pybind_trianglemesh_methods(py::module &m) {
               "The circle will be split into ``resolution`` segments"},
              {"split",
               "The ``height`` will be split into ``split`` segments."}});
-
-    m.def("create_mesh_torus", &geometry::CreateMeshTorus,
-          "Factory function to create a torus mesh.", "torus_radius"_a = 1.0,
-          "tube_radius"_a = 0.5, "radial_resolution"_a = 30,
-          "tubular_resolution"_a = 20);
-    docstring::FunctionDocInject(
-            m, "create_mesh_torus",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_torus",
             {{"torus_radius",
               "The radius from the center of the torus to the center of the "
               "tube."},
@@ -511,14 +527,8 @@ void pybind_trianglemesh_methods(py::module &m) {
               "The number of segments along the radial direction."},
              {"tubular_resolution",
               "The number of segments along the tubular direction."}});
-
-    m.def("create_mesh_arrow", &geometry::CreateMeshArrow,
-          "Factory function to create an arrow mesh", "cylinder_radius"_a = 1.0,
-          "cone_radius"_a = 1.5, "cylinder_height"_a = 5.0,
-          "cone_height"_a = 4.0, "resolution"_a = 20, "cylinder_split"_a = 4,
-          "cone_split"_a = 1);
-    docstring::FunctionDocInject(
-            m, "create_mesh_arrow",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_arrow",
             {{"cylinder_radius", "The radius of the cylinder."},
              {"cone_radius", "The radius of the cone."},
              {"cylinder_height",
@@ -535,23 +545,12 @@ void pybind_trianglemesh_methods(py::module &m) {
              {"cone_split",
               "The ``cone_height`` will be split into ``cone_split`` "
               "segments."}});
-
-    m.def("create_mesh_coordinate_frame", &geometry::CreateMeshCoordinateFrame,
-          "Factory function to create a coordinate frame mesh. The coordinate "
-          "frame will be centered at ``origin``. The x, y, z axis will be "
-          "rendered as red, green, and blue arrows respectively.",
-          "size"_a = 1.0, "origin"_a = Eigen::Vector3d(0.0, 0.0, 0.0));
-    docstring::FunctionDocInject(
-            m, "create_mesh_coordinate_frame",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_coordinate_frame",
             {{"size", "The size of the coordinate frame."},
              {"origin", "The origin of the cooridnate frame."}});
-
-    m.def("create_mesh_moebius", &geometry::CreateMeshMoebius,
-          "Factory function to create a Moebius strip.", "length_split"_a = 70,
-          "width_split"_a = 15, "twists"_a = 1, "raidus"_a = 1,
-          "flatness"_a = 1, "width"_a = 1, "scale"_a = 1);
-    docstring::FunctionDocInject(
-            m, "create_mesh_moebius",
+    docstring::ClassMethodDocInject(
+            m, "TriangleMesh", "create_moebius",
             {{"length_split",
               "The number of segments along the Moebius strip."},
              {"width_split",
@@ -562,3 +561,5 @@ void pybind_trianglemesh_methods(py::module &m) {
              {"width", "Width of the Moebius strip."},
              {"scale", "Scale the complete Moebius strip."}});
 }
+
+void pybind_trianglemesh_methods(py::module &m) {}

--- a/src/Python/geometry/voxelgrid.cpp
+++ b/src/Python/geometry/voxelgrid.cpp
@@ -95,6 +95,10 @@ void pybind_voxelgrid(py::module &m) {
             .def("from_octree", &geometry::VoxelGrid::FromOctree,
                  "octree"_a
                  "Convert from Octree.")
+            .def_static("create_from_point_cloud",
+                        &geometry::VoxelGrid::CreateFromPointCloud,
+                        "Function to make voxels from scanned point cloud",
+                        "input"_a, "voxel_size"_a)
             .def_readwrite("origin", &geometry::VoxelGrid::origin_,
                            "``float64`` vector of length 3: Coorindate of the "
                            "origin point.")
@@ -109,15 +113,10 @@ void pybind_voxelgrid(py::module &m) {
     docstring::ClassMethodDocInject(
             m, "VoxelGrid", "from_octree",
             {{"octree", "geometry.Octree: The source octree."}});
-}
-
-void pybind_voxelgrid_methods(py::module &m) {
-    m.def("create_surface_voxel_grid_from_point_cloud",
-          &geometry::CreateSurfaceVoxelGridFromPointCloud,
-          "Function to make voxels from scanned point cloud", "point_cloud"_a,
-          "voxel_size"_a);
-    docstring::FunctionDocInject(
-            m, "create_surface_voxel_grid_from_point_cloud",
-            {{"point_cloud", "The input point cloud."},
+    docstring::ClassMethodDocInject(
+            m, "VoxelGrid", "create_from_point_cloud",
+            {{"input", "The input PointCloud"},
              {"voxel_size", "Voxel size of of the VoxelGrid construction."}});
 }
+
+void pybind_voxelgrid_methods(py::module &m) {}

--- a/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
         if (voxel_size > 0.0) {
             utility::PrintInfo("Downsample point cloud with voxel size %.4f.\n",
                                voxel_size);
-            source_ptr = geometry::VoxelDownSample(*source_ptr, voxel_size);
+            source_ptr = source_ptr->VoxelDownSample(voxel_size);
         }
         if (max_corres_distance > 0.0) {
             utility::PrintInfo("ICP with max correspondence distance %.4f.\n",
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
         if (voxel_size > 0.0) {
             utility::PrintInfo("Downsample point cloud with voxel size %.4f.\n",
                                voxel_size);
-            source_ptr = geometry::VoxelDownSample(*source_ptr, voxel_size);
+            source_ptr = source_ptr->VoxelDownSample(voxel_size);
         }
         std::string source_filename =
                 utility::filesystem::GetFileNameWithoutExtension(
@@ -186,14 +186,12 @@ int main(int argc, char **argv) {
         FILE *f;
 
         io::WritePointCloud(source_filename, *source_ptr);
-        auto source_dis = geometry::ComputePointCloudToPointCloudDistance(
-                *source_ptr, *target_ptr);
+        auto source_dis = source_ptr->ComputePointCloudDistance(*target_ptr);
         f = fopen(source_binname.c_str(), "wb");
         fwrite(source_dis.data(), sizeof(double), source_dis.size(), f);
         fclose(f);
         io::WritePointCloud(target_filename, *target_ptr);
-        auto target_dis = geometry::ComputePointCloudToPointCloudDistance(
-                *target_ptr, *source_ptr);
+        auto target_dis = target_ptr->ComputePointCloudDistance(*source_ptr);
         f = fopen(target_binname.c_str(), "wb");
         fwrite(target_dis.data(), sizeof(double), target_dis.size(), f);
         fclose(f);

--- a/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
@@ -192,8 +192,8 @@ void VisualizerForAlignment::KeyPressCallback(
                     utility::PrintInfo(
                             "Voxel downsample with voxel size %.4f.\n",
                             voxel_size_);
-                    *source_copy_ptr_ = *geometry::VoxelDownSample(
-                            *source_copy_ptr_, voxel_size_);
+                    *source_copy_ptr_ =
+                            *source_copy_ptr_->VoxelDownSample(voxel_size_);
                     UpdateGeometry();
                 } else {
                     utility::PrintInfo(
@@ -341,14 +341,14 @@ void VisualizerForAlignment::EvaluateAlignmentAndSave(
     FILE *f;
 
     io::WritePointCloud(source_filename, *source_copy_ptr_);
-    auto source_dis = geometry::ComputePointCloudToPointCloudDistance(
-            *source_copy_ptr_, *target_copy_ptr_);
+    auto source_dis =
+            source_copy_ptr_->ComputePointCloudDistance(*target_copy_ptr_);
     f = fopen(source_binname.c_str(), "wb");
     fwrite(source_dis.data(), sizeof(double), source_dis.size(), f);
     fclose(f);
     io::WritePointCloud(target_filename, *target_copy_ptr_);
-    auto target_dis = geometry::ComputePointCloudToPointCloudDistance(
-            *target_copy_ptr_, *source_copy_ptr_);
+    auto target_dis =
+            target_copy_ptr_->ComputePointCloudDistance(*source_copy_ptr_);
     f = fopen(target_binname.c_str(), "wb");
     fwrite(target_dis.data(), sizeof(double), target_dis.size(), f);
     fclose(f);

--- a/src/Tools/ViewGeometry.cpp
+++ b/src/Tools/ViewGeometry.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
                                                 239.5);
         }
         auto image_ptr = io::CreateImageFromFile(depth_filename);
-        auto pointcloud_ptr = geometry::CreatePointCloudFromDepthImage(
+        auto pointcloud_ptr = geometry::PointCloud::CreateFromDepthImage(
                 *image_ptr, parameters.intrinsic_, parameters.extrinsic_);
         if (visualizer.AddGeometry(pointcloud_ptr) == false) {
             utility::PrintWarning("Failed adding depth image.\n");

--- a/src/UnitTest/ColorMap/ColorMapOptimization.cpp
+++ b/src/UnitTest/ColorMap/ColorMapOptimization.cpp
@@ -216,7 +216,7 @@ TEST(ColorMapOptimization, DISABLED_MakeVertexAndImageVisibility) {
     size_t size = 10;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 20);
+            geometry::TriangleMesh::CreateSphere(10.0, 20);
     vector<geometry::RGBDImage> images_rgbd =
             GenerateRGBDImages(width, height, size);
     vector<geometry::Image> images_mask = GenerateImages(
@@ -508,7 +508,7 @@ TEST(ColorMapOptimization, DISABLED_SetProxyIntensityForVertex) {
     int bytes_per_channel = 4;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 10);
+            geometry::TriangleMesh::CreateSphere(10.0, 10);
 
     vector<shared_ptr<geometry::Image>> images_gray = GenerateSharedImages(
             width, height, num_of_channels, bytes_per_channel, size);
@@ -579,7 +579,7 @@ TEST(ColorMapOptimization, DISABLED_SetProxyIntensityForVertex_WarpingField) {
     int bytes_per_channel = 4;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 10);
+            geometry::TriangleMesh::CreateSphere(10.0, 10);
 
     // TODO: change the initialization in such a way that the fields have an
     // effect on the outcome of QueryImageIntensity.
@@ -635,7 +635,7 @@ TEST(ColorMapOptimization, DISABLED_OptimizeImageCoorNonrigid) {
     int bytes_per_channel = 4;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 5);
+            geometry::TriangleMesh::CreateSphere(10.0, 5);
 
     vector<shared_ptr<geometry::Image>> images_gray = GenerateSharedImages(
             width, height, num_of_channels, bytes_per_channel, size);
@@ -715,7 +715,7 @@ TEST(ColorMapOptimization, DISABLED_OptimizeImageCoorRigid) {
     int bytes_per_channel = 4;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 5);
+            geometry::TriangleMesh::CreateSphere(10.0, 5);
 
     vector<shared_ptr<geometry::Image>> images_gray = GenerateSharedImages(
             width, height, num_of_channels, bytes_per_channel, size);
@@ -792,7 +792,7 @@ TEST(ColorMapOptimization, DISABLED_SetGeometryColorAverage) {
     int height = 240;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 5);
+            geometry::TriangleMesh::CreateSphere(10.0, 5);
 
     vector<geometry::RGBDImage> images_rgbd =
             GenerateRGBDImages(width, height, size);
@@ -849,7 +849,7 @@ TEST(ColorMapOptimization, DISABLED_SetGeometryColorAverage_WarpingFields) {
     int height = 240;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 5);
+            geometry::TriangleMesh::CreateSphere(10.0, 5);
 
     // TODO: change the initialization in such a way that the fields have an
     // effect on the outcome of QueryImageIntensity.
@@ -1125,7 +1125,7 @@ TEST(ColorMapOptimization, DISABLED_ColorMapOptimization) {
     int bytes_per_channel = 4;
 
     shared_ptr<geometry::TriangleMesh> mesh =
-            geometry::CreateMeshSphere(10.0, 5);
+            geometry::TriangleMesh::CreateSphere(10.0, 5);
 
     vector<geometry::RGBDImage> rgbdImages =
             GenerateRGBDImages(width, height, size);

--- a/src/UnitTest/ColorMap/ColorMapOptimization.cpp
+++ b/src/UnitTest/ColorMap/ColorMapOptimization.cpp
@@ -53,7 +53,7 @@ vector<geometry::Image> GenerateImages(const int& width,
     for (size_t i = 0; i < size; i++) {
         geometry::Image image;
 
-        image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+        image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
         if (bytes_per_channel == 4) {
             float* const depthData = reinterpret_cast<float*>(&image.data_[0]);
@@ -327,7 +327,7 @@ TEST(ColorMapOptimization, DISABLED_QueryImageIntensity) {
     int bytes_per_channel = 4;
 
     geometry::Image img;
-    img.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    img.Prepare(width, height, num_of_channels, bytes_per_channel);
     float* const depthData = reinterpret_cast<float*>(&img.data_[0]);
     Rand(depthData, width * height, 10.0, 100.0, 0);
 
@@ -412,7 +412,7 @@ TEST(ColorMapOptimization, DISABLED_QueryImageIntensity_WarpingField) {
     int bytes_per_channel = 4;
 
     geometry::Image img;
-    img.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    img.Prepare(width, height, num_of_channels, bytes_per_channel);
     float* const depthData = reinterpret_cast<float*>(&img.data_[0]);
     Rand(depthData, width * height, 10.0, 100.0, 0);
 

--- a/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
@@ -254,43 +254,44 @@ void assert_ordreded_edges(
 
 TEST(HalfEdgeTriangleMesh, Constructor_TwoTriangles) {
     geometry::TriangleMesh mesh = get_mesh_two_triangles();
-    auto he_mesh = geometry::CreateHalfEdgeMeshFromMesh(mesh);
+    auto he_mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh);
     EXPECT_FALSE(he_mesh->IsEmpty());
 }
 
 TEST(HalfEdgeTriangleMesh, Constructor_TwoTrianglesFlipped) {
     geometry::TriangleMesh mesh = get_mesh_two_triangles_flipped();
-    ASSERT_THROW(geometry::CreateHalfEdgeMeshFromMesh(mesh),
+    ASSERT_THROW(geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh),
                  std::runtime_error);  // Non-manifold
 }
 
 TEST(HalfEdgeTriangleMesh, Constructor_TwoTrianglesInvalidVertex) {
     geometry::TriangleMesh mesh = get_mesh_two_triangles_invalid_vertex();
-    ASSERT_THROW(geometry::CreateHalfEdgeMeshFromMesh(mesh),
+    ASSERT_THROW(geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh),
                  std::runtime_error);  // Non-manifold
 }
 
 TEST(HalfEdgeTriangleMesh, Constructor_Hexagon) {
     geometry::TriangleMesh mesh = get_mesh_hexagon();
-    auto he_mesh = geometry::CreateHalfEdgeMeshFromMesh(mesh);
+    auto he_mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh);
     EXPECT_FALSE(he_mesh->IsEmpty());
 }
 
 TEST(HalfEdgeTriangleMesh, Constructor_PartialHexagon) {
     geometry::TriangleMesh mesh = get_mesh_partial_hexagon();
-    auto he_mesh = geometry::CreateHalfEdgeMeshFromMesh(mesh);
+    auto he_mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh);
     EXPECT_FALSE(he_mesh->IsEmpty());
 }
 
 TEST(HalfEdgeTriangleMesh, Constructor_Sphere) {
     geometry::TriangleMesh mesh;
     io::ReadTriangleMesh(std::string(TEST_DATA_DIR) + "/sphere.ply", mesh);
-    auto he_mesh = geometry::CreateHalfEdgeMeshFromMesh(mesh);
+    auto he_mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(mesh);
     EXPECT_FALSE(he_mesh->IsEmpty());
 }
 
 TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_TwoTriangles) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_two_triangles());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_two_triangles());
     EXPECT_FALSE(mesh->IsEmpty());
     assert_ordreded_neighbor(mesh, 0, {2});
     assert_ordreded_neighbor(mesh, 1, {0, 2});
@@ -299,7 +300,8 @@ TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_TwoTriangles) {
 }
 
 TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_Hexagon) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_hexagon());
+    auto mesh =
+            geometry::HalfEdgeTriangleMesh::CreateFromMesh(get_mesh_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     assert_ordreded_neighbor(mesh, 0, {2, 3});
     assert_ordreded_neighbor(mesh, 1, {0, 3});
@@ -312,8 +314,8 @@ TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_Hexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_PartialHexagon) {
-    auto mesh =
-            geometry::CreateHalfEdgeMeshFromMesh(get_mesh_partial_hexagon());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_partial_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     assert_ordreded_neighbor(mesh, 0, {2, 3});
     assert_ordreded_neighbor(mesh, 1, {0, 3});
@@ -325,7 +327,8 @@ TEST(HalfEdgeTriangleMesh, OrderedHalfEdgesFromVertex_PartialHexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_TwoTriangles) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_two_triangles());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_two_triangles());
     EXPECT_FALSE(mesh->IsEmpty());
 
     assert_ordreded_edges(mesh, mesh->BoundaryHalfEdgesFromVertex(0),
@@ -339,7 +342,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_TwoTriangles) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_Hexagon) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_hexagon());
+    auto mesh =
+            geometry::HalfEdgeTriangleMesh::CreateFromMesh(get_mesh_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
 
     assert_ordreded_edges(mesh, mesh->BoundaryHalfEdgesFromVertex(0),
@@ -359,8 +363,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_Hexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_PartialHexagon) {
-    auto mesh =
-            geometry::CreateHalfEdgeMeshFromMesh(get_mesh_partial_hexagon());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_partial_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
 
     assert_ordreded_edges(
@@ -387,7 +391,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_PartialHexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_TwoTriangles) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_two_triangles());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_two_triangles());
     EXPECT_FALSE(mesh->IsEmpty());
     ExpectEQ(mesh->BoundaryVerticesFromVertex(0), {0, 2, 3, 1});
     ExpectEQ(mesh->BoundaryVerticesFromVertex(1), {1, 0, 2, 3});
@@ -396,7 +401,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_TwoTriangles) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundarVerticesFromVertex_Hexagon) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_hexagon());
+    auto mesh =
+            geometry::HalfEdgeTriangleMesh::CreateFromMesh(get_mesh_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     ExpectEQ(mesh->BoundaryVerticesFromVertex(0), {0, 2, 5, 6, 4, 1});
     ExpectEQ(mesh->BoundaryVerticesFromVertex(1), {1, 0, 2, 5, 6, 4});
@@ -409,8 +415,8 @@ TEST(HalfEdgeTriangleMesh, BoundarVerticesFromVertex_Hexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_PartialHexagon) {
-    auto mesh =
-            geometry::CreateHalfEdgeMeshFromMesh(get_mesh_partial_hexagon());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_partial_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     ExpectEQ(mesh->BoundaryVerticesFromVertex(0), {0, 2, 5, 6, 3, 4, 1});
     ExpectEQ(mesh->BoundaryVerticesFromVertex(1), {1, 0, 2, 5, 6, 3, 4});
@@ -422,7 +428,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_PartialHexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, GetBoundaries_TwoTriangles) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_two_triangles());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_two_triangles());
     EXPECT_FALSE(mesh->IsEmpty());
     EXPECT_EQ(mesh->GetBoundaries().size(), 1);
     assert_vector_eq(mesh->GetBoundaries()[0], {0, 2, 3, 1}, true);
@@ -430,7 +437,8 @@ TEST(HalfEdgeTriangleMesh, GetBoundaries_TwoTriangles) {
 }
 
 TEST(HalfEdgeTriangleMesh, GetBoundaries_Hexagon) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(get_mesh_hexagon());
+    auto mesh =
+            geometry::HalfEdgeTriangleMesh::CreateFromMesh(get_mesh_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     EXPECT_EQ(mesh->GetBoundaries().size(), 1);
     assert_vector_eq(mesh->GetBoundaries()[0], {0, 2, 5, 6, 4, 1}, true);
@@ -438,8 +446,8 @@ TEST(HalfEdgeTriangleMesh, GetBoundaries_Hexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, GetBoundaries_PartialHexagon) {
-    auto mesh =
-            geometry::CreateHalfEdgeMeshFromMesh(get_mesh_partial_hexagon());
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
+            get_mesh_partial_hexagon());
     EXPECT_FALSE(mesh->IsEmpty());
     EXPECT_EQ(mesh->GetBoundaries().size(), 1);
     assert_vector_eq(mesh->GetBoundaries()[0], {0, 2, 5, 6, 3, 4, 1}, true);
@@ -447,7 +455,7 @@ TEST(HalfEdgeTriangleMesh, GetBoundaries_PartialHexagon) {
 }
 
 TEST(HalfEdgeTriangleMesh, GetBoundaries_FourTrianglesDisconnect) {
-    auto mesh = geometry::CreateHalfEdgeMeshFromMesh(
+    auto mesh = geometry::HalfEdgeTriangleMesh::CreateFromMesh(
             get_mesh_four_triangles_disconnect());
     EXPECT_FALSE(mesh->IsEmpty());
     EXPECT_EQ(mesh->GetBoundaries().size(), 2);

--- a/src/UnitTest/Geometry/Image.cpp
+++ b/src/UnitTest/Geometry/Image.cpp
@@ -65,7 +65,7 @@ TEST(Image, DefaultConstructor) {
 }
 
 // ----------------------------------------------------------------------------
-// test PrepareImage aka image creation
+// test Prepare aka image creation
 // ----------------------------------------------------------------------------
 TEST(Image, CreateImage) {
     int width = 1920;
@@ -75,7 +75,7 @@ TEST(Image, CreateImage) {
 
     geometry::Image image;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     // public member variables
     EXPECT_EQ(width, image.width_);
@@ -108,7 +108,7 @@ TEST(Image, Clear) {
 
     geometry::Image image;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     image.Clear();
 
@@ -141,7 +141,7 @@ TEST(Image, FloatValueAt) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     float* const im = Cast<float>(&image.data_[0]);
 
@@ -171,7 +171,7 @@ TEST(Image, DISABLED_MemberData) {
 
     geometry::Image image;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     int temp_width = 320;
     int temp_height = 240;
@@ -245,7 +245,7 @@ void TEST_CreateFloatImage(
     int height = 5;
     int float_num_of_channels = 1;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -455,7 +455,7 @@ TEST(Image, PointerAt) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     float* const im = Cast<float>(&image.data_[0]);
 
@@ -494,7 +494,7 @@ TEST(Image, ConvertDepthToFloatImage) {
     int bytes_per_channel = 1;
     int float_num_of_channels = 1;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -532,7 +532,7 @@ TEST(Image, FlipImage) {
     int bytes_per_channel = 4;
     int flip_bytes_per_channel = 1;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -562,7 +562,7 @@ void TEST_Filter(const vector<uint8_t>& ref,
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -691,7 +691,7 @@ TEST(Image, FilterHorizontal) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -712,7 +712,7 @@ TEST(Image, FilterHorizontal) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, DownsampleImage) {
+TEST(Image, Downsample) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {172, 41, 59,  204, 93, 130, 242, 232,
                            22,  91, 205, 233, 49, 169, 227, 87};
@@ -725,13 +725,13 @@ TEST(Image, DownsampleImage) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
     auto float_image = image.CreateFloatImage();
 
-    auto output = float_image->DownsampleImage();
+    auto output = float_image->Downsample();
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ((int)(width / 2), output->width_);
@@ -744,7 +744,7 @@ TEST(Image, DownsampleImage) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, DilateImage) {
+TEST(Image, Dilate) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             255, 255, 0,   0,   0,   0,   0,   255, 255, 255, 255, 255, 0,
@@ -764,13 +764,13 @@ TEST(Image, DilateImage) {
     int num_of_channels = 1;
     int bytes_per_channel = 1;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
     for (size_t i = 0; i < image.data_.size(); i++)
         if (i % 9 == 0) image.data_[i] = 255;
 
-    auto output = image.DilateImage();
+    auto output = image.Dilate();
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -783,7 +783,7 @@ TEST(Image, DilateImage) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, LinearTransformImage) {
+TEST(Image, LinearTransform) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             144, 77,  101, 204, 139, 26,  245, 195, 154, 153, 25,  62,  92,
@@ -803,13 +803,13 @@ TEST(Image, LinearTransformImage) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
     auto output = image.CreateFloatImage();
 
-    output->LinearTransformImage(2.3, 0.15);
+    output->LinearTransform(2.3, 0.15);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -822,7 +822,7 @@ TEST(Image, LinearTransformImage) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, ClipIntensityImage) {
+TEST(Image, ClipIntensity) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             195, 245, 168, 62,  195, 245, 168, 62,  195, 245, 168, 62,  195,
@@ -842,13 +842,13 @@ TEST(Image, ClipIntensityImage) {
     int num_of_channels = 1;
     int bytes_per_channel = 4;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
     auto output = image.CreateFloatImage();
 
-    output->ClipIntensityImage(0.33, 0.71);
+    output->ClipIntensity(0.33, 0.71);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -871,7 +871,7 @@ void TEST_CreateImageFromFloatImage() {
     int num_of_channels = 1;
     int bytes_per_channel = sizeof(T);
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -935,7 +935,7 @@ TEST(Image, FilterPyramid) {
     int bytes_per_channel = 4;
     int num_of_levels = 2;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -992,7 +992,7 @@ TEST(Image, CreatePyramid) {
     int bytes_per_channel = 4;
     int num_of_levels = 2;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 

--- a/src/UnitTest/Geometry/Image.cpp
+++ b/src/UnitTest/Geometry/Image.cpp
@@ -210,8 +210,9 @@ TEST(Image, CreateDepthToCameraDistanceMultiplierFloatImage) {
     camera::PinholeCameraIntrinsic intrinsic = camera::PinholeCameraIntrinsic(
             camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
 
-    auto image = geometry::CreateDepthToCameraDistanceMultiplierFloatImage(
-            intrinsic);
+    auto image =
+            geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(
+                    intrinsic);
 
     // test image dimensions
     int width = 640;
@@ -248,7 +249,7 @@ void TEST_CreateFloatImageFromImage(
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
     EXPECT_FALSE(float_image->IsEmpty());
     EXPECT_EQ(width, float_image->width_);
@@ -463,10 +464,10 @@ TEST(Image, PointerAt) {
     im[1 * width + 0] = 2.0f;
     im[1 * width + 1] = 3.0f;
 
-    EXPECT_NEAR(0.0f, *geometry::PointerAt<float>(image, 0, 0), THRESHOLD_1E_6);
-    EXPECT_NEAR(1.0f, *geometry::PointerAt<float>(image, 1, 0), THRESHOLD_1E_6);
-    EXPECT_NEAR(2.0f, *geometry::PointerAt<float>(image, 0, 1), THRESHOLD_1E_6);
-    EXPECT_NEAR(3.0f, *geometry::PointerAt<float>(image, 1, 1), THRESHOLD_1E_6);
+    EXPECT_NEAR(0.0f, *image.PointerAt<float>(0, 0), THRESHOLD_1E_6);
+    EXPECT_NEAR(1.0f, *image.PointerAt<float>(1, 0), THRESHOLD_1E_6);
+    EXPECT_NEAR(2.0f, *image.PointerAt<float>(0, 1), THRESHOLD_1E_6);
+    EXPECT_NEAR(3.0f, *image.PointerAt<float>(1, 1), THRESHOLD_1E_6);
 }
 
 // ----------------------------------------------------------------------------
@@ -497,7 +498,7 @@ TEST(Image, ConvertDepthToFloatImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = geometry::ConvertDepthToFloatImage(image);
+    auto float_image = image.ConvertDepthToFloatImage();
 
     EXPECT_FALSE(float_image->IsEmpty());
     EXPECT_EQ(width, float_image->width_);
@@ -535,7 +536,7 @@ TEST(Image, FlipImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto flip_image = geometry::ConvertDepthToFloatImage(image);
+    auto flip_image = image.ConvertDepthToFloatImage();
 
     EXPECT_FALSE(flip_image->IsEmpty());
     EXPECT_EQ(width, flip_image->width_);
@@ -565,9 +566,9 @@ void TEST_FilterImage(const vector<uint8_t>& ref,
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
-    auto output = geometry::FilterImage(*float_image, filter);
+    auto output = float_image->FilterImage(filter);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -694,11 +695,11 @@ TEST(Image, FilterHorizontalImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
     const std::vector<double> Gaussian3 = {0.25, 0.5, 0.25};
 
-    auto output = geometry::FilterHorizontalImage(*float_image, Gaussian3);
+    auto output = float_image->FilterHorizontalImage(Gaussian3);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -728,9 +729,9 @@ TEST(Image, DownsampleImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
-    auto output = geometry::DownsampleImage(*float_image);
+    auto output = float_image->DownsampleImage();
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ((int)(width / 2), output->width_);
@@ -769,7 +770,7 @@ TEST(Image, DilateImage) {
     for (size_t i = 0; i < image.data_.size(); i++)
         if (i % 9 == 0) image.data_[i] = 255;
 
-    auto output = geometry::DilateImage(image);
+    auto output = image.DilateImage();
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -806,9 +807,9 @@ TEST(Image, LinearTransformImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto output = CreateFloatImageFromImage(image);
+    auto output = image.CreateFloatImageFromImage();
 
-    geometry::LinearTransformImage(*output, 2.3, 0.15);
+    output->LinearTransformImage(2.3, 0.15);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -845,9 +846,9 @@ TEST(Image, ClipIntensityImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto output = CreateFloatImageFromImage(image);
+    auto output = image.CreateFloatImageFromImage();
 
-    geometry::ClipIntensityImage(*output, 0.33, 0.71);
+    output->ClipIntensityImage(0.33, 0.71);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -874,9 +875,9 @@ void TEST_CreateImageFromFloatImage() {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
-    auto output = geometry::CreateImageFromFloatImage<T>(*float_image);
+    auto output = float_image->CreateImageFromFloatImage<T>();
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -938,12 +939,12 @@ TEST(Image, FilterImagePyramid) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
-    auto pyramid = geometry::CreateImagePyramid(*float_image, num_of_levels);
+    auto pyramid = float_image->CreateImagePyramid(num_of_levels);
 
     auto output_pyramid =
-            geometry::FilterImagePyramid(pyramid, FilterType::Gaussian3);
+            geometry::Image::FilterImagePyramid(pyramid, FilterType::Gaussian3);
 
     EXPECT_EQ(pyramid.size(), output_pyramid.size());
 
@@ -995,9 +996,9 @@ TEST(Image, CreateImagePyramid) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = CreateFloatImageFromImage(image);
+    auto float_image = image.CreateFloatImageFromImage();
 
-    auto pyramid = geometry::CreateImagePyramid(*float_image, num_of_levels);
+    auto pyramid = float_image->CreateImagePyramid(num_of_levels);
 
     int expected_width = width;
     int expected_height = width;

--- a/src/UnitTest/Geometry/Image.cpp
+++ b/src/UnitTest/Geometry/Image.cpp
@@ -233,7 +233,7 @@ TEST(Image, CreateDepthToCameraDistanceMultiplierFloatImage) {
 // 1: 1/2/4
 // 3: 1/2/4 with either Equal or Weighted type
 // ----------------------------------------------------------------------------
-void TEST_CreateFloatImageFromImage(
+void TEST_CreateFloatImage(
         const int& num_of_channels,
         const int& bytes_per_channel,
         const vector<uint8_t>& ref,
@@ -249,7 +249,7 @@ void TEST_CreateFloatImageFromImage(
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
     EXPECT_FALSE(float_image->IsEmpty());
     EXPECT_EQ(width, float_image->width_);
@@ -264,7 +264,7 @@ void TEST_CreateFloatImageFromImage(
 // channels: 1
 // bytes per channel: 1
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_1_1) {
+TEST(Image, CreateFloatImage_1_1) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             215, 214, 86,  63,  201, 200, 200, 62,  200, 199, 71,  63,  204,
@@ -276,7 +276,7 @@ TEST(Image, CreateFloatImageFromImage_1_1) {
             26,  63,  129, 128, 128, 60,  245, 244, 116, 62,  137, 136, 8,
             62,  206, 205, 77,  63,  157, 156, 28,  62};
 
-    TEST_CreateFloatImageFromImage(1, 1, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(1, 1, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -284,7 +284,7 @@ TEST(Image, CreateFloatImageFromImage_1_1) {
 // channels: 1
 // bytes per channel: 2
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_1_2) {
+TEST(Image, CreateFloatImage_1_2) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             0, 172, 201, 70, 0, 199, 75,  71, 0, 160, 75,  70, 0, 85,  67,  71,
@@ -295,7 +295,7 @@ TEST(Image, CreateFloatImageFromImage_1_2) {
             0, 134, 68,  71, 0, 102, 99,  71, 0, 144, 178, 70, 0, 205, 106, 71,
             0, 17,  114, 71};
 
-    TEST_CreateFloatImageFromImage(1, 2, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(1, 2, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -303,7 +303,7 @@ TEST(Image, CreateFloatImageFromImage_1_2) {
 // channels: 1
 // bytes per channel: 4
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_1_4) {
+TEST(Image, CreateFloatImage_1_4) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             214, 100, 199, 203, 232, 50,  85,  195, 70,  141, 121, 160, 93,
@@ -315,7 +315,7 @@ TEST(Image, CreateFloatImageFromImage_1_4) {
             163, 90,  175, 42,  112, 224, 211, 84,  58,  227, 89,  175, 243,
             150, 167, 218, 112, 235, 101, 207, 174, 232};
 
-    TEST_CreateFloatImageFromImage(1, 4, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(1, 4, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -324,7 +324,7 @@ TEST(Image, CreateFloatImageFromImage_1_4) {
 // bytes per channel: 1
 // ColorToIntensityConversionType: Weighted
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_1_Weighted) {
+TEST(Image, CreateFloatImage_3_1_Weighted) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             45,  241, 17,  63,  29,  96,  75,  63,  154, 112, 20,  63,  0,
@@ -336,7 +336,7 @@ TEST(Image, CreateFloatImageFromImage_3_1_Weighted) {
             143, 62,  9,   228, 61,  63,  224, 255, 239, 62,  57,  33,  29,
             63,  197, 186, 3,   63,  145, 27,  72,  63};
 
-    TEST_CreateFloatImageFromImage(3, 1, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(3, 1, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -345,7 +345,7 @@ TEST(Image, CreateFloatImageFromImage_3_1_Weighted) {
 // bytes per channel: 1
 // ColorToIntensityConversionType: Equal
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_1_Equal) {
+TEST(Image, CreateFloatImage_3_1_Equal) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             45,  241, 17,  63,  29,  96,  75,  63,  154, 112, 20,  63,  0,
@@ -357,7 +357,7 @@ TEST(Image, CreateFloatImageFromImage_3_1_Equal) {
             143, 62,  9,   228, 61,  63,  224, 255, 239, 62,  57,  33,  29,
             63,  197, 186, 3,   63,  145, 27,  72,  63};
 
-    TEST_CreateFloatImageFromImage(3, 1, ref, ConversionType::Equal);
+    TEST_CreateFloatImage(3, 1, ref, ConversionType::Equal);
 }
 
 // ----------------------------------------------------------------------------
@@ -366,7 +366,7 @@ TEST(Image, CreateFloatImageFromImage_3_1_Equal) {
 // bytes per channel: 2
 // ColorToIntensityConversionType: Weighted
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_2_Weighted) {
+TEST(Image, CreateFloatImage_3_2_Weighted) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             16,  146, 27,  71,  44,  160, 31,  71,  234, 31,  69,  71,  39,
@@ -378,7 +378,7 @@ TEST(Image, CreateFloatImageFromImage_3_2_Weighted) {
             219, 70,  12,  108, 22,  71,  198, 41,  183, 70,  225, 5,   23,
             71,  210, 181, 85,  71,  101, 14,  28,  71};
 
-    TEST_CreateFloatImageFromImage(3, 2, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(3, 2, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -387,7 +387,7 @@ TEST(Image, CreateFloatImageFromImage_3_2_Weighted) {
 // bytes per channel: 2
 // ColorToIntensityConversionType: Equal
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_2_Equal) {
+TEST(Image, CreateFloatImage_3_2_Equal) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             16,  146, 27,  71,  44,  160, 31,  71,  234, 31,  69,  71,  39,
@@ -399,7 +399,7 @@ TEST(Image, CreateFloatImageFromImage_3_2_Equal) {
             219, 70,  12,  108, 22,  71,  198, 41,  183, 70,  225, 5,   23,
             71,  210, 181, 85,  71,  101, 14,  28,  71};
 
-    TEST_CreateFloatImageFromImage(3, 2, ref, ConversionType::Equal);
+    TEST_CreateFloatImage(3, 2, ref, ConversionType::Equal);
 }
 
 // ----------------------------------------------------------------------------
@@ -408,7 +408,7 @@ TEST(Image, CreateFloatImageFromImage_3_2_Equal) {
 // bytes per channel: 4
 // ColorToIntensityConversionType: Weighted
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_4_Weighted) {
+TEST(Image, CreateFloatImage_3_4_Weighted) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             153, 122, 238, 202, 65,  5,   17,  233, 117, 224, 24,  213, 166,
@@ -420,7 +420,7 @@ TEST(Image, CreateFloatImageFromImage_3_4_Weighted) {
             15,  114, 245, 201, 149, 76,  224, 3,   24,  64,  17,  103, 98,
             222, 145, 236, 94,  233, 36,  85,  141, 233};
 
-    TEST_CreateFloatImageFromImage(3, 4, ref, ConversionType::Weighted);
+    TEST_CreateFloatImage(3, 4, ref, ConversionType::Weighted);
 }
 
 // ----------------------------------------------------------------------------
@@ -429,7 +429,7 @@ TEST(Image, CreateFloatImageFromImage_3_4_Weighted) {
 // bytes per channel: 4
 // ColorToIntensityConversionType: Equal
 // ----------------------------------------------------------------------------
-TEST(Image, CreateFloatImageFromImage_3_4_Equal) {
+TEST(Image, CreateFloatImage_3_4_Equal) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             153, 122, 238, 202, 65,  5,   17,  233, 117, 224, 24,  213, 166,
@@ -441,7 +441,7 @@ TEST(Image, CreateFloatImageFromImage_3_4_Equal) {
             15,  114, 245, 201, 149, 76,  224, 3,   24,  64,  17,  103, 98,
             222, 145, 236, 94,  233, 36,  85,  141, 233};
 
-    TEST_CreateFloatImageFromImage(3, 4, ref, ConversionType::Equal);
+    TEST_CreateFloatImage(3, 4, ref, ConversionType::Equal);
 }
 
 // ----------------------------------------------------------------------------
@@ -552,8 +552,8 @@ TEST(Image, FlipImage) {
 // 1: 1/2/4
 // 3: 1/2/4 with either Equal or Weighted type
 // ----------------------------------------------------------------------------
-void TEST_FilterImage(const vector<uint8_t>& ref,
-                      const geometry::Image::FilterType& filter) {
+void TEST_Filter(const vector<uint8_t>& ref,
+                 const geometry::Image::FilterType& filter) {
     geometry::Image image;
 
     // test image dimensions
@@ -566,9 +566,9 @@ void TEST_FilterImage(const vector<uint8_t>& ref,
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
-    auto output = float_image->FilterImage(filter);
+    auto output = float_image->Filter(filter);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -581,7 +581,7 @@ void TEST_FilterImage(const vector<uint8_t>& ref,
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImage_Gaussian3) {
+TEST(Image, Filter_Gaussian3) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             41,  194, 49,  204, 116, 56,  130, 211, 198, 225, 181, 232, 198,
@@ -593,13 +593,13 @@ TEST(Image, FilterImage_Gaussian3) {
             128, 233, 36,  49,  20,  226, 223, 39,  141, 226, 137, 164, 52,
             234, 108, 176, 182, 234, 146, 238, 64,  234};
 
-    TEST_FilterImage(ref, FilterType::Gaussian3);
+    TEST_Filter(ref, FilterType::Gaussian3);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImage_Gaussian5) {
+TEST(Image, Filter_Gaussian5) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             61,  94,  205, 231, 230, 96,  109, 232, 15,  16,  218, 232, 2,
@@ -611,13 +611,13 @@ TEST(Image, FilterImage_Gaussian5) {
             159, 233, 35,  111, 205, 231, 102, 26,  76,  233, 255, 241, 44,
             234, 32,  174, 126, 234, 84,  234, 47,  234};
 
-    TEST_FilterImage(ref, FilterType::Gaussian5);
+    TEST_Filter(ref, FilterType::Gaussian5);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImage_Gaussian7) {
+TEST(Image, Filter_Gaussian7) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             71,  19,  68,  232, 29,  11,  169, 232, 178, 140, 214, 232, 35,
@@ -629,13 +629,13 @@ TEST(Image, FilterImage_Gaussian7) {
             168, 233, 187, 237, 232, 232, 99,  40,  161, 233, 128, 206, 18,
             234, 108, 135, 55,  234, 187, 97,  17,  234};
 
-    TEST_FilterImage(ref, FilterType::Gaussian7);
+    TEST_Filter(ref, FilterType::Gaussian7);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImage_Sobel3Dx) {
+TEST(Image, Filter_Sobel3Dx) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             172, 2,   109, 77,  136, 55,  130, 213, 198, 225, 181, 234, 254,
@@ -647,13 +647,13 @@ TEST(Image, FilterImage_Sobel3Dx) {
             107, 107, 28,  239, 8,   228, 119, 32,  52,  97,  114, 163, 52,
             236, 140, 27,  131, 233, 33,  139, 48,  108};
 
-    TEST_FilterImage(ref, FilterType::Sobel3Dx);
+    TEST_Filter(ref, FilterType::Sobel3Dx);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImage_Sobel3Dy) {
+TEST(Image, Filter_Sobel3Dy) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             151, 248, 205, 205, 67,  56,  130, 213, 93,  130, 242, 105, 93,
@@ -665,13 +665,13 @@ TEST(Image, FilterImage_Sobel3Dy) {
             128, 235, 189, 150, 69,  227, 36,  53,  188, 227, 97,  219, 112,
             235, 229, 149, 243, 235, 12,  159, 128, 235};
 
-    TEST_FilterImage(ref, FilterType::Sobel3Dy);
+    TEST_Filter(ref, FilterType::Sobel3Dy);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterHorizontalImage) {
+TEST(Image, FilterHorizontal) {
     // reference data used to validate the filtering of an image
     vector<uint8_t> ref = {
             187, 139, 149, 203, 171, 101, 199, 202, 93,  130, 242, 232, 93,
@@ -695,11 +695,11 @@ TEST(Image, FilterHorizontalImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
     const std::vector<double> Gaussian3 = {0.25, 0.5, 0.25};
 
-    auto output = float_image->FilterHorizontalImage(Gaussian3);
+    auto output = float_image->FilterHorizontal(Gaussian3);
 
     EXPECT_FALSE(output->IsEmpty());
     EXPECT_EQ(width, output->width_);
@@ -729,7 +729,7 @@ TEST(Image, DownsampleImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
     auto output = float_image->DownsampleImage();
 
@@ -807,7 +807,7 @@ TEST(Image, LinearTransformImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto output = image.CreateFloatImageFromImage();
+    auto output = image.CreateFloatImage();
 
     output->LinearTransformImage(2.3, 0.15);
 
@@ -846,7 +846,7 @@ TEST(Image, ClipIntensityImage) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto output = image.CreateFloatImageFromImage();
+    auto output = image.CreateFloatImage();
 
     output->ClipIntensityImage(0.33, 0.71);
 
@@ -875,7 +875,7 @@ void TEST_CreateImageFromFloatImage() {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
     auto output = float_image->CreateImageFromFloatImage<T>();
 
@@ -907,7 +907,7 @@ TEST(Image, CreateImageFromFloatImage_16bit) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FilterImagePyramid) {
+TEST(Image, FilterPyramid) {
     // reference data used to validate the filtering of an image
     vector<vector<uint8_t>> ref = {
             {110, 56,  130, 211, 17,  56,  2,   212, 198, 225, 181, 232,
@@ -939,12 +939,12 @@ TEST(Image, FilterImagePyramid) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
-    auto pyramid = float_image->CreateImagePyramid(num_of_levels);
+    auto pyramid = float_image->CreatePyramid(num_of_levels);
 
     auto output_pyramid =
-            geometry::Image::FilterImagePyramid(pyramid, FilterType::Gaussian3);
+            geometry::Image::FilterPyramid(pyramid, FilterType::Gaussian3);
 
     EXPECT_EQ(pyramid.size(), output_pyramid.size());
 
@@ -964,7 +964,7 @@ TEST(Image, FilterImagePyramid) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, CreateImagePyramid) {
+TEST(Image, CreatePyramid) {
     // reference data used to validate the filtering of an image
     vector<vector<uint8_t>> ref = {
             {214, 100, 199, 203, 232, 50,  85,  195, 70,  141, 121, 160,
@@ -996,9 +996,9 @@ TEST(Image, CreateImagePyramid) {
 
     Rand(image.data_, 0, 255, 0);
 
-    auto float_image = image.CreateFloatImageFromImage();
+    auto float_image = image.CreateFloatImage();
 
-    auto pyramid = float_image->CreateImagePyramid(num_of_levels);
+    auto pyramid = float_image->CreatePyramid(num_of_levels);
 
     int expected_width = width;
     int expected_height = width;

--- a/src/UnitTest/Geometry/LineSet.cpp
+++ b/src/UnitTest/Geometry/LineSet.cpp
@@ -491,8 +491,8 @@ TEST(LineSet, CreateLineSetFromPointCloudCorrespondences) {
         correspondence[i] = pair<int, int>(first, second);
     }
 
-    auto ls = CreateLineSetFromPointCloudCorrespondences(pc0, pc1,
-                                                         correspondence);
+    auto ls = geometry::LineSet::CreateFromPointCloudCorrespondences(
+            pc0, pc1, correspondence);
 
     ExpectEQ(ref_points, ls->points_);
     ExpectEQ(ref_lines, ls->lines_);

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -971,8 +971,8 @@ TEST(PointCloud, CreatePointCloudFromDepthImage) {
     int local_num_of_channels = 1;
     int local_bytes_per_channel = 2;
 
-    image.PrepareImage(local_width, local_height, local_num_of_channels,
-                       local_bytes_per_channel);
+    image.Prepare(local_width, local_height, local_num_of_channels,
+                  local_bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
@@ -1006,10 +1006,10 @@ void TEST_CreatePointCloudFromRGBDImage(const int& color_num_of_channels,
     int num_of_channels = 1;
     int bytes_per_channel = 1;
 
-    image.PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
-    color.PrepareImage(width, height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(width, height, color_num_of_channels,
+                  color_bytes_per_channel);
 
     Rand(image.data_, 100, 150, 0);
     Rand(color.data_, 130, 200, 0);

--- a/src/UnitTest/Geometry/RGBDImage.cpp
+++ b/src/UnitTest/Geometry/RGBDImage.cpp
@@ -55,11 +55,11 @@ TEST(RGBDImage, Constructor) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    image.PrepareImage(image_width, image_height, image_num_of_channels,
-                       image_bytes_per_channel);
+    image.Prepare(image_width, image_height, image_num_of_channels,
+                  image_bytes_per_channel);
 
     Rand(image.data_, 100, 150, 0);
     Rand(color.data_, 130, 200, 0);
@@ -117,11 +117,11 @@ TEST(RGBDImage, CreateFromColorAndDepth) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -174,11 +174,11 @@ TEST(RGBDImage, CreateFromRedwoodFormat) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -231,11 +231,11 @@ TEST(RGBDImage, CreateFromTUMFormat) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -287,11 +287,11 @@ TEST(RGBDImage, CreateFromSUNFormat) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -343,11 +343,11 @@ TEST(RGBDImage, CreateFromNYUFormat) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -402,11 +402,11 @@ TEST(RGBDImage, FilterPyramid) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
@@ -469,11 +469,11 @@ TEST(RGBDImage, CreatePyramid) {
     const int color_num_of_channels = 3;
     const int color_bytes_per_channel = 1;
 
-    color.PrepareImage(color_width, color_height, color_num_of_channels,
-                       color_bytes_per_channel);
+    color.Prepare(color_width, color_height, color_num_of_channels,
+                  color_bytes_per_channel);
 
-    depth.PrepareImage(depth_width, depth_height, depth_num_of_channels,
-                       depth_bytes_per_channel);
+    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
+                  depth_bytes_per_channel);
 
     float* const float_data = Cast<float>(&depth.data_[0]);
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);

--- a/src/UnitTest/Geometry/RGBDImage.cpp
+++ b/src/UnitTest/Geometry/RGBDImage.cpp
@@ -80,7 +80,7 @@ TEST(RGBDImage, DISABLED_MemberData) { unit_test::NotImplemented(); }
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImageFromColorAndDepth) {
+TEST(RGBDImage, CreateFromColorAndDepth) {
     vector<uint8_t> ref_color = {
             216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -137,7 +137,7 @@ TEST(RGBDImage, CreateRGBDImageFromColorAndDepth) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImageFromRedwoodFormat) {
+TEST(RGBDImage, CreateFromRedwoodFormat) {
     vector<uint8_t> ref_color = {
             216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -194,7 +194,7 @@ TEST(RGBDImage, CreateRGBDImageFromRedwoodFormat) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImageFromTUMFormat) {
+TEST(RGBDImage, CreateFromTUMFormat) {
     vector<uint8_t> ref_color = {
             216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -250,7 +250,7 @@ TEST(RGBDImage, CreateRGBDImageFromTUMFormat) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImageFromSUNFormat) {
+TEST(RGBDImage, CreateFromSUNFormat) {
     vector<uint8_t> ref_color = {
             216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -306,7 +306,7 @@ TEST(RGBDImage, CreateRGBDImageFromSUNFormat) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImageFromNYUFormat) {
+TEST(RGBDImage, CreateFromNYUFormat) {
     vector<uint8_t> ref_color = {
             216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -362,7 +362,7 @@ TEST(RGBDImage, CreateRGBDImageFromNYUFormat) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, FilterRGBDImagePyramid) {
+TEST(RGBDImage, FilterPyramid) {
     vector<vector<uint8_t>> ref_color = {
             {49,  63,  46,  63,  234, 198, 45,  63,  152, 189, 39,  63,  151,
              141, 36,  63,  165, 233, 38,  63,  44,  66,  47,  63,  54,  137,
@@ -415,8 +415,8 @@ TEST(RGBDImage, FilterRGBDImagePyramid) {
     size_t num_of_levels = 2;
     auto rgbd_image =
             geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
-    auto pyramid = rgbd_image->CreateRGBDImagePyramid(num_of_levels);
-    auto filtered = geometry::RGBDImage::FilterRGBDImagePyramid(
+    auto pyramid = rgbd_image->CreatePyramid(num_of_levels);
+    auto filtered = geometry::RGBDImage::FilterPyramid(
             pyramid, geometry::Image::FilterType::Gaussian3);
 
     for (size_t j = 0; j < num_of_levels; j++) {
@@ -428,7 +428,7 @@ TEST(RGBDImage, FilterRGBDImagePyramid) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(RGBDImage, CreateRGBDImagePyramid) {
+TEST(RGBDImage, CreatePyramid) {
     vector<vector<uint8_t>> ref_color = {
             {216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
              72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
@@ -482,7 +482,7 @@ TEST(RGBDImage, CreateRGBDImagePyramid) {
     size_t num_of_levels = 2;
     auto rgbd_image =
             geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
-    auto pyramid = rgbd_image->CreateRGBDImagePyramid(num_of_levels);
+    auto pyramid = rgbd_image->CreatePyramid(num_of_levels);
 
     for (size_t j = 0; j < num_of_levels; j++) {
         EXPECT_EQ(ref_color[j], pyramid[j]->color_.data_);

--- a/src/UnitTest/Geometry/RGBDImage.cpp
+++ b/src/UnitTest/Geometry/RGBDImage.cpp
@@ -64,7 +64,7 @@ TEST(RGBDImage, Constructor) {
     Rand(image.data_, 100, 150, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto depth = geometry::ConvertDepthToFloatImage(image);
+    auto depth = image.ConvertDepthToFloatImage();
 
     geometry::RGBDImage rgbd_image(color, *depth);
 
@@ -127,7 +127,8 @@ TEST(RGBDImage, CreateRGBDImageFromColorAndDepth) {
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto rgbd_image = geometry::CreateRGBDImageFromColorAndDepth(color, depth);
+    auto rgbd_image =
+            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
 
     ExpectEQ(ref_color, rgbd_image->color_.data_);
     ExpectEQ(ref_depth, rgbd_image->depth_.data_);
@@ -183,7 +184,8 @@ TEST(RGBDImage, CreateRGBDImageFromRedwoodFormat) {
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto rgbd_image = geometry::CreateRGBDImageFromRedwoodFormat(color, depth);
+    auto rgbd_image =
+            geometry::RGBDImage::CreateFromRedwoodFormat(color, depth);
 
     ExpectEQ(ref_color, rgbd_image->color_.data_);
     ExpectEQ(ref_depth, rgbd_image->depth_.data_);
@@ -239,7 +241,7 @@ TEST(RGBDImage, CreateRGBDImageFromTUMFormat) {
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto rgbd_image = geometry::CreateRGBDImageFromTUMFormat(color, depth);
+    auto rgbd_image = geometry::RGBDImage::CreateFromTUMFormat(color, depth);
 
     ExpectEQ(ref_color, rgbd_image->color_.data_);
     ExpectEQ(ref_depth, rgbd_image->depth_.data_);
@@ -295,7 +297,7 @@ TEST(RGBDImage, CreateRGBDImageFromSUNFormat) {
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto rgbd_image = geometry::CreateRGBDImageFromSUNFormat(color, depth);
+    auto rgbd_image = geometry::RGBDImage::CreateFromSUNFormat(color, depth);
 
     ExpectEQ(ref_color, rgbd_image->color_.data_);
     ExpectEQ(ref_depth, rgbd_image->depth_.data_);
@@ -351,7 +353,7 @@ TEST(RGBDImage, CreateRGBDImageFromNYUFormat) {
     Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
     Rand(color.data_, 130, 200, 0);
 
-    auto rgbd_image = geometry::CreateRGBDImageFromNYUFormat(color, depth);
+    auto rgbd_image = geometry::RGBDImage::CreateFromNYUFormat(color, depth);
 
     ExpectEQ(ref_color, rgbd_image->color_.data_);
     ExpectEQ(ref_depth, rgbd_image->depth_.data_);
@@ -411,9 +413,10 @@ TEST(RGBDImage, FilterRGBDImagePyramid) {
     Rand(color.data_, 130, 200, 0);
 
     size_t num_of_levels = 2;
-    auto rgbd_image = geometry::CreateRGBDImageFromColorAndDepth(color, depth);
-    auto pyramid = geometry::CreateRGBDImagePyramid(*rgbd_image, num_of_levels);
-    auto filtered = geometry::FilterRGBDImagePyramid(
+    auto rgbd_image =
+            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
+    auto pyramid = rgbd_image->CreateRGBDImagePyramid(num_of_levels);
+    auto filtered = geometry::RGBDImage::FilterRGBDImagePyramid(
             pyramid, geometry::Image::FilterType::Gaussian3);
 
     for (size_t j = 0; j < num_of_levels; j++) {
@@ -477,8 +480,9 @@ TEST(RGBDImage, CreateRGBDImagePyramid) {
     Rand(color.data_, 130, 200, 0);
 
     size_t num_of_levels = 2;
-    auto rgbd_image = geometry::CreateRGBDImageFromColorAndDepth(color, depth);
-    auto pyramid = geometry::CreateRGBDImagePyramid(*rgbd_image, num_of_levels);
+    auto rgbd_image =
+            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
+    auto pyramid = rgbd_image->CreateRGBDImagePyramid(num_of_levels);
 
     for (size_t j = 0; j < num_of_levels; j++) {
         EXPECT_EQ(ref_color[j], pyramid[j]->color_.data_);

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -681,7 +681,7 @@ TEST(TriangleMesh, Purge) {
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, SamplePointsUniformly) {
     auto mesh_empty = geometry::TriangleMesh();
-    auto pcd_empty = geometry::SamplePointsUniformly(mesh_empty, 100);
+    auto pcd_empty = mesh_empty.SamplePointsUniformly(100);
     EXPECT_TRUE(pcd_empty->points_.size() == 0);
     EXPECT_TRUE(pcd_empty->colors_.size() == 0);
     EXPECT_TRUE(pcd_empty->normals_.size() == 0);
@@ -694,7 +694,7 @@ TEST(TriangleMesh, SamplePointsUniformly) {
     mesh_simple.triangles_ = triangles;
 
     size_t n_points = 100;
-    auto pcd_simple = geometry::SamplePointsUniformly(mesh_simple, n_points);
+    auto pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
     EXPECT_TRUE(pcd_simple->points_.size() == n_points);
     EXPECT_TRUE(pcd_simple->colors_.size() == 0);
     EXPECT_TRUE(pcd_simple->normals_.size() == 0);
@@ -703,7 +703,7 @@ TEST(TriangleMesh, SamplePointsUniformly) {
     vector<Vector3d> normals = {{0, 1, 0}, {0, 1, 0}, {0, 1, 0}};
     mesh_simple.vertex_colors_ = colors;
     mesh_simple.vertex_normals_ = normals;
-    pcd_simple = geometry::SamplePointsUniformly(mesh_simple, n_points);
+    pcd_simple = mesh_simple.SamplePointsUniformly(n_points);
     EXPECT_TRUE(pcd_simple->points_.size() == n_points);
     EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
     EXPECT_TRUE(pcd_simple->normals_.size() == n_points);
@@ -718,94 +718,94 @@ TEST(TriangleMesh, SamplePointsUniformly) {
 //
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, FilterSharpen) {
-    auto mesh = geometry::TriangleMesh();
-    mesh.vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
-    mesh.triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
+    auto mesh = std::make_shared<geometry::TriangleMesh>();
+    mesh->vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
+    mesh->triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
 
-    mesh.FilterSharpen(1, 1);
+    mesh = mesh->FilterSharpen(1, 1);
     std::vector<Eigen::Vector3d> ref1 = {
             {0, 0, 0}, {4, 0, 0}, {0, 4, 0}, {-4, 0, 0}, {0, -4, 0}};
-    ExpectEQ(mesh.vertices_, ref1);
+    ExpectEQ(mesh->vertices_, ref1);
 
-    mesh.FilterSharpen(9, 0.1);
+    mesh = mesh->FilterSharpen(9, 0.1);
     std::vector<Eigen::Vector3d> ref2 = {{0, 0, 0},
                                          {42.417997, 0, 0},
                                          {0, 42.417997, 0},
                                          {-42.417997, 0, 0},
                                          {0, -42.417997, 0}};
-    ExpectEQ(mesh.vertices_, ref2);
+    ExpectEQ(mesh->vertices_, ref2);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, FilterSmoothSimple) {
-    auto mesh = geometry::TriangleMesh();
-    mesh.vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
-    mesh.triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
+    auto mesh = std::make_shared<geometry::TriangleMesh>();
+    mesh->vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
+    mesh->triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
 
-    mesh.FilterSmoothSimple(1);
+    mesh = mesh->FilterSmoothSimple(1);
     std::vector<Eigen::Vector3d> ref1 = {{0, 0, 0},
                                          {0.25, 0, 0},
                                          {0, 0.25, 0},
                                          {-0.25, 0, 0},
                                          {0, -0.25, 0}};
-    ExpectEQ(mesh.vertices_, ref1);
+    ExpectEQ(mesh->vertices_, ref1);
 
-    mesh.FilterSmoothSimple(3);
+    mesh = mesh->FilterSmoothSimple(3);
     std::vector<Eigen::Vector3d> ref2 = {{0, 0, 0},
                                          {0.003906, 0, 0},
                                          {0, 0.003906, 0},
                                          {-0.003906, 0, 0},
                                          {0, -0.003906, 0}};
-    ExpectEQ(mesh.vertices_, ref2);
+    ExpectEQ(mesh->vertices_, ref2);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, FilterSmoothLaplacian) {
-    auto mesh = geometry::TriangleMesh();
-    mesh.vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
-    mesh.triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
+    auto mesh = std::make_shared<geometry::TriangleMesh>();
+    mesh->vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
+    mesh->triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
 
-    mesh.FilterSmoothLaplacian(1, 0.5);
+    mesh = mesh->FilterSmoothLaplacian(1, 0.5);
     std::vector<Eigen::Vector3d> ref1 = {
             {0, 0, 0}, {0.5, 0, 0}, {0, 0.5, 0}, {-0.5, 0, 0}, {0, -0.5, 0}};
-    ExpectEQ(mesh.vertices_, ref1);
+    ExpectEQ(mesh->vertices_, ref1);
 
-    mesh.FilterSmoothLaplacian(10, 0.5);
+    mesh = mesh->FilterSmoothLaplacian(10, 0.5);
     std::vector<Eigen::Vector3d> ref2 = {{0, 0, 0},
                                          {0.000488, 0, 0},
                                          {0, 0.000488, 0},
                                          {-0.000488, 0, 0},
                                          {0, -0.000488, 0}};
-    ExpectEQ(mesh.vertices_, ref2);
+    ExpectEQ(mesh->vertices_, ref2);
 }
 
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, FilterSmoothTaubin) {
-    auto mesh = geometry::TriangleMesh();
-    mesh.vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
-    mesh.triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
+    auto mesh = std::make_shared<geometry::TriangleMesh>();
+    mesh->vertices_ = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {-1, 0, 0}, {0, -1, 0}};
+    mesh->triangles_ = {{0, 1, 2}, {0, 2, 3}, {0, 3, 4}, {0, 4, 1}};
 
-    mesh.FilterSmoothTaubin(1, 0.5, -0.53);
+    mesh = mesh->FilterSmoothTaubin(1, 0.5, -0.53);
     std::vector<Eigen::Vector3d> ref1 = {{0, 0, 0},
                                          {0.765, 0, 0},
                                          {0, 0.765, 0},
                                          {-0.765, 0, 0},
                                          {0, -0.765, 0}};
-    ExpectEQ(mesh.vertices_, ref1);
+    ExpectEQ(mesh->vertices_, ref1);
 
-    mesh.FilterSmoothTaubin(10, 0.5, -0.53);
+    mesh = mesh->FilterSmoothTaubin(10, 0.5, -0.53);
     std::vector<Eigen::Vector3d> ref2 = {{0, 0, 0},
                                          {0.052514, 0, 0},
                                          {0, 0.052514, 0},
                                          {-0.052514, 0, 0},
                                          {0, -0.052514, 0}};
-    ExpectEQ(mesh.vertices_, ref2);
+    ExpectEQ(mesh->vertices_, ref2);
 }
 
 // ----------------------------------------------------------------------------
@@ -964,16 +964,20 @@ TEST(TriangleMesh, PaintUniformColor) {
 //
 // ----------------------------------------------------------------------------
 TEST(TriangleMesh, EulerPoincareCharacteristic) {
-    EXPECT_EQ(geometry::CreateMeshBox()->EulerPoincareCharacteristic() == 2,
+    EXPECT_EQ(geometry::TriangleMesh::CreateBox()
+                              ->EulerPoincareCharacteristic() == 2,
               true);
-    EXPECT_EQ(geometry::CreateMeshSphere()->EulerPoincareCharacteristic() == 2,
+    EXPECT_EQ(geometry::TriangleMesh::CreateSphere()
+                              ->EulerPoincareCharacteristic() == 2,
               true);
-    EXPECT_EQ(
-            geometry::CreateMeshCylinder()->EulerPoincareCharacteristic() == 2,
-            true);
-    EXPECT_EQ(geometry::CreateMeshCone()->EulerPoincareCharacteristic() == 2,
+    EXPECT_EQ(geometry::TriangleMesh::CreateCylinder()
+                              ->EulerPoincareCharacteristic() == 2,
               true);
-    EXPECT_EQ(geometry::CreateMeshTorus()->EulerPoincareCharacteristic() == 0,
+    EXPECT_EQ(geometry::TriangleMesh::CreateCone()
+                              ->EulerPoincareCharacteristic() == 2,
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateTorus()
+                              ->EulerPoincareCharacteristic() == 0,
               true);
 
     geometry::TriangleMesh mesh0;
@@ -990,17 +994,24 @@ TEST(TriangleMesh, EulerPoincareCharacteristic) {
 }
 
 TEST(TriangleMesh, IsEdgeManifold) {
-    EXPECT_EQ(geometry::CreateMeshBox()->IsEdgeManifold(true), true);
-    EXPECT_EQ(geometry::CreateMeshSphere()->IsEdgeManifold(true), true);
-    EXPECT_EQ(geometry::CreateMeshCylinder()->IsEdgeManifold(true), true);
-    EXPECT_EQ(geometry::CreateMeshCone()->IsEdgeManifold(true), true);
-    EXPECT_EQ(geometry::CreateMeshTorus()->IsEdgeManifold(true), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateBox()->IsEdgeManifold(true), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateSphere()->IsEdgeManifold(true),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCylinder()->IsEdgeManifold(true),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCone()->IsEdgeManifold(true), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateTorus()->IsEdgeManifold(true),
+              true);
 
-    EXPECT_EQ(geometry::CreateMeshBox()->IsEdgeManifold(false), true);
-    EXPECT_EQ(geometry::CreateMeshSphere()->IsEdgeManifold(false), true);
-    EXPECT_EQ(geometry::CreateMeshCylinder()->IsEdgeManifold(false), true);
-    EXPECT_EQ(geometry::CreateMeshCone()->IsEdgeManifold(false), true);
-    EXPECT_EQ(geometry::CreateMeshTorus()->IsEdgeManifold(false), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateBox()->IsEdgeManifold(false), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateSphere()->IsEdgeManifold(false),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCylinder()->IsEdgeManifold(false),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCone()->IsEdgeManifold(false),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateTorus()->IsEdgeManifold(false),
+              true);
 
     geometry::TriangleMesh mesh0;
     mesh0.vertices_ = {{0, 0, 0}, {0, 0, 1}, {0, 1, 1}, {0, 0, 2}, {1, 0.5, 1}};
@@ -1016,11 +1027,12 @@ TEST(TriangleMesh, IsEdgeManifold) {
 }
 
 TEST(TriangleMesh, IsVertexManifold) {
-    EXPECT_EQ(geometry::CreateMeshBox()->IsVertexManifold(), true);
-    EXPECT_EQ(geometry::CreateMeshSphere()->IsVertexManifold(), true);
-    EXPECT_EQ(geometry::CreateMeshCylinder()->IsVertexManifold(), true);
-    EXPECT_EQ(geometry::CreateMeshCone()->IsVertexManifold(), true);
-    EXPECT_EQ(geometry::CreateMeshTorus()->IsVertexManifold(), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateBox()->IsVertexManifold(), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateSphere()->IsVertexManifold(), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCylinder()->IsVertexManifold(),
+              true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCone()->IsVertexManifold(), true);
+    EXPECT_EQ(geometry::TriangleMesh::CreateTorus()->IsVertexManifold(), true);
 
     geometry::TriangleMesh mesh0;
     mesh0.vertices_ = {{0, 0, 0}, {1, 1, 1},  {1, 0, 1},
@@ -1036,11 +1048,15 @@ TEST(TriangleMesh, IsVertexManifold) {
 }
 
 TEST(TriangleMesh, IsSelfIntersecting) {
-    EXPECT_EQ(geometry::CreateMeshBox()->IsSelfIntersecting(), false);
-    EXPECT_EQ(geometry::CreateMeshSphere()->IsSelfIntersecting(), false);
-    EXPECT_EQ(geometry::CreateMeshCylinder()->IsSelfIntersecting(), false);
-    EXPECT_EQ(geometry::CreateMeshCone()->IsSelfIntersecting(), false);
-    EXPECT_EQ(geometry::CreateMeshTorus()->IsSelfIntersecting(), false);
+    EXPECT_EQ(geometry::TriangleMesh::CreateBox()->IsSelfIntersecting(), false);
+    EXPECT_EQ(geometry::TriangleMesh::CreateSphere()->IsSelfIntersecting(),
+              false);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCylinder()->IsSelfIntersecting(),
+              false);
+    EXPECT_EQ(geometry::TriangleMesh::CreateCone()->IsSelfIntersecting(),
+              false);
+    EXPECT_EQ(geometry::TriangleMesh::CreateTorus()->IsSelfIntersecting(),
+              false);
 
     // simple intersection
     geometry::TriangleMesh mesh0;
@@ -1194,7 +1210,7 @@ TEST(TriangleMesh, SelectDownSample) {
     vector<size_t> indices(size / 40);
     Rand(indices, 0, size - 1, 0);
 
-    auto output_tm = geometry::SelectDownSample(tm, indices);
+    auto output_tm = tm.SelectDownSample(indices);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_vertex_normals, output_tm->vertex_normals_);
@@ -1260,7 +1276,7 @@ TEST(TriangleMesh, CropTriangleMesh) {
     Vector3d cropBoundMin(300.0, 300.0, 300.0);
     Vector3d cropBoundMax(800.0, 800.0, 800.0);
 
-    auto output_tm = geometry::CropTriangleMesh(tm, cropBoundMin, cropBoundMax);
+    auto output_tm = tm.Crop(cropBoundMin, cropBoundMax);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_vertex_normals, output_tm->vertex_normals_);
@@ -1338,7 +1354,7 @@ TEST(TriangleMesh, CreateMeshSphere) {
             {38, 29, 28}, {38, 39, 29}, {39, 30, 29}, {39, 40, 30},
             {40, 31, 30}, {40, 41, 31}, {41, 22, 31}, {41, 32, 22}};
 
-    auto output_tm = geometry::CreateMeshSphere(1.0, 5);
+    auto output_tm = geometry::TriangleMesh::CreateSphere(1.0, 5);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_triangles, output_tm->triangles_);
@@ -1391,7 +1407,7 @@ TEST(TriangleMesh, CreateMeshCylinder) {
             {24, 20, 19}, {24, 25, 20}, {25, 21, 20}, {25, 26, 21},
             {26, 17, 21}, {26, 22, 17}};
 
-    auto output_tm = geometry::CreateMeshCylinder(1.0, 2.0, 5);
+    auto output_tm = geometry::TriangleMesh::CreateCylinder(1.0, 2.0, 5);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_triangles, output_tm->triangles_);
@@ -1411,7 +1427,7 @@ TEST(TriangleMesh, CreateMeshCone) {
             {0, 3, 2}, {1, 2, 3}, {0, 4, 3}, {1, 3, 4}, {0, 5, 4},
             {1, 4, 5}, {0, 6, 5}, {1, 5, 6}, {0, 2, 6}, {1, 6, 2}};
 
-    auto output_tm = geometry::CreateMeshCone(1.0, 2.0, 5);
+    auto output_tm = geometry::TriangleMesh::CreateCone(1.0, 2.0, 5);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_triangles, output_tm->triangles_);
@@ -1457,7 +1473,7 @@ TEST(TriangleMesh, CreateMeshArrow) {
             {27, 31, 30}, {28, 30, 31}, {27, 32, 31}, {28, 31, 32},
             {27, 33, 32}, {28, 32, 33}, {27, 29, 33}, {28, 33, 29}};
 
-    auto output_tm = geometry::CreateMeshArrow(1.0, 1.5, 2.0, 1.0, 5);
+    auto output_tm = geometry::TriangleMesh::CreateArrow(1.0, 1.5, 2.0, 1.0, 5);
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_triangles, output_tm->triangles_);
@@ -1519,7 +1535,7 @@ TEST(TriangleMesh, CreateMeshCoordinateFrame) {
             {0.648601, 0.051046, -0.759415},  {0.018369, -0.233406, -0.972206},
             {0.156434, 0.000000, 0.987688},   {-0.987688, -0.156434, 0.000000}};
 
-    auto output_tm = geometry::CreateMeshCoordinateFrame(0.1);
+    auto output_tm = geometry::TriangleMesh::CreateCoordinateFrame(0.1);
 
     EXPECT_EQ(1134, output_tm->vertices_.size());
     EXPECT_EQ(1134, output_tm->vertex_normals_.size());
@@ -1538,7 +1554,7 @@ TEST(TriangleMesh, CreateMeshCoordinateFrame) {
     }
     unique(indices.begin(), indices.end());
     sort(indices.begin(), indices.end());
-    auto output = geometry::SelectDownSample(*output_tm, indices);
+    auto output = output_tm->SelectDownSample(indices);
 
     ExpectEQ(ref_vertices, output->vertices_);
     ExpectEQ(ref_vertex_normals, output->vertex_normals_);

--- a/src/UnitTest/Integration/UniformTSDFVolume.cpp
+++ b/src/UnitTest/Integration/UniformTSDFVolume.cpp
@@ -138,7 +138,7 @@ TEST(UniformTSDFVolume, RealData) {
 
         // Ingegrate
         std::shared_ptr<geometry::RGBDImage> im_rgbd =
-                geometry::CreateRGBDImageFromColorAndDepth(
+                geometry::RGBDImage::CreateFromColorAndDepth(
                         im_color, im_depth, /*depth_scale*/ 1000.0,
                         /*depth_func*/ 4.0, /*convert_rgb_to_intensity*/ false);
         tsdf_volume.Integrate(*im_rgbd, intrinsic, extrinsics[i]);

--- a/src/UnitTest/Odometry/OdometryTools.cpp
+++ b/src/UnitTest/Odometry/OdometryTools.cpp
@@ -43,7 +43,7 @@ shared_ptr<geometry::Image> odometry_tools::GenerateImage(
         const int& seed) {
     shared_ptr<geometry::Image> image = make_shared<geometry::Image>();
 
-    image->PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image->Prepare(width, height, num_of_channels, bytes_per_channel);
 
     float* const depthData = Cast<float>(&image->data_[0]);
     Rand(depthData, width * height, vmin, vmax, seed);
@@ -98,7 +98,7 @@ shared_ptr<geometry::Image> odometry_tools::CorrespondenceMap(const int& width,
 
     shared_ptr<geometry::Image> image = make_shared<geometry::Image>();
 
-    image->PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image->Prepare(width, height, num_of_channels, bytes_per_channel);
 
     int* const int_data = Cast<int>(&image->data_[0]);
     size_t image_size = image->data_.size() / sizeof(int);
@@ -120,7 +120,7 @@ shared_ptr<geometry::Image> odometry_tools::DepthBuffer(const int& width,
 
     shared_ptr<geometry::Image> image = make_shared<geometry::Image>();
 
-    image->PrepareImage(width, height, num_of_channels, bytes_per_channel);
+    image->Prepare(width, height, num_of_channels, bytes_per_channel);
 
     float* const float_data = Cast<float>(&image->data_[0]);
     size_t image_size = image->data_.size() / sizeof(float);


### PR DESCRIPTION
Refactoring the `geometry` API such that no more functions are used. Instead, most methods are now class methods. Exceptions are `create_*` functions, which are now static class methods. Changes are applied to C++ and Python API. Therefore, I also retested the Python examples (and found also a few other minor bugs).

I tried to be as consistent with the naming of the methods as possible.

Note: `HalfEdgeTriangleMesh` is/was in some kind of limbo state. Should be revisited in another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1003)
<!-- Reviewable:end -->
