### PR TITLE
K4a with dlopen

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -337,7 +337,6 @@ list(APPEND 3RDPARTY_LIBRARY_DIRS
     ${GLFW_LIBRARY_DIRS}
     ${JSONCPP_LIBRARY_DIRS}
     ${PNG_LIBRARY_DIRS}
-    ${k4a_LIBRARY_DIRS}
 )
 
 # set 3RDPARTY_LIBRARIES
@@ -352,7 +351,6 @@ list(APPEND 3RDPARTY_LIBRARIES
      ${qhull_LIBRARIES}
      ${googletest_LIBRARIES}
      ${fmt_LIBRARIES}
-     ${k4a_LIBRARIES}
 )
 
 # set PRE_BUILT_3RDPARTY_LIBRARIES. When building Open3D as shared library,

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -42,9 +42,9 @@ if (BUILD_AZURE_KINECT)
 
             # Alias target to be consistent with windows
             add_library(k4a INTERFACE)
-            target_link_libraries(k4a INTERFACE ${k4a_LIBRARIES})
+            # target_link_libraries(k4a INTERFACE ${k4a_LIBRARIES})
             add_library(k4arecord INTERFACE)
-            target_link_libraries(k4arecord INTERFACE ${k4arecord_LIBRARIES})
+            # target_link_libraries(k4arecord INTERFACE ${k4arecord_LIBRARIES})
 
             set(k4a_INCLUDE_DIRS k4a_INCLUDE_DIRS)
 

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
@@ -28,7 +28,6 @@
 // Licensed under the MIT License.
 
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.h"
-#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 
 #include <assert.h>
 #include <Eigen/Core>
@@ -41,6 +40,7 @@
 #include <k4arecord/record.h>
 
 #include "Open3D/Geometry/RGBDImage.h"
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 #include "Open3D/IO/Sensor/AzureKinect/MKVReader.h"
 #include "Open3D/Visualization/Utility/ColorMap.h"
 #include "Open3D/Visualization/Visualizer/VisualizerWithKeyCallback.h"
@@ -70,7 +70,7 @@ bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
                               filename);
             return false;
         }
