### PR TITLE
Revert #1080 and added method for constant z planes

### DIFF
--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -96,20 +96,28 @@ def intersecting_boxes():
     return mesh
 
 
+def _relative_path(path):
+    script_path = os.path.realpath(__file__)
+    script_dir = os.path.dirname(script_path)
+    print(script_dir)
+    return os.path.join(script_dir, path)
+
+
 def knot():
-    mesh = o3d.io.read_triangle_mesh('../../TestData/knot.ply')
+    mesh = o3d.io.read_triangle_mesh(_relative_path('../../TestData/knot.ply'))
     mesh.compute_vertex_normals()
     return mesh
 
 
 def bathtub():
-    mesh = o3d.io.read_triangle_mesh("../../TestData/bathtub_0154.ply")
+    mesh = o3d.io.read_triangle_mesh(
+        _relative_path('../../TestData/bathtub_0154.ply'))
     mesh.compute_vertex_normals()
     return mesh
 
 
 def armadillo():
-    armadillo_path = '../../TestData/Armadillo.ply'
+    armadillo_path = _relative_path('../../TestData/Armadillo.ply')
     if not os.path.exists(armadillo_path):
         print('downloading armadillo mesh')
         url = 'http://graphics.stanford.edu/pub/3Dscanrep/armadillo/Armadillo.ply.gz'
@@ -125,7 +133,7 @@ def armadillo():
 
 
 def bunny():
-    bunny_path = '../../TestData/Bunny.ply'
+    bunny_path = _relative_path('../../TestData/Bunny.ply')
     if not os.path.exists(bunny_path):
         print('downloading bunny mesh')
         url = 'http://graphics.stanford.edu/pub/3Dscanrep/bunny.tar.gz'

--- a/examples/Python/Basic/meshes.py
+++ b/examples/Python/Basic/meshes.py
@@ -99,7 +99,6 @@ def intersecting_boxes():
 def _relative_path(path):
     script_path = os.path.realpath(__file__)
     script_dir = os.path.dirname(script_path)
-    print(script_dir)
     return os.path.join(script_dir, path)
 
 

