### PR TITLE
CMake, Registry, Tensor and Array for CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,20 @@ option(BUILD_TINYFILEDIALOGS     "Build tinyfiledialogs from source"        ON)
 option(BUILD_QHULL               "Build qhull from source"                  ON)
 option(ENABLE_JUPYTER            "Enable Jupyter support for Open3D"        ON)
 option(STATIC_WINDOWS_RUNTIME    "Use static (MT/MTd) Windows runtime"      OFF)
+option(BUILD_CUDA_MODULE         "Build the CUDA module"                    ON)
+
+# Build CUDA module by defalt if CUDA is available
+if (BUILD_CUDA_MODULE)
+    find_package(CUDA 8.0)
+    if (CUDA_FOUND)
+        message(STATUS "Building CUDA enabled")
+    else()
+        set(BUILD_CUDA_MODULE OFF)
+        message(STATUS "Building CUDA disabled")
+    endif()
+else ()
+    message(STATUS "Building CUDA disabled")
+endif ()
 
 # default built type
 if (NOT CMAKE_BUILD_TYPE)

--- a/src/Open3D/CMakeLists.txt
+++ b/src/Open3D/CMakeLists.txt
@@ -7,6 +7,7 @@ configure_file("${PROJECT_SOURCE_DIR}/src/Open3D/Open3DConfig.h.in"
 # Subdirectories
 add_subdirectory(Camera)
 add_subdirectory(ColorMap)
+add_subdirectory(Container)
 add_subdirectory(Geometry)
 add_subdirectory(Integration)
 add_subdirectory(Odometry)
@@ -18,6 +19,7 @@ add_subdirectory(Visualization)
 # Source group for Visual Studio
 ADD_SOURCE_GROUP(Camera)
 ADD_SOURCE_GROUP(ColorMap)
+ADD_SOURCE_GROUP(Container)
 ADD_SOURCE_GROUP(Geometry)
 ADD_SOURCE_GROUP(Integration)
 ADD_SOURCE_GROUP(Odometry)
@@ -37,7 +39,6 @@ install(DIRECTORY   "${CMAKE_CURRENT_SOURCE_DIR}"
 # note: adding at least one real source file to any target that references
 # reference: https://cmake.org/cmake/help/v3.12/command/add_library.html#object-libraries
 add_library(${CMAKE_PROJECT_NAME}
-    Open3DConfig.h
     Open3DConfig.cpp
     $<TARGET_OBJECTS:Camera>
     $<TARGET_OBJECTS:ColorMap>
@@ -61,9 +62,20 @@ else ()
     target_link_libraries(${CMAKE_PROJECT_NAME} ${OPENGL_LIBRARIES})
 endif ()
 
+# Use whole-archive to support static registration
+# TODO: handle Windows
+if(APPLE)
+    set(ENABLE_WHOLE_ARCHIVE -Wl,-force_load)
+    set(DISABLE_WHOLE_ARCHIVE "") # -noall_load is obsolete
+else()
+    set(ENABLE_WHOLE_ARCHIVE -Wl,--whole-archive)
+    set(DISABLE_WHOLE_ARCHIVE -Wl,--no-whole-archive)
+endif()
+
 target_link_libraries(${CMAKE_PROJECT_NAME}
                       ${3RDPARTY_LIBRARIES}
-                      ${OMP_LIBRARIES})
+                      ${OMP_LIBRARIES}
+                      ${ENABLE_WHOLE_ARCHIVE} Container ${DISABLE_WHOLE_ARCHIVE})
 
 # input_dirs: a list of absolute paths in the source dir
 # output_dirs: a list of relative paths in the install dir

--- a/src/Open3D/Container/CMakeLists.txt
+++ b/src/Open3D/Container/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Build
+
+# Common source code shared by CUDA and host
+set (SRC_CPU
+    MemoryManager.cpp
+    MemoryManagerCPU.cpp
+)
+
+# Additional source code for when CUDA is enabled
+set (SRC_GPU
+    MemoryManagerGPU.cpp
+)
+
+# Create object library
+if (BUILD_CUDA_MODULE)
+    add_definitions(-DBUILD_CUDA_MODULE)
+    cuda_add_library(Container ${SRC_CPU} ${SRC_GPU})
+    target_include_directories(Container PUBLIC ${CUDA_INCLUDE_DIRS})
+else()
+    add_library(Container ${SRC_CPU})
+endif()

--- a/src/Open3D/Container/MemoryManager.cpp
+++ b/src/Open3D/Container/MemoryManager.cpp
@@ -1,0 +1,89 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Container/MemoryManager.h"
+
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+
+OPEN3D_DEFINE_REGISTRY_FOR_SINGLETON(MemoryManagerBackendRegistry,
+                                     std::shared_ptr<MemoryManagerBackend>);
+
+std::shared_ptr<MemoryManagerBackend> MemoryManager::GetImpl(
+        const std::string& device) {
+    if (MemoryManagerBackendRegistry()->Has(device)) {
+        return MemoryManagerBackendRegistry()->GetSingletonObject(device);
+    } else {
+        throw std::runtime_error("Cannot get MemoryManager impl for " + device);
+    }
+}
+
+void* MemoryManager::Allocate(size_t byte_size, const std::string& device) {
+    return GetImpl(device)->Allocate(byte_size);
+}
+
+// TODO: consider removing the "device" argument, check ptr device first
+void MemoryManager::Free(void* ptr) {
+    if (ptr) {
+        if (IsCUDAPointer(ptr)) {
+            GetImpl("gpu")->Free(ptr);
+        } else {
+            GetImpl("cpu")->Free(ptr);
+        }
+    }
+}
+
+void MemoryManager::CopyTo(void* dst_ptr,
+                           const void* src_ptr,
+                           std::size_t num_bytes) {
+    if (dst_ptr == nullptr || src_ptr == nullptr) {
+        throw std::runtime_error("CopyTo: nullptr detected");
+    }
+    std::string dst_device = IsCUDAPointer(dst_ptr) ? "gpu" : "cpu";
+    std::string src_device = IsCUDAPointer(src_ptr) ? "gpu" : "cpu";
+
+    if (src_device == "gpu" || dst_device == "gpu") {
+        GetImpl("gpu")->CopyTo(dst_ptr, src_ptr, num_bytes);
+    } else {
+        GetImpl("cpu")->CopyTo(dst_ptr, src_ptr, num_bytes);
+    }
+}
+
+bool MemoryManager::IsCUDAPointer(const void* ptr) {
+    if (MemoryManagerBackendRegistry()->Has("gpu")) {
+        return GetImpl("gpu")->IsCUDAPointer(ptr);
+    } else {
+        return GetImpl("cpu")->IsCUDAPointer(ptr);
+    }
+}
+
+}  // namespace open3d

--- a/src/Open3D/Container/MemoryManager.h
+++ b/src/Open3D/Container/MemoryManager.h
@@ -1,0 +1,70 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "Open3D/Registry.h"
+
+namespace open3d {
+
+// Base class for MemoryManagerCPU and MemoryManagerGPU
+// This can futher be extened to a stateful memory manager (e.g memory pool)
+class MemoryManagerBackend {
+public:
+    virtual void* Allocate(size_t byte_size) = 0;
+    virtual void Free(void* ptr) = 0;
+    virtual void CopyTo(void* dst_ptr,
+                        const void* src_ptr,
+                        std::size_t num_bytes) = 0;
+    virtual bool IsCUDAPointer(const void* ptr) = 0;
+};
+
+OPEN3D_DECLARE_REGISTRY_FOR_SINGLETON(MemoryManagerBackendRegistry,
+                                      std::shared_ptr<MemoryManagerBackend>);
+
+// MemoryManager external API
+// MemoryManager is stateless (static functions), except for the registry
+class MemoryManager {
+public:
+    static void* Allocate(size_t byte_size, const std::string& device);
+    static void Free(void* ptr);
+    static void CopyTo(void* dst_ptr,
+                       const void* src_ptr,
+                       std::size_t num_bytes);
+    static bool IsCUDAPointer(const void* ptr);
+
+protected:
+    static std::shared_ptr<MemoryManagerBackend> GetImpl(
+            const std::string& device);
+};
+
+}  // namespace open3d

--- a/src/Open3D/Container/MemoryManagerCPU.cpp
+++ b/src/Open3D/Container/MemoryManagerCPU.cpp
@@ -1,0 +1,62 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Container/MemoryManagerCPU.h"
+#include "Open3D/Registry.h"
+
+namespace open3d {
+
+void* MemoryManagerCPU::Allocate(size_t byte_size) {
+    void* ptr = malloc(byte_size);
+    if (byte_size != 0 && !ptr) {
+        std::runtime_error("CPU malloc failed");
+        throw std::bad_alloc();
+    }
+    return ptr;
+}
+
+void MemoryManagerCPU::Free(void* ptr) {
+    if (ptr) {
+        free(ptr);
+    }
+}
+
+void MemoryManagerCPU::CopyTo(void* dst_ptr,
+                              const void* src_ptr,
+                              std::size_t num_bytes) {
+    if (dst_ptr == nullptr || src_ptr == nullptr) {
+        throw std::runtime_error("CopyTo: nullptr detected");
+    }
+    std::memcpy(dst_ptr, src_ptr, num_bytes);
+}
+
+bool MemoryManagerCPU::IsCUDAPointer(const void* ptr) { return false; }
+
+OPEN3D_REGISTER_SINGLETON_OBJECT(MemoryManagerBackendRegistry,
+                                 "cpu",
+                                 std::make_shared<MemoryManagerCPU>());
+
+}  // namespace open3d

--- a/src/Open3D/Container/MemoryManagerCPU.h
+++ b/src/Open3D/Container/MemoryManagerCPU.h
@@ -1,0 +1,43 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "Open3D/Container/MemoryManager.h"
+
+namespace open3d {
+
+class MemoryManagerCPU : public MemoryManagerBackend {
+public:
+    void* Allocate(size_t byte_size) final;
+    void Free(void* ptr) final;
+    void CopyTo(void* dst_ptr,
+                const void* src_ptr,
+                std::size_t num_bytes) final;
+    bool IsCUDAPointer(const void* ptr) final;
+};
+
+}  // namespace open3d

--- a/src/Open3D/Container/MemoryManagerGPU.cpp
+++ b/src/Open3D/Container/MemoryManagerGPU.cpp
@@ -1,0 +1,84 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Container/MemoryManagerGPU.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace open3d {
+
+void* MemoryManagerGPU::Allocate(size_t byte_size) {
+    void* ptr;
+    cudaMalloc(static_cast<void**>(&ptr), byte_size);
+    return ptr;
+}
+
+void MemoryManagerGPU::Free(void* ptr) {
+    if (ptr) {
+        if (IsCUDAPointer(ptr)) {
+            cudaFree(ptr);
+        } else {
+            throw std::runtime_error("MemoryManagerGPU::Free: host pointer");
+        }
+    }
+}
+
+void MemoryManagerGPU::CopyTo(void* dst_ptr,
+                              const void* src_ptr,
+                              std::size_t num_bytes) {
+    if (dst_ptr == nullptr || src_ptr == nullptr) {
+        throw std::runtime_error("CopyTo: nullptr detected");
+    }
+
+    std::string dst_device = IsCUDAPointer(dst_ptr) ? "gpu" : "cpu";
+    std::string src_device = IsCUDAPointer(src_ptr) ? "gpu" : "cpu";
+
+    if (src_device == "cpu" && dst_device == "cpu") {
+        std::memcpy(dst_ptr, src_ptr, num_bytes);
+    } else if (src_device == "cpu" && dst_device == "gpu") {
+        cudaMemcpy(dst_ptr, src_ptr, num_bytes, cudaMemcpyHostToDevice);
+    } else if (src_device == "gpu" && dst_device == "cpu") {
+        cudaMemcpy(dst_ptr, src_ptr, num_bytes, cudaMemcpyDeviceToHost);
+    } else if (src_device == "gpu" && dst_device == "gpu") {
+        cudaMemcpy(dst_ptr, src_ptr, num_bytes, cudaMemcpyDeviceToDevice);
+    }
+}
+
+bool MemoryManagerGPU::IsCUDAPointer(const void* ptr) {
+    cudaPointerAttributes attributes;
+    cudaPointerGetAttributes(&attributes, ptr);
+    if (attributes.devicePointer != nullptr) {
+        return true;
+    }
+    return false;
+}
+
+OPEN3D_REGISTER_SINGLETON_OBJECT(MemoryManagerBackendRegistry,
+                                 "gpu",
+                                 std::make_shared<MemoryManagerGPU>());
+
+}  // namespace open3d

--- a/src/Open3D/Container/MemoryManagerGPU.h
+++ b/src/Open3D/Container/MemoryManagerGPU.h
@@ -1,0 +1,43 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "Open3D/Container/MemoryManager.h"
+
+namespace open3d {
+
+class MemoryManagerGPU : public MemoryManagerBackend {
+public:
+    void* Allocate(size_t byte_size) final;
+    void Free(void* ptr) final;
+    void CopyTo(void* dst_ptr,
+                const void* src_ptr,
+                std::size_t num_bytes) final;
+    bool IsCUDAPointer(const void* ptr) final;
+};
+
+}  // namespace open3d

--- a/src/Open3D/Container/Shape.h
+++ b/src/Open3D/Container/Shape.h
@@ -1,0 +1,77 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace open3d {
+
+// Ref:
+// https://github.com/NervanaSystems/ngraph/blob/master/src/ngraph/shape.hpp
+class Shape : public std::vector<size_t> {
+public:
+    Shape(const std::initializer_list<size_t>& dim_sizes)
+        : std::vector<size_t>(dim_sizes) {}
+
+    Shape(const std::vector<size_t>& dim_sizes)
+        : std::vector<size_t>(dim_sizes) {}
+
+    Shape(const Shape& other) : std::vector<size_t>(other) {}
+
+    explicit Shape(size_t n, size_t initial_value = 0)
+        : std::vector<size_t>(n, initial_value) {}
+
+    template <class InputIterator>
+    Shape(InputIterator first, InputIterator last)
+        : std::vector<size_t>(first, last) {}
+
+    Shape() {}
+
+    Shape& operator=(const Shape& v) {
+        static_cast<std::vector<size_t>*>(this)->operator=(v);
+        return *this;
+    }
+
+    Shape& operator=(Shape&& v) {
+        static_cast<std::vector<size_t>*>(this)->operator=(v);
+        return *this;
+    }
+
+    size_t NumElements() const {
+        if (this->size() == 0) {
+            return 0;
+        }
+        size_t size = 1;
+        for (const size_t& d : *this) {
+            size *= d;
+        }
+        return size;
+    }
+};
+
+}  // namespace open3d

--- a/src/Open3D/Container/Tensor.h
+++ b/src/Open3D/Container/Tensor.h
@@ -1,0 +1,93 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include "Open3D/Container/MemoryManager.h"
+#include "Open3D/Container/Shape.h"
+
+// TODO: move the contents of this folder to "Open3D/src"?
+//       currently they are in "open3d" top namespace but under "TensorArray"
+//       folder
+namespace open3d {
+
+template <typename T>
+class Tensor {
+public:
+    Tensor(const Shape& shape, const std::string& device = "cpu")
+        : shape_(shape),
+          device_(device),
+          num_elements_(shape.NumElements()),
+          byte_size_(sizeof(T) * shape.NumElements()) {
+        if (device == "cpu" || device == "gpu") {
+            v_ = static_cast<T*>(MemoryManager::Allocate(byte_size_, device_));
+        } else {
+            throw std::runtime_error("Unrecognized device");
+        }
+    }
+
+    Tensor(const std::vector<T>& init_vals,
+           const Shape& shape,
+           const std::string& device = "cpu")
+        : Tensor(shape, device) {
+        if (init_vals.size() != num_elements_) {
+            throw std::runtime_error(
+                    "Tensor initialization values' size does not match the "
+                    "shape.");
+        }
+
+        if (device == "cpu" || device == "gpu") {
+            MemoryManager::CopyTo(v_, init_vals.data(), byte_size_);
+        } else if (device == "gpu") {
+            throw std::runtime_error("Unimplemented");
+        } else {
+            throw std::runtime_error("Unrecognized device");
+        }
+    }
+
+    ~Tensor() { MemoryManager::Free(v_); };
+
+    std::vector<T> ToStdVector() const {
+        std::vector<T> vec(num_elements_);
+        MemoryManager::CopyTo(vec.data(), v_, byte_size_);
+        return vec;
+    }
+
+public:
+    T* v_;
+
+public:
+    const Shape shape_;
+    const std::string device_;
+    const size_t num_elements_;  // Num elements
+    const size_t byte_size_;     // Num bytes
+};
+
+}  // namespace open3d

--- a/src/Open3D/Container/TensorArray.h
+++ b/src/Open3D/Container/TensorArray.h
@@ -40,10 +40,10 @@ public:
     TensorArray(const Shape& tensor_shape,
                 size_t max_size,
                 const std::string& device = "cpu")
-        : tensor_shape_(tensor_shape),
+        : curr_size_(0),
           max_size_(max_size),
-          device_(device),
-          curr_size_(0) {
+          tensor_shape_(tensor_shape),
+          device_(device) {
         if (device == "cpu" || device == "gpu") {
             v_ = static_cast<T*>(MemoryManager::Allocate(
                     TensorByteSize() * max_size_, device_));

--- a/src/Open3D/Container/TensorArray.h
+++ b/src/Open3D/Container/TensorArray.h
@@ -1,0 +1,71 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "Open3D/Container/MemoryManager.h"
+#include "Open3D/Container/Shape.h"
+
+namespace open3d {
+
+template <typename T>
+class TensorArray {
+public:
+    TensorArray(const Shape& tensor_shape,
+                size_t max_size,
+                const std::string& device = "cpu")
+        : tensor_shape_(tensor_shape),
+          max_size_(max_size),
+          device_(device),
+          curr_size_(0) {
+        if (device == "cpu" || device == "gpu") {
+            v_ = static_cast<T*>(MemoryManager::Allocate(
+                    TensorByteSize() * max_size_, device_));
+        } else {
+            throw std::runtime_error("Unrecognized device");
+        }
+    }
+
+    ~TensorArray() { MemoryManager::Free(v_); };
+
+    size_t TensorByteSize() const {
+        return sizeof(T) * tensor_shape_.NumElements();
+    }
+
+public:
+    T* v_;
+    size_t curr_size_;
+    size_t max_size_;
+
+public:
+    const Shape tensor_shape_;
+    const std::string device_;
+};
+
+}  // namespace open3d

--- a/src/Open3D/Macro.h
+++ b/src/Open3D/Macro.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#define DISABLE_COPY_AND_ASSIGN(classname) \
+    classname(const classname&) = delete;  \
+    classname& operator=(const classname&) = delete
+
+#ifdef _WIN32
+#if defined(OPEN3D_BUILD_SHARED_LIBS)
+#define OPEN3D_EXPORT __declspec(dllexport)
+#define OPEN3D_IMPORT __declspec(dllimport)
+#else
+#define OPEN3D_EXPORT
+#define OPEN3D_IMPORT
+#endif
+#else  // _WIN32
+#if defined(__GNUC__)
+#define OPEN3D_EXPORT __attribute__((__visibility__("default")))
+#else  // defined(__GNUC__)
+#define OPEN3D_EXPORT
+#endif  // defined(__GNUC__)
+#define OPEN3D_IMPORT OPEN3D_EXPORT
+#endif  // _WIN32
+
+#define OPEN3D_CONCATENATE_IMPL(s1, s2) s1##s2
+#define OPEN3D_CONCATENATE(s1, s2) OPEN3D_CONCATENATE_IMPL(s1, s2)
+#define OPEN3D_ANONYMOUS_VARIABLE(str) OPEN3D_CONCATENATE(str, __LINE__)

--- a/src/Open3D/Registry.h
+++ b/src/Open3D/Registry.h
@@ -1,0 +1,245 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <typeinfo>
+#include <unordered_map>
+#include <vector>
+
+#include "Open3D/Macro.h"
+
+namespace open3d {
+
+// Registry for classes that have both CPU and GPU version
+// Ref: https://github.com/pytorch/pytorch/blob/master/c10/util/Registry.h
+template <class ObjectPtrType, class... Args>
+class RegistryForClass {
+public:
+    typedef std::function<ObjectPtrType(Args...)> Factory;
+
+    RegistryForClass() : registry_() {}
+
+    void Register(const std::string& key, Factory factory) {
+        std::lock_guard<std::mutex> lock(register_mutex_);
+        if (registry_.count(key) == 0) {
+            registry_[key] = factory;
+        }
+    }
+
+    inline bool Has(const std::string& key) {
+        return (registry_.count(key) != 0);
+    }
+
+    Factory GetFactory(const std::string& key) {
+        if (registry_.count(key) == 0) {
+            // Returns nullptr if the key is not registered.
+            return nullptr;
+        }
+        return registry_[key];
+    }
+
+    // Returns the keys currently registered as a std::vector.
+    std::vector<std::string> Keys() const {
+        std::vector<std::string> keys;
+        for (const auto& it : registry_) {
+            keys.push_back(it.first);
+        }
+        return keys;
+    }
+
+private:
+    std::unordered_map<std::string, Factory> registry_;
+    std::mutex register_mutex_;
+
+    DISABLE_COPY_AND_ASSIGN(RegistryForClass);
+};
+
+template <class ObjectPtrType, class... Args>
+class RegistererForClass {
+public:
+    explicit RegistererForClass(
+            const std::string& key,
+            const std::shared_ptr<RegistryForClass<ObjectPtrType, Args...>>&
+                    registry,
+            typename RegistryForClass<ObjectPtrType, Args...>::Factory
+                    factory) {
+        registry->Register(key, factory);
+    }
+
+    template <class DerivedType>
+    static ObjectPtrType DefaultCreator(Args... args) {
+        return ObjectPtrType(new DerivedType(args...));
+    }
+};
+
+// Registry for functions that have both CPU and GPU version
+template <class FunctionType>
+class RegistryForFunction {
+public:
+    RegistryForFunction() : registry_() {}
+
+    void Register(const std::string& key, FunctionType func) {
+        std::lock_guard<std::mutex> lock(register_mutex_);
+        if (registry_.count(key) == 0) {
+            registry_[key] = func;
+        }
+    }
+
+    inline bool Has(const std::string& key) {
+        return (registry_.count(key) != 0);
+    }
+
+    FunctionType GetFunction(const std::string& key) {
+        if (registry_.count(key) == 0) {
+            // Returns nullptr if the key is not registered.
+            return nullptr;
+        }
+        return registry_[key];
+    }
+
+    // Returns the keys currently registered as a std::vector.
+    std::vector<std::string> Keys() const {
+        std::vector<std::string> keys;
+        for (const auto& it : registry_) {
+            keys.push_back(it.first);
+        }
+        return keys;
+    }
+
+private:
+    std::unordered_map<std::string, FunctionType> registry_;
+    std::mutex register_mutex_;
+
+    DISABLE_COPY_AND_ASSIGN(RegistryForFunction);
+};
+
+template <class FunctionType>
+class RegistererForFunction {
+public:
+    explicit RegistererForFunction(
+            const std::string& key,
+            const std::shared_ptr<RegistryForFunction<FunctionType>>& registry,
+            FunctionType func) {
+        registry->Register(key, func);
+    }
+};
+
+// Registry for singleton objects referenced by shared_ptr
+// Every registry can register multiple singleton objects index by name
+template <class ObjectPtrType>
+class RegistryForSingleton {
+public:
+    RegistryForSingleton() : registry_() {}
+
+    void Register(const std::string& key, ObjectPtrType obj_ptr) {
+        std::lock_guard<std::mutex> lock(register_mutex_);
+        if (registry_.count(key) == 0) {
+            registry_[key] = obj_ptr;
+        }
+    }
+
+    inline bool Has(const std::string& key) {
+        return (registry_.count(key) != 0);
+    }
+
+    ObjectPtrType GetSingletonObject(const std::string& key) {
+        if (registry_.count(key) == 0) {
+            // Returns nullptr if the key is not registered.
+            return nullptr;
+        }
+        return registry_[key];
+    }
+
+    // Returns the keys currently registered as a std::vector.
+    std::vector<std::string> Keys() const {
+        std::vector<std::string> keys;
+        for (const auto& it : registry_) {
+            keys.push_back(it.first);
+        }
+        return keys;
+    }
+
+private:
+    std::unordered_map<std::string, ObjectPtrType> registry_;
+    std::mutex register_mutex_;
+
+    DISABLE_COPY_AND_ASSIGN(RegistryForSingleton);
+};
+
+template <class ObjectPtrType>
+class RegistererForSingleton {
+public:
+    explicit RegistererForSingleton(
+            const std::string& key,
+            const std::shared_ptr<RegistryForSingleton<ObjectPtrType>>&
+                    registry,
+            ObjectPtrType obj_ptr) {
+        registry->Register(key, obj_ptr);
+    }
+};
+}  // namespace open3d
+
+#define OPEN3D_DECLARE_REGISTRY_FOR_CLASS(RegistryName, ObjectType, ...) \
+    OPEN3D_IMPORT std::shared_ptr<::open3d::RegistryForClass<            \
+            std::shared_ptr<ObjectType>, ##__VA_ARGS__>>                 \
+    RegistryName();                                                      \
+    typedef ::open3d::RegistererForClass<std::shared_ptr<ObjectType>,    \
+                                         ##__VA_ARGS__>                  \
+            RegistererForClass##RegistryName
+
+#define OPEN3D_DEFINE_REGISTRY_FOR_CLASS(RegistryName, ObjectType, ...)     \
+    OPEN3D_EXPORT std::shared_ptr<::open3d::RegistryForClass<               \
+            std::shared_ptr<ObjectType>, ##__VA_ARGS__>>                    \
+    RegistryName() {                                                        \
+        static auto registry = std::make_shared<::open3d::RegistryForClass< \
+                std::shared_ptr<ObjectType>, ##__VA_ARGS__>>();             \
+        return registry;                                                    \
+    }
+
+#define OPEN3D_REGISTER_CLASS(RegistryName, key, ...)                  \
+    static RegistererForClass##RegistryName OPEN3D_ANONYMOUS_VARIABLE( \
+            g_##RegistryName)(                                         \
+            key, RegistryName(),                                       \
+            RegistererForClass##RegistryName::DefaultCreator<__VA_ARGS__>);
+
+#define OPEN3D_DECLARE_REGISTRY_FOR_FUNCTION(RegistryName, FunctionType)       \
+    OPEN3D_IMPORT std::shared_ptr<::open3d::RegistryForFunction<FunctionType>> \
+    RegistryName();                                                            \
+    typedef ::open3d::RegistererForFunction<FunctionType>                      \
+            RegistererForFunction##RegistryName
+
+#define OPEN3D_DEFINE_REGISTRY_FOR_FUNCTION(RegistryName, FunctionType)        \
+    OPEN3D_EXPORT std::shared_ptr<::open3d::RegistryForFunction<FunctionType>> \
+    RegistryName() {                                                           \
+        static auto registry = std::make_shared<                               \
+                ::open3d::RegistryForFunction<FunctionType>>();                \
+        return registry;                                                       \
+    }
+
+#define OPEN3D_REGISTER_FUNCTION(RegistryName, key, func)                 \
+    static RegistererForFunction##RegistryName OPEN3D_ANONYMOUS_VARIABLE( \
+            g_##RegistryName)(key, RegistryName(), func);
+
+#define OPEN3D_DECLARE_REGISTRY_FOR_SINGLETON(RegistryName, ObjectPtrType) \
+    OPEN3D_IMPORT                                                          \
+    std::shared_ptr<::open3d::RegistryForSingleton<ObjectPtrType>>         \
+    RegistryName();                                                        \
+    typedef ::open3d::RegistererForSingleton<ObjectPtrType>                \
+            RegistererForSingleton##RegistryName
+
+#define OPEN3D_DEFINE_REGISTRY_FOR_SINGLETON(RegistryName, ObjectPtrType) \
+    OPEN3D_EXPORT                                                         \
+    std::shared_ptr<::open3d::RegistryForSingleton<ObjectPtrType>>        \
+    RegistryName() {                                                      \
+        static auto registry = std::make_shared<                          \
+                ::open3d::RegistryForSingleton<ObjectPtrType>>();         \
+        return registry;                                                  \
+    }
+
+#define OPEN3D_REGISTER_SINGLETON_OBJECT(RegistryName, key, obj_ptr)       \
+    static RegistererForSingleton##RegistryName OPEN3D_ANONYMOUS_VARIABLE( \
+            g_##RegistryName)(key, RegistryName(), obj_ptr);

--- a/src/UnitTest/CMakeLists.txt
+++ b/src/UnitTest/CMakeLists.txt
@@ -19,5 +19,12 @@ endif()
 add_executable(unitTests ${UNIT_TEST_SOURCE_FILES})
 add_definitions(-DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/examples/TestData")
 
+# If gpu not available, add "DISABLED_" to the gpu test names
+if(BUILD_CUDA_MODULE)
+    add_definitions(-DGPU_CONDITIONAL_TEST_STR=) # Empty string
+else()
+    add_definitions(-DGPU_CONDITIONAL_TEST_STR=DISABLED_)
+endif()
+
 target_link_libraries(unitTests pthread ${CMAKE_PROJECT_NAME})
 ShowAndAbortOnWarning(unitTests)

--- a/src/UnitTest/Container/Tensor.cpp
+++ b/src/UnitTest/Container/Tensor.cpp
@@ -1,0 +1,85 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Container/Tensor.h"
+#include "Open3D/Container/MemoryManager.h"
+#include "Open3D/Container/TensorArray.h"
+#include "TestUtility/UnitTest.h"
+
+using namespace std;
+using namespace open3d;
+
+TEST(Container, Registry) {
+    EXPECT_TRUE(MemoryManagerBackendRegistry()->Has("cpu"));
+    EXPECT_NE(MemoryManagerBackendRegistry()->GetSingletonObject("cpu"),
+              nullptr);
+}
+
+TEST(Container, CPU_Tensor) {
+    Shape shape;
+
+    // Create tensor
+    shape = {4, 4};
+    Tensor<float> matrix4f(shape, "cpu");
+
+    // Create tensor with init values
+    shape = {3};
+    std::vector<float> init_val({1, 2, 3});
+    Tensor<float> vector3f(init_val, shape, "cpu");
+
+    // Check that the values are actually copied
+    std::vector<float> out_val = vector3f.ToStdVector();
+    unit_test::ExpectEQ(out_val, {1, 2, 3});
+}
+
+TEST(Container, CPU_Array) {
+    Shape tensor_shape = {3};
+    size_t max_size = 10000;
+    TensorArray<float> points(tensor_shape, max_size, "cpu");
+}
+
+TEST(Container, GPU_CONDITIONAL_TEST(GPU_Tensor)) {
+    Shape shape;
+
+    // Create tensor
+    shape = {4, 4};
+    Tensor<float> matrix4f(shape, "gpu");
+
+    // Create tensor with init values
+    shape = {3};
+    std::vector<float> init_val({1, 2, 3});
+    Tensor<float> vector3f(init_val, shape, "gpu");
+
+    // Check that the values are actually copied
+    std::vector<float> out_val = vector3f.ToStdVector();
+    unit_test::ExpectEQ(out_val, {1, 2, 3});
+}
+
+TEST(Container, GPU_CONDITIONAL_TEST(GPU_Array)) {
+    Shape tensor_shape = {3};
+    size_t max_size = 100000;
+    TensorArray<float> points(tensor_shape, max_size, "gpu");
+}

--- a/src/UnitTest/Registry.cpp
+++ b/src/UnitTest/Registry.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include "Open3D/Registry.h"
+
+// PointCloud.h
+class PointCloud {
+public:
+    PointCloud();
+    virtual ~PointCloud() {}
+};
+OPEN3D_DECLARE_REGISTRY_FOR_CLASS(PointCloudRegistry, PointCloud);
+
+// PointCloud.cc
+PointCloud::PointCloud() {}
+OPEN3D_DEFINE_REGISTRY_FOR_CLASS(PointCloudRegistry, PointCloud);
+
+// PointCloudCPU.h
+class PointCloudCPU : public PointCloud {
+public:
+    PointCloudCPU();
+    ~PointCloudCPU() {}
+};
+
+// PointCloudCPU.cc
+PointCloudCPU::PointCloudCPU() : PointCloud() {}
+OPEN3D_REGISTER_CLASS(PointCloudRegistry, "cpu", PointCloudCPU);
+
+// PointCloudGPU.h, conditionally included
+class PointCloudGPU : public PointCloud {
+public:
+    PointCloudGPU();
+    ~PointCloudGPU() {}
+};
+
+// PointCloudGPU.cc, conditionally compiled
+PointCloudGPU::PointCloudGPU() : PointCloud() {}
+OPEN3D_REGISTER_CLASS(PointCloudRegistry, "gpu", PointCloudGPU);
+
+TEST(RegistryForClass, CanRunCreator) {
+    std::shared_ptr<PointCloud> pcd_cpu =
+            PointCloudRegistry()->GetFactory("cpu")();
+    EXPECT_TRUE(pcd_cpu != nullptr);
+
+    std::shared_ptr<PointCloud> pcd_gpu =
+            PointCloudRegistry()->GetFactory("gpu")();
+    EXPECT_TRUE(pcd_cpu != nullptr);
+
+    EXPECT_TRUE(PointCloudRegistry()->GetFactory("tpu") == nullptr);
+}
+
+class Foo {
+public:
+    explicit Foo(int x) {}
+    explicit Foo(int x, int y) {}
+    virtual ~Foo() {}
+};
+
+OPEN3D_DECLARE_REGISTRY_FOR_CLASS(FooRegistry, Foo, int);
+OPEN3D_DEFINE_REGISTRY_FOR_CLASS(FooRegistry, Foo, int);
+
+OPEN3D_DECLARE_REGISTRY_FOR_CLASS(FooRegistryTwoArg, Foo, int, int);
+OPEN3D_DEFINE_REGISTRY_FOR_CLASS(FooRegistryTwoArg, Foo, int, int);
+OPEN3D_REGISTER_CLASS(FooRegistryTwoArg, "Foo", Foo);
+
+class Bar : public Foo {
+public:
+    explicit Bar(int x) : Foo(x) {}
+};
+OPEN3D_REGISTER_CLASS(FooRegistry, "Bar", Bar)
+
+class AnotherBar : public Foo {
+public:
+    explicit AnotherBar(int x) : Foo(x) {}
+};
+OPEN3D_REGISTER_CLASS(FooRegistry, "AnotherBar", AnotherBar);
+
+TEST(RegistryForClass, CanRunCreatorWithArgs) {
+    std::shared_ptr<Foo> foo_two_args =
+            FooRegistryTwoArg()->GetFactory("Foo")(123, 456);
+    EXPECT_TRUE(foo_two_args != nullptr) << "Cannot create Foo with two args.";
+
+    std::shared_ptr<Foo> bar = FooRegistry()->GetFactory("Bar")(123);
+    EXPECT_TRUE(bar != nullptr) << "Cannot create bar.";
+
+    std::shared_ptr<Foo> another_bar =
+            FooRegistry()->GetFactory("AnotherBar")(456);
+    EXPECT_TRUE(another_bar != nullptr) << "Cannot create another_bar.";
+}
+
+TEST(RegistryForClass, ReturnNullOnNonExistingCreatorWithArgs) {
+    EXPECT_EQ(FooRegistry()->GetFactory("Non-existing bar"), nullptr);
+}
+
+// registration.h
+int RegistrationICP(int i, int j, const std::string& device);
+OPEN3D_DECLARE_REGISTRY_FOR_FUNCTION(RegistrationICPRegistry,
+                                     std::function<int(int, int)>);
+
+// registration.cc
+int RegistrationICP(int i, int j, const std::string& device) {
+    return RegistrationICPRegistry()->GetFunction(device)(i, j);
+}
+OPEN3D_DEFINE_REGISTRY_FOR_FUNCTION(RegistrationICPRegistry,
+                                    std::function<int(int, int)>);
+
+// registration_cpu.h
+int RegistrationICPCPU(int i, int j);
+
+// registration_cpu.cc
+int RegistrationICPCPU(int i, int j) { return i + j; }
+OPEN3D_REGISTER_FUNCTION(RegistrationICPRegistry, "cpu", RegistrationICPCPU);
+
+// registration_gpu.h, conditionally included
+int RegistrationICPGPU(int i, int j);
+
+// registration_gpu.cc, conditionally compiled
+int RegistrationICPGPU(int i, int j) { return i + j + 1; }
+OPEN3D_REGISTER_FUNCTION(RegistrationICPRegistry, "gpu", RegistrationICPGPU);
+
+TEST(RegistryForFunction, CanRunCreator) {
+    EXPECT_EQ(RegistrationICPRegistry()->GetFunction("cpu")(1, 2), 3);
+    EXPECT_EQ(RegistrationICPRegistry()->GetFunction("gpu")(1, 2), 4);
+    EXPECT_EQ(RegistrationICPRegistry()->GetFunction("tpu"), nullptr);
+}

--- a/src/UnitTest/TestUtility/UnitTest.h
+++ b/src/UnitTest/TestUtility/UnitTest.h
@@ -40,6 +40,13 @@
 #include "UnitTest/TestUtility/Rand.h"
 #include "UnitTest/TestUtility/Sort.h"
 
+#include "Open3D/Macro.h"
+
+// GPU_CONDITIONAL_COMPILE_STR is "" if gpu is available, otherwise "DISABLED_"
+// The GPU_CONDITIONAL_COMPILE_STR value is configured in CMake
+#define GPU_CONDITIONAL_TEST(test_name) \
+    OPEN3D_CONCATENATE(GPU_CONDITIONAL_TEST_STR, test_name)
+
 namespace unit_test {
 // thresholds for comparing floating point values
 const double THRESHOLD_1E_6 = 1e-6;


### PR DESCRIPTION
- CMakes for enabling/disabling CUDA build
    - Enable with `BUILD_CUDA_MODULE=ON` flag
- Registry for static initialization
    - Eliminate conditional compilation of GPU code with `#ifdef`, instead, CPU/GPU classes/functions register themselves to the registry and available backends can be queried from the registry
    - Includes: Class registry, function registry, and singleton registry for globally unique objects
- Initial `Tensor` and `Array` class that uses `MemoryManager`, only the basic framework is implemented, details will be added later
- Unit tests
- Merging to `gpu` branch, not `master` branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1043)
<!-- Reviewable:end -->