-        if (K4A_FAILED(k4a_record_write_header(recording_))) {
+        if (K4A_FAILED(k4a_plugin::k4a_record_write_header(recording_))) {
             utility::LogError("Unable to write header\n");
             return false;
         }
@@ -84,11 +84,11 @@ bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
 bool AzureKinectRecorder::CloseRecord() {
     if (is_record_created_) {
         utility::LogInfo("Saving recording...\n");
-        if (K4A_FAILED(k4a_record_flush(recording_))) {
+        if (K4A_FAILED(k4a_plugin::k4a_record_flush(recording_))) {
             utility::LogError("Unable to flush record file\n");
             return false;
         }
-        k4a_record_close(recording_);
+        k4a_plugin::k4a_record_close(recording_);
         utility::LogInfo("Done\n");
 
         is_record_created_ = false;
@@ -100,7 +100,8 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectRecorder::RecordFrame(
         bool write, bool enable_align_depth_to_color) {
     k4a_capture_t capture = sensor_.CaptureRawFrame();
     if (capture != nullptr && is_record_created_ && write) {
-        if (K4A_FAILED(k4a_record_write_capture(recording_, capture))) {
+        if (K4A_FAILED(k4a_plugin::k4a_record_write_capture(recording_,
+                                                            capture))) {
             utility::LogError("Unable to write to capture\n");
             return nullptr;
         }
@@ -114,7 +115,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectRecorder::RecordFrame(
         utility::LogInfo("Invalid capture, skipping this frame\n");
         return nullptr;
     }
-    k4a_capture_release(capture);
+    k4a_plugin::k4a_capture_release(capture);
     return im_rgbd;
 }
 }  // namespace io

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
@@ -28,6 +28,7 @@
 // Licensed under the MIT License.
 
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.h"
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 
 #include <assert.h>
 #include <Eigen/Core>
@@ -61,7 +62,7 @@ bool AzureKinectRecorder::InitSensor() {
 
 bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
     if (!is_record_created_) {
-        if (K4A_FAILED(k4a_record_create(
+        if (K4A_FAILED(k4a_plugin::k4a_record_create(
                     filename.c_str(), sensor_.device_,
                     sensor_.sensor_config_.ConvertToNativeConfig(),
                     &recording_))) {

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.h
@@ -24,12 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
 #pragma once
 
-#include <k4arecord/types.h>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -37,6 +33,8 @@
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.h"
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.h"
 #include "Open3D/IO/Sensor/RGBDRecorder.h"
+
+struct _k4a_record_t;  // typedef _k4a_record_t* k4a_record_t;
 
 namespace open3d {
 
@@ -63,7 +61,7 @@ public:
 
 protected:
     AzureKinectSensor sensor_;
-    k4a_record_t recording_;
+    _k4a_record_t* recording_;
     size_t device_index_;
 
     bool is_record_created_ = false;

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.h
@@ -26,11 +26,15 @@
 
 #pragma once
 
-#include <k4a/k4a.h>
 #include <memory>
 
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.h"
 #include "Open3D/IO/Sensor/RGBDSensor.h"
+
+struct _k4a_capture_t;         // typedef _k4a_capture_t* k4a_capture_t;
+struct _k4a_device_t;          // typedef _k4a_device_t* k4a_device_t;
+struct _k4a_transformation_t;  // typedef _k4a_transformation_t*
+                               // k4a_transformation_t;
 
 namespace open3d {
 namespace geometry {
@@ -45,24 +49,24 @@ class AzureKinectRecorder;
 
 class AzureKinectSensor : public RGBDSensor {
 public:
-    AzureKinectSensor(const AzureKinectSensorConfig &sensor_config);
+    AzureKinectSensor(const AzureKinectSensorConfig& sensor_config);
     ~AzureKinectSensor();
 
     int Connect(size_t sensor_index) override;
     std::shared_ptr<geometry::RGBDImage> CaptureFrame(
             bool enable_align_depth_to_color) const override;
 
-    static int PrintFirmware(k4a_device_t device);
+    static int PrintFirmware(_k4a_device_t* device);
     static int ListDevices();
     static std::shared_ptr<geometry::RGBDImage> DecompressCapture(
-            k4a_capture_t capture, k4a_transformation_t transformation);
+            _k4a_capture_t* capture, _k4a_transformation_t* transformation);
 
 protected:
-    k4a_capture_t CaptureRawFrame() const;
+    _k4a_capture_t* CaptureRawFrame() const;
 
     AzureKinectSensorConfig sensor_config_;
-    k4a_transformation_t transform_depth_to_color_;
-    k4a_device_t device_;
+    _k4a_transformation_t* transform_depth_to_color_;
+    _k4a_device_t* device_;
     int timeout_;
 
     friend class AzureKinectRecorder;

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.h
@@ -32,8 +32,6 @@
 #include "Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.h"
 #include "Open3D/IO/Sensor/RGBDSensor.h"
 
-struct _k4a_device_configuration_t;
-
 namespace open3d {
 namespace geometry {
 class RGBDImage;

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 #include "Open3D/Utility/Console.h"
 
 namespace open3d {

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -66,7 +66,7 @@ static void* GetLibHandle() {
     return handle;
 }
 
-#define DEFINE_BRIDGED_FUNC_WITH_COUNT(f_name, return_type, num_args, ...)     \
+#define DEFINE_BRIDGED_FUNC_WITH_COUNT(return_type, f_name, num_args, ...)     \
     return_type f_name(CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) {     \
         typedef return_type (*f_type)(                                         \
                 CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));             \
@@ -81,12 +81,12 @@ static void* GetLibHandle() {
         return f(CALL_EXTRACT_PARAMS(num_args, __VA_ARGS__));                  \
     }
 
-#define DEFINE_BRIDGED_FUNC(f_name, return_type, ...)   \
-    DEFINE_BRIDGED_FUNC_WITH_COUNT(f_name, return_type, \
+#define DEFINE_BRIDGED_FUNC(return_type, f_name, ...)   \
+    DEFINE_BRIDGED_FUNC_WITH_COUNT(return_type, f_name, \
                                    COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
 
-DEFINE_BRIDGED_FUNC(k4a_record_create,
-                    k4a_result_t,
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_create,
                     const char*,
                     path,
                     k4a_device_t,
@@ -96,24 +96,24 @@ DEFINE_BRIDGED_FUNC(k4a_record_create,
                     k4a_record_t*,
                     recording_handle)
 
-DEFINE_BRIDGED_FUNC(k4a_record_write_header,
-                    k4a_result_t,
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_write_header,
                     k4a_record_t,
                     recording_handle)
 
-DEFINE_BRIDGED_FUNC(k4a_record_write_capture,
-                    k4a_result_t,
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_write_capture,
                     k4a_record_t,
                     recording_handle,
                     k4a_capture_t,
                     capture_handle)
 
-DEFINE_BRIDGED_FUNC(k4a_record_flush,
-                    k4a_result_t,
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_flush,
                     k4a_record_t,
                     recording_handle)
 
-DEFINE_BRIDGED_FUNC(k4a_record_close, void, k4a_record_t, recording_handle)
+DEFINE_BRIDGED_FUNC(void, k4a_record_close, k4a_record_t, recording_handle)
 
 }  // namespace k4a_plugin
 }  // namespace io

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -33,12 +33,11 @@
 
 #include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 #include "Open3D/IO/Sensor/AzureKinect/PluginMacros.h"
+#include "Open3D/Utility/Console.h"
 
-// using UnknownStruct = struct unknown_struct {
-//     void* pointers[3];
-//     struct unknown_struct* ptr;
-// };
-// using LinkMap = struct link_map;
+namespace open3d {
+namespace io {
+namespace k4a_plugin {
 
 static void* GetLibHandle() {
     static void* handle = nullptr;
@@ -89,10 +88,6 @@ static void* GetLibHandle() {
 #define DEFINE_BRIDGED_FUNC(f_name, return_type, ...)   \
     DEFINE_BRIDGED_FUNC_WITH_COUNT(f_name, return_type, \
                                    COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
-
-namespace open3d {
-namespace io {
-namespace k4a_plugin {
 
 DEFINE_BRIDGED_FUNC(k4a_record_create,
                     k4a_result_t,

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -74,9 +74,9 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
 
 #define DEFINE_BRIDGED_FUNC_WITH_COUNT(lib_name, return_type, f_name,          \
                                        num_args, ...)                          \
-    return_type f_name(CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) {     \
+    return_type f_name(EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) {          \
         typedef return_type (*f_type)(                                         \
-                CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));             \
+                EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));                  \
         static f_type f = nullptr;                                             \
                                                                                \
         if (!f) {                                                              \
@@ -85,7 +85,7 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
                 utility::LogFatal("Cannot load {}: {}\n", #f_name, dlerror()); \
             }                                                                  \
         }                                                                      \
-        return f(CALL_EXTRACT_PARAMS(num_args, __VA_ARGS__));                  \
+        return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));                       \
     }
 
 #define DEFINE_BRIDGED_FUNC(lib_name, return_type, f_name, ...)   \

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -38,7 +38,7 @@ namespace open3d {
 namespace io {
 namespace k4a_plugin {
 
-static void* GetLibHandle() {
+static void* GetDynamicLibHandle() {
     static void* handle = nullptr;
     static const std::string lib_name = "libk4arecord.so";
 
@@ -73,7 +73,7 @@ static void* GetLibHandle() {
         static f_type f = nullptr;                                             \
                                                                                \
         if (!f) {                                                              \
-            f = (f_type)dlsym(GetLibHandle(), #f_name);                        \
+            f = (f_type)dlsym(GetDynamicLibHandle(), #f_name);                 \
             if (!f) {                                                          \
                 utility::LogFatal("Cannot load {}: {}\n", #f_name, dlerror()); \
             }                                                                  \

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -34,11 +34,11 @@
 #include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 #include "Open3D/IO/Sensor/AzureKinect/PluginMacros.h"
 
-using UnknownStruct = struct unknown_struct {
-    void* pointers[3];
-    struct unknown_struct* ptr;
-};
-using LinkMap = struct link_map;
+// using UnknownStruct = struct unknown_struct {
+//     void* pointers[3];
+//     struct unknown_struct* ptr;
+// };
+// using LinkMap = struct link_map;
 
 static void* GetLibHandle() {
     static void* handle = nullptr;
@@ -52,20 +52,16 @@ static void* GetLibHandle() {
             throw std::runtime_error("Cannot load " + std::string(msg));
         } else {
             std::cout << "Loaded " << lib_name << std::endl;
-
-            auto* p = reinterpret_cast<UnknownStruct*>(handle)->ptr;
-            auto* map = reinterpret_cast<LinkMap*>(p->ptr);
-            while (map) {
-                std::cout << map->l_name << std::endl;
-                map = map->l_next;
+            struct link_map* map = nullptr;
+            if (!dlinfo(handle, RTLD_DI_LINKMAP, &map)) {
+                if (map != nullptr) {
+                    std::cout << "Library path: " << map->l_name << std::endl;
+                } else {
+                    std::cout << "Cannot get link_map" << std::endl;
+                }
+            } else {
+                std::cout << "Cannot get dlinfo " << lib_name << std::endl;
             }
-
-            // struct link_map* map = nullptr;
-            // if (!dlinfo(handle, RTLD_DI_LINKMAP, map)) {
-            //     std::cout << "map.l_name " << map->l_name << std::endl;
-            // } else {
-            //     std::cout << "Cannot get dlinfo " << lib_name << std::endl;
-            // }
         }
     }
 

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -47,19 +47,18 @@ static void* GetLibHandle() {
         handle = dlopen(lib_name.c_str(), RTLD_LAZY);
 
         if (!handle) {
-            const char* msg = dlerror();
-            throw std::runtime_error("Cannot load " + std::string(msg));
+            utility::LogFatal("Cannot load {}\n", dlerror());
         } else {
-            std::cout << "Loaded " << lib_name << std::endl;
+            utility::LogInfo("Loaded {}\n", lib_name);
             struct link_map* map = nullptr;
             if (!dlinfo(handle, RTLD_DI_LINKMAP, &map)) {
                 if (map != nullptr) {
-                    std::cout << "Library path: " << map->l_name << std::endl;
+                    utility::LogInfo("Library path: {}\n", map->l_name);
                 } else {
-                    std::cout << "Cannot get link_map" << std::endl;
+                    utility::LogWarning("Cannot get link_map\n");
                 }
             } else {
-                std::cout << "Cannot get dlinfo " << lib_name << std::endl;
+                utility::LogWarning("Cannot get dlinfo\n");
             }
         }
     }

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -29,7 +29,6 @@
 #include <k4arecord/record.h>
 #include <link.h>
 #include <cstring>
-#include <iostream>
 
 #include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 #include "Open3D/IO/Sensor/AzureKinect/PluginMacros.h"

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -1,0 +1,90 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <dlfcn.h>
+#include <k4a/k4a.h>
+#include <k4arecord/record.h>
+#include <iostream>
+
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
+#include "Open3D/IO/Sensor/AzureKinect/PluginMacros.h"
+
+static void* GetLibHandle() {
+    static void* handle = nullptr;
+    static const std::string lib_name = "libk4arecord.so.1.1.1";
+
+    if (!handle) {
+        handle = dlopen(lib_name.c_str(), RTLD_LAZY);
+        std::cout << "Loaded " << lib_name << std::endl;
+        if (!handle) {
+            const char* msg = dlerror();
+            throw std::runtime_error("Cannot load " + std::string(msg));
+        }
+    }
+
+    // handle != nullptr guaranteed here
+    return handle;
+}
+
+#define DEFINE_BRIDGED_FUNC_WITH_COUNT(f_name, return_type, num_args, ...) \
+    return_type f_name(CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) { \
+        typedef return_type (*f_type)(                                     \
+                CALL_EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));         \
+        static f_type f = nullptr;                                         \
+                                                                           \
+        if (!f) {                                                          \
+            f = (f_type)dlsym(GetLibHandle(), #f_name);                    \
+            if (!f) {                                                      \
+                const char* msg = dlerror();                               \
+                throw std::runtime_error(std::string("Cannot load ") +     \
+                                         #f_name + ": " + msg);            \
+            }                                                              \
+        }                                                                  \
+        return f(CALL_EXTRACT_PARAMS(num_args, __VA_ARGS__));              \
+    }
+
+#define DEFINE_BRIDGED_FUNC(f_name, return_type, ...)   \
+    DEFINE_BRIDGED_FUNC_WITH_COUNT(f_name, return_type, \
+                                   COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+namespace open3d {
+namespace io {
+namespace k4a_plugin {
+
+DEFINE_BRIDGED_FUNC(k4a_record_create,
+                    k4a_result_t,
+                    const char*,
+                    path,
+                    k4a_device_t,
+                    device,
+                    const k4a_device_configuration_t,
+                    device_config,
+                    k4a_record_t*,
+                    recording_handle)
+
+}  // namespace k4a_plugin
+}  // namespace io
+}  // namespace open3d

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -85,6 +85,25 @@ DEFINE_BRIDGED_FUNC(k4a_record_create,
                     k4a_record_t*,
                     recording_handle)
 
+DEFINE_BRIDGED_FUNC(k4a_record_write_header,
+                    k4a_result_t,
+                    k4a_record_t,
+                    recording_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_record_write_capture,
+                    k4a_result_t,
+                    k4a_record_t,
+                    recording_handle,
+                    k4a_capture_t,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_record_flush,
+                    k4a_result_t,
+                    k4a_record_t,
+                    recording_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_record_close, void, k4a_record_t, recording_handle)
+
 }  // namespace k4a_plugin
 }  // namespace io
 }  // namespace open3d

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -26,6 +26,7 @@
 
 #include <dlfcn.h>
 #include <k4a/k4a.h>
+#include <k4arecord/playback.h>
 #include <k4arecord/record.h>
 #include <link.h>
 #include <cstring>
@@ -155,6 +156,106 @@ DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
                     k4a_record_close,
                     k4a_record_t,
                     recording_handle)
+
+////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_result_t,
+                    k4a_playback_open,
+                    const char*,
+                    path,
+                    k4a_playback_t*,
+                    playback_handle)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_buffer_result_t,
+                    k4a_playback_get_raw_calibration,
+                    k4a_playback_t,
+                    playback_handle,
+                    uint8_t*,
+                    data,
+                    size_t*,
+                    data_size)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_result_t,
+                    k4a_playback_get_calibration,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_calibration_t*,
+                    calibration)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_result_t,
+                    k4a_playback_get_record_configuration,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_record_configuration_t*,
+                    config)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_buffer_result_t,
+                    k4a_playback_get_tag,
+                    k4a_playback_t,
+                    playback_handle,
+                    const char*,
+                    name,
+                    char*,
+                    value,
+                    size_t*,
+                    value_size)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_result_t,
+                    k4a_playback_set_color_conversion,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_image_format_t,
+                    target_format)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_stream_result_t,
+                    k4a_playback_get_next_capture,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_capture_t*,
+                    capture_handle)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_stream_result_t,
+                    k4a_playback_get_previous_capture,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_capture_t*,
+                    capture_handle)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_stream_result_t,
+                    k4a_playback_get_next_imu_sample,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_imu_sample_t*,
+                    imu_sample)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_stream_result_t,
+                    k4a_playback_get_previous_imu_sample,
+                    k4a_playback_t,
+                    playback_handle,
+                    k4a_imu_sample_t*,
+                    imu_sample)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    k4a_result_t,
+                    k4a_playback_seek_timestamp,
+                    k4a_playback_t,
+                    playback_handle,
+                    int64_t,
+                    offset_usec,
+                    k4a_playback_seek_origin_t,
+                    origin)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    uint64_t,
+                    k4a_playback_get_last_timestamp_usec,
+                    k4a_playback_t,
+                    playback_handle)
+DEFINE_BRIDGED_FUNC(k4arecord_lib_name,
+                    void,
+                    k4a_playback_close,
+                    k4a_playback_t,
+                    playback_handle)
+
+////////////////////////////////////////////////////////////////////////////////
 
 DEFINE_BRIDGED_FUNC(k4a_lib_name, uint32_t, k4a_device_get_installed_count)
 

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -85,6 +85,8 @@ static void* GetLibHandle() {
     DEFINE_BRIDGED_FUNC_WITH_COUNT(return_type, f_name, \
                                    COUNT_ARGS(__VA_ARGS__), __VA_ARGS__)
 
+////////////////////////////////////////////////////////////////////////////////
+
 DEFINE_BRIDGED_FUNC(k4a_result_t,
                     k4a_record_create,
                     const char*,
@@ -94,6 +96,20 @@ DEFINE_BRIDGED_FUNC(k4a_result_t,
                     const k4a_device_configuration_t,
                     device_config,
                     k4a_record_t*,
+                    recording_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_add_tag,
+                    k4a_record_t,
+                    recording_handle,
+                    const char*,
+                    name,
+                    const char*,
+                    value)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_add_imu_track,
+                    k4a_record_t,
                     recording_handle)
 
 DEFINE_BRIDGED_FUNC(k4a_result_t,
@@ -109,11 +125,432 @@ DEFINE_BRIDGED_FUNC(k4a_result_t,
                     capture_handle)
 
 DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_record_write_imu_sample,
+                    k4a_record_t,
+                    recording_handle,
+                    k4a_imu_sample_t,
+                    imu_sample)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
                     k4a_record_flush,
                     k4a_record_t,
                     recording_handle)
 
 DEFINE_BRIDGED_FUNC(void, k4a_record_close, k4a_record_t, recording_handle)
+
+DEFINE_BRIDGED_FUNC(uint32_t, k4a_device_get_installed_count, )
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_set_debug_message_handler,
+                    k4a_logging_message_cb_t*,
+                    message_cb,
+                    void*,
+                    message_cb_context,
+                    k4a_log_level_t,
+                    min_level)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_open,
+                    uint32_t,
+                    index,
+                    k4a_device_t*,
+                    device_handle)
+
+DEFINE_BRIDGED_FUNC(void, k4a_device_close, k4a_device_t, device_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_wait_result_t,
+                    k4a_device_get_capture,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_capture_t*,
+                    capture_handle,
+                    int32_t,
+                    timeout_in_ms)
+
+DEFINE_BRIDGED_FUNC(k4a_wait_result_t,
+                    k4a_device_get_imu_sample,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_imu_sample_t*,
+                    imu_sample,
+                    int32_t,
+                    timeout_in_ms)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_capture_create,
+                    k4a_capture_t*,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(void, k4a_capture_release, k4a_capture_t, capture_handle)
+
+DEFINE_BRIDGED_FUNC(void, k4a_capture_reference, k4a_capture_t, capture_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_image_t,
+                    k4a_capture_get_color_image,
+                    k4a_capture_t,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_image_t,
+                    k4a_capture_get_depth_image,
+                    k4a_capture_t,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_image_t,
+                    k4a_capture_get_ir_image,
+                    k4a_capture_t,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_capture_set_color_image,
+                    k4a_capture_t,
+                    capture_handle,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_capture_set_depth_image,
+                    k4a_capture_t,
+                    capture_handle,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_capture_set_ir_image,
+                    k4a_capture_t,
+                    capture_handle,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_capture_set_temperature_c,
+                    k4a_capture_t,
+                    capture_handle,
+                    float,
+                    temperature_c)
+
+DEFINE_BRIDGED_FUNC(float,
+                    k4a_capture_get_temperature_c,
+                    k4a_capture_t,
+                    capture_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_image_create,
+                    k4a_image_format_t,
+                    format,
+                    int,
+                    width_pixels,
+                    int,
+                    height_pixels,
+                    int,
+                    stride_bytes,
+                    k4a_image_t*,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_image_create_from_buffer,
+                    k4a_image_format_t,
+                    format,
+                    int,
+                    width_pixels,
+                    int,
+                    height_pixels,
+                    int,
+                    stride_bytes,
+                    uint8_t*,
+                    buffer,
+                    size_t,
+                    buffer_size,
+                    k4a_memory_destroy_cb_t*,
+                    buffer_release_cb,
+                    void*,
+                    buffer_release_cb_context,
+                    k4a_image_t*,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(uint8_t*, k4a_image_get_buffer, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(size_t, k4a_image_get_size, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_image_format_t,
+                    k4a_image_get_format,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(int, k4a_image_get_width_pixels, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(int, k4a_image_get_height_pixels, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(int, k4a_image_get_stride_bytes, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(uint64_t,
+                    k4a_image_get_timestamp_usec,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(uint64_t,
+                    k4a_image_get_exposure_usec,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(uint32_t,
+                    k4a_image_get_white_balance,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(uint32_t,
+                    k4a_image_get_iso_speed,
+                    k4a_image_t,
+                    image_handle)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_image_set_timestamp_usec,
+                    k4a_image_t,
+                    image_handle,
+                    uint64_t,
+                    timestamp_usec)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_image_set_exposure_time_usec,
+                    k4a_image_t,
+                    image_handle,
+                    uint64_t,
+                    exposure_usec)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_image_set_white_balance,
+                    k4a_image_t,
+                    image_handle,
+                    uint32_t,
+                    white_balance)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_image_set_iso_speed,
+                    k4a_image_t,
+                    image_handle,
+                    uint32_t,
+                    iso_speed)
+
+DEFINE_BRIDGED_FUNC(void, k4a_image_reference, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(void, k4a_image_release, k4a_image_t, image_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_start_cameras,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_device_configuration_t*,
+                    config)
+
+DEFINE_BRIDGED_FUNC(void, k4a_device_stop_cameras, k4a_device_t, device_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_start_imu,
+                    k4a_device_t,
+                    device_handle)
+
+DEFINE_BRIDGED_FUNC(void, k4a_device_stop_imu, k4a_device_t, device_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_buffer_result_t,
+                    k4a_device_get_serialnum,
+                    k4a_device_t,
+                    device_handle,
+                    char*,
+                    serial_number,
+                    size_t*,
+                    serial_number_size)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_get_version,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_hardware_version_t*,
+                    version)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_get_color_control_capabilities,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_color_control_command_t,
+                    command,
+                    bool*,
+                    supports_auto,
+                    int32_t*,
+                    min_value,
+                    int32_t*,
+                    max_value,
+                    int32_t*,
+                    step_value,
+                    int32_t*,
+                    default_value,
+                    k4a_color_control_mode_t*,
+                    default_mode)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_get_color_control,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_color_control_command_t,
+                    command,
+                    k4a_color_control_mode_t*,
+                    mode,
+                    int32_t*,
+                    value)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_set_color_control,
+                    k4a_device_t,
+                    device_handle,
+                    k4a_color_control_command_t,
+                    command,
+                    k4a_color_control_mode_t,
+                    mode,
+                    int32_t,
+                    value)
+
+DEFINE_BRIDGED_FUNC(k4a_buffer_result_t,
+                    k4a_device_get_raw_calibration,
+                    k4a_device_t,
+                    device_handle,
+                    uint8_t*,
+                    data,
+                    size_t*,
+                    data_size)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_get_calibration,
+                    k4a_device_t,
+                    device_handle,
+                    const k4a_depth_mode_t,
+                    depth_mode,
+                    const k4a_color_resolution_t,
+                    color_resolution,
+                    k4a_calibration_t*,
+                    calibration)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_device_get_sync_jack,
+                    k4a_device_t,
+                    device_handle,
+                    bool*,
+                    sync_in_jack_connected,
+                    bool*,
+                    sync_out_jack_connected)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_calibration_get_from_raw,
+                    char*,
+                    raw_calibration,
+                    size_t,
+                    raw_calibration_size,
+                    const k4a_depth_mode_t,
+                    depth_mode,
+                    const k4a_color_resolution_t,
+                    color_resolution,
+                    k4a_calibration_t*,
+                    calibration)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_calibration_3d_to_3d,
+                    const k4a_calibration_t*,
+                    calibration,
+                    const k4a_float3_t*,
+                    source_point3d_mm,
+                    const k4a_calibration_type_t,
+                    source_camera,
+                    const k4a_calibration_type_t,
+                    target_camera,
+                    k4a_float3_t*,
+                    target_point3d_mm)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_calibration_2d_to_3d,
+                    const k4a_calibration_t*,
+                    calibration,
+                    const k4a_float2_t*,
+                    source_point2d,
+                    const float,
+                    source_depth_mm,
+                    const k4a_calibration_type_t,
+                    source_camera,
+                    const k4a_calibration_type_t,
+                    target_camera,
+                    k4a_float3_t*,
+                    target_point3d_mm,
+                    int*,
+                    valid)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_calibration_3d_to_2d,
+                    const k4a_calibration_t*,
+                    calibration,
+                    const k4a_float3_t*,
+                    source_point3d_mm,
+                    const k4a_calibration_type_t,
+                    source_camera,
+                    const k4a_calibration_type_t,
+                    target_camera,
+                    k4a_float2_t*,
+                    target_point2d,
+                    int*,
+                    valid)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_calibration_2d_to_2d,
+                    const k4a_calibration_t*,
+                    calibration,
+                    const k4a_float2_t*,
+                    source_point2d,
+                    const float,
+                    source_depth_mm,
+                    const k4a_calibration_type_t,
+                    source_camera,
+                    const k4a_calibration_type_t,
+                    target_camera,
+                    k4a_float2_t*,
+                    target_point2d,
+                    int*,
+                    valid)
+
+DEFINE_BRIDGED_FUNC(k4a_transformation_t,
+                    k4a_transformation_create,
+                    const k4a_calibration_t*,
+                    calibration)
+
+DEFINE_BRIDGED_FUNC(void,
+                    k4a_transformation_destroy,
+                    k4a_transformation_t,
+                    transformation_handle)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_transformation_depth_image_to_color_camera,
+                    k4a_transformation_t,
+                    transformation_handle,
+                    const k4a_image_t,
+                    depth_image,
+                    k4a_image_t,
+                    transformed_depth_image)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_transformation_color_image_to_depth_camera,
+                    k4a_transformation_t,
+                    transformation_handle,
+                    const k4a_image_t,
+                    depth_image,
+                    const k4a_image_t,
+                    color_image,
+                    k4a_image_t,
+                    transformed_color_image)
+
+DEFINE_BRIDGED_FUNC(k4a_result_t,
+                    k4a_transformation_depth_image_to_point_cloud,
+                    k4a_transformation_t,
+                    transformation_handle,
+                    const k4a_image_t,
+                    depth_image,
+                    const k4a_calibration_type_t,
+                    camera,
+                    k4a_image_t,
+                    xyz_image)
 
 }  // namespace k4a_plugin
 }  // namespace io

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
@@ -40,271 +40,232 @@ k4a_result_t k4a_record_create(const char *path,
                                const k4a_device_configuration_t device_config,
                                k4a_record_t *recording_handle);
 
-// k4a_result_t k4a_record_add_tag(k4a_record_t recording_handle,
-//                                 const char *name,
-//                                 const char *value);
+k4a_result_t k4a_record_add_tag(k4a_record_t recording_handle,
+                                const char *name,
+                                const char *value);
 
-// k4a_result_t k4a_record_add_imu_track(k4a_record_t recording_handle);
+k4a_result_t k4a_record_add_imu_track(k4a_record_t recording_handle);
 
 k4a_result_t k4a_record_write_header(k4a_record_t recording_handle);
 
 k4a_result_t k4a_record_write_capture(k4a_record_t recording_handle,
                                       k4a_capture_t capture_handle);
 
-// k4a_result_t k4a_record_write_imu_sample(k4a_record_t recording_handle,
-//                                          k4a_imu_sample_t imu_sample);
+k4a_result_t k4a_record_write_imu_sample(k4a_record_t recording_handle,
+                                         k4a_imu_sample_t imu_sample);
 
 k4a_result_t k4a_record_flush(k4a_record_t recording_handle);
 
 void k4a_record_close(k4a_record_t recording_handle);
 
-// uint32_t k4a_device_get_installed_count(void);
+uint32_t k4a_device_get_installed_count(void);
 
-// // k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t
-// // *message_cb,
-// //                                            void *message_cb_context,
-// //                                            k4a_log_level_t min_level);
+k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t *message_cb,
+                                           void *message_cb_context,
+                                           k4a_log_level_t min_level);
 
-// k4a_result_t k4a_device_open(uint32_t index, k4a_device_t *device_handle);
+k4a_result_t k4a_device_open(uint32_t index, k4a_device_t *device_handle);
 
-// void k4a_device_close(k4a_device_t device_handle);
+void k4a_device_close(k4a_device_t device_handle);
 
-// k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
-//                                          k4a_capture_t *capture_handle,
-//                                          int32_t timeout_in_ms);
+k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
+                                         k4a_capture_t *capture_handle,
+                                         int32_t timeout_in_ms);
 
-// // k4a_wait_result_t k4a_device_get_imu_sample(k4a_device_t device_handle,
-// //                                             k4a_imu_sample_t *imu_sample,
-// //                                             int32_t timeout_in_ms);
+k4a_wait_result_t k4a_device_get_imu_sample(k4a_device_t device_handle,
+                                            k4a_imu_sample_t *imu_sample,
+                                            int32_t timeout_in_ms);
 
-// // k4a_result_t k4a_capture_create(k4a_capture_t *capture_handle);
+k4a_result_t k4a_capture_create(k4a_capture_t *capture_handle);
 
-// void k4a_capture_release(k4a_capture_t capture_handle);
+void k4a_capture_release(k4a_capture_t capture_handle);
 
-// // void k4a_capture_reference(k4a_capture_t capture_handle);
+void k4a_capture_reference(k4a_capture_t capture_handle);
 
-// k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
+k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
 
-// k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
+k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
 
-// // k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
+k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
 
-// // void k4a_capture_set_color_image(k4a_capture_t capture_handle,
-// //                                  k4a_image_t image_handle);
+void k4a_capture_set_color_image(k4a_capture_t capture_handle,
+                                 k4a_image_t image_handle);
 
-// // void k4a_capture_set_depth_image(k4a_capture_t capture_handle,
-// //                                  k4a_image_t image_handle);
+void k4a_capture_set_depth_image(k4a_capture_t capture_handle,
+                                 k4a_image_t image_handle);
 
-// // void k4a_capture_set_ir_image(k4a_capture_t capture_handle,
-// //                               k4a_image_t image_handle);
+void k4a_capture_set_ir_image(k4a_capture_t capture_handle,
+                              k4a_image_t image_handle);
 
-// // void k4a_capture_set_temperature_c(k4a_capture_t capture_handle,
-// //                                    float temperature_c);
+void k4a_capture_set_temperature_c(k4a_capture_t capture_handle,
+                                   float temperature_c);
 
-// // float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
+float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
 
-// // k4a_result_t k4a_image_create(k4a_image_format_t format,
-// //                               int width_pixels,
-// //                               int height_pixels,
-// //                               int stride_bytes,
-// //                               k4a_image_t *image_handle);
+k4a_result_t k4a_image_create(k4a_image_format_t format,
+                              int width_pixels,
+                              int height_pixels,
+                              int stride_bytes,
+                              k4a_image_t *image_handle);
 
-// k4a_result_t k4a_image_create_from_buffer(
-//         k4a_image_format_t format,
-//         int width_pixels,
-//         int height_pixels,
-//         int stride_bytes,
-//         uint8_t *buffer,
-//         size_t buffer_size,
-//         k4a_memory_destroy_cb_t *buffer_release_cb,
-//         void *buffer_release_cb_context,
-//         k4a_image_t *image_handle);
+k4a_result_t k4a_image_create_from_buffer(
+        k4a_image_format_t format,
+        int width_pixels,
+        int height_pixels,
+        int stride_bytes,
+        uint8_t *buffer,
+        size_t buffer_size,
+        k4a_memory_destroy_cb_t *buffer_release_cb,
+        void *buffer_release_cb_context,
+        k4a_image_t *image_handle);
 
-// uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
+uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
 
-// size_t k4a_image_get_size(k4a_image_t image_handle);
+size_t k4a_image_get_size(k4a_image_t image_handle);
 
-// k4a_image_format_t k4a_image_get_format(k4a_image_t image_handle);
+k4a_image_format_t k4a_image_get_format(k4a_image_t image_handle);
 
-// int k4a_image_get_width_pixels(k4a_image_t image_handle);
+int k4a_image_get_width_pixels(k4a_image_t image_handle);
 
-// int k4a_image_get_height_pixels(k4a_image_t image_handle);
+int k4a_image_get_height_pixels(k4a_image_t image_handle);
 
-// // int k4a_image_get_stride_bytes(k4a_image_t image_handle);
+int k4a_image_get_stride_bytes(k4a_image_t image_handle);
 
-// // uint64_t k4a_image_get_timestamp_usec(k4a_image_t image_handle);
+uint64_t k4a_image_get_timestamp_usec(k4a_image_t image_handle);
 
-// // uint64_t k4a_image_get_exposure_usec(k4a_image_t image_handle);
+uint64_t k4a_image_get_exposure_usec(k4a_image_t image_handle);
 
-// // uint32_t k4a_image_get_white_balance(k4a_image_t image_handle);
+uint32_t k4a_image_get_white_balance(k4a_image_t image_handle);
 
-// // uint32_t k4a_image_get_iso_speed(k4a_image_t image_handle);
+uint32_t k4a_image_get_iso_speed(k4a_image_t image_handle);
 
-// // void k4a_image_set_timestamp_usec(k4a_image_t image_handle,
-// //                                   uint64_t timestamp_usec);
+void k4a_image_set_timestamp_usec(k4a_image_t image_handle,
+                                  uint64_t timestamp_usec);
 
-// // void k4a_image_set_exposure_time_usec(k4a_image_t image_handle,
-// //                                       uint64_t exposure_usec);
+void k4a_image_set_exposure_time_usec(k4a_image_t image_handle,
+                                      uint64_t exposure_usec);
 
-// // void k4a_image_set_white_balance(k4a_image_t image_handle,
-// //                                  uint32_t white_balance);
+void k4a_image_set_white_balance(k4a_image_t image_handle,
+                                 uint32_t white_balance);
 
-// // void k4a_image_set_iso_speed(k4a_image_t image_handle, uint32_t
-// iso_speed);
+void k4a_image_set_iso_speed(k4a_image_t image_handle, uint32_t iso_speed);
 
-// // void k4a_image_reference(k4a_image_t image_handle);
+void k4a_image_reference(k4a_image_t image_handle);
 
-// void k4a_image_release(k4a_image_t image_handle);
+void k4a_image_release(k4a_image_t image_handle);
 
-// k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle,
-//                                       k4a_device_configuration_t *config);
+k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle,
+                                      k4a_device_configuration_t *config);
 
-// void k4a_device_stop_cameras(k4a_device_t device_handle);
+void k4a_device_stop_cameras(k4a_device_t device_handle);
 
-// // k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
+k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
 
-// // void k4a_device_stop_imu(k4a_device_t device_handle);
+void k4a_device_stop_imu(k4a_device_t device_handle);
 
-// k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle,
-//                                              char *serial_number,
-//                                              size_t *serial_number_size);
+k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle,
+                                             char *serial_number,
+                                             size_t *serial_number_size);
 
-// k4a_result_t k4a_device_get_version(k4a_device_t device_handle,
-//                                     k4a_hardware_version_t *version);
+k4a_result_t k4a_device_get_version(k4a_device_t device_handle,
+                                    k4a_hardware_version_t *version);
 
-// // k4a_result_t k4a_device_get_color_control_capabilities(
-// //         k4a_device_t device_handle,
-// //         k4a_color_control_command_t command,
-// //         bool *supports_auto,
-// //         int32_t *min_value,
-// //         int32_t *max_value,
-// //         int32_t *step_value,
-// //         int32_t *default_value,
-// //         k4a_color_control_mode_t *default_mode);
+k4a_result_t k4a_device_get_color_control_capabilities(
+        k4a_device_t device_handle,
+        k4a_color_control_command_t command,
+        bool *supports_auto,
+        int32_t *min_value,
+        int32_t *max_value,
+        int32_t *step_value,
+        int32_t *default_value,
+        k4a_color_control_mode_t *default_mode);
 
-// k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
-//                                           k4a_color_control_command_t
-//                                           command, k4a_color_control_mode_t
-//                                           *mode, int32_t *value);
+k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
+                                          k4a_color_control_command_t command,
+                                          k4a_color_control_mode_t *mode,
+                                          int32_t *value);
 
-// k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle,
-//                                           k4a_color_control_command_t
-//                                           command, k4a_color_control_mode_t
-//                                           mode, int32_t value);
+k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle,
+                                          k4a_color_control_command_t command,
+                                          k4a_color_control_mode_t mode,
+                                          int32_t value);
 
-// // k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t
-// // device_handle,
-// //                                                    uint8_t *data,
-// //                                                    size_t *data_size);
+k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t device_handle,
+                                                   uint8_t *data,
+                                                   size_t *data_size);
 
-// k4a_result_t k4a_device_get_calibration(
-//         k4a_device_t device_handle,
-//         const k4a_depth_mode_t depth_mode,
-//         const k4a_color_resolution_t color_resolution,
-//         k4a_calibration_t *calibration);
+k4a_result_t k4a_device_get_calibration(
+        k4a_device_t device_handle,
+        const k4a_depth_mode_t depth_mode,
+        const k4a_color_resolution_t color_resolution,
+        k4a_calibration_t *calibration);
 
-// // k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
-// //                                       bool *sync_in_jack_connected,
-// //                                       bool *sync_out_jack_connected);
+k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
+                                      bool *sync_in_jack_connected,
+                                      bool *sync_out_jack_connected);
 
-// // k4a_result_t k4a_calibration_get_from_raw(
-// //         char *raw_calibration,
-// //         size_t raw_calibration_size,
-// //         const k4a_depth_mode_t depth_mode,
-// //         const k4a_color_resolution_t color_resolution,
-// //         k4a_calibration_t *calibration);
+k4a_result_t k4a_calibration_get_from_raw(
+        char *raw_calibration,
+        size_t raw_calibration_size,
+        const k4a_depth_mode_t depth_mode,
+        const k4a_color_resolution_t color_resolution,
+        k4a_calibration_t *calibration);
 
-// // k4a_result_t k4a_calibration_3d_to_3d(
-// //         const k4a_calibration_t *calibration,
-// //         const k4a_float3_t *source_point3d_mm,
-// //         const k4a_calibration_type_t source_camera,
-// //         const k4a_calibration_type_t target_camera,
-// //         k4a_float3_t *target_point3d_mm);
+k4a_result_t k4a_calibration_3d_to_3d(
+        const k4a_calibration_t *calibration,
+        const k4a_float3_t *source_point3d_mm,
+        const k4a_calibration_type_t source_camera,
+        const k4a_calibration_type_t target_camera,
+        k4a_float3_t *target_point3d_mm);
 
-// // k4a_result_t k4a_calibration_2d_to_3d(
-// //         const k4a_calibration_t *calibration,
-// //         const k4a_float2_t *source_point2d,
-// //         const float source_depth_mm,
-// //         const k4a_calibration_type_t source_camera,
-// //         const k4a_calibration_type_t target_camera,
-// //         k4a_float3_t *target_point3d_mm,
-// //         int *valid);
+k4a_result_t k4a_calibration_2d_to_3d(
+        const k4a_calibration_t *calibration,
+        const k4a_float2_t *source_point2d,
+        const float source_depth_mm,
+        const k4a_calibration_type_t source_camera,
+        const k4a_calibration_type_t target_camera,
+        k4a_float3_t *target_point3d_mm,
+        int *valid);
 
-// // k4a_result_t k4a_calibration_3d_to_2d(
-// //         const k4a_calibration_t *calibration,
-// //         const k4a_float3_t *source_point3d_mm,
-// //         const k4a_calibration_type_t source_camera,
-// //         const k4a_calibration_type_t target_camera,
-// //         k4a_float2_t *target_point2d,
-// //         int *valid);
+k4a_result_t k4a_calibration_3d_to_2d(
+        const k4a_calibration_t *calibration,
+        const k4a_float3_t *source_point3d_mm,
+        const k4a_calibration_type_t source_camera,
+        const k4a_calibration_type_t target_camera,
+        k4a_float2_t *target_point2d,
+        int *valid);
 
-// // k4a_result_t k4a_calibration_2d_to_2d(
-// //         const k4a_calibration_t *calibration,
-// //         const k4a_float2_t *source_point2d,
-// //         const float source_depth_mm,
-// //         const k4a_calibration_type_t source_camera,
-// //         const k4a_calibration_type_t target_camera,
-// //         k4a_float2_t *target_point2d,
-// //         int *valid);
+k4a_result_t k4a_calibration_2d_to_2d(
+        const k4a_calibration_t *calibration,
+        const k4a_float2_t *source_point2d,
+        const float source_depth_mm,
+        const k4a_calibration_type_t source_camera,
+        const k4a_calibration_type_t target_camera,
+        k4a_float2_t *target_point2d,
+        int *valid);
 
-// k4a_transformation_t k4a_transformation_create(
-//         const k4a_calibration_t *calibration);
+k4a_transformation_t k4a_transformation_create(
+        const k4a_calibration_t *calibration);
 
-// // void k4a_transformation_destroy(k4a_transformation_t
-// transformation_handle);
+void k4a_transformation_destroy(k4a_transformation_t transformation_handle);
 
-// k4a_result_t k4a_transformation_depth_image_to_color_camera(
-//         k4a_transformation_t transformation_handle,
-//         const k4a_image_t depth_image,
-//         k4a_image_t transformed_depth_image);
+k4a_result_t k4a_transformation_depth_image_to_color_camera(
+        k4a_transformation_t transformation_handle,
+        const k4a_image_t depth_image,
+        k4a_image_t transformed_depth_image);
 
-// // k4a_result_t k4a_transformation_color_image_to_depth_camera(
-// //         k4a_transformation_t transformation_handle,
-// //         const k4a_image_t depth_image,
-// //         const k4a_image_t color_image,
-// //         k4a_image_t transformed_color_image);
+k4a_result_t k4a_transformation_color_image_to_depth_camera(
+        k4a_transformation_t transformation_handle,
+        const k4a_image_t depth_image,
+        const k4a_image_t color_image,
+        k4a_image_t transformed_color_image);
 
-// // k4a_result_t k4a_transformation_depth_image_to_point_cloud(
-// //         k4a_transformation_t transformation_handle,
-// //         const k4a_image_t depth_image,
-// //         const k4a_calibration_type_t camera,
-// //         k4a_image_t xyz_image);
+k4a_result_t k4a_transformation_depth_image_to_point_cloud(
+        k4a_transformation_t transformation_handle,
+        const k4a_image_t depth_image,
+        const k4a_calibration_type_t camera,
+        k4a_image_t xyz_image);
 
 }  // namespace k4a_plugin
 }  // namespace io
 }  // namespace open3d