--- a/src/Open3D/Visualization/Visualizer/ViewControl.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewControl.cpp
@@ -63,15 +63,24 @@ void ViewControl::SetViewMatrices(
     glViewport(0, 0, window_width_, window_height_);
     if (GetProjectionType() == ProjectionType::Perspective) {
         // Perspective projection
-        z_near_ = std::max(1e-6, distance_ - 3.0 * bounding_box_.GetSize());
-        z_far_ = distance_ + 3.0 * bounding_box_.GetSize();
+        z_near_ = constant_z_near_ > 0
+                          ? constant_z_near_
+                          : std::max(0.01 * bounding_box_.GetSize(),
+                                     distance_ - 3.0 * bounding_box_.GetSize());
+        z_far_ = constant_z_far_ > 0
+                         ? constant_z_far_
+                         : distance_ + 3.0 * bounding_box_.GetSize();
         projection_matrix_ =
                 GLHelper::Perspective(field_of_view_, aspect_, z_near_, z_far_);
     } else {
         // Orthogonal projection
         // We use some black magic to support distance_ in orthogonal view
-        z_near_ = distance_ - 3.0 * bounding_box_.GetSize();
-        z_far_ = distance_ + 3.0 * bounding_box_.GetSize();
+        z_near_ = constant_z_near_ > 0
+                          ? constant_z_near_
+                          : distance_ - 3.0 * bounding_box_.GetSize();
+        z_far_ = constant_z_far_ > 0
+                         ? constant_z_far_
+                         : distance_ + 3.0 * bounding_box_.GetSize();
         projection_matrix_ =
                 GLHelper::Ortho(-aspect_ * view_ratio_, aspect_ * view_ratio_,
                                 -view_ratio_, view_ratio_, z_near_, z_far_);

--- a/src/Open3D/Visualization/Visualizer/ViewControl.h
+++ b/src/Open3D/Visualization/Visualizer/ViewControl.h
@@ -137,6 +137,11 @@ public:
     double GetZNear() const { return z_near_; }
     double GetZFar() const { return z_far_; }
 
+    void SetConstantZNear(double z_near) { constant_z_near_ = z_near; }
+    void SetConstantZFar(double z_far) { constant_z_far_ = z_far; }
+    void UnsetConstantZNear() { constant_z_near_ = -1; }
+    void UnsetConstantZFar() { constant_z_far_ = -1; }
+
 protected:
     int window_width_ = 0;
     int window_height_ = 0;
@@ -153,6 +158,8 @@ protected:
     double aspect_;
     double z_near_;
     double z_far_;
+    double constant_z_near_ = -1;
+    double constant_z_far_ = -1;
     GLHelper::GLMatrix4f projection_matrix_;
     GLHelper::GLMatrix4f view_matrix_;
     GLHelper::GLMatrix4f model_matrix_;

--- a/src/Python/visualization/viewcontrol.cpp
+++ b/src/Python/visualization/viewcontrol.cpp
@@ -41,6 +41,8 @@ static const std::unordered_map<std::string, std::string>
                 {"xo", "Original point coordinate of the mouse in x-axis."},
                 {"yo", "Original point coordinate of the mouse in y-axis."},
                 {"step", "The step to change field of view."},
+                {"z_near", "The depth of the near z-plane of the visualizer."},
+                {"z_far", "The depth of the far z-plane of the visualizer."},
 };
 
 void pybind_viewcontrol(py::module &m) {
@@ -79,7 +81,29 @@ void pybind_viewcontrol(py::module &m) {
                  "Function to get field of view")
             .def("change_field_of_view",
                  &visualization::ViewControl::ChangeFieldOfView,
-                 "Function to change field of view", "step"_a = 0.45);
+                 "Function to change field of view", "step"_a = 0.45)
+            .def("set_constant_z_near",
+                 &visualization::ViewControl::SetConstantZNear,
+                 "Function to change the near z-plane of the visualizer to a "
+                 "constant value, i.e., independent of zoom and bounding box "
+                 "size.",
+                 "z_near"_a)
+            .def("set_constant_z_far",
+                 &visualization::ViewControl::SetConstantZFar,
+                 "Function to change the far z-plane of the visualizer to a "
+                 "constant value, i.e., independent of zoom and bounding box "
+                 "size.",
+                 "z_far"_a)
+            .def("unset_constant_z_near",
+                 &visualization::ViewControl::UnsetConstantZNear,
+                 "Function to remove a previously set constant z near value, "
+                 "i.e., near z-plane of the visualizer is dynamically set "
+                 "dependent on zoom and bounding box size.")
+            .def("unset_constant_z_far",
+                 &visualization::ViewControl::UnsetConstantZFar,
+                 "Function to remove a previously set constant z far value, "
+                 "i.e., far z-plane of the visualizer is dynamically set "
+                 "dependent on zoom and bounding box size.");
     docstring::ClassMethodDocInject(m, "ViewControl", "change_field_of_view",
                                     map_view_control_docstrings);
     docstring::ClassMethodDocInject(m, "ViewControl",
@@ -95,6 +119,14 @@ void pybind_viewcontrol(py::module &m) {
     docstring::ClassMethodDocInject(m, "ViewControl", "scale",
                                     map_view_control_docstrings);
     docstring::ClassMethodDocInject(m, "ViewControl", "translate",
+                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(m, "ViewControl", "set_constant_z_near",
+                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(m, "ViewControl", "set_constant_z_far",
+                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(m, "ViewControl", "unset_constant_z_near",
+                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(m, "ViewControl", "unset_constant_z_far",
                                     map_view_control_docstrings);
 }
 


### PR DESCRIPTION
#1080 introduced problems in the rendering of meshes, see for example #1096. This PR reverts those changes.
In addition, I added a methods to set/unset constant z planes of the visualizer, i.e., that are independent of the zoom and the bounding box size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1122)
<!-- Reviewable:end -->
