### PR TITLE
Added Documentation to build docs

### DIFF
--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -1,0 +1,68 @@
+.. _builddocs:
+
+Building Documentation
+=====================
+
+You can build the documentation of Open3D and contribute to the documentation process.
+
+**Prerequisites:**
+
+Make sure you have cloned the repository and have built both the C++ and Python documentation from source.
+Visit `compiling from source <http://www.open3d.org/docs/compilation.html>`_ on how to build the source code.
+
+Documentation:
+``````````````
+
+The python documentation is written in
+`reStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ and compiled
+with `sphinx <http://www.sphinx-doc.org/>`_.
+
+Documentation for C++ API is made with `Doxygen <http://www.doxygen.nl/>`_
+
+
+
+Installing Sphinx
+`````````````````
+
+.. tip:: Make sure you have pip installed. You can check by typing the 'pip' command in the terminal.
+
+.. code-block:: bash
+
+    pip install sphinx sphinx-autobuild sphinx-rtd-theme
+
+Installing Doxygen
+``````````````````
+
+**Ubuntu:**
+
+.. code-block:: bash
+
+	sudo apt-get -y install doxygen
+
+**Windows:**
+
+Visit `Doxygen downloads <http://www.doxygen.nl/download.html>`_ page to checkout the source or binaries.
+You can download the latest binaries `here <https://sourceforge.net/projects/doxygen/files/snapshots/>`_.
+
+.. tip:: Make sure you have Python x86 installed as the current version of doxygen has issues with x64
+
+Make sure you have a version of GNU Windows installed to perform the 'make' command in windows
+
+Building the Documentation
+``````````````````````````
+
+In your Open3D sourcedirectory goto ``docs`` and run: 
+
+.. code-block:: bash
+
+    make html
+
+Builds the python docs present at `Open3D <http://www.open3d.org/docs>`_
+
+.. code-block:: bash
+
+    doxygen doxyfile
+
+Builds the C++ docs present at `Open3D C++ API <http://open3d.org/cppapi/index.html>`_
+
+The documentation is built on CI with `make documentation <https://github.com/intel-isl/Open3D/blob/master/util/scripts/make-documentation.sh>`_

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -13,7 +13,7 @@ Visit `compiling from source <http://www.open3d.org/docs/compilation.html>`_ on 
 Documentation:
 ``````````````
 
-The python documentation is written in
+The Python documentation is written in
 `reStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ and compiled
 with `sphinx <http://www.sphinx-doc.org/>`_.
 
@@ -46,18 +46,19 @@ You can download the latest binaries `here <https://sourceforge.net/projects/dox
 
 .. tip:: Make sure you have Python x86 installed as the current version of doxygen has issues with x64
 
-Make sure you have a version of GNU Windows installed to perform the 'make' command in windows
+Make sure you have a version of `GNU Windows <http://gnuwin32.sourceforge.net/>`_ installed to perform the 'make' command in windows.
+You can download make for windows `here <http://gnuwin32.sourceforge.net/packages/make.htm>`_
 
 Building the Documentation
 ``````````````````````````
 
-In your Open3D sourcedirectory goto ``docs`` and run: 
+In your Open3D source directory goto ``docs`` and run: 
 
 .. code-block:: bash
 
     make html
 
-Builds the python docs present at `Open3D <http://www.open3d.org/docs>`_
+Builds the Python docs present at `Open3D <http://www.open3d.org/docs>`_
 
 .. code-block:: bash
 
@@ -65,4 +66,4 @@ Builds the python docs present at `Open3D <http://www.open3d.org/docs>`_
 
 Builds the C++ docs present at `Open3D C++ API <http://open3d.org/cppapi/index.html>`_
 
-The documentation is built on CI with `make documentation <https://github.com/intel-isl/Open3D/blob/master/util/scripts/make-documentation.sh>`_
+The documentation is built on CI with `make documentation script <https://github.com/intel-isl/Open3D/blob/master/util/scripts/make-documentation.sh>`_

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -1,7 +1,7 @@
 .. _builddocs:
 
 Building Documentation
