### PR TITLE
Added option to remove NaN points in ReadPointCloud

### DIFF
--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -184,7 +184,7 @@ PointCloud &PointCloud::RemoveNanPoints() {
     for (size_t i = 0; i < old_point_num; i++) {  // old index
         if (std::isnan(points_[i](0)) == false &&
             std::isnan(points_[i](1)) == false &&
-            std::isnan(points_[i](0)) == false) {
+            std::isnan(points_[i](2)) == false) {
             points_[k] = points_[i];
             if (has_normal) normals_[k] = normals_[i];
             if (has_color) colors_[k] = colors_[i];

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -196,6 +196,7 @@ PointCloud &PointCloud::RemoveNanPoints() {
     if (has_color) colors_.resize(k);
     utility::PrintDebug("[Purge] %d nan points have been removed.\n",
                         (int)(old_point_num - k));
+    return *this;
 }
 
 std::tuple<Eigen::Vector3d, Eigen::Matrix3d>

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -176,15 +176,20 @@ std::vector<double> PointCloud::ComputePointCloudDistance(
     return distances;
 }
 
-PointCloud &PointCloud::RemoveNanPoints() {
+PointCloud &PointCloud::RemoveNoneFinitePoints(bool remove_nan,
+                                               bool remove_infinite) {
     bool has_normal = HasNormals();
     bool has_color = HasColors();
     size_t old_point_num = points_.size();
     size_t k = 0;                                 // new index
     for (size_t i = 0; i < old_point_num; i++) {  // old index
-        if (std::isnan(points_[i](0)) == false &&
-            std::isnan(points_[i](1)) == false &&
-            std::isnan(points_[i](2)) == false) {
+        bool is_nan = remove_nan &&
+                      (std::isnan(points_[i](0)) || std::isnan(points_[i](1)) ||
+                       std::isnan(points_[i](2)));
+        bool is_infinite = remove_infinite && (std::isinf(points_[i](0)) ||
+                                               std::isinf(points_[i](1)) ||
+                                               std::isinf(points_[i](2)));
+        if (!is_nan && !is_infinite) {
             points_[k] = points_[i];
             if (has_normal) normals_[k] = normals_[i];
             if (has_color) colors_[k] = colors_[i];

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -176,6 +176,28 @@ std::vector<double> PointCloud::ComputePointCloudDistance(
     return distances;
 }
 
+PointCloud &PointCloud::RemoveNanPoints() {
+    bool has_normal = HasNormals();
+    bool has_color = HasColors();
+    size_t old_point_num = points_.size();
+    size_t k = 0;                                 // new index
+    for (size_t i = 0; i < old_point_num; i++) {  // old index
+        if (std::isnan(points_[i](0)) == false &&
+            std::isnan(points_[i](1)) == false &&
+            std::isnan(points_[i](0)) == false) {
+            points_[k] = points_[i];
+            if (has_normal) normals_[k] = normals_[i];
+            if (has_color) colors_[k] = colors_[i];
+            k++;
+        }
+    }
+    points_.resize(k);
+    if (has_normal) normals_.resize(k);
+    if (has_color) colors_.resize(k);
+    utility::PrintDebug("[Purge] %d nan points have been removed.\n",
+                        (int)(old_point_num - k));
+}
+
 std::tuple<Eigen::Vector3d, Eigen::Matrix3d>
 PointCloud::ComputeMeanAndCovariance() const {
     if (IsEmpty()) {

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -92,6 +92,10 @@ public:
         return *this;
     }
 
+    /// Remove all points fromt he point cloud that have a nan entry
+    /// also removes the corresponding normals and color entries
+    PointCloud &RemoveNanPoints();
+
     /// Function to select points from \param input pointcloud into
     /// \return output pointcloud
     /// Points with indices in \param indices are selected.

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -92,9 +92,11 @@ public:
         return *this;
     }
 
-    /// Remove all points fromt he point cloud that have a nan entry
-    /// also removes the corresponding normals and color entries
-    PointCloud &RemoveNanPoints();
+    /// Remove all points fromt he point cloud that have a nan entry, or
+    /// infinite entries.
+    /// Also removes the corresponding normals and color entries.
+    PointCloud &RemoveNoneFinitePoints(bool remove_nan = true,
+                                       bool remove_infinite = true);
 
     /// Function to select points from \param input pointcloud into
     /// \return output pointcloud

--- a/src/Open3D/IO/ClassIO/PointCloudIO.cpp
+++ b/src/Open3D/IO/ClassIO/PointCloudIO.cpp
@@ -75,7 +75,8 @@ std::shared_ptr<geometry::PointCloud> CreatePointCloudFromFile(
 bool ReadPointCloud(const std::string &filename,
                     geometry::PointCloud &pointcloud,
                     const std::string &format,
-                    bool remove_nan_points) {
+                    bool remove_nan_points,
+                    bool remove_infinite_points) {
     std::string filename_ext;
     if (format == "auto") {
         filename_ext =
@@ -99,7 +100,8 @@ bool ReadPointCloud(const std::string &filename,
     utility::PrintDebug("Read geometry::PointCloud: %d vertices.\n",
                         (int)pointcloud.points_.size());
     if (remove_nan_points) {
-        pointcloud.RemoveNanPoints();
+        pointcloud.RemoveNoneFinitePoints(remove_nan_points,
+                                          remove_infinite_points);
     }
     return success;
 }

--- a/src/Open3D/IO/ClassIO/PointCloudIO.cpp
+++ b/src/Open3D/IO/ClassIO/PointCloudIO.cpp
@@ -74,7 +74,8 @@ std::shared_ptr<geometry::PointCloud> CreatePointCloudFromFile(
 
 bool ReadPointCloud(const std::string &filename,
                     geometry::PointCloud &pointcloud,
-                    const std::string &format) {
+                    const std::string &format,
+                    bool remove_nan_points) {
     std::string filename_ext;
     if (format == "auto") {
         filename_ext =
@@ -97,6 +98,9 @@ bool ReadPointCloud(const std::string &filename,
     bool success = map_itr->second(filename, pointcloud);
     utility::PrintDebug("Read geometry::PointCloud: %d vertices.\n",
                         (int)pointcloud.points_.size());
+    if (remove_nan_points) {
+        pointcloud.RemoveNanPoints();
+    }
     return success;
 }
 

--- a/src/Open3D/IO/ClassIO/PointCloudIO.h
+++ b/src/Open3D/IO/ClassIO/PointCloudIO.h
@@ -44,7 +44,8 @@ std::shared_ptr<geometry::PointCloud> CreatePointCloudFromFile(
 bool ReadPointCloud(const std::string &filename,
                     geometry::PointCloud &pointcloud,
                     const std::string &format = "auto",
-                    bool remove_nan_points = true);
+                    bool remove_nan_points = true,
+                    bool remove_infinite_points = true);
 
 /// The general entrance for writing a PointCloud to a file
 /// The function calls write functions based on the extension name of filename.

--- a/src/Open3D/IO/ClassIO/PointCloudIO.h
+++ b/src/Open3D/IO/ClassIO/PointCloudIO.h
@@ -43,7 +43,8 @@ std::shared_ptr<geometry::PointCloud> CreatePointCloudFromFile(
 /// \return return true if the read function is successful, false otherwise.
 bool ReadPointCloud(const std::string &filename,
                     geometry::PointCloud &pointcloud,
-                    const std::string &format = "auto");
+                    const std::string &format = "auto",
+                    bool remove_nan_points = true);
 
 /// The general entrance for writing a PointCloud to a file
 /// The function calls write functions based on the extension name of filename.

--- a/src/Open3D/IO/FileFormat/FilePCD.cpp
+++ b/src/Open3D/IO/FileFormat/FilePCD.cpp
@@ -517,28 +517,6 @@ bool ReadPCDData(FILE *file,
     return true;
 }
 
-void RemoveNanData(geometry::PointCloud &pointcloud) {
-    bool has_normal = pointcloud.HasNormals();
-    bool has_color = pointcloud.HasColors();
-    size_t old_point_num = pointcloud.points_.size();
-    size_t k = 0;                                 // new index
-    for (size_t i = 0; i < old_point_num; i++) {  // old index
-        if (std::isnan(pointcloud.points_[i](0)) == false &&
-            std::isnan(pointcloud.points_[i](1)) == false &&
-            std::isnan(pointcloud.points_[i](0)) == false) {
-            pointcloud.points_[k] = pointcloud.points_[i];
-            if (has_normal) pointcloud.normals_[k] = pointcloud.normals_[i];
-            if (has_color) pointcloud.colors_[k] = pointcloud.colors_[i];
-            k++;
-        }
-    }
-    pointcloud.points_.resize(k);
-    if (has_normal) pointcloud.normals_.resize(k);
-    if (has_color) pointcloud.colors_.resize(k);
-    utility::PrintDebug("[Purge] %d nan points have been removed.\n",
-                        (int)(old_point_num - k));
-}
-
 bool GenerateHeader(const geometry::PointCloud &pointcloud,
                     const bool write_ascii,
                     const bool compressed,
@@ -764,8 +742,6 @@ bool ReadPointCloudFromPCD(const std::string &filename,
         return false;
     }
     fclose(file);
-    // Some PCD files include nan floating numbers. They should be removed.
-    RemoveNanData(pointcloud);
     return true;
 }
 

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -92,6 +92,10 @@ void pybind_pointcloud(py::module &m) {
             .def("crop", &geometry::PointCloud::Crop,
                  "Function to crop input pointcloud into output pointcloud",
                  "min_bound"_a, "max_bound"_a)
+            .def("remove_none_finite_points",
+                 &geometry::PointCloud::RemoveNoneFinitePoints,
+                 "Function to remove none-finite points from the PointCloud",
+                 "remove_nan"_a = true, "remove_infinite"_a = true)
             .def("remove_radius_outlier",
                  &geometry::PointCloud::RemoveRadiusOutliers,
                  "Function to remove points that have less than nb_points"
@@ -210,6 +214,11 @@ void pybind_pointcloud(py::module &m) {
             m, "PointCloud", "crop",
             {{"min_bound", "Minimum bound for point coordinate"},
              {"max_bound", "Maximum bound for point coordinate"}});
+    docstring::ClassMethodDocInject(
+            m, "PointCloud", "remove_none_finite_points",
+            {{"remove_nan", "Remove NaN values from the PointCloud"},
+             {"remove_infinite",
+              "Remove infinite values from the PointCloud"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "remove_radius_outlier",
             {{"nb_points", "Number of points within the radius."},

--- a/src/Python/io/io.cpp
+++ b/src/Python/io/io.cpp
@@ -54,6 +54,9 @@ static const std::unordered_map<std::string, std::string>
                 {"format",
                  "The format of the input file. When not specified or set as "
                  "``auto``, the format is inferred from file extension name."},
+                {"remove_nan_points",
+                 "If true, the all points that include a NaN are removed from "
+                 "the PointCloud."},
                 {"quality", "Quality of the output file."},
                 {"write_ascii",
                  "Set to ``True`` to output in ascii format, otherwise binary "
@@ -123,13 +126,14 @@ void pybind_io(py::module &m) {
 
     // open3d::geometry::PointCloud
     m_io.def("read_point_cloud",
-             [](const std::string &filename, const std::string &format) {
+             [](const std::string &filename, const std::string &format,
+                bool remove_nan_points) {
                  geometry::PointCloud pcd;
-                 io::ReadPointCloud(filename, pcd, format);
+                 io::ReadPointCloud(filename, pcd, format, remove_nan_points);
                  return pcd;
              },
              "Function to read PointCloud from file", "filename"_a,
-             "format"_a = "auto");
+             "format"_a = "auto", "remove_nan_points"_a = true);
     docstring::FunctionDocInject(m_io, "read_point_cloud",
                                  map_shared_argument_docstrings);
 

--- a/src/Python/io/io.cpp
+++ b/src/Python/io/io.cpp
@@ -57,6 +57,9 @@ static const std::unordered_map<std::string, std::string>
                 {"remove_nan_points",
                  "If true, all points that include a NaN are removed from "
                  "the PointCloud."},
+                {"remove_infinite_points",
+                 "If true, all points that include an infinite value are "
+                 "removed from the PointCloud."},
                 {"quality", "Quality of the output file."},
                 {"write_ascii",
                  "Set to ``True`` to output in ascii format, otherwise binary "
@@ -127,13 +130,15 @@ void pybind_io(py::module &m) {
     // open3d::geometry::PointCloud
     m_io.def("read_point_cloud",
              [](const std::string &filename, const std::string &format,
-                bool remove_nan_points) {
+                bool remove_nan_points, bool remove_infinite_points) {
                  geometry::PointCloud pcd;
-                 io::ReadPointCloud(filename, pcd, format, remove_nan_points);
+                 io::ReadPointCloud(filename, pcd, format, remove_nan_points,
+                                    remove_infinite_points);
                  return pcd;
              },
              "Function to read PointCloud from file", "filename"_a,
-             "format"_a = "auto", "remove_nan_points"_a = true);
+             "format"_a = "auto", "remove_nan_points"_a = true,
+             "remove_infinite_points"_a = true);
     docstring::FunctionDocInject(m_io, "read_point_cloud",
                                  map_shared_argument_docstrings);
 

--- a/src/Python/io/io.cpp
+++ b/src/Python/io/io.cpp
@@ -55,7 +55,7 @@ static const std::unordered_map<std::string, std::string>
                  "The format of the input file. When not specified or set as "
                  "``auto``, the format is inferred from file extension name."},
                 {"remove_nan_points",
-                 "If true, the all points that include a NaN are removed from "
+                 "If true, all points that include a NaN are removed from "
                  "the PointCloud."},
                 {"quality", "Quality of the output file."},
                 {"write_ascii",


### PR DESCRIPTION
This addresses issue #1016. I added a parameter to control if NaNs should be removed after reading a `PointCloud`, or not. The default is set to `true`, such that the function is backwards compatible. 

Note that this fixes also a subtle bug in the `RemoveNaN` function that has so far been unnoticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1022)
<!-- Reviewable:end -->
