### PR TITLE
Point Mapping in ConvexHull and Hidden Point Removal Operator

### DIFF
--- a/examples/Python/Basic/convex_hull.py
+++ b/examples/Python/Basic/convex_hull.py
@@ -4,15 +4,7 @@
 
 # examples/Python/Basic/convex_hull.py
 
-import numpy as np
-import os
-import urllib.request
-import gzip
-import tarfile
-import shutil
-import time
 import open3d as o3d
-
 import meshes
 
 
@@ -27,13 +19,13 @@ def mesh_generator():
 if __name__ == "__main__":
     for mesh in mesh_generator():
         mesh.compute_vertex_normals()
-        hull = mesh.compute_convex_hull()
+        hull, _ = mesh.compute_convex_hull()
         hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)
         hull_ls.paint_uniform_color((1, 0, 0))
         o3d.visualization.draw_geometries([mesh, hull_ls])
 
         pcl = mesh.sample_points_poisson_disk(number_of_points=2000)
-        hull = pcl.compute_convex_hull()
+        hull, _ = pcl.compute_convex_hull()
         hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)
         hull_ls.paint_uniform_color((1, 0, 0))
         o3d.visualization.draw_geometries([pcl, hull_ls])

--- a/examples/Python/Basic/hidden_point_removal.py
+++ b/examples/Python/Basic/hidden_point_removal.py
@@ -1,0 +1,67 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+import numpy as np
+import open3d as o3d
+import meshes
+
+
+def mesh_generator():
+    yield o3d.geometry.TriangleMesh.create_sphere()
+    yield meshes.knot()
+    yield meshes.bunny()
+    yield meshes.armadillo()
+
+
+if __name__ == "__main__":
+
+    for mesh in mesh_generator():
+
+        print("Convert mesh to a point cloud and estimate dimensions")
+        pcl = o3d.geometry.PointCloud()
+        pcl.points = mesh.vertices
+        pcl.colors = mesh.vertex_colors
+        diameter = np.linalg.norm(
+            np.asarray(pcl.get_max_bound()) - np.asarray(pcl.get_min_bound()))
+
+        print("Define parameters used for hidden_point_removal")
+        camera = [diameter, diameter * 0.5, diameter * 0.5]
+        radius = diameter * 100
+
+        print("Create coordinate frame for visualizing the camera location")
+        camera_frame = o3d.geometry.TriangleMesh.create_coordinate_frame(
+            size=diameter / 5, origin=camera)
+
+        print("Remove all hidden points viewed from the camera location")
+        hull, _ = pcl.hidden_point_removal(camera, radius)
+
+        print("Visualize result")
+        hull_ls = o3d.geometry.LineSet.create_from_triangle_mesh(hull)
+        hull_ls.paint_uniform_color((1, 0, 0))
+        pcl.paint_uniform_color((0.5, 0.5, 1))
+        o3d.visualization.draw_geometries([pcl, hull_ls, camera_frame])
+
+    print("Create a point cloud representing a sphere")
+    mesh = o3d.geometry.TriangleMesh.create_sphere()
+    pcl = o3d.geometry.PointCloud()
+    pcl.points = mesh.vertices
+
+    print("Assign colors based on their index (green to red)")
+    l = len(pcl.points)
+    colors = np.array(
+        [np.arange(0, l, 1) / l,
+         np.arange(l, 0, -1) / l,
+         np.zeros(l)]).transpose()
+    pcl.colors = o3d.utility.Vector3dVector(colors)
+
+    print("Remove all hidden points viewed from the camera location")
+    mesh, pt_map = pcl.hidden_point_removal([4, 0, 0], 100)
+
+    print("Add back colors using the point map")
+    mesh.vertex_colors = o3d.utility.Vector3dVector(colors[np.asarray(pt_map)])
+
+    print("Visualize the result")
+    mesh.compute_vertex_normals()
+    mesh.orient_triangles()
+    o3d.visualization.draw_geometries([mesh, pcl])

