### PR TITLE
Using correct Euclidean distance in RemoveStatisticalOutliers

### DIFF
--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -455,6 +455,8 @@ PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
         double mean = -1.0;
         if (dist.size() > 0u) {
             valid_distances++;
+            std::for_each(dist.begin(), dist.end(),
+                          [](double &d) { d = std::sqrt(d); });
             mean = std::accumulate(dist.begin(), dist.end(), 0.0) / dist.size();
         }
         avg_distances[i] = mean;


### PR DESCRIPTION
Addressing #1105, using Euclidean distance instead of squared Euclidean distance to compute the mean and std.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1126)
<!-- Reviewable:end -->
