### PR TITLE
Add function is_watertight() to TriangleMesh

### DIFF
--- a/examples/Python/Basic/mesh_properties.py
+++ b/examples/Python/Basic/mesh_properties.py
@@ -47,7 +47,7 @@ def check_properties(name, mesh):
     print('  vertex_manifold:        %s' % fmt_bool(vertex_manifold))
     self_intersecting = mesh.is_self_intersecting()
     print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
-    watertight = edge_manifold_boundary and vertex_manifold and not self_intersecting
+    watertight = mesh.is_watertight()
     print('  watertight:             %s' % fmt_bool(watertight))
     orientable = mesh.is_orientable()
     print('  orientable:             %s' % fmt_bool(orientable))

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -1082,6 +1082,10 @@ bool TriangleMesh::IsOrientable() const {
     return OrientTriangleHelper(triangles_, NoOp);
 }
 
+bool TriangleMesh::IsWatertight() const {
+    return IsEdgeManifold(false) && IsVertexManifold() && !IsSelfIntersecting();
+}
+
 bool TriangleMesh::OrientTriangles() {
     auto SwapTriangleOrder = [&](int tidx, int idx0, int idx1) {
         std::swap(triangles_[tidx](idx0), triangles_[tidx](idx1));

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -100,7 +100,7 @@ public:
     TriangleMesh &RemoveUnreferencedVertices();
 
     /// Function that removes degenerate triangles, i.e., triangles that
-    /// references a single vertex multiple times in a single triangle.
+    /// reference a single vertex multiple times in a single triangle.
     /// They are usually the product of removing duplicated vertices.
     TriangleMesh &RemoveDegenerateTriangles();
 
@@ -218,9 +218,9 @@ public:
             bool allow_boundary_edges = true) const;
 
     /// Function that checks if the given triangle mesh is edge-manifold.
-    /// A mesh is edge­manifold if each edge is bounding either one or two
-    /// triangles. If allow_boundary_edges is set to false, than returns false
-    /// if there exists boundary edges.
+    /// A mesh is edge­-manifold if each edge is bounding either one or two
+    /// triangles. If allow_boundary_edges is set to false, then this function
+    /// returns false if there exists boundary edges.
     bool IsEdgeManifold(bool allow_boundary_edges = true) const;
 
     /// Function that returns a list of non-manifold vertex indices.
@@ -254,8 +254,14 @@ public:
     /// towards the outside.
     bool IsOrientable() const;
 
-    /// If the mesh is orientable then this functions re-arranges the triangles
-    /// such that all normals point towards the outside/inside.
+    /// Function that tests if the given triangle mesh is watertight by
+    /// checking if it is vertex manifold and edge-manifold with no boundary
+    /// edges, but not self-intersecting.
+    bool IsWatertight() const;
+
+    /// If the mesh is orientable then this function rearranges the
+    /// triangles such that all normals point towards the
+    /// outside/inside.
     bool OrientTriangles();
 
     /// Function that returns a map from edges (vertex0, vertex1) to the
@@ -359,14 +365,14 @@ public:
     /// distance from the center to the mesh vertices.
     static std::shared_ptr<TriangleMesh> CreateTetrahedron(double radius = 1.0);
 
-    /// Factory function to create a octahedron mesh (trianglemeshfactory.cpp).
+    /// Factory function to create an octahedron mesh (trianglemeshfactory.cpp).
     /// the mesh centroid will be at (0,0,0) and \param radius defines the
     /// distance from the center to the mesh vertices.
     static std::shared_ptr<TriangleMesh> CreateOctahedron(double radius = 1.0);
 
-    /// Factory function to create a icosahedron mesh (trianglemeshfactory.cpp).
-    /// the mesh centroid will be at (0,0,0) and \param radius defines the
-    /// distance from the center to the mesh vertices.
+    /// Factory function to create an icosahedron mesh
+    /// (trianglemeshfactory.cpp). the mesh centroid will be at (0,0,0) and
+    /// \param radius defines the distance from the center to the mesh vertices.
     static std::shared_ptr<TriangleMesh> CreateIcosahedron(double radius = 1.0);
 
     /// Factory function to create a box mesh (TriangleMeshFactory.cpp)

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -192,16 +192,18 @@ void pybind_trianglemesh(py::module &m) {
                  "Tests if all vertices of the triangle mesh are manifold.")
             .def("is_self_intersecting",
                  &geometry::TriangleMesh::IsSelfIntersecting,
-                 "Tests the triangle mesh is self-intersecting")
+                 "Tests if the triangle mesh is self-intersecting.")
             .def("get_self_intersecting_triangles",
                  &geometry::TriangleMesh::GetSelfIntersectingTriangles,
                  "Returns a list of indices to triangles that intersect the "
                  "mesh.")
             .def("is_intersecting", &geometry::TriangleMesh::IsIntersecting,
-                 "Tests the triangle mesh is intersecting the other triangle "
-                 "mesh.")
+                 "Tests if the triangle mesh is intersecting the other "
+                 "triangle mesh.")
             .def("is_orientable", &geometry::TriangleMesh::IsOrientable,
-                 "Tests the triangle mesh is orientable")
+                 "Tests if the triangle mesh is orientable.")
+            .def("is_watertight", &geometry::TriangleMesh::IsWatertight,
+                 "Tests if the triangle mesh is watertight.")
             .def("orient_triangles", &geometry::TriangleMesh::OrientTriangles,
                  "If the mesh is orientable this function orients all "
                  "triangles such that all normals point towards the same "
@@ -395,6 +397,7 @@ void pybind_trianglemesh(py::module &m) {
             m, "TriangleMesh", "is_intersecting",
             {{"other", "Other triangle mesh to test intersection with."}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "is_orientable");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "is_watertight");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "orient_triangles");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "remove_duplicated_vertices");


### PR DESCRIPTION
Adds a convenience function which replaces
```
watertight = mesh.is_edge_manifold(allow_boundary_edges=False) and mesh.is_vertex_manifold() and not mesh.is_self_intersecting()
```
with
```
watertight = mesh.is_watertight()
```

Some minor typos are also corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1053)
<!-- Reviewable:end -->