-
-// k4a_capture_get_color_image
-// k4a_capture_get_depth_image
-// k4a_capture_release
-// k4a_device_close
-// k4a_device_get_calibration
-// k4a_device_get_capture
-// k4a_device_get_installed_count
-// k4a_device_get_serialnum
-// k4a_device_get_version
-// k4a_device_open
-// k4a_device_set_color_control
-// k4a_device_start_cameras
-// k4a_device_stop_cameras
-// k4a_image_create_from_buffer
-// k4a_image_get_buffer
-// k4a_image_get_format
-// k4a_image_get_height_pixels
-// k4a_image_get_size
-// k4a_image_get_width_pixels
-// k4a_image_release
-// k4a_playback_close
-// k4a_playback_get_calibration
-// k4a_playback_get_last_timestamp_usec
-// k4a_playback_get_next_capture
-// k4a_playback_get_tag
-// k4a_playback_open
-// k4a_playback_seek_timestamp
-// k4a_record_close
-// k4a_record_create
-// k4a_record_flush
-// k4a_record_write_capture
-// k4a_record_write_header
-// k4a_transformation_create
-// k4a_transformation_depth_image_to_color_camera

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
@@ -58,215 +58,217 @@ k4a_result_t k4a_record_flush(k4a_record_t recording_handle);
 
 void k4a_record_close(k4a_record_t recording_handle);
 
