### PR TITLE
s/Debug/Warning

### DIFF
--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
                                                        extrinsic, stride);
         }
     }
-    utility::PrintDebug(
+    utility::PrintWarning(
             "[CreatePointCloudFromDepthImage] Unsupported image format.\n");
     return std::make_shared<PointCloud>();
 }
@@ -157,7 +157,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
                                                             extrinsic);
         }
     }
-    utility::PrintDebug(
+    utility::PrintWarning(
             "[CreatePointCloudFromRGBDImage] Unsupported image format.\n");
     return std::make_shared<PointCloud>();
 }


### PR DESCRIPTION
Took me a while to figure out why I wasn't getting any points in my point cloud from a single byte depth image.  Might also make sense to add something mentioning that depth images need to be at least 2 bytes per pixel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1075)
<!-- Reviewable:end -->
