### PR TITLE
FileOBJ for TriangleMesh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,7 @@
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
 	branch = master
+[submodule "3rdparty/tinyobjloader"]
+	path = 3rdparty/tinyobjloader
+	url = https://github.com/syoyo/tinyobjloader.git
+	branch = master

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -197,6 +197,19 @@ else ()
     message(SEND_ERROR "TINYFILEDIALOGS dependency not met.")
 endif ()
 
+# tinyobjloader
+message(STATUS "Building tinyobjloader from source")
+include_directories("tinyobjloader/")
+add_library(tinyobjloader STATIC tinyobjloader/tiny_obj_loader.cc)
+if (NOT BUILD_SHARED_LIBS)
+  install(TARGETS tinyobjloader 
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+endif()
+set(tinyobjloader_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/tinyobjloader")
+set(tinyobjloader_LIBRARIES tinyobjloader) 
+
 # rply
 Directories("${CMAKE_CURRENT_SOURCE_DIR}/rply"   rply_INCLUDE_DIRS)
 
@@ -302,6 +315,7 @@ list(APPEND 3RDPARTY_INCLUDE_DIRS
      ${PNG_INCLUDE_DIRS}
      ${rply_INCLUDE_DIRS}
      ${tinyfiledialogs_INCLUDE_DIRS}
+     ${tinyfobjloader_INCLUDE_DIRS}
      ${qhull_INCLUDE_DIRS}
      ${googletest_INCLUDE_DIRS})
 
@@ -330,6 +344,7 @@ list(APPEND 3RDPARTY_LIBRARIES
      ${JSONCPP_LIBRARIES}
      ${PNG_LIBRARIES}
      ${tinyfiledialogs_LIBRARIES}
+     ${tinyobjloader_LIBRARIES}
      ${qhull_LIBRARIES}
      ${googletest_LIBRARIES})
 

--- a/3rdparty/README.txt
+++ b/3rdparty/README.txt
@@ -61,6 +61,10 @@ tinyfiledialogs             2.7.2                                   zlib license
 A lightweight cross-platform file dialog library
 https://sourceforge.net/projects/tinyfiledialogs/
 --------------------------------------------------------------------------------
+tinyobjloader                v1.0.0                                  MIT license
+Tiny but powerful single file wavefront obj loader
+https://github.com/syoyo/tinyobjloader
+--------------------------------------------------------------------------------
 pybind11                    2.2                                      BSD license
 Python binding for C++11
 https://github.com/pybind/pybind11

--- a/docs/tutorial/Basic/file_io.rst
+++ b/docs/tutorial/Basic/file_io.rst
@@ -31,7 +31,7 @@ This script reads and writes a point cloud.
     Testing IO for point cloud ...
     PointCloud with 113662 points.
 
-By default, Open3D tries to infer point cloud file type by extension. Below is
+By default, Open3D tries to infer the file type by the filename extension. Below is
 a list of supported point cloud file types.
 
 ========== =======================================================================================
@@ -78,8 +78,8 @@ Compared to the data structure of point cloud, mesh has triangles that define su
     Testing IO for meshes ...
     TriangleMesh with 1440 points and 2880 triangles.
 
-By default, Open3D tries to infer point cloud file type by extension. Below is
-a list of supported point cloud file types.
+By default, Open3D tries to infer the file type by the filename extension. Below is
+a list of supported triangle mesh file types.
 
 ========== =======================================================================================
 Format     Description

--- a/docs/tutorial/Basic/file_io.rst
+++ b/docs/tutorial/Basic/file_io.rst
@@ -78,6 +78,17 @@ Compared to the data structure of point cloud, mesh has triangles that define su
     Testing IO for meshes ...
     TriangleMesh with 1440 points and 2880 triangles.
 
+By default, Open3D tries to infer point cloud file type by extension. Below is
+a list of supported point cloud file types.
+
+========== =======================================================================================
+Format     Description
+========== =======================================================================================
+``ply``    See `Polygon File Format <http://paulbourke.net/dataformats/ply>`_,
+           the ``ply`` file can contain both point cloud and mesh
+``stl``    See `StereoLithography <http://www.fabbers.com/tech/STL_Format>`_
+``obj``    See `Object Files <http://paulbourke.net/dataformats/obj/>`_
+========== =======================================================================================
 
 .. _io_image:
 

--- a/examples/Python/Basic/mesh_io.py
+++ b/examples/Python/Basic/mesh_io.py
@@ -1,0 +1,61 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+import numpy as np
+import open3d as o3d
+import os
+
+import meshes
+
+if __name__ == "__main__":
+    mesh = meshes.bunny()
+    mesh.remove_unreferenced_vertices()
+    triangles = np.asarray(mesh.triangles)
+    vertices = np.asarray(mesh.vertices)
+    vertex_normals = np.asarray(mesh.vertex_normals)
+    n_vertices = vertices.shape[0]
+    vertex_colors = np.random.uniform(0, 1, size=(n_vertices, 3))
+    mesh.vertex_colors = o3d.utility.Vector3dVector(vertex_colors)
+
+    def test_float_array(array_a, array_b, eps=1e-6):
+        diff = array_a - array_b
+        dist = np.linalg.norm(diff, axis=1)
+        return np.all(dist < eps)
+
+    def test_int_array(array_a, array_b):
+        diff = array_a - array_b
+        return np.all(diff == 0)
+
+    def compare_mesh(mesh):
+        success = True
+        if not test_float_array(vertices, np.asarray(mesh.vertices)):
+            success = False
+            print('[WARNING] vertices are not the same')
+        if not test_float_array(vertex_normals, np.asarray(
+                mesh.vertex_normals)):
+            success = False
+            print('[WARNING] vertex_normals are not the same')
+        if not test_float_array(
+                vertex_colors, np.asarray(mesh.vertex_colors), eps=1e-2):
+            success = False
+            print('[WARNING] vertex_colors are not the same')
+        if not test_int_array(triangles, np.asarray(mesh.triangles)):
+            success = False
+            print('[WARNING] triangles are not the same')
+        if success:
+            print('[INFO] written and read mesh are equal')
+
+    print('Write ply file')
+    o3d.io.write_triangle_mesh('tmp.ply', mesh)
+    print('Read ply file')
+    mesh_test = o3d.io.read_triangle_mesh('tmp.ply')
+    compare_mesh(mesh_test)
+    os.remove('tmp.ply')
+
+    print('Write ply file')
+    o3d.io.write_triangle_mesh('tmp.obj', mesh)
+    print('Read obj file')
+    mesh_test = o3d.io.read_triangle_mesh('tmp.obj')
+    compare_mesh(mesh_test)
+    os.remove('tmp.obj')

--- a/examples/Python/Basic/mesh_io.py
+++ b/examples/Python/Basic/mesh_io.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     compare_mesh(mesh_test)
     os.remove('tmp.ply')
 
-    print('Write ply file')
+    print('Write obj file')
     o3d.io.write_triangle_mesh('tmp.obj', mesh)
     print('Read obj file')
     mesh_test = o3d.io.read_triangle_mesh('tmp.obj')

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
@@ -42,6 +42,7 @@ static const std::unordered_map<
         file_extension_to_trianglemesh_read_function{
                 {"ply", ReadTriangleMeshFromPLY},
                 {"stl", ReadTriangleMeshFromSTL},
+                {"obj", ReadTriangleMeshFromOBJ},
         };
 
 static const std::unordered_map<
@@ -53,6 +54,7 @@ static const std::unordered_map<
         file_extension_to_trianglemesh_write_function{
                 {"ply", WriteTriangleMeshToPLY},
                 {"stl", WriteTriangleMeshToSTL},
+                {"obj", WriteTriangleMeshToOBJ},
         };
 
 }  // unnamed namespace

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.h
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.h
@@ -70,5 +70,13 @@ bool WriteTriangleMeshToSTL(const std::string &filename,
                             bool write_ascii = false,
                             bool compressed = false);
 
+bool ReadTriangleMeshFromOBJ(const std::string &filename,
+                             geometry::TriangleMesh &mesh);
+
+bool WriteTriangleMeshToOBJ(const std::string &filename,
+                            const geometry::TriangleMesh &mesh,
+                            bool write_ascii = false,
+                            bool compressed = false);
+
 }  // namespace io
 }  // namespace open3d

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -48,11 +48,11 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
                                 filename.c_str());
 
     if (!warn.empty()) {
-        utility::PrintWarning("Read OBJ failed: %s\n", warn);
+        utility::PrintWarning("Read OBJ failed: %s\n", warn.c_str());
     }
 
     if (!err.empty()) {
-        utility::PrintError("Read OBJ failed: %s\n", err);
+        utility::PrintError("Read OBJ failed: %s\n", err.c_str());
     }
 
     if (!ret) {

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -123,6 +123,7 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
     if (!all_normals_set) {
         mesh.vertex_normals_.clear();
     }
+    return true;
 }
 
 bool WriteTriangleMeshToOBJ(const std::string& filename,

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -1,0 +1,185 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <fstream>
+#include <numeric>
+#include <vector>
+
+#include "Open3D/IO/ClassIO/TriangleMeshIO.h"
+#include "Open3D/Utility/Console.h"
+
+#define TINYOBJLOADER_IMPLEMENTATION
+#include "tinyobjloader/tiny_obj_loader.h"
+
+namespace open3d {
+namespace io {
+
+bool ReadTriangleMeshFromOBJ(const std::string& filename,
+                             geometry::TriangleMesh& mesh) {
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn;
+    std::string err;
+    bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
+                                filename.c_str());
+
+    if (!warn.empty()) {
+        utility::PrintWarning("Read OBJ failed: %s\n", warn);
+    }
+
+    if (!err.empty()) {
+        utility::PrintError("Read OBJ failed: %s\n", err);
+    }
+
+    if (!ret) {
+        return false;
+    }
+
+    mesh.Clear();
+
+    // copy vertex and vertex_color data
+    for (int vidx = 0; vidx < attrib.vertices.size(); vidx += 3) {
+        tinyobj::real_t vx = attrib.vertices[vidx + 0];
+        tinyobj::real_t vy = attrib.vertices[vidx + 1];
+        tinyobj::real_t vz = attrib.vertices[vidx + 2];
+        mesh.vertices_.push_back(Eigen::Vector3d(vx, vy, vz));
+    }
+    for (int vidx = 0; vidx < attrib.colors.size(); vidx += 3) {
+        tinyobj::real_t r = attrib.colors[vidx + 0];
+        tinyobj::real_t g = attrib.colors[vidx + 1];
+        tinyobj::real_t b = attrib.colors[vidx + 2];
+        mesh.vertex_colors_.push_back(Eigen::Vector3d(r, g, b));
+    }
+
+    // resize normal data and create bool indicator vector
+    mesh.vertex_normals_.resize(mesh.vertices_.size());
+    std::vector<bool> normals_indicator(mesh.vertices_.size(), false);
+
+    // copy face data and copy normals data
+    for (size_t s = 0; s < shapes.size(); s++) {
+        size_t index_offset = 0;
+        for (size_t f = 0; f < shapes[s].mesh.num_face_vertices.size(); f++) {
+            int fv = shapes[s].mesh.num_face_vertices[f];
+            if (fv != 3) {
+                utility::PrintWarning(
+                        "Read OBJ failed: facet with number of vertices not "
+                        "equal to 3\n");
+                return false;
+            }
+
+            Eigen::Vector3i facet;
+            for (size_t v = 0; v < fv; v++) {
+                tinyobj::index_t idx = shapes[s].mesh.indices[index_offset + v];
+                int vidx = idx.vertex_index;
+                facet(v) = vidx;
+
+                if (!normals_indicator[vidx] &&
+                    (3 * idx.normal_index + 2) < attrib.normals.size()) {
+                    tinyobj::real_t nx =
+                            attrib.normals[3 * idx.normal_index + 0];
+                    tinyobj::real_t ny =
+                            attrib.normals[3 * idx.normal_index + 1];
+                    tinyobj::real_t nz =
+                            attrib.normals[3 * idx.normal_index + 2];
+                    mesh.vertex_normals_[vidx](0) = nx;
+                    mesh.vertex_normals_[vidx](1) = ny;
+                    mesh.vertex_normals_[vidx](2) = nz;
+                    normals_indicator[vidx] = true;
+                }
+            }
+            mesh.triangles_.push_back(facet);
+            index_offset += fv;
+        }
+    }
+
+    // if not all normals have been set, then remove the vertex normals
+    bool all_normals_set =
+            std::accumulate(normals_indicator.begin(), normals_indicator.end(),
+                            true, [](bool a, bool b) { return a && b; });
+    if (!all_normals_set) {
+        mesh.vertex_normals_.clear();
+    }
+}
+
+bool WriteTriangleMeshToOBJ(const std::string& filename,
+                            const geometry::TriangleMesh& mesh,
+                            bool write_ascii /* = false*/,
+                            bool compressed /* = false*/) {
+    std::ofstream file(filename.c_str(), std::ios::out | std::ios::binary);
+
+    if (!file) {
+        utility::PrintWarning("Write OBJ failed: unable to open file.\n");
+        return false;
+    }
+
+    if (mesh.HasTriangleNormals()) {
+        utility::PrintWarning("Write OBJ can not include triangle normals.\n");
+    }
+
+    file << "# Created by Open3D \n";
+    file << "# number of vertices: " << mesh.vertices_.size() << "\n";
+    file << "# number of triangles: " << mesh.triangles_.size() << "\n";
+    utility::ResetConsoleProgress(
+            mesh.vertices_.size() + mesh.triangles_.size(), "Writing OBJ: ");
+    bool has_vertex_normals = mesh.HasVertexNormals();
+    bool has_vertex_colors = mesh.HasVertexColors();
+    for (int vidx = 0; vidx < mesh.vertices_.size(); ++vidx) {
+        const Eigen::Vector3d& vertex = mesh.vertices_[vidx];
+        file << "v " << vertex(0) << " " << vertex(1) << " " << vertex(2);
+        if (has_vertex_colors) {
+            const Eigen::Vector3d& color = mesh.vertex_colors_[vidx];
+            file << " " << color(0) << " " << color(1) << " " << color(2);
+        }
+        file << "\n";
+
+        if (has_vertex_normals) {
+            const Eigen::Vector3d& normal = mesh.vertex_normals_[vidx];
+            file << "vn " << normal(0) << " " << normal(1) << " " << normal(2)
+                 << "\n";
+        }
+
+        utility::AdvanceConsoleProgress();
+    }
+
+    for (int tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
+        const Eigen::Vector3i& triangle = mesh.triangles_[tidx];
+        if (has_vertex_normals) {
+            file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1 << " "
+                 << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
+                 << triangle(2) + 1 << "//" << triangle(2) + 1 << "\n";
+        } else {
+            file << "f " << triangle(0) + 1 << " " << triangle(1) + 1 << " "
+                 << triangle(2) + 1 << "\n";
+        }
+        utility::AdvanceConsoleProgress();
+    }
+
+    return true;
+}
+
+}  // namespace io
+}  // namespace open3d


### PR DESCRIPTION
Added IO support for obj (http://paulbourke.net/dataformats/obj/) file types. This is based on the `tinyobjloader` library added as submodule. Note that we only support vertex, vertex normals and vertex colors at the moment and no textures, or materials. This addresses issue #772 

I further added the supported mesh types for IO to the documentation. This addresses issue #1019

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1021)
<!-- Reviewable:end -->
