### PR TITLE
Fix master build error, fix yapf==0.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - mkdir build
         - cd build
         - cmake -DPYTHON_EXECUTABLE=`which python` ..
-        - pip install -U yapf
+        - pip install -U yapf==0.28.0
         - make check-style
 
     # Build docs only

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -165,15 +165,18 @@ Install YAPF
 -------------------------------
 
 We use `YAPF <https://github.com/google/yapf.git>`_ for Python formatting.
+Different YAPF versions may produce slightly different formatting results, thus
+we choose version ``0.28.0`` as the standard version to be used.
+
 Install YAPF with
 
 .. code:: bash
 
    # For Pip
-   pip install yapf
+   pip install yapf==0.28.0
 
    # For conda
-   conda install yapf
+   conda install yapf=0.28.0
 
 You can also download `YAPF <https://github.com/google/yapf.git>`_ and install
 it from source.

--- a/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
+++ b/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
@@ -44,9 +44,9 @@ def save_intrinsic_as_json(filename, frame):
         obj = json.dump(
             {
                 'width':
-                intrinsics.width,
+                    intrinsics.width,
                 'height':
-                intrinsics.height,
+                    intrinsics.height,
                 'intrinsic_matrix': [
                     intrinsics.fx, 0, 0, 0, intrinsics.fy, 0, intrinsics.ppx,
                     intrinsics.ppy, 1


### PR DESCRIPTION
A new version of yapf was released recently causing master build error. To avoid future issues like this, yapf used by Travis is fixed to `0.28.0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1071)
<!-- Reviewable:end -->
