### PR TITLE
PointCloud EstimateNormals fix

### DIFF
--- a/examples/Python/Basic/pointcloud_estimate_normals.py
+++ b/examples/Python/Basic/pointcloud_estimate_normals.py
@@ -1,0 +1,68 @@
+import numpy as np
+import open3d as o3d
+import time
+import meshes
+
+np.random.seed(42)
+
+
+def knn_generator():
+    yield 'knn20', o3d.geometry.KDTreeSearchParamKNN(20)
+    yield 'radius', o3d.geometry.KDTreeSearchParamRadius(0.01666)
+    yield 'hybrid', o3d.geometry.KDTreeSearchParamHybrid(0.01666, 60)
+
+
+def pointcloud_generator():
+    pts = np.random.uniform(-30, 30, size=(int(1e6), 3))
+    pcl = o3d.geometry.PointCloud()
+    pcl.points = o3d.utility.Vector3dVector(pts)
+    yield 'uniform', pcl
+
+    yield 'moebius', o3d.geometry.TriangleMesh.create_moebius(
+    ).sample_points_uniformly(int(1e6))
+
+    yield 'bunny', meshes.bunny().sample_points_uniformly(int(1e6))
+
+    yield 'fragment', o3d.io.read_point_cloud('../../TestData/fragment.ply')
+
+
+if __name__ == "__main__":
+    # Test normals of flat surface
+    X, Y = np.mgrid[0:1:0.1, 0:1:0.1]
+    X = X.flatten()
+    Y = Y.flatten()
+
+    pts = np.zeros((3, X.size))
+    pts[0] = X
+    pts[1] = Y
+
+    shape = o3d.geometry.PointCloud()
+    shape.points = o3d.utility.Vector3dVector(pts.T)
+    shape.paint_uniform_color([0, 0.651, 0.929])  # blue
+
+    shape.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=0.5,
+                                                                max_nn=30),
+                           fast_normal_computation=True)
+    o3d.visualization.draw_geometries([shape])
+
+    shape.estimate_normals(o3d.geometry.KDTreeSearchParamHybrid(radius=0.5,
+                                                                max_nn=30),
+                           fast_normal_computation=False)
+    o3d.visualization.draw_geometries([shape])
+
+    # Benchmark
+    for pcl_name, pcl in pointcloud_generator():
+        for knn_name, knn in knn_generator():
+            print('-' * 80)
+            for fast_normal_computation in [True, False]:
+                times = []
+                for _ in range(10):
+                    tic = time.time()
+                    pcl.estimate_normals(
+                        o3d.geometry.KDTreeSearchParamHybrid(radius=0.5,
+                                                             max_nn=30),
+                        fast_normal_computation=fast_normal_computation)
+                    times.append(time.time() - tic)
+                print('fast={}: {}, {} -- avg time={}[s]'.format(
+                    fast_normal_computation, pcl_name, knn_name,
+                    np.mean(times)))

--- a/src/Open3D/Geometry/EstimateNormals.cpp
+++ b/src/Open3D/Geometry/EstimateNormals.cpp
@@ -37,43 +37,232 @@ using namespace geometry;
 
 double sqr(double x) { return x * x; }
 
