### PR TITLE
Add flags to the write triangle mesh methods

### DIFF
--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
@@ -51,6 +51,8 @@ static const std::unordered_map<
         std::function<bool(const std::string &,
                            const geometry::TriangleMesh &,
                            const bool,
+                           const bool,
+                           const bool,
                            const bool)>>
         file_extension_to_trianglemesh_write_function{
                 {"ply", WriteTriangleMeshToPLY},
@@ -104,7 +106,9 @@ bool ReadTriangleMesh(const std::string &filename,
 bool WriteTriangleMesh(const std::string &filename,
                        const geometry::TriangleMesh &mesh,
                        bool write_ascii /* = false*/,
-                       bool compressed /* = false*/) {
+                       bool compressed /* = false*/,
+                       bool write_vertex_normals /* = true*/,
+                       bool write_vertex_colors /* = true*/) {
     std::string filename_ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
@@ -121,7 +125,8 @@ bool WriteTriangleMesh(const std::string &filename,
                 "extension.\n");
         return false;
     }
-    bool success = map_itr->second(filename, mesh, write_ascii, compressed);
+    bool success = map_itr->second(filename, mesh, write_ascii, compressed,
+                                   write_vertex_normals, write_vertex_colors);
     utility::PrintDebug(
             "Write geometry::TriangleMesh: %d triangles and %d vertices.\n",
             (int)mesh.triangles_.size(), (int)mesh.vertices_.size());

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.h
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.h
@@ -52,7 +52,9 @@ bool ReadTriangleMesh(const std::string &filename,
 bool WriteTriangleMesh(const std::string &filename,
                        const geometry::TriangleMesh &mesh,
                        bool write_ascii = false,
-                       bool compressed = false);
+                       bool compressed = false,
+                       bool write_vertex_normals = true,
+                       bool write_vertex_colors = true);
 
 bool ReadTriangleMeshFromPLY(const std::string &filename,
                              geometry::TriangleMesh &mesh);
@@ -60,7 +62,9 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
 bool WriteTriangleMeshToPLY(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii = false,
-                            bool compressed = false);
+                            bool compressed = false,
+                            bool write_vertex_normals = true,
+                            bool write_vertex_colors = true);
 
 bool ReadTriangleMeshFromSTL(const std::string &filename,
                              geometry::TriangleMesh &mesh);
@@ -68,7 +72,9 @@ bool ReadTriangleMeshFromSTL(const std::string &filename,
 bool WriteTriangleMeshToSTL(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii = false,
-                            bool compressed = false);
+                            bool compressed = false,
+                            bool write_vertex_normals = true,
+                            bool write_vertex_colors = true);
 
 bool ReadTriangleMeshFromOBJ(const std::string &filename,
                              geometry::TriangleMesh &mesh);
@@ -76,7 +82,9 @@ bool ReadTriangleMeshFromOBJ(const std::string &filename,
 bool WriteTriangleMeshToOBJ(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii = false,
-                            bool compressed = false);
+                            bool compressed = false,
+                            bool write_vertex_normals = true,
+                            bool write_vertex_colors = true);
 
 bool ReadTriangleMeshFromOFF(const std::string &filename,
                              geometry::TriangleMesh &mesh);
@@ -84,7 +92,9 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
 bool WriteTriangleMeshToOFF(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii = false,
-                            bool compressed = false);
+                            bool compressed = false,
+                            bool write_vertex_normals = true,
+                            bool write_vertex_colors = true);
 
 }  // namespace io
 }  // namespace open3d

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -129,7 +129,9 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
 bool WriteTriangleMeshToOBJ(const std::string& filename,
                             const geometry::TriangleMesh& mesh,
                             bool write_ascii /* = false*/,
-                            bool compressed /* = false*/) {
+                            bool compressed /* = false*/,
+                            bool write_vertex_normals /* = true*/,
+                            bool write_vertex_colors /* = true*/) {
     std::ofstream file(filename.c_str(), std::ios::out | std::ios::binary);
 
     if (!file) {
@@ -151,13 +153,13 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     for (int vidx = 0; vidx < mesh.vertices_.size(); ++vidx) {
         const Eigen::Vector3d& vertex = mesh.vertices_[vidx];
         file << "v " << vertex(0) << " " << vertex(1) << " " << vertex(2);
-        if (has_vertex_colors) {
+        if (write_vertex_colors && has_vertex_colors) {
             const Eigen::Vector3d& color = mesh.vertex_colors_[vidx];
             file << " " << color(0) << " " << color(1) << " " << color(2);
         }
         file << "\n";
 
-        if (has_vertex_normals) {
+        if (write_vertex_normals && has_vertex_normals) {
             const Eigen::Vector3d& normal = mesh.vertex_normals_[vidx];
             file << "vn " << normal(0) << " " << normal(1) << " " << normal(2)
                  << "\n";
@@ -168,7 +170,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
 
     for (int tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
         const Eigen::Vector3i& triangle = mesh.triangles_[tidx];
-        if (has_vertex_normals) {
+        if (write_vertex_normals && has_vertex_normals) {
             file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1 << " "
                  << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
                  << triangle(2) + 1 << "//" << triangle(2) + 1 << "\n";

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -148,18 +148,18 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     file << "# number of triangles: " << mesh.triangles_.size() << "\n";
     utility::ResetConsoleProgress(
             mesh.vertices_.size() + mesh.triangles_.size(), "Writing OBJ: ");
-    bool has_vertex_normals = mesh.HasVertexNormals();
-    bool has_vertex_colors = mesh.HasVertexColors();
+    write_vertex_normals = write_vertex_normals && mesh.HasVertexNormals();
+    write_vertex_colors = write_vertex_colors && mesh.HasVertexColors();
     for (int vidx = 0; vidx < mesh.vertices_.size(); ++vidx) {
         const Eigen::Vector3d& vertex = mesh.vertices_[vidx];
         file << "v " << vertex(0) << " " << vertex(1) << " " << vertex(2);
-        if (write_vertex_colors && has_vertex_colors) {
+        if (write_vertex_colors) {
             const Eigen::Vector3d& color = mesh.vertex_colors_[vidx];
             file << " " << color(0) << " " << color(1) << " " << color(2);
         }
         file << "\n";
 
-        if (write_vertex_normals && has_vertex_normals) {
+        if (write_vertex_normals) {
             const Eigen::Vector3d& normal = mesh.vertex_normals_[vidx];
             file << "vn " << normal(0) << " " << normal(1) << " " << normal(2)
                  << "\n";
@@ -170,7 +170,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
 
     for (int tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
         const Eigen::Vector3i& triangle = mesh.triangles_[tidx];
-        if (write_vertex_normals && has_vertex_normals) {
+        if (write_vertex_normals) {
             file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1 << " "
                  << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
                  << triangle(2) + 1 << "//" << triangle(2) + 1 << "\n";

--- a/src/Open3D/IO/FileFormat/FileOFF.cpp
+++ b/src/Open3D/IO/FileFormat/FileOFF.cpp
@@ -173,12 +173,12 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
         return false;
     }
 
-    bool has_vertex_normals = mesh.HasVertexNormals();
-    bool has_vertex_colors = mesh.HasVertexColors();
-    if (write_vertex_colors && has_vertex_colors) {
+    write_vertex_normals = write_vertex_normals && mesh.HasVertexNormals();
+    write_vertex_colors = write_vertex_colors && mesh.HasVertexColors();
+    if (write_vertex_colors) {
         file << "C";
     }
-    if (write_vertex_normals && has_vertex_normals) {
+    if (write_vertex_normals) {
         file << "N";
     }
     file << "OFF\n";
@@ -189,11 +189,11 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
     for (int vidx = 0; vidx < num_of_vertices; ++vidx) {
         const Eigen::Vector3d &vertex = mesh.vertices_[vidx];
         file << vertex(0) << " " << vertex(1) << " " << vertex(2);
-        if (write_vertex_normals && has_vertex_normals) {
+        if (write_vertex_normals) {
             const Eigen::Vector3d &normal = mesh.vertex_normals_[vidx];
             file << " " << normal(0) << " " << normal(1) << " " << normal(2);
         }
-        if (write_vertex_colors && has_vertex_colors) {
+        if (write_vertex_colors) {
             const Eigen::Vector3d &color = mesh.vertex_colors_[vidx];
             file << " " << std::round(color(0) * 255.0) << " "
                  << std::round(color(1) * 255.0) << " "

--- a/src/Open3D/IO/FileFormat/FileOFF.cpp
+++ b/src/Open3D/IO/FileFormat/FileOFF.cpp
@@ -153,7 +153,9 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
 bool WriteTriangleMeshToOFF(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii /* = false*/,
-                            bool compressed /* = false*/) {
+                            bool compressed /* = false*/,
+                            bool write_vertex_normals /* = true*/,
+                            bool write_vertex_colors /* = true*/) {
     std::ofstream file(filename.c_str(), std::ios::out);
     if (!file) {
         utility::PrintWarning("Write OFF failed: unable to open file.\n");
@@ -173,10 +175,10 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
 
     bool has_vertex_normals = mesh.HasVertexNormals();
     bool has_vertex_colors = mesh.HasVertexColors();
-    if (has_vertex_colors) {
+    if (write_vertex_colors && has_vertex_colors) {
         file << "C";
     }
-    if (has_vertex_normals) {
+    if (write_vertex_normals && has_vertex_normals) {
         file << "N";
     }
     file << "OFF\n";
@@ -187,11 +189,11 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
     for (int vidx = 0; vidx < num_of_vertices; ++vidx) {
         const Eigen::Vector3d &vertex = mesh.vertices_[vidx];
         file << vertex(0) << " " << vertex(1) << " " << vertex(2);
-        if (has_vertex_normals) {
+        if (write_vertex_normals && has_vertex_normals) {
             const Eigen::Vector3d &normal = mesh.vertex_normals_[vidx];
             file << " " << normal(0) << " " << normal(1) << " " << normal(2);
         }
-        if (has_vertex_colors) {
+        if (write_vertex_colors && has_vertex_colors) {
             const Eigen::Vector3d &color = mesh.vertex_colors_[vidx];
             file << " " << std::round(color(0) * 255.0) << " "
                  << std::round(color(1) * 255.0) << " "

--- a/src/Open3D/IO/FileFormat/FilePLY.cpp
+++ b/src/Open3D/IO/FileFormat/FilePLY.cpp
@@ -563,8 +563,8 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
         return false;
     }
 
-    bool has_vertex_normals = mesh.HasVertexNormals();
-    bool has_vertex_colors = mesh.HasVertexColors();
+    write_vertex_normals = write_vertex_normals && mesh.HasVertexNormals();
+    write_vertex_colors = write_vertex_colors && mesh.HasVertexColors();
 
     ply_add_comment(ply_file, "Created by Open3D");
     ply_add_element(ply_file, "vertex",
@@ -572,12 +572,12 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
     ply_add_property(ply_file, "x", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "y", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "z", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
-    if (write_vertex_normals && has_vertex_normals) {
+    if (write_vertex_normals) {
         ply_add_property(ply_file, "nx", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
         ply_add_property(ply_file, "ny", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
         ply_add_property(ply_file, "nz", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     }
-    if (write_vertex_colors && has_vertex_colors) {
+    if (write_vertex_colors) {
         ply_add_property(ply_file, "red", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
         ply_add_property(ply_file, "green", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
         ply_add_property(ply_file, "blue", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
@@ -599,13 +599,13 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
         ply_write(ply_file, vertex(0));
         ply_write(ply_file, vertex(1));
         ply_write(ply_file, vertex(2));
-        if (write_vertex_normals && has_vertex_normals) {
+        if (write_vertex_normals) {
             const auto &normal = mesh.vertex_normals_[i];
             ply_write(ply_file, normal(0));
             ply_write(ply_file, normal(1));
             ply_write(ply_file, normal(2));
         }
-        if (write_vertex_colors && has_vertex_colors) {
+        if (write_vertex_colors) {
             const auto &color = mesh.vertex_colors_[i];
             ply_write(ply_file, color(0) * 255.0);
             ply_write(ply_file, color(1) * 255.0);

--- a/src/Open3D/IO/FileFormat/FilePLY.cpp
+++ b/src/Open3D/IO/FileFormat/FilePLY.cpp
@@ -546,7 +546,9 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
 bool WriteTriangleMeshToPLY(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii /* = false*/,
-                            bool compressed /* = false*/) {
+                            bool compressed /* = false*/,
+                            bool write_vertex_normals /* = true*/,
+                            bool write_vertex_colors /* = true*/) {
     if (mesh.IsEmpty()) {
         utility::PrintWarning("Write PLY failed: mesh has 0 vertices.\n");
         return false;
@@ -560,18 +562,22 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
                               filename.c_str());
         return false;
     }
+
+    bool has_vertex_normals = mesh.HasVertexNormals();
+    bool has_vertex_colors = mesh.HasVertexColors();
+
     ply_add_comment(ply_file, "Created by Open3D");
     ply_add_element(ply_file, "vertex",
                     static_cast<long>(mesh.vertices_.size()));
     ply_add_property(ply_file, "x", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "y", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     ply_add_property(ply_file, "z", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
-    if (mesh.HasVertexNormals()) {
+    if (write_vertex_normals && has_vertex_normals) {
         ply_add_property(ply_file, "nx", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
         ply_add_property(ply_file, "ny", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
         ply_add_property(ply_file, "nz", PLY_DOUBLE, PLY_DOUBLE, PLY_DOUBLE);
     }
-    if (mesh.HasVertexColors()) {
+    if (write_vertex_colors && has_vertex_colors) {
         ply_add_property(ply_file, "red", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
         ply_add_property(ply_file, "green", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
         ply_add_property(ply_file, "blue", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
@@ -593,13 +599,13 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
         ply_write(ply_file, vertex(0));
         ply_write(ply_file, vertex(1));
         ply_write(ply_file, vertex(2));
-        if (mesh.HasVertexNormals()) {
+        if (write_vertex_normals && has_vertex_normals) {
             const auto &normal = mesh.vertex_normals_[i];
             ply_write(ply_file, normal(0));
             ply_write(ply_file, normal(1));
             ply_write(ply_file, normal(2));
         }
-        if (mesh.HasVertexColors()) {
+        if (write_vertex_colors && has_vertex_colors) {
             const auto &color = mesh.vertex_colors_[i];
             ply_write(ply_file, color(0) * 255.0);
             ply_write(ply_file, color(1) * 255.0);

--- a/src/Open3D/IO/FileFormat/FileSTL.cpp
+++ b/src/Open3D/IO/FileFormat/FileSTL.cpp
@@ -98,7 +98,9 @@ bool ReadTriangleMeshFromSTL(const std::string &filename,
 bool WriteTriangleMeshToSTL(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
                             bool write_ascii /* = false*/,
-                            bool compressed /* = false*/) {
+                            bool compressed /* = false*/,
+                            bool write_vertex_normals /* = true*/,
+                            bool write_vertex_colors /* = true*/) {
     std::ofstream myFile(filename.c_str(), std::ios::out | std::ios::binary);
 
     if (!myFile) {

--- a/src/Python/io/io.cpp
+++ b/src/Python/io/io.cpp
@@ -64,6 +64,12 @@ static const std::unordered_map<std::string, std::string>
                 {"write_ascii",
                  "Set to ``True`` to output in ascii format, otherwise binary "
                  "format will be used."},
+                {"write_vertex_normals",
+                 "Set to ``False`` to not write any vertex normals, even if "
+                 "present on the mesh"},
+                {"write_vertex_colors",
+                 "Set to ``False`` to not write any vertex colors, even if "
+                 "present on the mesh"},
                 // Entities
                 {"pointcloud", "The ``PointCloud`` object for I/O"},
                 {"mesh", "The ``TriangleMesh`` object for I/O"},
@@ -167,12 +173,15 @@ void pybind_io(py::module &m) {
 
     m_io.def("write_triangle_mesh",
              [](const std::string &filename, const geometry::TriangleMesh &mesh,
-                bool write_ascii, bool compressed) {
+                bool write_ascii, bool compressed, bool write_vertex_normals,
+                bool write_vertex_colors) {
                  return io::WriteTriangleMesh(filename, mesh, write_ascii,
-                                              compressed);
+                                              compressed, write_vertex_normals,
+                                              write_vertex_colors);
              },
              "Function to write TriangleMesh to file", "filename"_a, "mesh"_a,
-             "write_ascii"_a = false, "compressed"_a = false);
+             "write_ascii"_a = false, "compressed"_a = false,
+             "write_vertex_normals"_a = true, "write_vertex_colors"_a = true);
     docstring::FunctionDocInject(m_io, "write_triangle_mesh",
                                  map_shared_argument_docstrings);
 


### PR DESCRIPTION
Adds an option for the user to specify whether vertex normals and/or vertex colors should be written when saving a mesh. By default, these options are set to `True`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1051)
<!-- Reviewable:end -->