-uint32_t k4a_device_get_installed_count(void);
+// uint32_t k4a_device_get_installed_count(void);
 
-// k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t
-// *message_cb,
-//                                            void *message_cb_context,
-//                                            k4a_log_level_t min_level);
+// // k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t
+// // *message_cb,
+// //                                            void *message_cb_context,
+// //                                            k4a_log_level_t min_level);
 
-k4a_result_t k4a_device_open(uint32_t index, k4a_device_t *device_handle);
+// k4a_result_t k4a_device_open(uint32_t index, k4a_device_t *device_handle);
 
-void k4a_device_close(k4a_device_t device_handle);
+// void k4a_device_close(k4a_device_t device_handle);
 
-k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
-                                         k4a_capture_t *capture_handle,
-                                         int32_t timeout_in_ms);
+// k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
+//                                          k4a_capture_t *capture_handle,
+//                                          int32_t timeout_in_ms);
 
-// k4a_wait_result_t k4a_device_get_imu_sample(k4a_device_t device_handle,
-//                                             k4a_imu_sample_t *imu_sample,
-//                                             int32_t timeout_in_ms);
+// // k4a_wait_result_t k4a_device_get_imu_sample(k4a_device_t device_handle,
+// //                                             k4a_imu_sample_t *imu_sample,
+// //                                             int32_t timeout_in_ms);
 