-Eigen::Vector3d FastEigen3x3(const Eigen::Matrix3d &A) {
-    // Based on:
-    // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
-    double p1 = sqr(A(0, 1)) + sqr(A(0, 2)) + sqr(A(1, 2));
-    Eigen::Vector3d eigenvalues;
-    if (p1 == 0.0) {
-        eigenvalues(2) = std::min(A(0, 0), std::min(A(1, 1), A(2, 2)));
-        eigenvalues(0) = std::max(A(0, 0), std::max(A(1, 1), A(2, 2)));
-        eigenvalues(1) = A.trace() - eigenvalues(0) - eigenvalues(2);
-    } else {
-        double q = A.trace() / 3.0;
-        double p2 = sqr((A(0, 0) - q)) + sqr(A(1, 1) - q) + sqr(A(2, 2) - q) +
-                    2 * p1;
-        double p = sqrt(p2 / 6.0);
-        Eigen::Matrix3d B = (1.0 / p) * (A - q * Eigen::Matrix3d::Identity());
-        double r = B.determinant() / 2.0;
-        double phi;
-        if (r <= -1) {
-            phi = M_PI / 3.0;
-        } else if (r >= 1) {
-            phi = 0.0;
-        } else {
-            phi = std::acos(r) / 3.0;
-        }
-        eigenvalues(0) = q + 2.0 * p * std::cos(phi);
-        eigenvalues(2) = q + 2.0 * p * std::cos(phi + 2.0 * M_PI / 3.0);
-        eigenvalues(1) = q * 3.0 - eigenvalues(0) - eigenvalues(2);
+// Eigen::Vector3d FastEigen3x3(Eigen::Matrix3d &A) {
+//     // Based on:
+//     // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
+
+//     // Precondition
+//     double max_coeff = A.array().abs().matrix().maxCoeff();
+//     if (max_coeff == 0) {
+//         return Eigen::Vector3d::Zero();
+//     }
+//     A /= max_coeff;
+
+//     double p1 = sqr(A(0, 1)) + sqr(A(0, 2)) + sqr(A(1, 2));
+//     Eigen::Vector3d eigenvalues;
+//     if (p1 == 0.0) {
+//         eigenvalues(2) = std::min(A(0, 0), std::min(A(1, 1), A(2, 2)));
+//         eigenvalues(0) = std::max(A(0, 0), std::max(A(1, 1), A(2, 2)));
+//         eigenvalues(1) = A.trace() - eigenvalues(0) - eigenvalues(2);
+//     } else {
+//         double q = A.trace() / 3.0;
+//         double p2 = sqr((A(0, 0) - q)) + sqr(A(1, 1) - q) + sqr(A(2, 2) - q)
+//         +
+//                     2 * p1;
+//         double p = sqrt(p2 / 6.0);
+//         Eigen::Matrix3d B = (1.0 / p) * (A - q *
+//         Eigen::Matrix3d::Identity()); double r = B.determinant() / 2.0;
+//         double phi;
+//         if (r <= -1) {
+//             phi = M_PI / 3.0;
+//         } else if (r >= 1) {
+//             phi = 0.0;
+//         } else {
+//             phi = std::acos(r) / 3.0;
+//         }
+//         eigenvalues(0) = q + 2.0 * p * std::cos(phi);
+//         eigenvalues(2) = q + 2.0 * p * std::cos(phi + 2.0 * M_PI / 3.0);
+//         eigenvalues(1) = q * 3.0 - eigenvalues(0) - eigenvalues(2);
+//     }
+
+//     Eigen::Vector3d eigenvector =
+//             (A - Eigen::Matrix3d::Identity() * eigenvalues(0)) *
+//             (A.col(0) - Eigen::Vector3d(eigenvalues(1), 0.0, 0.0));
+//     double len = eigenvector.norm();
+//     A *= max_coeff;
+//     if (len == 0.0) {
+//         return Eigen::Vector3d::Zero();
+//     } else {
+//         return eigenvector.normalized();
+//     }
+// }
+
+Eigen::Vector3d ComputeEigenvector0(const Eigen::Matrix3d &A, double eval0) {
+    Eigen::Vector3d row0(A(0, 0) - eval0, A(0, 1), A(0, 2));
+    Eigen::Vector3d row1(A(0, 1), A(1, 1) - eval0, A(1, 2));
+    Eigen::Vector3d row2(A(0, 2), A(1, 2), A(2, 2) - eval0);
+    Eigen::Vector3d r0xr1 = row0.cross(row1);
+    Eigen::Vector3d r0xr2 = row0.cross(row2);
+    Eigen::Vector3d r1xr2 = row1.cross(row2);
+    double d0 = r0xr1.dot(r0xr1);
+    double d1 = r0xr2.dot(r0xr2);
+    double d2 = r1xr2.dot(r1xr2);
+
+    double dmax = d0;
+    int imax = 0;
+    if (d1 > dmax) {
+        dmax = d1;
+        imax = 1;
+    }
+    if (d2 > dmax) {
+        imax = 2;
     }
 
-    Eigen::Vector3d eigenvector =
-            (A - Eigen::Matrix3d::Identity() * eigenvalues(0)) *
-            (A.col(0) - Eigen::Vector3d(eigenvalues(1), 0.0, 0.0));
-    double len = eigenvector.norm();
-    if (len == 0.0) {
-        return Eigen::Vector3d::Zero();
+    if (imax == 0) {
+        return r0xr1 / std::sqrt(d0);
+    } else if (imax == 1) {
+        return r0xr2 / std::sqrt(d1);
     } else {
-        return eigenvector.normalized();
+        return r1xr2 / std::sqrt(d2);
+    }
+}
+
+Eigen::Vector3d ComputeEigenvector1(const Eigen::Matrix3d &A,
+                                    const Eigen::Vector3d &evec0,
+                                    double eval1) {
+    Eigen::Vector3d U, V;
+    if (std::abs(evec0(0)) > std::abs(evec0(1))) {
+        double inv_length =
+                1 / std::sqrt(evec0(0) * evec0(0) + evec0(2) * evec0(2));
+        U << -evec0(2) * inv_length, 0, evec0(0) * inv_length;
+    } else {
+        double inv_length =
+                1 / std::sqrt(evec0(1) * evec0(1) + evec0(2) * evec0(2));
+        U << 0, evec0(2) * inv_length, -evec0(1) * inv_length;
+    }
+    V = evec0.cross(U);
+
+    Eigen::Vector3d AU(A(0, 0) * U(0) + A(0, 1) * U(1) + A(0, 2) * U(2),
+                       A(0, 1) * U(0) + A(1, 1) * U(1) + A(1, 2) * U(2),
+                       A(0, 2) * U(0) + A(1, 2) * U(1) + A(2, 2) * U(2));
+
+    Eigen::Vector3d AV = {A(0, 0) * V(0) + A(0, 1) * V(1) + A(0, 2) * V(2),
+                          A(0, 1) * V(0) + A(1, 1) * V(1) + A(1, 2) * V(2),
+                          A(0, 2) * V(0) + A(1, 2) * V(1) + A(2, 2) * V(2)};
+
+    double m00 = U(0) * AU(0) + U(1) * AU(1) + U(2) * AU(2) - eval1;
+    double m01 = U(0) * AV(0) + U(1) * AV(1) + U(2) * AV(2);
+    double m11 = V(0) * AV(0) + V(1) * AV(1) + V(2) * AV(2) - eval1;
+
+    double absM00 = std::abs(m00);
+    double absM01 = std::abs(m01);
+    double absM11 = std::abs(m11);
+    double max_abs_comp;
+    if (absM00 >= absM11) {
+        max_abs_comp = std::max(absM00, absM01);
+        if (max_abs_comp > 0) {
+            if (absM00 >= absM01) {
+                m01 /= m00;
+                m00 = 1 / std::sqrt(1 + m01 * m01);
+                m01 *= m00;
+            } else {
+                m00 /= m01;
+                m01 = 1 / std::sqrt(1 + m00 * m00);
+                m00 *= m01;
+            }
+            return m01 * U - m00 * V;
+        } else {
+            return U;
+        }
+    } else {
+        max_abs_comp = std::max(absM11, absM01);
+        if (max_abs_comp > 0) {
+            if (absM11 >= absM01) {
+                m01 /= m11;
+                m11 = 1 / std::sqrt(1 + m01 * m01);
+                m01 *= m11;
+            } else {
+                m11 /= m01;
+                m01 = 1 / std::sqrt(1 + m11 * m11);
+                m11 *= m01;
+            }
+            return m11 * U - m01 * V;
+        } else {
+            return U;
+        }
+    }
+}
+
+Eigen::Vector3d FastEigen3x3(Eigen::Matrix3d &A) {
+    // Based on
+    // https://www.geometrictools.com/Documentation/RobustEigenSymmetric3x3.pdf
+
+    double max_coeff = A.maxCoeff();
+    if (max_coeff == 0) {
+        return Eigen::Vector3d::Zero();
+    }
+    A /= max_coeff;
+
+    double norm = A(0, 1) * A(0, 1) + A(0, 2) * A(0, 2) + A(1, 2) * A(1, 2);
+    if (norm > 0) {
+        Eigen::Vector3d eval;
+        Eigen::Vector3d evec0;
+        Eigen::Vector3d evec1;
+        Eigen::Vector3d evec2;
+
+        double q = (A(0, 0) + A(1, 1) + A(2, 2)) / 3;
+
+        double b00 = A(0, 0) - q;
+        double b11 = A(1, 1) - q;
+        double b22 = A(2, 2) - q;
+
+        double p =
+                std::sqrt((b00 * b00 + b11 * b11 + b22 * b22 + norm * 2) / 6);
+
+        double c00 = b11 * b22 - A(1, 2) * A(1, 2);
+        double c01 = A(0, 1) * b22 - A(1, 2) * A(0, 2);
+        double c02 = A(0, 1) * A(1, 2) - b11 * A(0, 2);
+        double det = (b00 * c00 - A(0, 1) * c01 + A(0, 2) * c02) / (p * p * p);
+
+        double half_det = det * 0.5;
+        half_det = std::min(std::max(half_det, -1.0), 1.0);
+
+        double angle = std::acos(half_det) / (double)3;
+        double const two_thirds_pi = 2.09439510239319549;
+        double beta2 = std::cos(angle) * 2;
+        double beta0 = std::cos(angle + two_thirds_pi) * 2;
+        double beta1 = -(beta0 + beta2);
+
+        eval(0) = q + p * beta0;
+        eval(1) = q + p * beta1;
+        eval(2) = q + p * beta2;
+
+        if (half_det >= 0) {
+            evec2 = ComputeEigenvector0(A, eval(2));
+            if (eval(2) < eval(0) && eval(2) < eval(1)) {
+                A *= max_coeff;
+                return evec2;
+            }
+            evec1 = ComputeEigenvector1(A, evec2, eval(1));
+            A *= max_coeff;
+            if (eval(1) < eval(0) && eval(1) < eval(2)) {
+                return evec1;
+            }
+            evec0 = evec1.cross(evec2);
+            return evec0;
+        } else {
+            evec0 = ComputeEigenvector0(A, eval(0));
+            if (eval(0) < eval(1) && eval(0) < eval(2)) {
+                A *= max_coeff;
+                return evec0;
+            }
+            evec1 = ComputeEigenvector1(A, evec0, eval(1));
+            A *= max_coeff;
+            if (eval(1) < eval(0) && eval(1) < eval(2)) {
+                return evec1;
+            }
+            evec2 = evec0.cross(evec1);
+            return evec2;
+        }
+    } else {
+        A *= max_coeff;
+        if (A(0, 0) < A(1, 1) && A(0, 0) < A(2, 2)) {
+            return Eigen::Vector3d(1, 0, 0);
+        } else if (A(1, 1) < A(0, 0) && A(1, 1) < A(2, 2)) {
+            return Eigen::Vector3d(0, 1, 0);
+        } else {
+            return Eigen::Vector3d(0, 0, 1);
+        }
     }
 }
 

--- a/src/Open3D/Geometry/EstimateNormals.cpp
+++ b/src/Open3D/Geometry/EstimateNormals.cpp
@@ -42,7 +42,7 @@ Eigen::Vector3d FastEigen3x3(const Eigen::Matrix3d &A) {
     // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
     double p1 = sqr(A(0, 1)) + sqr(A(0, 2)) + sqr(A(1, 2));
     Eigen::Vector3d eigenvalues;
-    if (p1 == 0.0) {
+    if (p == 0) {
         eigenvalues(2) = std::min(A(0, 0), std::min(A(1, 1), A(2, 2)));
         eigenvalues(0) = std::max(A(0, 0), std::max(A(1, 1), A(2, 2)));
         eigenvalues(1) = A.trace() - eigenvalues(0) - eigenvalues(2);
@@ -108,10 +108,10 @@ Eigen::Vector3d ComputeNormal(const PointCloud &cloud,
     covariance(1, 2) = cumulants(7) - cumulants(1) * cumulants(2);
     covariance(2, 1) = covariance(1, 2);
 
-    return FastEigen3x3(covariance);
-    // Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver;
-    // solver.compute(covariance, Eigen::ComputeEigenvectors);
-    // return solver.eigenvectors().col(0);
+    // return FastEigen3x3(covariance);
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver;
+    solver.compute(covariance, Eigen::ComputeEigenvectors);
+    return solver.eigenvectors().col(0);
 }
 
 }  // unnamed namespace

--- a/src/Open3D/Geometry/EstimateNormals.cpp
+++ b/src/Open3D/Geometry/EstimateNormals.cpp
@@ -37,56 +37,6 @@ using namespace geometry;
 
 double sqr(double x) { return x * x; }
 
-// Eigen::Vector3d FastEigen3x3(Eigen::Matrix3d &A) {
-//     // Based on:
-//     // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
-
-//     // Precondition
-//     double max_coeff = A.array().abs().matrix().maxCoeff();
-//     if (max_coeff == 0) {
-//         return Eigen::Vector3d::Zero();
-//     }
-//     A /= max_coeff;
-
-//     double p1 = sqr(A(0, 1)) + sqr(A(0, 2)) + sqr(A(1, 2));
-//     Eigen::Vector3d eigenvalues;
-//     if (p1 == 0.0) {
-//         eigenvalues(2) = std::min(A(0, 0), std::min(A(1, 1), A(2, 2)));
-//         eigenvalues(0) = std::max(A(0, 0), std::max(A(1, 1), A(2, 2)));
-//         eigenvalues(1) = A.trace() - eigenvalues(0) - eigenvalues(2);
-//     } else {
-//         double q = A.trace() / 3.0;
-//         double p2 = sqr((A(0, 0) - q)) + sqr(A(1, 1) - q) + sqr(A(2, 2) - q)
-//         +
-//                     2 * p1;
-//         double p = sqrt(p2 / 6.0);
-//         Eigen::Matrix3d B = (1.0 / p) * (A - q *
-//         Eigen::Matrix3d::Identity()); double r = B.determinant() / 2.0;
-//         double phi;
-//         if (r <= -1) {
-//             phi = M_PI / 3.0;
-//         } else if (r >= 1) {
-//             phi = 0.0;
-//         } else {
-//             phi = std::acos(r) / 3.0;
-//         }
-//         eigenvalues(0) = q + 2.0 * p * std::cos(phi);
-//         eigenvalues(2) = q + 2.0 * p * std::cos(phi + 2.0 * M_PI / 3.0);
-//         eigenvalues(1) = q * 3.0 - eigenvalues(0) - eigenvalues(2);
-//     }
-
-//     Eigen::Vector3d eigenvector =
-//             (A - Eigen::Matrix3d::Identity() * eigenvalues(0)) *
-//             (A.col(0) - Eigen::Vector3d(eigenvalues(1), 0.0, 0.0));
-//     double len = eigenvector.norm();
-//     A *= max_coeff;
-//     if (len == 0.0) {
-//         return Eigen::Vector3d::Zero();
-//     } else {
-//         return eigenvector.normalized();
-//     }
-// }
-
 Eigen::Vector3d ComputeEigenvector0(const Eigen::Matrix3d &A, double eval0) {
     Eigen::Vector3d row0(A(0, 0) - eval0, A(0, 1), A(0, 2));
     Eigen::Vector3d row1(A(0, 1), A(1, 1) - eval0, A(1, 2));
@@ -184,8 +134,11 @@ Eigen::Vector3d ComputeEigenvector1(const Eigen::Matrix3d &A,
 }
 
 Eigen::Vector3d FastEigen3x3(Eigen::Matrix3d &A) {
-    // Based on
+    // Previous version based on:
+    // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
+    // Current version based on
     // https://www.geometrictools.com/Documentation/RobustEigenSymmetric3x3.pdf
+    // which handles edge cases like points on a plane
 
     double max_coeff = A.maxCoeff();
     if (max_coeff == 0) {

--- a/src/Open3D/Geometry/EstimateNormals.cpp
+++ b/src/Open3D/Geometry/EstimateNormals.cpp
@@ -42,7 +42,7 @@ Eigen::Vector3d FastEigen3x3(const Eigen::Matrix3d &A) {
     // https://en.wikipedia.org/wiki/Eigenvalue_algorithm#3.C3.973_matrices
     double p1 = sqr(A(0, 1)) + sqr(A(0, 2)) + sqr(A(1, 2));
     Eigen::Vector3d eigenvalues;
-    if (p == 0) {
+    if (p1 == 0.0) {
         eigenvalues(2) = std::min(A(0, 0), std::min(A(1, 1), A(2, 2)));
         eigenvalues(0) = std::max(A(0, 0), std::max(A(1, 1), A(2, 2)));
         eigenvalues(1) = A.trace() - eigenvalues(0) - eigenvalues(2);

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -138,7 +138,8 @@ public:
     /// normals exist in the input. \param search_param The KDTree search
     /// parameters
     bool EstimateNormals(
-            const KDTreeSearchParam &search_param = KDTreeSearchParamKNN());
+            const KDTreeSearchParam &search_param = KDTreeSearchParamKNN(),
+            bool fast_normal_computation = true);
 
     /// Function to orient the normals of a point cloud
     /// \param cloud is the input point cloud. It must have normals.

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -106,7 +106,8 @@ void pybind_pointcloud(py::module &m) {
                  "Function to compute the normals of a point cloud. Normals "
                  "are oriented with respect to the input point cloud if "
                  "normals exist",
-                 "search_param"_a = geometry::KDTreeSearchParamKNN())
+                 "search_param"_a = geometry::KDTreeSearchParamKNN(),
+                 "fast_normal_computation"_a = true)
             .def("orient_normals_to_align_with_direction",
                  &geometry::PointCloud::OrientNormalsToAlignWithDirection,
                  "Function to orient the normals of a point cloud",
@@ -220,7 +221,11 @@ void pybind_pointcloud(py::module &m) {
     docstring::ClassMethodDocInject(
             m, "PointCloud", "estimate_normals",
             {{"search_param",
-              "The KDTree search parameters for neighborhood search."}});
+              "The KDTree search parameters for neighborhood search."},
+             {"fast_normal_computation",
+              "If true, the normal estiamtion uses a non-iterative method to "
+              "extract the eigenvector from the covariance matrix. This is "
+              "faster, but is not as numerical stable."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "orient_normals_to_align_with_direction",
             {{"orientation_reference",

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -683,8 +683,24 @@ TEST(PointCloud, EstimateNormals) {
     pc.points_.resize(size);
     Rand(pc.points_, vmin, vmax, 0);
 
-    bool result = pc.EstimateNormals();
+    bool result;
 
+    result = pc.EstimateNormals(geometry::KDTreeSearchParamKNN(), true);
+    for (int idx = 0; idx < ref.size(); ++idx) {
+        if ((ref[idx](0) < 0 && pc.points_[idx](0) > 0) ||
+            (ref[idx](0) > 0 && pc.points_[idx](0) < 0)) {
+            pc.points_[idx] *= -1;
+        }
+    }
+    ExpectEQ(ref, pc.normals_);
+
+    result = pc.EstimateNormals(geometry::KDTreeSearchParamKNN(), false);
+    for (int idx = 0; idx < ref.size(); ++idx) {
+        if ((ref[idx](0) < 0 && pc.points_[idx](0) > 0) ||
+            (ref[idx](0) > 0 && pc.points_[idx](0) < 0)) {
+            pc.points_[idx] *= -1;
+        }
+    }
     ExpectEQ(ref, pc.normals_);
 }
 

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -687,18 +687,18 @@ TEST(PointCloud, EstimateNormals) {
 
     result = pc.EstimateNormals(geometry::KDTreeSearchParamKNN(), true);
     for (int idx = 0; idx < ref.size(); ++idx) {
-        if ((ref[idx](0) < 0 && pc.points_[idx](0) > 0) ||
-            (ref[idx](0) > 0 && pc.points_[idx](0) < 0)) {
-            pc.points_[idx] *= -1;
+        if ((ref[idx](0) < 0 && pc.normals_[idx](0) > 0) ||
+            (ref[idx](0) > 0 && pc.normals_[idx](0) < 0)) {
+            pc.normals_[idx] *= -1;
         }
     }
     ExpectEQ(ref, pc.normals_);
 
     result = pc.EstimateNormals(geometry::KDTreeSearchParamKNN(), false);
     for (int idx = 0; idx < ref.size(); ++idx) {
-        if ((ref[idx](0) < 0 && pc.points_[idx](0) > 0) ||
-            (ref[idx](0) > 0 && pc.points_[idx](0) < 0)) {
-            pc.points_[idx] *= -1;
+        if ((ref[idx](0) < 0 && pc.normals_[idx](0) > 0) ||
+            (ref[idx](0) > 0 && pc.normals_[idx](0) < 0)) {
+            pc.normals_[idx] *= -1;
         }
     }
     ExpectEQ(ref, pc.normals_);


### PR DESCRIPTION
Reverted the eigenvector computation in `EstimateNormals` in `PointCloud` back to `EigenSolver`. This solves the problem in issue #880, and benchmarking results indicate that it is less than 3ms slower for larger point clouds (1e6 points).

Otherwise the `FastEigen3x3` method needs to handle a few special cases. See https://www.geometrictools.com/Documentation/RobustEigenSymmetric3x3.pdf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1011)
<!-- Reviewable:end -->