--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -168,7 +168,7 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
 OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
         const std::vector<Eigen::Vector3d>& points) {
     PointCloud hull_pcd;
-    hull_pcd.points_ = Qhull::ComputeConvexHull(points)->vertices_;
+    hull_pcd.points_ = std::get<0>(Qhull::ComputeConvexHull(points))->vertices_;
 
     Eigen::Vector3d mean;
     Eigen::Matrix3d cov;

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -288,8 +288,9 @@ std::vector<double> PointCloud::ComputeNearestNeighborDistance() const {
     return nn_dis;
 }
 
-std::shared_ptr<TriangleMesh> PointCloud::ComputeConvexHull() const {
-    return Qhull::ComputeConvexHull(points_);
+std::shared_ptr<TriangleMesh> PointCloud::ComputeConvexHull(
+        std::vector<int> &pt_map) const {
+    return Qhull::ComputeConvexHull(points_, pt_map);
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -293,5 +293,11 @@ std::shared_ptr<TriangleMesh> PointCloud::ComputeConvexHull(
     return Qhull::ComputeConvexHull(points_, pt_map);
 }
 
+std::shared_ptr<TriangleMesh> PointCloud::HiddenPointRemoval(
+        Eigen::Vector3d camera, double radius,
+        std::vector<int> &pt_map) const {
+    return Qhull::HiddenPointRemoval(points_, camera, radius, pt_map);
+}
+
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -26,6 +26,7 @@
 
 #include "Open3D/Geometry/PointCloud.h"
 #include "Open3D/Geometry/BoundingVolume.h"
+#include "Open3D/Geometry/TriangleMesh.h"
 
 #include <Eigen/Dense>
 #include <numeric>
@@ -288,15 +289,73 @@ std::vector<double> PointCloud::ComputeNearestNeighborDistance() const {
     return nn_dis;
 }
 
-std::shared_ptr<TriangleMesh> PointCloud::ComputeConvexHull(
-        std::vector<int> &pt_map) const {
-    return Qhull::ComputeConvexHull(points_, pt_map);
+std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+PointCloud::ComputeConvexHull() const {
+    return Qhull::ComputeConvexHull(points_);
 }
 
-std::shared_ptr<TriangleMesh> PointCloud::HiddenPointRemoval(
-        Eigen::Vector3d camera, double radius,
-        std::vector<int> &pt_map) const {
-    return Qhull::HiddenPointRemoval(points_, camera, radius, pt_map);
+std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+PointCloud::HiddenPointRemoval(const Eigen::Vector3d &camera_location,
+                               const double radius) const {
+    if (radius <= 0) {
+        utility::LogWarning(
+                "[HiddenPointRemoval] radius must be larger than zero.\n");
+        return std::make_tuple(std::make_shared<TriangleMesh>(),
+                               std::vector<size_t>());
+    }
+
+    // perform spherical projection
+    std::vector<Eigen::Vector3d> spherical_projection;
+    for (size_t pidx = 0; pidx < points_.size(); ++pidx) {
+        Eigen::Vector3d projected_point = points_[pidx] - camera_location;
+        double norm = projected_point.norm();
+        spherical_projection.push_back(
+                projected_point + 2 * (radius - norm) * projected_point / norm);
+    }
+
+    // add origin
+    size_t origin_pidx = spherical_projection.size();
+    spherical_projection.push_back(Eigen::Vector3d(0, 0, 0));
+
+    // calculate convex hull of spherical projection
+    std::shared_ptr<TriangleMesh> visible_mesh;
+    std::vector<size_t> pt_map;
+    std::tie(visible_mesh, pt_map) =
+            Qhull::ComputeConvexHull(spherical_projection);
+
+    // reassign original points to mesh
+    int origin_vidx = pt_map.size();
+    for (size_t vidx = 0; vidx < pt_map.size(); vidx++) {
+        size_t pidx = pt_map[vidx];
+        visible_mesh->vertices_[vidx] = points_[pidx];
+        if (pidx == origin_pidx) {
+            origin_vidx = vidx;
+            visible_mesh->vertices_[vidx] = camera_location;
+        }
+    }
+
+    // erase origin if part of mesh
+    if (origin_vidx < (int)(visible_mesh->vertices_.size())) {
+        visible_mesh->vertices_.erase(visible_mesh->vertices_.begin() +
+                                      origin_vidx);
+        pt_map.erase(pt_map.begin() + origin_vidx);
+        for (size_t tidx = visible_mesh->triangles_.size(); tidx-- > 0;) {
+            if (visible_mesh->triangles_[tidx](0) == origin_vidx ||
+                visible_mesh->triangles_[tidx](1) == origin_vidx ||
+                visible_mesh->triangles_[tidx](2) == origin_vidx) {
+                visible_mesh->triangles_.erase(
+                        visible_mesh->triangles_.begin() + tidx);
+            } else {
+                if (visible_mesh->triangles_[tidx](0) > origin_vidx)
+                    visible_mesh->triangles_[tidx](0) -= 1;
+                if (visible_mesh->triangles_[tidx](1) > origin_vidx)
+                    visible_mesh->triangles_[tidx](1) -= 1;
+                if (visible_mesh->triangles_[tidx](2) > origin_vidx)
+                    visible_mesh->triangles_[tidx](2) -= 1;
+            }
+        }
+    }
+    return std::make_tuple(visible_mesh, pt_map);
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -185,14 +185,19 @@ public:
     std::vector<double> ComputeNearestNeighborDistance() const;
 
     /// Function that computes the convex hull of the point cloud using qhull
-    std::shared_ptr<TriangleMesh> ComputeConvexHull(
-            std::vector<int> &pt_map) const;
+    std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+    ComputeConvexHull() const;
 
-    /// Function that creates a mesh for a given view point, removing all
-    /// invisible (hidden) points
-    std::shared_ptr<TriangleMesh> HiddenPointRemoval(
-            Eigen::Vector3d camera, double radius,
-            std::vector<int> &pt_map) const;
+    /// This is an implementation of the Hidden Point Removal operator
+    /// described in Katz et. al. 'Direct Visibility of Point Sets', 2007.
+    /// \param camera_location is the view point that is used to remove
+    /// invisible points. \param radius defines the radius of the spherical
+    /// projection. Additional information about the choice of \param radius
+    /// for noisy point clouds can be found in Mehra et. al. 'Visibility of
+    /// Noisy Point Cloud Data', 2010.
+    std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+    HiddenPointRemoval(const Eigen::Vector3d &camera_location,
+                       const double radius) const;
 
     /// Cluster PointCloud using the DBSCAN algorithm
     /// Ester et al., "A Density-Based Algorithm for Discovering Clusters

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -188,6 +188,12 @@ public:
     std::shared_ptr<TriangleMesh> ComputeConvexHull(
             std::vector<int> &pt_map) const;
 
+    /// Function that creates a mesh for a given view point, removing all
+    /// invisible (hidden) points
+    std::shared_ptr<TriangleMesh> HiddenPointRemoval(
+            Eigen::Vector3d camera, double radius,
+            std::vector<int> &pt_map) const;
+
     /// Cluster PointCloud using the DBSCAN algorithm
     /// Ester et al., "A Density-Based Algorithm for Discovering Clusters
     /// in Large Spatial Databases with Noise", 1996

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -185,7 +185,8 @@ public:
     std::vector<double> ComputeNearestNeighborDistance() const;
 
     /// Function that computes the convex hull of the point cloud using qhull
-    std::shared_ptr<TriangleMesh> ComputeConvexHull() const;
+    std::shared_ptr<TriangleMesh> ComputeConvexHull(
+            std::vector<int> &pt_map) const;
 
     /// Cluster PointCloud using the DBSCAN algorithm
     /// Ester et al., "A Density-Based Algorithm for Discovering Clusters

--- a/src/Open3D/Geometry/Qhull.cpp
+++ b/src/Open3D/Geometry/Qhull.cpp
@@ -39,7 +39,7 @@ namespace open3d {
 namespace geometry {
 
 std::shared_ptr<TriangleMesh> Qhull::ComputeConvexHull(
-        const std::vector<Eigen::Vector3d>& points) {
+        const std::vector<Eigen::Vector3d>& points, std::vector<int> &pt_map) {
     auto convex_hull = std::make_shared<TriangleMesh>();
 
     std::vector<double> qhull_points_data(points.size() * 3);
@@ -84,6 +84,7 @@ std::shared_ptr<TriangleMesh> Qhull::ComputeConvexHull(
                 double* coords = p.coordinates();
                 convex_hull->vertices_.push_back(
                         Eigen::Vector3d(coords[0], coords[1], coords[2]));
+                pt_map.push_back(vidx);
             }
         }
 
@@ -100,7 +101,7 @@ std::shared_ptr<TriangleMesh> Qhull::ComputeConvexHull(
 }
 
 std::shared_ptr<TetraMesh> Qhull::ComputeDelaunayTetrahedralization(
-        const std::vector<Eigen::Vector3d>& points) {
+        const std::vector<Eigen::Vector3d>& points, std::vector<int> &pt_map) {
     typedef decltype(TetraMesh::tetras_)::value_type Vector4i;
     auto delaunay_triangulation = std::make_shared<TetraMesh>();
 
@@ -161,6 +162,7 @@ std::shared_ptr<TetraMesh> Qhull::ComputeDelaunayTetrahedralization(
                 double* coords = p.coordinates();
                 delaunay_triangulation->vertices_.push_back(
                         Eigen::Vector3d(coords[0], coords[1], coords[2]));
+                pt_map.push_back(vidx);
             }
         }
 

--- a/src/Open3D/Geometry/Qhull.cpp
+++ b/src/Open3D/Geometry/Qhull.cpp
@@ -216,7 +216,10 @@ std::shared_ptr<TriangleMesh> Qhull::HiddenPointRemoval(
     for (size_t vidx = 0; vidx < pt_map.size(); vidx++) {
         size_t pidx = pt_map[vidx];
         visible_mesh->vertices_[vidx] = points[pidx];
-        if(pidx == origin_pidx) origin_vidx = vidx;
+        if(pidx == origin_pidx) {
+            origin_vidx = vidx;
+            visible_mesh->vertices_[vidx] = camera;
+        }
     }
 
     // erase origin if part of mesh
@@ -230,6 +233,14 @@ std::shared_ptr<TriangleMesh> Qhull::HiddenPointRemoval(
                     visible_mesh->triangles_[tidx](2) == origin_vidx) {
                 visible_mesh->triangles_.erase(
                     visible_mesh->triangles_.begin() + tidx);
+            }
+            else {
+                if(visible_mesh->triangles_[tidx](0) > origin_vidx)
+                    visible_mesh->triangles_[tidx](0) -= 1;
+                if(visible_mesh->triangles_[tidx](1) > origin_vidx)
+                    visible_mesh->triangles_[tidx](1) -= 1;
+                if(visible_mesh->triangles_[tidx](2) > origin_vidx)
+                    visible_mesh->triangles_[tidx](2) -= 1;
             }
         }
     }

--- a/src/Open3D/Geometry/Qhull.h
+++ b/src/Open3D/Geometry/Qhull.h
@@ -39,10 +39,24 @@ class TetraMesh;
 class Qhull {
 public:
     static std::shared_ptr<TriangleMesh> ComputeConvexHull(
-            const std::vector<Eigen::Vector3d>& points);
+            const std::vector<Eigen::Vector3d>& points,
+            std::vector<int> &pt_map);
+
+    static std::shared_ptr<TriangleMesh> ComputeConvexHull(
+            const std::vector<Eigen::Vector3d>& points){
+        std::vector<int> pt_map;
+        return Qhull::ComputeConvexHull(points, pt_map);
+    };
 
     static std::shared_ptr<TetraMesh> ComputeDelaunayTetrahedralization(
-            const std::vector<Eigen::Vector3d>& points);
+            const std::vector<Eigen::Vector3d>& points,
+            std::vector<int> &pt_map);
+
+    static std::shared_ptr<TetraMesh> ComputeDelaunayTetrahedralization(
+            const std::vector<Eigen::Vector3d>& points){
+        std::vector<int> pt_map;
+        return Qhull::ComputeDelaunayTetrahedralization(points, pt_map);
+    };
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/Qhull.h
+++ b/src/Open3D/Geometry/Qhull.h
@@ -57,6 +57,17 @@ public:
         std::vector<int> pt_map;
         return Qhull::ComputeDelaunayTetrahedralization(points, pt_map);
     };
+
+    static std::shared_ptr<TriangleMesh> HiddenPointRemoval(
+        const std::vector<Eigen::Vector3d>& points, Eigen::Vector3d camera,
+        double radius, std::vector<int> &pt_map);
+
+    static std::shared_ptr<TriangleMesh> HiddenPointRemoval(
+        const std::vector<Eigen::Vector3d>& points, Eigen::Vector3d camera,
+        double radius){
+      std::vector<int> pt_map;
+      return Qhull::HiddenPointRemoval(points, camera, radius, pt_map);
+    };
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/Qhull.h
+++ b/src/Open3D/Geometry/Qhull.h
@@ -38,36 +38,12 @@ class TetraMesh;
 
 class Qhull {
 public:
-    static std::shared_ptr<TriangleMesh> ComputeConvexHull(
-            const std::vector<Eigen::Vector3d>& points,
-            std::vector<int> &pt_map);
+    static std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+    ComputeConvexHull(const std::vector<Eigen::Vector3d>& points);
 
-    static std::shared_ptr<TriangleMesh> ComputeConvexHull(
-            const std::vector<Eigen::Vector3d>& points){
-        std::vector<int> pt_map;
-        return Qhull::ComputeConvexHull(points, pt_map);
-    };
-
-    static std::shared_ptr<TetraMesh> ComputeDelaunayTetrahedralization(
-            const std::vector<Eigen::Vector3d>& points,
-            std::vector<int> &pt_map);
-
-    static std::shared_ptr<TetraMesh> ComputeDelaunayTetrahedralization(
-            const std::vector<Eigen::Vector3d>& points){
-        std::vector<int> pt_map;
-        return Qhull::ComputeDelaunayTetrahedralization(points, pt_map);
-    };
-
-    static std::shared_ptr<TriangleMesh> HiddenPointRemoval(
-        const std::vector<Eigen::Vector3d>& points, Eigen::Vector3d camera,
-        double radius, std::vector<int> &pt_map);
-
-    static std::shared_ptr<TriangleMesh> HiddenPointRemoval(
-        const std::vector<Eigen::Vector3d>& points, Eigen::Vector3d camera,
-        double radius){
-      std::vector<int> pt_map;
-      return Qhull::HiddenPointRemoval(points, camera, radius, pt_map);
-    };
+    static std::tuple<std::shared_ptr<TetraMesh>, std::vector<size_t>>
+    ComputeDelaunayTetrahedralization(
+            const std::vector<Eigen::Vector3d>& points);
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TetraMeshFactory.cpp
+++ b/src/Open3D/Geometry/TetraMeshFactory.cpp
@@ -40,7 +40,8 @@ std::shared_ptr<TetraMesh> TetraMesh::CreateFromPointCloud(
                 "tetrahedral mesh.\n");
         return std::make_shared<TetraMesh>();
     }
-    return Qhull::ComputeDelaunayTetrahedralization(point_cloud.points_);
+    return std::get<0>(
+            Qhull::ComputeDelaunayTetrahedralization(point_cloud.points_));
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -1358,7 +1358,8 @@ bool TriangleMesh::IsIntersecting(const TriangleMesh &other) const {
     return false;
 }
 
-std::shared_ptr<TriangleMesh> TriangleMesh::ComputeConvexHull() const {
+std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+TriangleMesh::ComputeConvexHull() const {
     return Qhull::ComputeConvexHull(vertices_);
 }
 

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -28,6 +28,7 @@
 
 #include <Eigen/Core>
 #include <memory>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -302,7 +303,8 @@ public:
     Eigen::Vector4d GetTrianglePlane(size_t triangle_idx) const;
 
     /// Function that computes the convex hull of the triangle mesh using qhull
-    std::shared_ptr<TriangleMesh> ComputeConvexHull() const;
+    std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
+    ComputeConvexHull() const;
 
     /// Function to sample \param number_of_points points uniformly from the
     /// mesh

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -31,6 +31,7 @@
 #include "Python/docstring.h"
 #include "Python/geometry/geometry.h"
 #include "Python/geometry/geometry_trampoline.h"
+#include <vector>
 
 using namespace open3d;
 
@@ -143,7 +144,8 @@ void pybind_pointcloud(py::module &m) {
                  "neighbor in the point cloud")
             .def("compute_convex_hull",
                  &geometry::PointCloud::ComputeConvexHull,
-                 "Computes the convex hull of the point cloud.")
+                 "Computes the convex hull of the point cloud.",
+                 "pt_map"_a = std::vector<int>())
             .def("cluster_dbscan", &geometry::PointCloud::ClusterDBSCAN,
                  "Cluster PointCloud using the DBSCAN algorithm  Ester et al., "
                  "'A Density-Based Algorithm for Discovering Clusters in Large "
@@ -258,8 +260,11 @@ void pybind_pointcloud(py::module &m) {
                                     "compute_mahalanobis_distance");
     docstring::ClassMethodDocInject(m, "PointCloud",
                                     "compute_nearest_neighbor_distance");
-    docstring::ClassMethodDocInject(m, "PointCloud", "compute_convex_hull",
-                                    {{"input", "The input point cloud."}});
+    docstring::ClassMethodDocInject(
+            m, "PointCloud", "compute_convex_hull",
+            {{"input", "The input point cloud."},
+             {"pt_map", "A IntVector that is filled with the indices of the "
+              "input points corresponding to the points in the mesh."}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "cluster_dbscan",
             {{"eps",

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -146,6 +146,12 @@ void pybind_pointcloud(py::module &m) {
                  &geometry::PointCloud::ComputeConvexHull,
                  "Computes the convex hull of the point cloud.",
                  "pt_map"_a = std::vector<int>())
+            .def("hidden_point_removal",
+                 &geometry::PointCloud::HiddenPointRemoval,
+                 "Remove hidden points from a point cloud and return a mesh of "
+                 "the remaining points. Based on Katz et al. 'Direct "
+                 "Visibility of Point Sets', 2007.",
+                 "camera"_a, "radius"_a, "pt_map"_a = std::vector<int>())
             .def("cluster_dbscan", &geometry::PointCloud::ClusterDBSCAN,
                  "Cluster PointCloud using the DBSCAN algorithm  Ester et al., "
                  "'A Density-Based Algorithm for Discovering Clusters in Large "

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -25,13 +25,13 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/Geometry/PointCloud.h"
+#include <vector>
 #include "Open3D/Camera/PinholeCameraIntrinsic.h"
 #include "Open3D/Geometry/Image.h"
 #include "Open3D/Geometry/RGBDImage.h"
 #include "Python/docstring.h"
 #include "Python/geometry/geometry.h"
 #include "Python/geometry/geometry_trampoline.h"
-#include <vector>
 
 using namespace open3d;
 
@@ -144,14 +144,13 @@ void pybind_pointcloud(py::module &m) {
                  "neighbor in the point cloud")
             .def("compute_convex_hull",
                  &geometry::PointCloud::ComputeConvexHull,
-                 "Computes the convex hull of the point cloud.",
-                 "pt_map"_a = std::vector<int>())
+                 "Computes the convex hull of the point cloud.")
             .def("hidden_point_removal",
                  &geometry::PointCloud::HiddenPointRemoval,
-                 "Remove hidden points from a point cloud and return a mesh of "
-                 "the remaining points. Based on Katz et al. 'Direct "
+                 "Removes hidden points from a point cloud and returns a mesh "
+                 "of the remaining points. Based on Katz et al. 'Direct "
                  "Visibility of Point Sets', 2007.",
-                 "camera"_a, "radius"_a, "pt_map"_a = std::vector<int>())
+                 "camera_location"_a, "radius"_a)
             .def("cluster_dbscan", &geometry::PointCloud::ClusterDBSCAN,
                  "Cluster PointCloud using the DBSCAN algorithm  Ester et al., "
                  "'A Density-Based Algorithm for Discovering Clusters in Large "
@@ -266,11 +265,14 @@ void pybind_pointcloud(py::module &m) {
                                     "compute_mahalanobis_distance");
     docstring::ClassMethodDocInject(m, "PointCloud",
                                     "compute_nearest_neighbor_distance");
+    docstring::ClassMethodDocInject(m, "PointCloud", "compute_convex_hull",
+                                    {{"input", "The input point cloud."}});
     docstring::ClassMethodDocInject(
-            m, "PointCloud", "compute_convex_hull",
+            m, "PointCloud", "hidden_point_removal",
             {{"input", "The input point cloud."},
-             {"pt_map", "A IntVector that is filled with the indices of the "
-              "input points corresponding to the points in the mesh."}});
+             {"camera_location",
+              "All points not visible from that location will be reomved"},
+             {"radius", "The radius of the sperical projection"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "cluster_dbscan",
             {{"eps",


### PR DESCRIPTION
This pull request will add two new features:

1) The call to `point_cloud.compute_convex_hull` can contain an optional argument of an IntVector, which will be filled with the mapping between the point in the mesh (returned) and the points in the original point cloud. One possible application of this is to retain additional information in the mesh:
```
pc = o3d.geometry.PointCloud()
pc.points = points  # a numpy array of  x, y, z values
pc.colors = colors  # a numpy array of r, g, b values

pt_map = o3d.utility.IntVector()
mesh = pc.compute_convex_hull(pt_map=pt_map)
mesh.vertex_colors = colors[np.asarray(pt_map)]
```

2) Implement the Hidden Point Removal operator, discussed in [Katz et. al. 'Direct Visibility of Point Sets', 2007](https://cgm.technion.ac.il/Computer-Graphics-Multimedia/Publications/Papers/2007/2007_Direct_Visibility_of_Point_Sets.pdf) as a member function of the point_cloud class. With the above change this could be achieved in pure python, but I think this is a very useful feature.

Todo (not sure what would be suitable):
- [ ] Add tests
- [x] Add examples
- [ ] Add optional argument to retain the `camera` vertex in the mesh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1144)
<!-- Reviewable:end -->