-// k4a_result_t k4a_capture_create(k4a_capture_t *capture_handle);
+// // k4a_result_t k4a_capture_create(k4a_capture_t *capture_handle);
 
-void k4a_capture_release(k4a_capture_t capture_handle);
+// void k4a_capture_release(k4a_capture_t capture_handle);
 
-// void k4a_capture_reference(k4a_capture_t capture_handle);
+// // void k4a_capture_reference(k4a_capture_t capture_handle);
 
-k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
+// k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
 
-k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
+// k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
 
-// k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
+// // k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
 
-// void k4a_capture_set_color_image(k4a_capture_t capture_handle,
-//                                  k4a_image_t image_handle);
+// // void k4a_capture_set_color_image(k4a_capture_t capture_handle,
+// //                                  k4a_image_t image_handle);
 
-// void k4a_capture_set_depth_image(k4a_capture_t capture_handle,
-//                                  k4a_image_t image_handle);
+// // void k4a_capture_set_depth_image(k4a_capture_t capture_handle,
+// //                                  k4a_image_t image_handle);
 
-// void k4a_capture_set_ir_image(k4a_capture_t capture_handle,
-//                               k4a_image_t image_handle);
+// // void k4a_capture_set_ir_image(k4a_capture_t capture_handle,
+// //                               k4a_image_t image_handle);
 
-// void k4a_capture_set_temperature_c(k4a_capture_t capture_handle,
-//                                    float temperature_c);
+// // void k4a_capture_set_temperature_c(k4a_capture_t capture_handle,
+// //                                    float temperature_c);
 
-// float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
+// // float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
 
-// k4a_result_t k4a_image_create(k4a_image_format_t format,
-//                               int width_pixels,
-//                               int height_pixels,
-//                               int stride_bytes,
-//                               k4a_image_t *image_handle);
+// // k4a_result_t k4a_image_create(k4a_image_format_t format,
+// //                               int width_pixels,
+// //                               int height_pixels,
+// //                               int stride_bytes,
+// //                               k4a_image_t *image_handle);
 
-k4a_result_t k4a_image_create_from_buffer(
-        k4a_image_format_t format,
-        int width_pixels,
-        int height_pixels,
-        int stride_bytes,
-        uint8_t *buffer,
-        size_t buffer_size,
-        k4a_memory_destroy_cb_t *buffer_release_cb,
-        void *buffer_release_cb_context,
-        k4a_image_t *image_handle);
+// k4a_result_t k4a_image_create_from_buffer(
+//         k4a_image_format_t format,
+//         int width_pixels,
+//         int height_pixels,
+//         int stride_bytes,
+//         uint8_t *buffer,
+//         size_t buffer_size,
+//         k4a_memory_destroy_cb_t *buffer_release_cb,
+//         void *buffer_release_cb_context,
+//         k4a_image_t *image_handle);
 
-uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
+// uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
 
-size_t k4a_image_get_size(k4a_image_t image_handle);
+// size_t k4a_image_get_size(k4a_image_t image_handle);
 
-k4a_image_format_t k4a_image_get_format(k4a_image_t image_handle);
+// k4a_image_format_t k4a_image_get_format(k4a_image_t image_handle);
 
-int k4a_image_get_width_pixels(k4a_image_t image_handle);
+// int k4a_image_get_width_pixels(k4a_image_t image_handle);
 
-int k4a_image_get_height_pixels(k4a_image_t image_handle);
+// int k4a_image_get_height_pixels(k4a_image_t image_handle);
 
-// int k4a_image_get_stride_bytes(k4a_image_t image_handle);
+// // int k4a_image_get_stride_bytes(k4a_image_t image_handle);
 
-// uint64_t k4a_image_get_timestamp_usec(k4a_image_t image_handle);
+// // uint64_t k4a_image_get_timestamp_usec(k4a_image_t image_handle);
 
-// uint64_t k4a_image_get_exposure_usec(k4a_image_t image_handle);
+// // uint64_t k4a_image_get_exposure_usec(k4a_image_t image_handle);
 
-// uint32_t k4a_image_get_white_balance(k4a_image_t image_handle);
+// // uint32_t k4a_image_get_white_balance(k4a_image_t image_handle);
 
-// uint32_t k4a_image_get_iso_speed(k4a_image_t image_handle);
+// // uint32_t k4a_image_get_iso_speed(k4a_image_t image_handle);
 
-// void k4a_image_set_timestamp_usec(k4a_image_t image_handle,
-//                                   uint64_t timestamp_usec);
+// // void k4a_image_set_timestamp_usec(k4a_image_t image_handle,
+// //                                   uint64_t timestamp_usec);
 
-// void k4a_image_set_exposure_time_usec(k4a_image_t image_handle,
-//                                       uint64_t exposure_usec);
+// // void k4a_image_set_exposure_time_usec(k4a_image_t image_handle,
+// //                                       uint64_t exposure_usec);
 
-// void k4a_image_set_white_balance(k4a_image_t image_handle,
-//                                  uint32_t white_balance);
+// // void k4a_image_set_white_balance(k4a_image_t image_handle,
+// //                                  uint32_t white_balance);
 
-// void k4a_image_set_iso_speed(k4a_image_t image_handle, uint32_t iso_speed);
+// // void k4a_image_set_iso_speed(k4a_image_t image_handle, uint32_t
+// iso_speed);
 
-// void k4a_image_reference(k4a_image_t image_handle);
+// // void k4a_image_reference(k4a_image_t image_handle);
 
-void k4a_image_release(k4a_image_t image_handle);
+// void k4a_image_release(k4a_image_t image_handle);
 
-k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle,
-                                      k4a_device_configuration_t *config);
+// k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle,
+//                                       k4a_device_configuration_t *config);
 
-void k4a_device_stop_cameras(k4a_device_t device_handle);
+// void k4a_device_stop_cameras(k4a_device_t device_handle);
 
-// k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
+// // k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
 
-// void k4a_device_stop_imu(k4a_device_t device_handle);
+// // void k4a_device_stop_imu(k4a_device_t device_handle);
 
-k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle,
-                                             char *serial_number,
-                                             size_t *serial_number_size);
+// k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle,
+//                                              char *serial_number,
+//                                              size_t *serial_number_size);
 
-k4a_result_t k4a_device_get_version(k4a_device_t device_handle,
-                                    k4a_hardware_version_t *version);
+// k4a_result_t k4a_device_get_version(k4a_device_t device_handle,
+//                                     k4a_hardware_version_t *version);
 
