### PR TITLE
remove TSDFVoxelGrid class

### DIFF
--- a/src/Open3D/Integration/ScalableTSDFVolume.cpp
+++ b/src/Open3D/Integration/ScalableTSDFVolume.cpp
@@ -119,13 +119,10 @@ std::shared_ptr<geometry::PointCloud> ScalableTSDFVolume::ExtractPointCloud() {
                 for (int y = 0; y < volume0.resolution_; y++) {
                     for (int z = 0; z < volume0.resolution_; z++) {
                         Eigen::Vector3i idx0(x, y, z);
-                        w0 = volume0.voxel_grid_.voxels_[volume0.IndexOf(idx0)]
-                                     .weight_;
-                        f0 = volume0.voxel_grid_.voxels_[volume0.IndexOf(idx0)]
-                                     .tsdf_;
+                        w0 = volume0.voxels_[volume0.IndexOf(idx0)].weight_;
+                        f0 = volume0.voxels_[volume0.IndexOf(idx0)].tsdf_;
                         if (color_type_ != TSDFVolumeColorType::None)
-                            c0 = volume0.voxel_grid_
-                                         .voxels_[volume0.IndexOf(idx0)]
+                            c0 = volume0.voxels_[volume0.IndexOf(idx0)]
                                          .color_.cast<float>();
                         if (w0 != 0.0f && f0 < 0.98f && f0 >= -0.98f) {
                             Eigen::Vector3d p0 =
@@ -143,17 +140,14 @@ std::shared_ptr<geometry::PointCloud> ScalableTSDFVolume::ExtractPointCloud() {
                                 p1(i) += voxel_length_;
                                 idx1(i) += 1;
                                 if (idx1(i) < volume0.resolution_) {
-                                    w1 = volume0.voxel_grid_
-                                                 .voxels_[volume0.IndexOf(idx1)]
+                                    w1 = volume0.voxels_[volume0.IndexOf(idx1)]
                                                  .weight_;
-                                    f1 = volume0.voxel_grid_
-                                                 .voxels_[volume0.IndexOf(idx1)]
+                                    f1 = volume0.voxels_[volume0.IndexOf(idx1)]
                                                  .tsdf_;
                                     if (color_type_ !=
                                         TSDFVolumeColorType::None)
-                                        c1 = volume0.voxel_grid_
-                                                     .voxels_[volume0.IndexOf(
-                                                             idx1)]
+                                        c1 = volume0.voxels_[volume0.IndexOf(
+                                                                     idx1)]
                                                      .color_.cast<float>();
                                 } else {
                                     idx1(i) -= volume0.resolution_;
@@ -165,20 +159,18 @@ std::shared_ptr<geometry::PointCloud> ScalableTSDFVolume::ExtractPointCloud() {
                                     } else {
                                         const auto &volume1 =
                                                 *unit_itr->second.volume_;
-                                        w1 = volume1.voxel_grid_
-                                                     .voxels_[volume1.IndexOf(
-                                                             idx1)]
+                                        w1 = volume1.voxels_[volume1.IndexOf(
+                                                                     idx1)]
                                                      .weight_;
-                                        f1 = volume1.voxel_grid_
-                                                     .voxels_[volume1.IndexOf(
-                                                             idx1)]
+                                        f1 = volume1.voxels_[volume1.IndexOf(
+                                                                     idx1)]
                                                      .tsdf_;
                                         if (color_type_ !=
                                             TSDFVolumeColorType::None)
-                                            c1 = volume1.voxel_grid_
-                                                         .voxels_[volume1.IndexOf(
-                                                                 idx1)]
-                                                         .color_.cast<float>();
+                                            c1 = volume1.voxels_
+                                                         [volume1.IndexOf(idx1)]
+                                                                 .color_
+                                                                 .cast<float>();
                                     }
                                 }
                                 if (w1 != 0.0f && f1 < 0.98f && f1 >= -0.98f &&
@@ -246,23 +238,19 @@ ScalableTSDFVolume::ExtractTriangleMesh() {
                             if (idx1(0) < volume_unit_resolution_ &&
                                 idx1(1) < volume_unit_resolution_ &&
                                 idx1(2) < volume_unit_resolution_) {
-                                w[i] = volume0.voxel_grid_
-                                               .voxels_[volume0.IndexOf(idx1)]
+                                w[i] = volume0.voxels_[volume0.IndexOf(idx1)]
                                                .weight_;
-                                f[i] = volume0.voxel_grid_
-                                               .voxels_[volume0.IndexOf(idx1)]
+                                f[i] = volume0.voxels_[volume0.IndexOf(idx1)]
                                                .tsdf_;
                                 if (color_type_ == TSDFVolumeColorType::RGB8)
-                                    c[i] = volume0.voxel_grid_
-                                                   .voxels_[volume0.IndexOf(
-                                                           idx1)]
+                                    c[i] = volume0.voxels_[volume0.IndexOf(
+                                                                   idx1)]
                                                    .color_.cast<double>() /
                                            255.0;
                                 else if (color_type_ ==
                                          TSDFVolumeColorType::Gray32)
-                                    c[i] = volume0.voxel_grid_
-                                                   .voxels_[volume0.IndexOf(
-                                                           idx1)]
+                                    c[i] = volume0.voxels_[volume0.IndexOf(
+                                                                   idx1)]
                                                    .color_.cast<double>();
                             } else {
                                 for (int j = 0; j < 3; j++) {
@@ -278,26 +266,22 @@ ScalableTSDFVolume::ExtractTriangleMesh() {
                                 } else {
                                     const auto &volume1 =
                                             *unit_itr1->second.volume_;
-                                    w[i] = volume1.voxel_grid_
-                                                   .voxels_[volume1.IndexOf(
-                                                           idx1)]
+                                    w[i] = volume1.voxels_[volume1.IndexOf(
+                                                                   idx1)]
                                                    .weight_;
-                                    f[i] = volume1.voxel_grid_
-                                                   .voxels_[volume1.IndexOf(
-                                                           idx1)]
+                                    f[i] = volume1.voxels_[volume1.IndexOf(
+                                                                   idx1)]
                                                    .tsdf_;
                                     if (color_type_ ==
                                         TSDFVolumeColorType::RGB8)
-                                        c[i] = volume1.voxel_grid_
-                                                       .voxels_[volume1.IndexOf(
-                                                               idx1)]
+                                        c[i] = volume1.voxels_[volume1.IndexOf(
+                                                                       idx1)]
                                                        .color_.cast<double>() /
                                                255.0;
                                     else if (color_type_ ==
                                              TSDFVolumeColorType::Gray32)
-                                        c[i] = volume1.voxel_grid_
-                                                       .voxels_[volume1.IndexOf(
-                                                               idx1)]
+                                        c[i] = volume1.voxels_[volume1.IndexOf(
+                                                                       idx1)]
                                                        .color_.cast<double>();
                                 }
                             }
@@ -438,7 +422,7 @@ double ScalableTSDFVolume::GetTSDFAt(const Eigen::Vector3d &p) {
         if (idx1(0) < volume_unit_resolution_ &&
             idx1(1) < volume_unit_resolution_ &&
             idx1(2) < volume_unit_resolution_) {
-            f[i] = volume0.voxel_grid_.voxels_[volume0.IndexOf(idx1)].tsdf_;
+            f[i] = volume0.voxels_[volume0.IndexOf(idx1)].tsdf_;
         } else {
             for (int j = 0; j < 3; j++) {
                 if (idx1(j) >= volume_unit_resolution_) {
@@ -451,7 +435,7 @@ double ScalableTSDFVolume::GetTSDFAt(const Eigen::Vector3d &p) {
                 f[i] = 0.0f;
             } else {
                 const auto &volume1 = *unit_itr1->second.volume_;
-                f[i] = volume1.voxel_grid_.voxels_[volume1.IndexOf(idx1)].tsdf_;
+                f[i] = volume1.voxels_[volume1.IndexOf(idx1)].tsdf_;
             }
         }
     }

--- a/src/Open3D/Integration/UniformTSDFVolume.h
+++ b/src/Open3D/Integration/UniformTSDFVolume.h
@@ -46,11 +46,6 @@ public:
     float weight_ = 0;
 };
 
-class TSDFVoxelGrid : public VoxelGrid {
-public:
-    std::vector<TSDFVoxel> voxels_;
-};
-
 }  // namespace geometry
 
 namespace integration {
@@ -93,7 +88,7 @@ public:
     }
 
 public:
-    geometry::TSDFVoxelGrid voxel_grid_;
+    std::vector<geometry::TSDFVoxel> voxels_;
     Eigen::Vector3d origin_;
     double length_;
     int resolution_;

--- a/src/UnitTest/Integration/UniformTSDFVolume.cpp
+++ b/src/UnitTest/Integration/UniformTSDFVolume.cpp
@@ -93,8 +93,7 @@ TEST(UniformTSDFVolume, Constructor) {
     EXPECT_EQ(tsdf_volume.length_, length);
     EXPECT_EQ(tsdf_volume.resolution_, resolution);
     EXPECT_EQ(tsdf_volume.voxel_num_, resolution * resolution * resolution);
-    EXPECT_EQ(int(tsdf_volume.voxel_grid_.voxels_.size()),
-              tsdf_volume.voxel_num_);
+    EXPECT_EQ(int(tsdf_volume.voxels_.size()), tsdf_volume.voxel_num_);
 }
 
 TEST(UniformTSDFVolume, RealData) {


### PR DESCRIPTION
Fixes #1078 , since it is a dense voxel grid, we can simply use a `vector`.
As discussed, in the future, we will 1) split the voxel grid class to `DenseVoxelGrid` and `SparseVoxelGrid`, 2) use continuous buffers for each property separately, instead of a vector of voxels that contains different properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1079)
<!-- Reviewable:end -->
