### PR TITLE
Removed unary_function from hash_eigen

### DIFF
--- a/src/Open3D/Utility/Helper.h
+++ b/src/Open3D/Utility/Helper.h
@@ -87,7 +87,7 @@ struct hash<std::tuple<TT...>> {
 namespace hash_eigen {
 
 template <typename T>
-struct hash : std::unary_function<T, size_t> {
+struct hash {
     std::size_t operator()(T const& matrix) const {
         size_t seed = 0;
         for (int i = 0; i < (int)matrix.size(); i++) {


### PR DESCRIPTION
Addressing issue #934 by removing the inheritance from `unary_function` in `hash_eigen`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1023)
<!-- Reviewable:end -->