-=====================
+======================
 
 You can build the documentation of Open3D and contribute to the documentation process.
 
@@ -20,7 +20,6 @@ with `sphinx <http://www.sphinx-doc.org/>`_.
 Documentation for C++ API is made with `Doxygen <http://www.doxygen.nl/>`_
 
 
-
 Installing Sphinx
 `````````````````
 
@@ -37,33 +36,41 @@ Installing Doxygen
 
 .. code-block:: bash
 
-	sudo apt-get -y install doxygen
+    sudo apt-get -y install doxygen
 
 **Windows:**
 
 Visit `Doxygen downloads <http://www.doxygen.nl/download.html>`_ page to checkout the source or binaries.
-You can download the latest binaries `here <https://sourceforge.net/projects/doxygen/files/snapshots/>`_.
+You can download the latest `binaries <https://sourceforge.net/projects/doxygen/files/snapshots/>`_.
 
 .. tip:: Make sure you have Python x86 installed as the current version of doxygen has issues with x64
 
-Make sure you have a version of `GNU Windows <http://gnuwin32.sourceforge.net/>`_ installed to perform the 'make' command in windows.
-You can download make for windows `here <http://gnuwin32.sourceforge.net/packages/make.htm>`_
+You can install a version of `GNU Windows <http://gnuwin32.sourceforge.net/>`_ to perform the 'make html' command in Windows.
+You can download make for Windows `here <http://gnuwin32.sourceforge.net/packages/make.htm>`_
+
+Alternatively you can simply use 'python make.py html' command to build if you don't have GNU Windows installed.
 
 Building the Documentation
 ``````````````````````````
 
-In your Open3D source directory goto ``docs`` and run: 
+In your Open3D source directory goto ``docs``
+
+To build the Python documentation present at `Open3D <http://www.open3d.org/docs>`_:
 
 .. code-block:: bash
 
     make html
 
-Builds the Python docs present at `Open3D <http://www.open3d.org/docs>`_
+Or if you are using Windows without GNU Windows installed
+
+.. code-block:: bash
+
+    python make.py html
+
+To build the C++ documentation present at `Open3D C++ API <http://open3d.org/cppapi/index.html>`_:
 
 .. code-block:: bash
 
     doxygen doxyfile
-
-Builds the C++ docs present at `Open3D C++ API <http://open3d.org/cppapi/index.html>`_
 
 The documentation is built on CI with `make documentation script <https://github.com/intel-isl/Open3D/blob/master/util/scripts/make-documentation.sh>`_

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -425,23 +425,3 @@ reference.
     cmake -DBUILD_UNIT_TESTS=ON ..
     make -j
     ./bin/unitTests
-
-Documentation
-`````````````
-
-Documentation is written in
-`reStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ and compiled
-with `sphinx <http://www.sphinx-doc.org/>`_. From ``docs`` folder, run
-
-.. code-block:: bash
-
-    pip install sphinx sphinx-autobuild sphinx-rtd-theme
-    make html
-
-Documentation for C++ API is made with `Doxygen <http://www.stack.nl/~dimitri/doxygen/>`_.
-Follow the `Doxygen installation instruction <http://www.stack.nl/~dimitri/doxygen/manual/install.html>`_.
-From Open3D ``docs`` folder, run
-
-.. code-block:: bash
-
-    doxygen Doxyfile

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Open3D: A Modern Library for 3D Data Processing
     getting_started
     compilation
     contribute
+    builddocs
 
 .. _tutorial_index:
 


### PR DESCRIPTION
Created a separate page for documentation on how to build the docs in line with GSoD. I'll add more documentation later on such as editing .rst files and working with the C++ API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1036)
<!-- Reviewable:end -->