-// k4a_result_t k4a_device_get_color_control_capabilities(
+// // k4a_result_t k4a_device_get_color_control_capabilities(
+// //         k4a_device_t device_handle,
+// //         k4a_color_control_command_t command,
+// //         bool *supports_auto,
+// //         int32_t *min_value,
+// //         int32_t *max_value,
+// //         int32_t *step_value,
+// //         int32_t *default_value,
+// //         k4a_color_control_mode_t *default_mode);
+
+// k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
+//                                           k4a_color_control_command_t
+//                                           command, k4a_color_control_mode_t
+//                                           *mode, int32_t *value);
+
+// k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle,
+//                                           k4a_color_control_command_t
+//                                           command, k4a_color_control_mode_t
+//                                           mode, int32_t value);
+
+// // k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t
+// // device_handle,
+// //                                                    uint8_t *data,
+// //                                                    size_t *data_size);
+
+// k4a_result_t k4a_device_get_calibration(
 //         k4a_device_t device_handle,
-//         k4a_color_control_command_t command,
-//         bool *supports_auto,
-//         int32_t *min_value,
-//         int32_t *max_value,
-//         int32_t *step_value,
-//         int32_t *default_value,
-//         k4a_color_control_mode_t *default_mode);
-
-k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
-                                          k4a_color_control_command_t command,
-                                          k4a_color_control_mode_t *mode,
-                                          int32_t *value);
-
-k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle,
-                                          k4a_color_control_command_t command,
-                                          k4a_color_control_mode_t mode,
-                                          int32_t value);
-
-// k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t
-// device_handle,
-//                                                    uint8_t *data,
-//                                                    size_t *data_size);
-
-k4a_result_t k4a_device_get_calibration(
-        k4a_device_t device_handle,
-        const k4a_depth_mode_t depth_mode,
-        const k4a_color_resolution_t color_resolution,
-        k4a_calibration_t *calibration);
-
-// k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
-//                                       bool *sync_in_jack_connected,
-//                                       bool *sync_out_jack_connected);
-
-// k4a_result_t k4a_calibration_get_from_raw(
-//         char *raw_calibration,
-//         size_t raw_calibration_size,
 //         const k4a_depth_mode_t depth_mode,
 //         const k4a_color_resolution_t color_resolution,
 //         k4a_calibration_t *calibration);
 
-// k4a_result_t k4a_calibration_3d_to_3d(
-//         const k4a_calibration_t *calibration,
-//         const k4a_float3_t *source_point3d_mm,
-//         const k4a_calibration_type_t source_camera,
-//         const k4a_calibration_type_t target_camera,
-//         k4a_float3_t *target_point3d_mm);
+// // k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
+// //                                       bool *sync_in_jack_connected,
+// //                                       bool *sync_out_jack_connected);
 
-// k4a_result_t k4a_calibration_2d_to_3d(
-//         const k4a_calibration_t *calibration,
-//         const k4a_float2_t *source_point2d,
-//         const float source_depth_mm,
-//         const k4a_calibration_type_t source_camera,
-//         const k4a_calibration_type_t target_camera,
-//         k4a_float3_t *target_point3d_mm,
-//         int *valid);
+// // k4a_result_t k4a_calibration_get_from_raw(
+// //         char *raw_calibration,
+// //         size_t raw_calibration_size,
+// //         const k4a_depth_mode_t depth_mode,
+// //         const k4a_color_resolution_t color_resolution,
+// //         k4a_calibration_t *calibration);
 
-// k4a_result_t k4a_calibration_3d_to_2d(
-//         const k4a_calibration_t *calibration,
-//         const k4a_float3_t *source_point3d_mm,
-//         const k4a_calibration_type_t source_camera,
-//         const k4a_calibration_type_t target_camera,
-//         k4a_float2_t *target_point2d,
-//         int *valid);
+// // k4a_result_t k4a_calibration_3d_to_3d(
+// //         const k4a_calibration_t *calibration,
+// //         const k4a_float3_t *source_point3d_mm,
+// //         const k4a_calibration_type_t source_camera,
+// //         const k4a_calibration_type_t target_camera,
+// //         k4a_float3_t *target_point3d_mm);
 
-// k4a_result_t k4a_calibration_2d_to_2d(
-//         const k4a_calibration_t *calibration,
-//         const k4a_float2_t *source_point2d,
-//         const float source_depth_mm,
-//         const k4a_calibration_type_t source_camera,
-//         const k4a_calibration_type_t target_camera,
-//         k4a_float2_t *target_point2d,
-//         int *valid);
+// // k4a_result_t k4a_calibration_2d_to_3d(
+// //         const k4a_calibration_t *calibration,
+// //         const k4a_float2_t *source_point2d,
+// //         const float source_depth_mm,
+// //         const k4a_calibration_type_t source_camera,
+// //         const k4a_calibration_type_t target_camera,
+// //         k4a_float3_t *target_point3d_mm,
+// //         int *valid);
 
-k4a_transformation_t k4a_transformation_create(
-        const k4a_calibration_t *calibration);
+// // k4a_result_t k4a_calibration_3d_to_2d(
+// //         const k4a_calibration_t *calibration,
+// //         const k4a_float3_t *source_point3d_mm,
+// //         const k4a_calibration_type_t source_camera,
+// //         const k4a_calibration_type_t target_camera,
+// //         k4a_float2_t *target_point2d,
+// //         int *valid);
 
-// void k4a_transformation_destroy(k4a_transformation_t transformation_handle);
+// // k4a_result_t k4a_calibration_2d_to_2d(
+// //         const k4a_calibration_t *calibration,
+// //         const k4a_float2_t *source_point2d,
+// //         const float source_depth_mm,
+// //         const k4a_calibration_type_t source_camera,
+// //         const k4a_calibration_type_t target_camera,
+// //         k4a_float2_t *target_point2d,
+// //         int *valid);
 
-k4a_result_t k4a_transformation_depth_image_to_color_camera(
-        k4a_transformation_t transformation_handle,
-        const k4a_image_t depth_image,
-        k4a_image_t transformed_depth_image);
+// k4a_transformation_t k4a_transformation_create(
+//         const k4a_calibration_t *calibration);
 
-// k4a_result_t k4a_transformation_color_image_to_depth_camera(
+// // void k4a_transformation_destroy(k4a_transformation_t
+// transformation_handle);
+
+// k4a_result_t k4a_transformation_depth_image_to_color_camera(
 //         k4a_transformation_t transformation_handle,
 //         const k4a_image_t depth_image,
-//         const k4a_image_t color_image,
-//         k4a_image_t transformed_color_image);
+//         k4a_image_t transformed_depth_image);
 
