### PR TITLE
Class static methods docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,8 +29,10 @@ import re
 # This is a trick to show open3d.open3d as open3d in the docs
 # Only tested to work on Unix
 current_file_dir = os.path.dirname(os.path.realpath(__file__))
-sys.path.insert(0, os.path.join(current_file_dir, "..", "build", "lib",
-                                "python_package", "open3d"))
+sys.path.insert(
+    0,
+    os.path.join(current_file_dir, "..", "build", "lib", "python_package",
+                 "open3d"))
 
 html_theme = "sphinx_rtd_theme"
 
@@ -47,10 +49,10 @@ html_favicon = "_static/open3d_logo.ico"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax',
-              'sphinx.ext.autodoc',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.mathjax', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -74,7 +76,10 @@ author = u'www.open3d.org'
 # built documents.
 #
 # The short X.Y version.
-version_list = [line.rstrip('\n').split(' ')[1] for line in open('../src/Open3D/version.txt')]
+version_list = [
+    line.rstrip('\n').split(' ')[1]
+    for line in open('../src/Open3D/version.txt')
+]
 open3d_version = '.'.join(version_list)
 version = open3d_version
 # The full version, including alpha/beta/rc tags.
@@ -98,7 +103,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -121,18 +125,16 @@ html_static_path = ['_static']
 html_context = {
     'css_files': [
         '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+    ],
+}
 
 # added by Jaesik to hide "View page source"
 html_show_sourcelink = False
-
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Open3Ddoc'
-
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -158,20 +160,15 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Open3D.tex', u'Open3D Documentation',
-     u'Qianyi Zhou', 'manual'),
+    (master_doc, 'Open3D.tex', u'Open3D Documentation', u'Qianyi Zhou',
+     'manual'),
 ]
-
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'open3d', u'Open3D Documentation',
-     [author], 1)
-]
-
+man_pages = [(master_doc, 'open3d', u'Open3D Documentation', [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -179,9 +176,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Open3D', u'Open3D Documentation',
-     author, 'Open3D', 'One line description of project.',
-     'Miscellaneous'),
+    (master_doc, 'Open3D', u'Open3D Documentation', author, 'Open3D',
+     'One line description of project.', 'Miscellaneous'),
 ]
 
 # Version 0: Added by Jaesik to list Python members using the source order
@@ -191,6 +187,7 @@ autodoc_member_order = 'groupwise'
 
 
 def is_enum_class(func, func_name):
+
     def import_from_str(class_name):
         components = class_name.split('.')
         mod = __import__(components[0])
@@ -223,6 +220,7 @@ def skip(app, what, name, obj, would_skip, options):
         else:
             return False
     return would_skip
+
 
 def setup(app):
     app.connect("autodoc-skip-member", skip)

--- a/docs/make.py
+++ b/docs/make.py
@@ -45,12 +45,12 @@ SOURCE_DIR = "."
 BUILD_DIR = "_build"
 
 
-def clear_or_create_dir(dir_path):
+def create_or_clear(dir_path):
     if os.path.exists(dir_path):
         shutil.rmtree(dir_path)
-        print("Removing directory %s" % dir_path)
-    print("Creating directory %s" % dir_path)
+        print("Removed directory %s" % dir_path)
     os.makedirs(dir_path)
+    print("Created directory %s" % dir_path)
 
 
 class PyDocsBuilder:
@@ -72,7 +72,7 @@ class PyDocsBuilder:
               self.output_dir)
 
     def generate_rst(self):
