### PR TITLE
Check for mesh normals before saving STL file

### DIFF
--- a/src/Open3D/IO/FileFormat/FileSTL.cpp
+++ b/src/Open3D/IO/FileFormat/FileSTL.cpp
@@ -106,6 +106,11 @@ bool WriteTriangleMeshToSTL(const std::string &filename,
         return false;
     }
 
+    if (!mesh.HasVertexNormals() && !mesh.HasTriangleNormals()) {
+        utility::PrintWarning("Write STL failed: compute normals first.\n");
+        return false;
+    }
+
     size_t num_of_triangles = mesh.triangles_.size();
     if (num_of_triangles == 0) {
         utility::PrintWarning("Write STL failed: empty file.\n");

--- a/src/Open3D/IO/FileFormat/FileSTL.cpp
+++ b/src/Open3D/IO/FileFormat/FileSTL.cpp
@@ -106,7 +106,7 @@ bool WriteTriangleMeshToSTL(const std::string &filename,
         return false;
     }
 
-    if (!mesh.HasVertexNormals() && !mesh.HasTriangleNormals()) {
+    if (!mesh.HasTriangleNormals()) {
         utility::PrintWarning("Write STL failed: compute normals first.\n");
         return false;
     }


### PR DESCRIPTION
This PR addresses the following bug:
Reading a mesh without normals specified (e.g. "knot.ply" in TestData) and saving to .stl causes a segmentation fault. However, the mesh seems to be correctly saved if either `mesh.compute_vertex_normals()` or `mesh.compute_triangle_normals()` is done first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1041)
<!-- Reviewable:end -->