-// k4a_result_t k4a_transformation_depth_image_to_point_cloud(
-//         k4a_transformation_t transformation_handle,
-//         const k4a_image_t depth_image,
-//         const k4a_calibration_type_t camera,
-//         k4a_image_t xyz_image);
+// // k4a_result_t k4a_transformation_color_image_to_depth_camera(
+// //         k4a_transformation_t transformation_handle,
+// //         const k4a_image_t depth_image,
+// //         const k4a_image_t color_image,
+// //         k4a_image_t transformed_color_image);
+
+// // k4a_result_t k4a_transformation_depth_image_to_point_cloud(
+// //         k4a_transformation_t transformation_handle,
+// //         const k4a_image_t depth_image,
+// //         const k4a_calibration_type_t camera,
+// //         k4a_image_t xyz_image);
 
 }  // namespace k4a_plugin
 }  // namespace io

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
@@ -1,0 +1,308 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+// To prevent header dependency propagation
+// Do not include this file in any *.h, only in *.cc
+#include <k4a/k4a.h>
+#include <k4arecord/record.h>
+
+namespace open3d {
+namespace io {
+namespace k4a_plugin {
+
+k4a_result_t k4a_record_create(const char *path,
+                               k4a_device_t device,
+                               const k4a_device_configuration_t device_config,
+                               k4a_record_t *recording_handle);
+
+// k4a_result_t k4a_record_add_tag(k4a_record_t recording_handle,
+//                                 const char *name,
+//                                 const char *value);
+
+// k4a_result_t k4a_record_add_imu_track(k4a_record_t recording_handle);
+
+k4a_result_t k4a_record_write_header(k4a_record_t recording_handle);
+
+k4a_result_t k4a_record_write_capture(k4a_record_t recording_handle,
+                                      k4a_capture_t capture_handle);
+
+// k4a_result_t k4a_record_write_imu_sample(k4a_record_t recording_handle,
+//                                          k4a_imu_sample_t imu_sample);
+
+k4a_result_t k4a_record_flush(k4a_record_t recording_handle);
+
+void k4a_record_close(k4a_record_t recording_handle);
+
+uint32_t k4a_device_get_installed_count(void);
+
+// k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t
+// *message_cb,
+//                                            void *message_cb_context,
+//                                            k4a_log_level_t min_level);
+
+k4a_result_t k4a_device_open(uint32_t index, k4a_device_t *device_handle);
+
+void k4a_device_close(k4a_device_t device_handle);
+
+k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
+                                         k4a_capture_t *capture_handle,
+                                         int32_t timeout_in_ms);
+
+// k4a_wait_result_t k4a_device_get_imu_sample(k4a_device_t device_handle,
+//                                             k4a_imu_sample_t *imu_sample,
+//                                             int32_t timeout_in_ms);
+
+// k4a_result_t k4a_capture_create(k4a_capture_t *capture_handle);
+
+void k4a_capture_release(k4a_capture_t capture_handle);
+
+// void k4a_capture_reference(k4a_capture_t capture_handle);
+
+k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
+
+k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
+
+// k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
+
+// void k4a_capture_set_color_image(k4a_capture_t capture_handle,
+//                                  k4a_image_t image_handle);
+
+// void k4a_capture_set_depth_image(k4a_capture_t capture_handle,
+//                                  k4a_image_t image_handle);
+
+// void k4a_capture_set_ir_image(k4a_capture_t capture_handle,
+//                               k4a_image_t image_handle);
+
+// void k4a_capture_set_temperature_c(k4a_capture_t capture_handle,
+//                                    float temperature_c);
+
+// float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
+
+// k4a_result_t k4a_image_create(k4a_image_format_t format,
+//                               int width_pixels,
+//                               int height_pixels,
+//                               int stride_bytes,
+//                               k4a_image_t *image_handle);
+
+k4a_result_t k4a_image_create_from_buffer(
+        k4a_image_format_t format,
+        int width_pixels,
+        int height_pixels,
+        int stride_bytes,
+        uint8_t *buffer,
+        size_t buffer_size,
+        k4a_memory_destroy_cb_t *buffer_release_cb,
+        void *buffer_release_cb_context,
+        k4a_image_t *image_handle);
+
+uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
+
+size_t k4a_image_get_size(k4a_image_t image_handle);
+
+k4a_image_format_t k4a_image_get_format(k4a_image_t image_handle);
+
+int k4a_image_get_width_pixels(k4a_image_t image_handle);
+
+int k4a_image_get_height_pixels(k4a_image_t image_handle);
+
+// int k4a_image_get_stride_bytes(k4a_image_t image_handle);
+
+// uint64_t k4a_image_get_timestamp_usec(k4a_image_t image_handle);
+
+// uint64_t k4a_image_get_exposure_usec(k4a_image_t image_handle);
+
+// uint32_t k4a_image_get_white_balance(k4a_image_t image_handle);
+
+// uint32_t k4a_image_get_iso_speed(k4a_image_t image_handle);
+
+// void k4a_image_set_timestamp_usec(k4a_image_t image_handle,
+//                                   uint64_t timestamp_usec);
+
+// void k4a_image_set_exposure_time_usec(k4a_image_t image_handle,
+//                                       uint64_t exposure_usec);
+
+// void k4a_image_set_white_balance(k4a_image_t image_handle,
+//                                  uint32_t white_balance);
+
+// void k4a_image_set_iso_speed(k4a_image_t image_handle, uint32_t iso_speed);
+
+// void k4a_image_reference(k4a_image_t image_handle);
+
+void k4a_image_release(k4a_image_t image_handle);
+
+k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle,
+                                      k4a_device_configuration_t *config);
+
+void k4a_device_stop_cameras(k4a_device_t device_handle);
+
+// k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
+
+// void k4a_device_stop_imu(k4a_device_t device_handle);
+
+k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle,
+                                             char *serial_number,
+                                             size_t *serial_number_size);
+
+k4a_result_t k4a_device_get_version(k4a_device_t device_handle,
+                                    k4a_hardware_version_t *version);
+
+// k4a_result_t k4a_device_get_color_control_capabilities(
+//         k4a_device_t device_handle,
+//         k4a_color_control_command_t command,
+//         bool *supports_auto,
+//         int32_t *min_value,
+//         int32_t *max_value,
+//         int32_t *step_value,
+//         int32_t *default_value,
+//         k4a_color_control_mode_t *default_mode);
+
+k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
+                                          k4a_color_control_command_t command,
+                                          k4a_color_control_mode_t *mode,
+                                          int32_t *value);
+
+k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle,
+                                          k4a_color_control_command_t command,
+                                          k4a_color_control_mode_t mode,
+                                          int32_t value);
+
+// k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t
+// device_handle,
+//                                                    uint8_t *data,
+//                                                    size_t *data_size);
+
+k4a_result_t k4a_device_get_calibration(
+        k4a_device_t device_handle,
+        const k4a_depth_mode_t depth_mode,
+        const k4a_color_resolution_t color_resolution,
+        k4a_calibration_t *calibration);
+
+// k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
+//                                       bool *sync_in_jack_connected,
+//                                       bool *sync_out_jack_connected);
+
+// k4a_result_t k4a_calibration_get_from_raw(
+//         char *raw_calibration,
+//         size_t raw_calibration_size,
+//         const k4a_depth_mode_t depth_mode,
+//         const k4a_color_resolution_t color_resolution,
+//         k4a_calibration_t *calibration);
+
+// k4a_result_t k4a_calibration_3d_to_3d(
+//         const k4a_calibration_t *calibration,
+//         const k4a_float3_t *source_point3d_mm,
+//         const k4a_calibration_type_t source_camera,
+//         const k4a_calibration_type_t target_camera,
+//         k4a_float3_t *target_point3d_mm);
+
+// k4a_result_t k4a_calibration_2d_to_3d(
+//         const k4a_calibration_t *calibration,
+//         const k4a_float2_t *source_point2d,
+//         const float source_depth_mm,
+//         const k4a_calibration_type_t source_camera,
+//         const k4a_calibration_type_t target_camera,
+//         k4a_float3_t *target_point3d_mm,
+//         int *valid);
+
+// k4a_result_t k4a_calibration_3d_to_2d(
+//         const k4a_calibration_t *calibration,
+//         const k4a_float3_t *source_point3d_mm,
+//         const k4a_calibration_type_t source_camera,
+//         const k4a_calibration_type_t target_camera,
+//         k4a_float2_t *target_point2d,
+//         int *valid);
+
+// k4a_result_t k4a_calibration_2d_to_2d(
+//         const k4a_calibration_t *calibration,
+//         const k4a_float2_t *source_point2d,
+//         const float source_depth_mm,
+//         const k4a_calibration_type_t source_camera,
+//         const k4a_calibration_type_t target_camera,
+//         k4a_float2_t *target_point2d,
+//         int *valid);
+
+k4a_transformation_t k4a_transformation_create(
+        const k4a_calibration_t *calibration);
+
+// void k4a_transformation_destroy(k4a_transformation_t transformation_handle);
+
+k4a_result_t k4a_transformation_depth_image_to_color_camera(
+        k4a_transformation_t transformation_handle,
+        const k4a_image_t depth_image,
+        k4a_image_t transformed_depth_image);
+
+// k4a_result_t k4a_transformation_color_image_to_depth_camera(
+//         k4a_transformation_t transformation_handle,
+//         const k4a_image_t depth_image,
+//         const k4a_image_t color_image,
+//         k4a_image_t transformed_color_image);
+
+// k4a_result_t k4a_transformation_depth_image_to_point_cloud(
+//         k4a_transformation_t transformation_handle,
+//         const k4a_image_t depth_image,
+//         const k4a_calibration_type_t camera,
+//         k4a_image_t xyz_image);
+
+}  // namespace k4a_plugin
+}  // namespace io
+}  // namespace open3d
+
+// k4a_capture_get_color_image
+// k4a_capture_get_depth_image
+// k4a_capture_release
+// k4a_device_close
+// k4a_device_get_calibration
+// k4a_device_get_capture
+// k4a_device_get_installed_count
+// k4a_device_get_serialnum
+// k4a_device_get_version
+// k4a_device_open
+// k4a_device_set_color_control
+// k4a_device_start_cameras
+// k4a_device_stop_cameras
+// k4a_image_create_from_buffer
+// k4a_image_get_buffer
+// k4a_image_get_format
+// k4a_image_get_height_pixels
+// k4a_image_get_size
+// k4a_image_get_width_pixels
+// k4a_image_release
+// k4a_playback_close
+// k4a_playback_get_calibration
+// k4a_playback_get_last_timestamp_usec
+// k4a_playback_get_next_capture
+// k4a_playback_get_tag
+// k4a_playback_open
+// k4a_playback_seek_timestamp
+// k4a_record_close
+// k4a_record_create
+// k4a_record_flush
+// k4a_record_write_capture
+// k4a_record_write_header
+// k4a_transformation_create
+// k4a_transformation_depth_image_to_color_camera

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.h
@@ -29,6 +29,7 @@
 // To prevent header dependency propagation
 // Do not include this file in any *.h, only in *.cc
 #include <k4a/k4a.h>
