### PR TITLE
Remove python shortcuts

### DIFF
--- a/src/Python/package/open3d/__init__.py
+++ b/src/Python/package/open3d/__init__.py
@@ -24,27 +24,7 @@
 # IN THE SOFTWARE.
 # ----------------------------------------------------------------------------
 
-import importlib
 from .open3d import * # py2 py3 compatible
-from .open3d.camera import *
-from .open3d.color_map import *
-from .open3d.geometry import *
-from .open3d.io import *
-from .open3d.integration import *
-from .open3d.odometry import *
-from .open3d.registration import *
-from .open3d.utility import *
-from .open3d.visualization import *
-
-globals().update(importlib.import_module('open3d.open3d.camera').__dict__)
-globals().update(importlib.import_module('open3d.open3d.color_map').__dict__)
-globals().update(importlib.import_module('open3d.open3d.geometry').__dict__)
-globals().update(importlib.import_module('open3d.open3d.io').__dict__)
-globals().update(importlib.import_module('open3d.open3d.integration').__dict__)
-globals().update(importlib.import_module('open3d.open3d.odometry').__dict__)
-globals().update(importlib.import_module('open3d.open3d.registration').__dict__)
-globals().update(importlib.import_module('open3d.open3d.utility').__dict__)
-globals().update(importlib.import_module('open3d.open3d.visualization').__dict__)
 
 __version__ = '@PROJECT_VERSION@'
 


### PR DESCRIPTION
Before: with shortcut
```python
open3d.PointCloud
open3d.geometry.PointCloud
```

After: full module path must be used
```python
open3d.geometry.PointCloud
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1006)
<!-- Reviewable:end -->
