### PR TITLE
Extend functionality of FileGLTF for TriangleMesh

### DIFF
--- a/src/Open3D/IO/FileFormat/FileGLTF.cpp
+++ b/src/Open3D/IO/FileFormat/FileGLTF.cpp
@@ -115,7 +115,7 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
     }
 
     if (model.meshes.size() > 1) {
-        utility::LogWarning(
+        utility::LogInfo(
                 "The file contains more than one mesh. All meshes will be "
                 "loaded as a single mesh.\n");
     }
@@ -228,8 +228,9 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
                                         colors[2] / max_val);
                             }
                         } else {
-                            throw std::runtime_error(
-                                    "Unrecognized componentType");
+                            utility::LogWarning(
+                                    "Unrecognized component type for vertex "
+                                    "colors\n");
                         }
                     }
                 }

--- a/src/Open3D/IO/FileFormat/FileGLTF.cpp
+++ b/src/Open3D/IO/FileFormat/FileGLTF.cpp
@@ -199,14 +199,14 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
                             }
                         } else if (colors_accessor.componentType ==
                                    TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE) {
+                            double max_val =
+                                    (double)std::numeric_limits<uint8_t>::max();
                             for (size_t i = 0; i < colors_accessor.count; ++i) {
                                 const uint8_t* colors =
                                         reinterpret_cast<const uint8_t*>(
                                                 colors_buffer.data.data() +
                                                 colors_view.byteOffset +
                                                 i * byte_stride);
-                                double max_val = (double)
-                                        std::numeric_limits<uint8_t>::max();
                                 mesh_temp.vertex_colors_.emplace_back(
                                         colors[0] / max_val,
                                         colors[1] / max_val,
@@ -214,14 +214,14 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
                             }
                         } else if (colors_accessor.componentType ==
                                    TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
+                            double max_val = (double)
+                                    std::numeric_limits<uint16_t>::max();
                             for (size_t i = 0; i < colors_accessor.count; ++i) {
                                 const uint16_t* colors =
                                         reinterpret_cast<const uint16_t*>(
                                                 colors_buffer.data.data() +
                                                 colors_view.byteOffset +
                                                 i * byte_stride);
-                                double max_val = (double)
-                                        std::numeric_limits<uint16_t>::max();
                                 mesh_temp.vertex_colors_.emplace_back(
                                         colors[0] / max_val,
                                         colors[1] / max_val,

--- a/src/Open3D/IO/FileFormat/FileGLTF.cpp
+++ b/src/Open3D/IO/FileFormat/FileGLTF.cpp
@@ -186,51 +186,60 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
                                     tinygltf::GetComponentSizeInBytes(
                                             colors_accessor.componentType);
                         }
-                        if (colors_accessor.componentType ==
-                            TINYGLTF_COMPONENT_TYPE_FLOAT) {
-                            for (size_t i = 0; i < colors_accessor.count; ++i) {
-                                const float* colors =
-                                        reinterpret_cast<const float*>(
-                                                colors_buffer.data.data() +
-                                                colors_view.byteOffset +
-                                                i * byte_stride);
-                                mesh_temp.vertex_colors_.emplace_back(
-                                        colors[0], colors[1], colors[2]);
+                        switch (colors_accessor.componentType) {
+                            case TINYGLTF_COMPONENT_TYPE_FLOAT: {
+                                for (size_t i = 0; i < colors_accessor.count;
+                                     ++i) {
+                                    const float* colors =
+                                            reinterpret_cast<const float*>(
+                                                    colors_buffer.data.data() +
+                                                    colors_view.byteOffset +
+                                                    i * byte_stride);
+                                    mesh_temp.vertex_colors_.emplace_back(
+                                            colors[0], colors[1], colors[2]);
+                                }
+                                break;
                             }
-                        } else if (colors_accessor.componentType ==
-                                   TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE) {
-                            double max_val =
-                                    (double)std::numeric_limits<uint8_t>::max();
-                            for (size_t i = 0; i < colors_accessor.count; ++i) {
-                                const uint8_t* colors =
-                                        reinterpret_cast<const uint8_t*>(
-                                                colors_buffer.data.data() +
-                                                colors_view.byteOffset +
-                                                i * byte_stride);
-                                mesh_temp.vertex_colors_.emplace_back(
-                                        colors[0] / max_val,
-                                        colors[1] / max_val,
-                                        colors[2] / max_val);
+                            case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE: {
+                                double max_val = (double)
+                                        std::numeric_limits<uint8_t>::max();
+                                for (size_t i = 0; i < colors_accessor.count;
+                                     ++i) {
+                                    const uint8_t* colors =
+                                            reinterpret_cast<const uint8_t*>(
+                                                    colors_buffer.data.data() +
+                                                    colors_view.byteOffset +
+                                                    i * byte_stride);
+                                    mesh_temp.vertex_colors_.emplace_back(
+                                            colors[0] / max_val,
+                                            colors[1] / max_val,
+                                            colors[2] / max_val);
+                                }
+                                break;
                             }
-                        } else if (colors_accessor.componentType ==
-                                   TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
-                            double max_val = (double)
-                                    std::numeric_limits<uint16_t>::max();
-                            for (size_t i = 0; i < colors_accessor.count; ++i) {
-                                const uint16_t* colors =
-                                        reinterpret_cast<const uint16_t*>(
-                                                colors_buffer.data.data() +
-                                                colors_view.byteOffset +
-                                                i * byte_stride);
-                                mesh_temp.vertex_colors_.emplace_back(
-                                        colors[0] / max_val,
-                                        colors[1] / max_val,
-                                        colors[2] / max_val);
+                            case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT: {
+                                double max_val = (double)
+                                        std::numeric_limits<uint16_t>::max();
+                                for (size_t i = 0; i < colors_accessor.count;
+                                     ++i) {
+                                    const uint16_t* colors =
+                                            reinterpret_cast<const uint16_t*>(
+                                                    colors_buffer.data.data() +
+                                                    colors_view.byteOffset +
+                                                    i * byte_stride);
+                                    mesh_temp.vertex_colors_.emplace_back(
+                                            colors[0] / max_val,
+                                            colors[1] / max_val,
+                                            colors[2] / max_val);
+                                }
+                                break;
                             }
-                        } else {
-                            utility::LogWarning(
-                                    "Unrecognized component type for vertex "
-                                    "colors\n");
+                            default: {
+                                utility::LogWarning(
+                                        "Unrecognized component type for "
+                                        "vertex colors\n");
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR builds upon #1082, and implements the following extensions:
- All meshes given in a glTF file are loaded in the read function, and they are transformed based on any optional translation/rotation/scaling specified. [Test sample](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/OrientationTest)
- Vertex colors are now fully supported (VEC3/VEC4, FLOAT/UNSIGNED BYTE/UNSIGNED SHORT). [Test samples](https://github.com/KhronosGroup/glTF-Asset-Generator/tree/master/Output/Positive/Mesh_PrimitiveVertexColor)
- Minor optimization added to writing indices to file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1100)
<!-- Reviewable:end -->
