### PR TITLE
Triangulation by ear clipping

### DIFF
--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.h
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.h
@@ -96,10 +96,12 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
                             bool write_vertex_normals = true,
                             bool write_vertex_colors = true);
 
-/// Function to convert a polygon to decompose a polygon into a collection of
+/// Function to convert a polygon into a collection of
 /// triangles whose vertices are only those of the polygon.
 /// Assume that the vertices are connected by edges based on their order, and
 /// the final vertex connected to the first.
+/// The triangles are added to the mesh that is passed as reference. The mesh
+/// should contain all vertices prior to calling this function.
 /// \return return true if triangulation is successful, false otherwise.
 bool AddTrianglesByEarClipping(geometry::TriangleMesh &mesh,
                                std::vector<unsigned int> &indices);

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.h
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.h
@@ -96,5 +96,13 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
                             bool write_vertex_normals = true,
                             bool write_vertex_colors = true);
 
+/// Function to convert a polygon to decompose a polygon into a collection of
+/// triangles whose vertices are only those of the polygon.
+/// Assume that the vertices are connected by edges based on their order, and
+/// the final vertex connected to the first.
+/// \return return true if triangulation is successful, false otherwise.
+bool AddTrianglesByEarClipping(geometry::TriangleMesh &mesh,
+                               std::vector<unsigned int> &indices);
+
 }  // namespace io
 }  // namespace open3d

--- a/src/Open3D/IO/FileFormat/FileOFF.cpp
+++ b/src/Open3D/IO/FileFormat/FileOFF.cpp
@@ -47,7 +47,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
     if (header != "OFF" && header != "COFF" && header != "NOFF" &&
         header != "CNOFF") {
         utility::PrintWarning(
-                "Read OFF failed: header keyword not supported.\n",
+                "Read OFF failed: header keyword '%s' not supported.\n",
                 header.c_str());
         return false;
     }
@@ -57,8 +57,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
     std::getline(file, info);
     std::istringstream iss(info);
     if (!(iss >> num_of_vertices >> num_of_faces >> num_of_edges)) {
-        utility::PrintWarning("Read OFF failed: could not read file info.\n",
-                              info.c_str());
+        utility::PrintWarning("Read OFF failed: could not read file info.\n");
         return false;
     }
 
@@ -139,9 +138,11 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
             }
             indices.push_back(vertex_index);
         }
-        for (int vidx = 0; vidx <= n - 3; vidx++) {
-            mesh.triangles_.push_back(Eigen::Vector3i(
-                    indices[0], indices[vidx + 1], indices[vidx + 2]));
+        if (!AddTrianglesByEarClipping(mesh, indices)) {
+            utility::PrintWarning(
+                    "Read OFF failed: A polygon in the mesh could not be "
+                    "decomposed into triangles.\n");
+            return false;
         }
         utility::AdvanceConsoleProgress();
     }


### PR DESCRIPTION
This PR adds support for loading meshes with non-convex faces.
The implementation is partly based on the ear clipping approach used in the 3rdparty header `tinyobjloader.h` used to load .obj files. The point inclusion in polygon test is acquired from [here](https://stackoverflow.com/a/43896965).

Currently, the triangulation by ear clipping algorithm is only added to the .off-loader. Additionally, it should be added to loading .ply files, but I'm not sure what would be the best approach to do this. .obj-files are handled by `tinyobjloader.h` and .stl-files are triangular representations, per the specifications.

Example triangulations are given in the illustration below:
<img width="402" alt="Screenshot 2019-07-07 at 22 50 18" src="https://user-images.githubusercontent.com/13556755/60773905-a9aede80-a10c-11e9-849f-157b015b2a98.png">

The chosen ear to base the triangulation on is the first one found in each step (assuming counterclockwise ordering of vertices). This, as seen in the right polygon above, results in narrow triangles for (almost) convex polygons. If desirable, the implementation could be slightly changed to search for an "optimal" ear (which would be the most extruded one). 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1060)
<!-- Reviewable:end -->