+#include <k4arecord/playback.h>
 #include <k4arecord/record.h>
 
 namespace open3d {
@@ -57,6 +58,50 @@ k4a_result_t k4a_record_write_imu_sample(k4a_record_t recording_handle,
 k4a_result_t k4a_record_flush(k4a_record_t recording_handle);
 
 void k4a_record_close(k4a_record_t recording_handle);
+
+////////////////////////////////////////////////////////////////////////////////
+
+k4a_result_t k4a_playback_open(const char *path,
+                               k4a_playback_t *playback_handle);
+
+k4a_buffer_result_t k4a_playback_get_raw_calibration(
+        k4a_playback_t playback_handle, uint8_t *data, size_t *data_size);
+
+k4a_result_t k4a_playback_get_calibration(k4a_playback_t playback_handle,
+                                          k4a_calibration_t *calibration);
+
+k4a_result_t k4a_playback_get_record_configuration(
+        k4a_playback_t playback_handle, k4a_record_configuration_t *config);
+
+k4a_buffer_result_t k4a_playback_get_tag(k4a_playback_t playback_handle,
+                                         const char *name,
+                                         char *value,
+                                         size_t *value_size);
+
+k4a_result_t k4a_playback_set_color_conversion(
+        k4a_playback_t playback_handle, k4a_image_format_t target_format);
+
+k4a_stream_result_t k4a_playback_get_next_capture(
+        k4a_playback_t playback_handle, k4a_capture_t *capture_handle);
+
+k4a_stream_result_t k4a_playback_get_previous_capture(
+        k4a_playback_t playback_handle, k4a_capture_t *capture_handle);
+
+k4a_stream_result_t k4a_playback_get_next_imu_sample(
+        k4a_playback_t playback_handle, k4a_imu_sample_t *imu_sample);
+
+k4a_stream_result_t k4a_playback_get_previous_imu_sample(
+        k4a_playback_t playback_handle, k4a_imu_sample_t *imu_sample);
+
+k4a_result_t k4a_playback_seek_timestamp(k4a_playback_t playback_handle,
+                                         int64_t offset_usec,
+                                         k4a_playback_seek_origin_t origin);
+
+uint64_t k4a_playback_get_last_timestamp_usec(k4a_playback_t playback_handle);
+
+void k4a_playback_close(k4a_playback_t playback_handle);
+
+////////////////////////////////////////////////////////////////////////////////
 
 uint32_t k4a_device_get_installed_count(void);
 

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVMetadata.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVMetadata.cpp
@@ -25,9 +25,9 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/IO/Sensor/AzureKinect/MKVMetadata.h"
-#include <unordered_map>
 
 #include <json/json.h>
+#include <unordered_map>
 
 namespace open3d {
 namespace io {

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVReader.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVReader.h
@@ -30,7 +30,7 @@
 #include "Open3D/IO/Sensor/AzureKinect/MKVMetadata.h"
 #include "Open3D/Utility/IJsonConvertible.h"
 
-struct _k4a_playback_t;        // typedef _k4a_playback_t* k4a_device_t;
+struct _k4a_playback_t;        // typedef _k4a_playback_t* k4a_playback_t;
 struct _k4a_capture_t;         // typedef _k4a_capture_t* k4a_capture_t;
 struct _k4a_transformation_t;  // typedef _k4a_transformation_t*
                                // k4a_transformation_t;

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
@@ -25,11 +25,12 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/IO/Sensor/AzureKinect/MKVWriter.h"
-#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 
 #include <k4a/k4a.h>
 #include <k4arecord/playback.h>
 #include <k4arecord/record.h>
+
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 
 namespace open3d {
 namespace io {
@@ -43,8 +44,9 @@ int MKVWriter::Open(const std::string &filename,
         Close();
     }
 
-    if (K4A_RESULT_SUCCEEDED !=
-        k4a_record_create(filename.c_str(), device, config, &handle_)) {
+    if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_create(filename.c_str(),
+                                                              device, config,
+                                                              &handle_)) {
         utility::LogError("Unable to open file {}\n", filename);
         return -1;
     }
@@ -57,7 +59,7 @@ bool MKVWriter::IsOpened() { return handle_ != nullptr; }
 int MKVWriter::SetMetadata(const MKVMetadata &metadata) {
     metadata_ = metadata;
 
-    if (K4A_RESULT_SUCCEEDED != k4a_record_write_header(handle_)) {
+    if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_write_header(handle_)) {
         utility::LogError("Unable to write header\n");
         return -1;
     }
@@ -65,10 +67,10 @@ int MKVWriter::SetMetadata(const MKVMetadata &metadata) {
 }
 
 void MKVWriter::Close() {
-    if (K4A_RESULT_SUCCEEDED != k4a_record_flush(handle_)) {
+    if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_flush(handle_)) {
         utility::LogError("Unable to flush before writing\n");
     }
-    k4a_record_close(handle_);
+    k4a_plugin::k4a_record_close(handle_);
 }
 
 int MKVWriter::NextFrame(k4a_capture_t capture) {
@@ -77,7 +79,8 @@ int MKVWriter::NextFrame(k4a_capture_t capture) {
         return -1;
     }
 
-    if (K4A_RESULT_SUCCEEDED != k4a_record_write_capture(handle_, capture)) {
+    if (K4A_RESULT_SUCCEEDED !=
+        k4a_plugin::k4a_record_write_capture(handle_, capture)) {
         utility::LogError("Unable to write frame to mkv.\n");
         return -1;
     }

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/IO/Sensor/AzureKinect/MKVWriter.h"
+#include "Open3D/IO/Sensor/AzureKinect/K4aPlugin.h"
 
 #include <k4a/k4a.h>
 #include <k4arecord/playback.h>

--- a/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
@@ -140,7 +140,7 @@
 // clang-format on
 
 // Convert to list of "arg_type arg_name" caller
-#define CALL_EXTRACT_TYPES_PARAMS(num_args, ...) \
+#define EXTRACT_TYPES_PARAMS(num_args, ...) \
     EXTRACT_TYPES_PARAMS_##num_args(__VA_ARGS__)
 
 // Convert to list of "arg_name"
@@ -204,5 +204,4 @@
 // clang-format on
 
 // Convert to list of "arg_name" caller
-#define CALL_EXTRACT_PARAMS(num_args, ...) \
-    EXTRACT_PARAMS_##num_args(__VA_ARGS__)
+#define EXTRACT_PARAMS(num_args, ...) EXTRACT_PARAMS_##num_args(__VA_ARGS__)

--- a/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
@@ -1,0 +1,208 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+// clang-format off
+#define ARGS_1(a1, ...) a1
+#define ARGS_2(a1, a2, ...) a2
+#define ARGS_3(a1, a2, a3, ...) a3
+#define ARGS_4(a1, a2, a3, a4, ...) a4
+#define ARGS_5(a1, a2, a3, a4, a5, ...) a5
+#define ARGS_6(a1, a2, a3, a4, a5, a6, ...) a6
+#define ARGS_7(a1, a2, a3, a4, a5, a6, a7, ...) a7
+#define ARGS_8(a1, a2, a3, a4, a5, a6, a7, a8, ...) a8
+#define ARGS_9(a1, a2, a3, a4, a5, a6, a7, a8, a9, ...) a9
+#define ARGS_10(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ...) a10
+#define ARGS_11(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, ...) a11
+#define ARGS_12(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, ...) a12
+#define ARGS_13(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, ...) a13
+#define ARGS_14(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, ...) a14
+#define ARGS_15(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, ...) a15
+#define ARGS_16(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, ...) a16
+#define ARGS_17(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, ...) a17
+#define ARGS_18(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, ...) a18
+#define ARGS_19(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, ...) a19
+#define ARGS_20(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, ...) a20
+#define ARGS_21(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, ...) a21
+// clang-format on
+
+#define COUNT_ARGS(...)                                                      \
+    ARGS_21(dummy, ##__VA_ARGS__, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, \
+            8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+// Convert to list of "arg_type arg_name"
+// Converts:
+//     float, a1, int, a2, short, a3, double, a4
+// To:
+//     float a1, int a2, short a3, double a4
+
+// clang-format off
+#define EXTRACT_TYPES_PARAMS_0(...)
+
+#define EXTRACT_TYPES_PARAMS_2(...) \
+    ARGS_1(__VA_ARGS__) ARGS_2(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_4(...) \
+    ARGS_1(__VA_ARGS__) ARGS_2(__VA_ARGS__), \
+    ARGS_3(__VA_ARGS__) ARGS_4(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_6(...) \
+    ARGS_1(__VA_ARGS__) ARGS_2(__VA_ARGS__), \
+    ARGS_3(__VA_ARGS__) ARGS_4(__VA_ARGS__), \
+    ARGS_5(__VA_ARGS__) ARGS_6(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_8(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_10(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_12(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__), \
+    ARGS_11(__VA_ARGS__) ARGS_12(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_14(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__), \
+    ARGS_11(__VA_ARGS__) ARGS_12(__VA_ARGS__), \
+    ARGS_13(__VA_ARGS__) ARGS_14(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_16(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__), \
+    ARGS_11(__VA_ARGS__) ARGS_12(__VA_ARGS__), \
+    ARGS_13(__VA_ARGS__) ARGS_14(__VA_ARGS__), \
+    ARGS_15(__VA_ARGS__) ARGS_16(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_18(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__), \
+    ARGS_11(__VA_ARGS__) ARGS_12(__VA_ARGS__), \
+    ARGS_13(__VA_ARGS__) ARGS_14(__VA_ARGS__), \
+    ARGS_15(__VA_ARGS__) ARGS_16(__VA_ARGS__), \
+    ARGS_17(__VA_ARGS__) ARGS_18(__VA_ARGS__)
+
+#define EXTRACT_TYPES_PARAMS_20(...) \
+    ARGS_1 (__VA_ARGS__) ARGS_2 (__VA_ARGS__), \
+    ARGS_3 (__VA_ARGS__) ARGS_4 (__VA_ARGS__), \
+    ARGS_5 (__VA_ARGS__) ARGS_6 (__VA_ARGS__), \
+    ARGS_7 (__VA_ARGS__) ARGS_8 (__VA_ARGS__), \
+    ARGS_9 (__VA_ARGS__) ARGS_10(__VA_ARGS__), \
+    ARGS_11(__VA_ARGS__) ARGS_12(__VA_ARGS__), \
+    ARGS_13(__VA_ARGS__) ARGS_14(__VA_ARGS__), \
+    ARGS_15(__VA_ARGS__) ARGS_16(__VA_ARGS__), \
+    ARGS_17(__VA_ARGS__) ARGS_18(__VA_ARGS__), \
+    ARGS_19(__VA_ARGS__) ARGS_20(__VA_ARGS__)
+// clang-format on
+
+// Convert to list of "arg_type arg_name" caller
+#define CALL_EXTRACT_TYPES_PARAMS(num_args, ...) \
+    EXTRACT_TYPES_PARAMS_##num_args(__VA_ARGS__)
+
+// Convert to list of "arg_name"
+// Converts:
+//     float, a1, int, a2, short, a3, double, a4
+// To:
+//     a1, a2, a3, a4
+// clang-format off
+
+#define EXTRACT_PARAMS_0(...)
+
+#define EXTRACT_PARAMS_2(...) \
+    ARGS_2(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_4(...) \
+    ARGS_2(__VA_ARGS__), ARGS_4(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_6(...) \
+    ARGS_2(__VA_ARGS__), ARGS_4(__VA_ARGS__), \
+    ARGS_6(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_8(...) \
+    ARGS_2(__VA_ARGS__), ARGS_4(__VA_ARGS__), \
+    ARGS_6(__VA_ARGS__), ARGS_8(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_10(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_12(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__), ARGS_12(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_14(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__), ARGS_12(__VA_ARGS__), \
+    ARGS_14(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_16(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__), ARGS_12(__VA_ARGS__), \
+    ARGS_14(__VA_ARGS__), ARGS_16(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_18(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__), ARGS_12(__VA_ARGS__), \
+    ARGS_14(__VA_ARGS__), ARGS_16(__VA_ARGS__), \
+    ARGS_18(__VA_ARGS__)
+
+#define EXTRACT_PARAMS_20(...) \
+    ARGS_2 (__VA_ARGS__), ARGS_4 (__VA_ARGS__), \
+    ARGS_6 (__VA_ARGS__), ARGS_8 (__VA_ARGS__), \
+    ARGS_10(__VA_ARGS__), ARGS_12(__VA_ARGS__), \
+    ARGS_14(__VA_ARGS__), ARGS_16(__VA_ARGS__), \
+    ARGS_18(__VA_ARGS__), ARGS_20(__VA_ARGS__)
+// clang-format on
+
+// Convert to list of "arg_name" caller
+#define CALL_EXTRACT_PARAMS(num_args, ...) \
+    EXTRACT_PARAMS_##num_args(__VA_ARGS__)

--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -85,18 +85,6 @@ set_target_properties(${PACKAGE_NAME} PROPERTIES
 set(PYTHON_PACKAGE_DST_DIR "${CMAKE_BINARY_DIR}/lib/python_package")
 message(STATUS "PYPI_PACKAGE_NAME: ${PYPI_PACKAGE_NAME}")
 
-# https://stackoverflow.com/a/7216542/1255535
-function(JOIN VALUES GLUE OUTPUT)
-  string (REGEX REPLACE "([^\\]|^);" "\\1${GLUE}" _TMP_STR "${VALUES}")
-  string (REGEX REPLACE "[\\](.)" "\\1" _TMP_STR "${_TMP_STR}") # fixes escaping
-  set (${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
-endfunction()
-
-JOIN("${k4a_DYNAMIC_LIBRARY_ABSOLUTE_PATHS}" "#" DLL_LIBS)
-message(STATUS ${DLL_LIBS})
-# list(LENGTH DLL_LIBS dll_length)
-# message(FATAL_ERROR "dll_length: ${dll_length}")
-
 add_custom_target(python-package
     COMMAND ${CMAKE_COMMAND}
             -DPYTHON_PACKAGE_SRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/package
@@ -112,8 +100,6 @@ add_custom_target(python-package
             -DPROJECT_VERSION=${PROJECT_VERSION}
             -DPROJECT_VERSION_THREE_NUMBER=${PROJECT_VERSION_THREE_NUMBER}
             -DPYPI_PACKAGE_NAME=${PYPI_PACKAGE_NAME}
-            -DBUILD_AZURE_KINECT=${BUILD_AZURE_KINECT}
-            -Dk4a_DYNAMIC_LIBRARY_ABSOLUTE_PATHS="${DLL_LIBS}"
             -P ${CMAKE_CURRENT_SOURCE_DIR}/make_python_package.cmake
 )
 

--- a/src/Python/make_python_package.cmake
+++ b/src/Python/make_python_package.cmake
@@ -17,16 +17,6 @@ get_filename_component(PYTHON_COMPILED_MODULE_NAME ${PYTHON_COMPILED_MODULE_PATH
 file(COPY ${PYTHON_COMPILED_MODULE_PATH}
      DESTINATION ${PYTHON_PACKAGE_DST_DIR}/open3d)
 
-if (BUILD_AZURE_KINECT)
-    string(REPLACE "#" ";" DLL_LIST ${k4a_DYNAMIC_LIBRARY_ABSOLUTE_PATHS})
-    foreach(SRC_FILE ${DLL_LIST})
-        message("Copying ${SRC_FILE} to ${PYTHON_PACKAGE_DST_DIR}/open3d")
-        file(COPY "${SRC_FILE}"
-             DESTINATION ${PYTHON_PACKAGE_DST_DIR}/open3d)
-    endforeach()
-endif()
-
-
 # 3) Configured files and supporting files
 configure_file("${PYTHON_PACKAGE_SRC_DIR}/setup.py"
                "${PYTHON_PACKAGE_DST_DIR}/setup.py")


### PR DESCRIPTION
- Complete `dlopen` approach
- Stub k4a interface built-in
- Use macros to quickly define k4a functions
- Do not need to link libk4a.so or libk4arecord.so, they will be loaded at runtime
- Python package no longer carry the shared libs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1132)
<!-- Reviewable:end -->