-        clear_or_create_dir(self.output_dir)
+        create_or_clear(self.output_dir)
 
         main_c_module = importlib.import_module(self.c_module)
         sub_module_names = sorted(
@@ -271,7 +271,7 @@ class SphinxDocsBuilder:
         """
         Call Sphinx command with self.makefile_arg
         """
-        clear_or_create_dir(BUILD_DIR)
+        create_or_clear(BUILD_DIR)
         cmd = [
             SPHINX_BUILD,
             "-M",

--- a/docs/make.py
+++ b/docs/make.py
@@ -45,6 +45,14 @@ SOURCE_DIR = "."
 BUILD_DIR = "_build"
 
 
+def clear_or_create_dir(dir_path):
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
+        print("Removing directory %s" % dir_path)
+    print("Creating directory %s" % dir_path)
+    os.makedirs(dir_path)
+
+
 class PyDocsBuilder:
     """
     Generate Python API *.rst files, per (sub) module, per class, per function.
@@ -60,24 +68,22 @@ class PyDocsBuilder:
         self.output_dir = output_dir
         self.c_module = c_module
         self.c_module_relative = c_module_relative
-        print("Generating *.rst Python API docs in directory: %s" % self.output_dir)
+        print("Generating *.rst Python API docs in directory: %s" %
+              self.output_dir)
 
     def generate_rst(self):
-        if not os.path.exists(self.output_dir):
-            print("Creating directory %s" % self.output_dir)
-            os.makedirs(self.output_dir)
+        clear_or_create_dir(self.output_dir)
 
         main_c_module = importlib.import_module(self.c_module)
         sub_module_names = sorted(
-            [obj[0] for obj in getmembers(main_c_module) if ismodule(obj[1])]
-        )
+            [obj[0] for obj in getmembers(main_c_module) if ismodule(obj[1])])
         for sub_module_name in sub_module_names:
             PyDocsBuilder._generate_sub_module_class_function_docs(
-                sub_module_name, self.output_dir
-            )
+                sub_module_name, self.output_dir)
 
     @staticmethod
-    def _generate_function_doc(sub_module_full_name, function_name, output_path):
+    def _generate_function_doc(sub_module_full_name, function_name,
+                               output_path):
         # print("Generating docs: %s" % (output_path,))
         out_string = ""
         out_string += "%s.%s" % (sub_module_full_name, function_name)
@@ -106,9 +112,8 @@ class PyDocsBuilder:
             f.write(out_string)
 
     @staticmethod
-    def _generate_sub_module_doc(
-        sub_module_name, class_names, function_names, sub_module_doc_path
-    ):
+    def _generate_sub_module_doc(sub_module_name, class_names, function_names,
+                                 sub_module_doc_path):
         # print("Generating docs: %s" % (sub_module_doc_path,))
         class_names = sorted(class_names)
         function_names = sorted(function_names)
@@ -152,33 +157,37 @@ class PyDocsBuilder:
 
     @staticmethod
     def _generate_sub_module_class_function_docs(sub_module_name, output_dir):
-        sub_module = importlib.import_module("open3d.open3d.%s" % (sub_module_name,))
+        sub_module = importlib.import_module("open3d.open3d.%s" %
+                                             (sub_module_name,))
         sub_module_full_name = "open3d.%s" % (sub_module_name,)
         print("Generating docs for submodule: %s" % sub_module_full_name)
 
         # Class docs
-        class_names = [obj[0] for obj in getmembers(sub_module) if isclass(obj[1])]
+        class_names = [
+            obj[0] for obj in getmembers(sub_module) if isclass(obj[1])
+        ]
         for class_name in class_names:
             file_name = "%s.%s.rst" % (sub_module_full_name, class_name)
             output_path = os.path.join(output_dir, file_name)
-            PyDocsBuilder._generate_class_doc(
-                sub_module_full_name, class_name, output_path
-            )
+            PyDocsBuilder._generate_class_doc(sub_module_full_name, class_name,
+                                              output_path)
 
         # Function docs
-        function_names = [obj[0] for obj in getmembers(sub_module) if isbuiltin(obj[1])]
+        function_names = [
+            obj[0] for obj in getmembers(sub_module) if isbuiltin(obj[1])
+        ]
         for function_name in function_names:
             file_name = "%s.%s.rst" % (sub_module_full_name, function_name)
             output_path = os.path.join(output_dir, file_name)
-            PyDocsBuilder._generate_function_doc(
-                sub_module_full_name, function_name, output_path
-            )
+            PyDocsBuilder._generate_function_doc(sub_module_full_name,
+                                                 function_name, output_path)
 
         # Submodule docs
-        sub_module_doc_path = os.path.join(output_dir, sub_module_full_name + ".rst")
-        PyDocsBuilder._generate_sub_module_doc(
-            sub_module_name, class_names, function_names, sub_module_doc_path
-        )
+        sub_module_doc_path = os.path.join(output_dir,
+                                           sub_module_full_name + ".rst")
+        PyDocsBuilder._generate_sub_module_doc(sub_module_name, class_names,
+                                               function_names,
+                                               sub_module_doc_path)
 
 
 class SphinxDocsBuilder:
@@ -221,7 +230,8 @@ class SphinxDocsBuilder:
 
     def __init__(self, makefile_arg):
         if makefile_arg not in self.valid_makefile_args:
-            print('Invalid make argument: "%s", displaying help.' % makefile_arg)
+            print('Invalid make argument: "%s", displaying help.' %
+                  makefile_arg)
             self.is_valid_arg = False
         else:
             self.is_valid_arg = True
@@ -253,15 +263,15 @@ class SphinxDocsBuilder:
         Generate Python docs.
         Each module, class and function gets one .rst file.
         """
-        pd = PyDocsBuilder(
-            self.python_api_output_dir, self.c_module, self.c_module_relative
-        )
+        pd = PyDocsBuilder(self.python_api_output_dir, self.c_module,
+                           self.c_module_relative)
         pd.generate_rst()
 
     def _run_sphinx(self):
         """
         Call Sphinx command with self.makefile_arg
         """
+        clear_or_create_dir(BUILD_DIR)
         cmd = [
             SPHINX_BUILD,
             "-M",

--- a/util/scripts/apply-style.cmake
+++ b/util/scripts/apply-style.cmake
@@ -36,6 +36,7 @@ endfunction()
 set(DIRECTORIES_OF_INTEREST_PYTHON
     examples/Python
     src/UnitTest/Python
+    docs
 )
 
 message(STATUS "Python apply-style...")

--- a/util/scripts/check-style.cmake
+++ b/util/scripts/check-style.cmake
@@ -43,6 +43,7 @@ endmacro()
 set(DIRECTORIES_OF_INTEREST_PYTHON
     examples/Python
     src/UnitTest/Python
+    docs
 )
 
 message(STATUS "Python check-style...")


### PR DESCRIPTION
- Handles static class method docs for pybind code, fixes the 3rd issue in https://github.com/intel-isl/Open3D/pull/1003
- Update docs builder to clear `python_api` and `build_` dir each time before build
- Apply style in `docs` folder for `.py` files

Before
![Screenshot from 2019-06-05 15-45-49](https://user-images.githubusercontent.com/1501945/59060905-08a3de00-8857-11e9-8e60-d6666c4c194a.png)

After
![Screenshot from 2019-06-06 12-23-18](https://user-images.githubusercontent.com/1501945/59060915-0b9ece80-8857-11e9-9a9a-1894bf6b70f9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1005)
<!-- Reviewable:end -->
