### PR TITLE
DBSCAN speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ examples/Python/ReconstructionSystem/dataset/
 *.egg-info/
 *.ipynb_checkpoints/
 *.py[cod]
+*.bak
 node_modules/
 static/
 **/package-lock.json

--- a/examples/Python/Advanced/surface_reconstruction_ball_pivoting.py
+++ b/examples/Python/Advanced/surface_reconstruction_ball_pivoting.py
@@ -53,6 +53,7 @@ def problem_generator():
 
 if __name__ == "__main__":
     for pcd, radii in problem_generator():
+        o3d.visualization.draw_geometries([pcd])
         rec_mesh = o3d.geometry.TriangleMesh.create_from_point_cloud_ball_pivoting(
             pcd, o3d.utility.DoubleVector(radii))
         o3d.visualization.draw_geometries([pcd, rec_mesh])

--- a/examples/Python/Basic/clustering.py
+++ b/examples/Python/Basic/clustering.py
@@ -12,12 +12,12 @@ np.random.seed(42)
 
 
 def pointcloud_generator():
-    yield 'cube', o3d.geometry.TriangleMesh.create_sphere(
+    yield "cube", o3d.geometry.TriangleMesh.create_sphere(
     ).sample_points_uniformly(int(1e4)), 0.4
 
     mesh = o3d.geometry.TriangleMesh.create_torus().scale(5)
     mesh += o3d.geometry.TriangleMesh.create_torus()
-    yield 'torus', mesh.sample_points_uniformly(int(1e4)), 0.75
+    yield "torus", mesh.sample_points_uniformly(int(1e4)), 0.75
 
     d = 4
     mesh = o3d.geometry.TriangleMesh.create_tetrahedron().translate((-d, 0, 0))
@@ -28,15 +28,24 @@ def pointcloud_generator():
         (0, -d, 0))
     mesh += o3d.geometry.TriangleMesh.create_moebius(twists=2).translate(
         (d, -d, 0))
-    yield 'shapes', mesh.sample_points_uniformly(int(1e4)), 0.5
+    yield "shapes", mesh.sample_points_uniformly(int(1e5)), 0.5
+
+    yield "fragment", o3d.io.read_point_cloud(
+        "../../TestData/fragment.ply"), 0.02
 
 
 if __name__ == "__main__":
-    cmap = plt.get_cmap('Set2')
+    o3d.utility.set_verbosity_level(o3d.utility.Debug)
+
+    cmap = plt.get_cmap("tab20")
     for pcl_name, pcl, eps in pointcloud_generator():
-        labels = np.array(pcl.cluster_dbscan(eps=eps, min_points=10))
+        print("%s has %d points" % (pcl_name, np.asarray(pcl.points).shape[0]))
+        o3d.visualization.draw_geometries([pcl])
+
+        labels = np.array(
+            pcl.cluster_dbscan(eps=eps, min_points=10, print_progress=True))
         max_label = labels.max()
-        print('%s has %d clusters' % (pcl_name, max_label + 1))
+        print("%s has %d clusters" % (pcl_name, max_label + 1))
 
         colors = cmap(labels / (max_label if max_label > 0 else 1))
         colors[labels < 0] = 0

--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -65,6 +65,8 @@ Eigen::Vector3d OrientedBoundingBox::GetMaxBound() const {
             });
 }
 
+Eigen::Vector3d OrientedBoundingBox::GetCenter() const { return center_; }
+
 AxisAlignedBoundingBox OrientedBoundingBox::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(GetBoxPoints());
 }
@@ -95,8 +97,12 @@ OrientedBoundingBox& OrientedBoundingBox::Transform(
 }
 
 OrientedBoundingBox& OrientedBoundingBox::Translate(
-        const Eigen::Vector3d& translation) {
-    center_ += translation;
+        const Eigen::Vector3d& translation, bool relative) {
+    if (relative) {
+        center_ += translation;
+    } else {
+        center_ = translation;
+    }
     return *this;
 }
 
@@ -230,6 +236,10 @@ Eigen::Vector3d AxisAlignedBoundingBox::GetMaxBound() const {
     return max_bound_;
 }
 
+Eigen::Vector3d AxisAlignedBoundingBox::GetCenter() const {
+    return (min_bound_ + max_bound_) * 0.5;
+}
+
 AxisAlignedBoundingBox AxisAlignedBoundingBox::GetAxisAlignedBoundingBox()
         const {
     return *this;
@@ -248,9 +258,15 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Transform(
 }
 
 AxisAlignedBoundingBox& AxisAlignedBoundingBox::Translate(
-        const Eigen::Vector3d& translation) {
-    min_bound_ += translation;
-    max_bound_ += translation;
+        const Eigen::Vector3d& translation, bool relative) {
+    if (relative) {
+        min_bound_ += translation;
+        max_bound_ += translation;
+    } else {
+        const Eigen::Vector3d half_extend = GetHalfExtend();
+        min_bound_ = translation - half_extend;
+        max_bound_ = translation + half_extend;
+    }
     return *this;
 }
 

--- a/src/Open3D/Geometry/BoundingVolume.h
+++ b/src/Open3D/Geometry/BoundingVolume.h
@@ -51,12 +51,13 @@ public:
     bool IsEmpty() const override;
     virtual Eigen::Vector3d GetMinBound() const override;
     virtual Eigen::Vector3d GetMaxBound() const override;
+    virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     virtual OrientedBoundingBox GetOrientedBoundingBox() const override;
     virtual OrientedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
-    virtual OrientedBoundingBox& Translate(
-            const Eigen::Vector3d& translation) override;
+    virtual OrientedBoundingBox& Translate(const Eigen::Vector3d& translation,
+                                           bool relative = true) override;
     virtual OrientedBoundingBox& Scale(const double scale,
                                        bool center = true) override;
     virtual OrientedBoundingBox& Rotate(
@@ -100,12 +101,13 @@ public:
     bool IsEmpty() const override;
     virtual Eigen::Vector3d GetMinBound() const override;
     virtual Eigen::Vector3d GetMaxBound() const override;
+    virtual Eigen::Vector3d GetCenter() const override;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     virtual OrientedBoundingBox GetOrientedBoundingBox() const override;
     virtual AxisAlignedBoundingBox& Transform(
             const Eigen::Matrix4d& transformation) override;
     virtual AxisAlignedBoundingBox& Translate(
-            const Eigen::Vector3d& translation) override;
+            const Eigen::Vector3d& translation, bool relative = true) override;
     virtual AxisAlignedBoundingBox& Scale(const double scale,
                                           bool center = true) override;
     virtual AxisAlignedBoundingBox& Rotate(
@@ -121,10 +123,6 @@ public:
 
     double Volume() const;
     std::vector<Eigen::Vector3d> GetBoxPoints() const;
-
-    Eigen::Vector3d GetCenter() const {
-        return (min_bound_ + max_bound_) * 0.5;
-    }
 
     Eigen::Vector3d GetExtend() const { return (max_bound_ - min_bound_); }
 

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -52,10 +52,12 @@ public:
     bool IsEmpty() const override = 0;
     virtual Eigen::Vector3d GetMinBound() const = 0;
     virtual Eigen::Vector3d GetMaxBound() const = 0;
+    virtual Eigen::Vector3d GetCenter() const = 0;
     virtual AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const = 0;
     virtual OrientedBoundingBox GetOrientedBoundingBox() const = 0;
     virtual Geometry3D& Transform(const Eigen::Matrix4d& transformation) = 0;
-    virtual Geometry3D& Translate(const Eigen::Vector3d& translation) = 0;
+    virtual Geometry3D& Translate(const Eigen::Vector3d& translation,
+                                  bool relative = true) = 0;
     virtual Geometry3D& Scale(const double scale, bool center = true) = 0;
     virtual Geometry3D& Rotate(const Eigen::Vector3d& rotation,
                                bool center = true,

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -282,6 +282,16 @@ Eigen::Vector3d HalfEdgeTriangleMesh::GetMaxBound() const {
     return Eigen::Vector3d((*itr_x)(0), (*itr_y)(1), (*itr_z)(2));
 }
 
+Eigen::Vector3d HalfEdgeTriangleMesh::GetCenter() const {
+    Eigen::Vector3d center(0, 0, 0);
+    if (!HasVertices()) {
+        return center;
+    }
+    center = std::accumulate(vertices_.begin(), vertices_.end(), center);
+    center /= double(vertices_.size());
+    return center;
+}
+
 AxisAlignedBoundingBox HalfEdgeTriangleMesh::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(vertices_);
 }
@@ -316,9 +326,13 @@ HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Transform(
 }
 
 HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Translate(
-        const Eigen::Vector3d &translation) {
+        const Eigen::Vector3d &translation, bool relative) {
+    Eigen::Vector3d transform = translation;
+    if (!relative) {
+        transform -= GetCenter();
+    }
     for (auto &vertex : vertices_) {
-        vertex += translation;
+        vertex += transform;
     }
     return *this;
 }
@@ -327,9 +341,7 @@ HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Scale(const double scale,
                                                   bool center) {
     Eigen::Vector3d vertex_center(0, 0, 0);
     if (center && !vertices_.empty()) {
-        vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
-                                        vertex_center);
-        vertex_center /= double(vertices_.size());
+        vertex_center = GetCenter();
     }
     for (auto &vertex : vertices_) {
         vertex = (vertex - vertex_center) * scale + vertex_center;
@@ -341,9 +353,7 @@ HalfEdgeTriangleMesh &HalfEdgeTriangleMesh::Rotate(
         const Eigen::Vector3d &rotation, bool center, RotationType type) {
     Eigen::Vector3d vertex_center(0, 0, 0);
     if (center && !vertices_.empty()) {
-        vertex_center = std::accumulate(vertices_.begin(), vertices_.end(),
-                                        vertex_center);
-        vertex_center /= double(vertices_.size());
+        vertex_center = GetCenter();
     }
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto &vertex : vertices_) {

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.h
@@ -71,12 +71,13 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     HalfEdgeTriangleMesh &Transform(
             const Eigen::Matrix4d &transformation) override;
-    HalfEdgeTriangleMesh &Translate(
-            const Eigen::Vector3d &translation) override;
+    HalfEdgeTriangleMesh &Translate(const Eigen::Vector3d &translation,
+                                    bool relative = true) override;
     HalfEdgeTriangleMesh &Scale(const double scale,
                                 bool center = true) override;
     HalfEdgeTriangleMesh &Rotate(

--- a/src/Open3D/Geometry/LineSet.cpp
+++ b/src/Open3D/Geometry/LineSet.cpp
@@ -63,6 +63,16 @@ Eigen::Vector3d LineSet::GetMaxBound() const {
             });
 }
 
+Eigen::Vector3d LineSet::GetCenter() const {
+    Eigen::Vector3d center(0, 0, 0);
+    if (!HasPoints()) {
+        return center;
+    }
+    center = std::accumulate(points_.begin(), points_.end(), center);
+    center /= double(points_.size());
+    return center;
+}
+
 AxisAlignedBoundingBox LineSet::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(points_);
 }
@@ -81,9 +91,13 @@ LineSet &LineSet::Transform(const Eigen::Matrix4d &transformation) {
     return *this;
 }
 
-LineSet &LineSet::Translate(const Eigen::Vector3d &translation) {
+LineSet &LineSet::Translate(const Eigen::Vector3d &translation, bool relative) {
+    Eigen::Vector3d transform = translation;
+    if (!relative) {
+        transform -= GetCenter();
+    }
     for (auto &point : points_) {
-        point += translation;
+        point += transform;
     }
     return *this;
 }
@@ -91,9 +105,7 @@ LineSet &LineSet::Translate(const Eigen::Vector3d &translation) {
 LineSet &LineSet::Scale(const double scale, bool center) {
     Eigen::Vector3d point_center(0, 0, 0);
     if (center && !points_.empty()) {
-        point_center =
-                std::accumulate(points_.begin(), points_.end(), point_center);
-        point_center /= double(points_.size());
+        point_center = GetCenter();
     }
     for (auto &point : points_) {
         point = (point - point_center) * scale + point_center;
@@ -106,9 +118,7 @@ LineSet &LineSet::Rotate(const Eigen::Vector3d &rotation,
                          RotationType type) {
     Eigen::Vector3d point_center(0, 0, 0);
     if (center && !points_.empty()) {
-        point_center =
-                std::accumulate(points_.begin(), points_.end(), point_center);
-        point_center /= double(points_.size());
+        point_center = GetCenter();
     }
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto &point : points_) {

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -51,10 +51,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     LineSet &Transform(const Eigen::Matrix4d &transformation) override;
-    LineSet &Translate(const Eigen::Vector3d &translation) override;
+    LineSet &Translate(const Eigen::Vector3d &translation,
+                       bool relative = true) override;
     LineSet &Scale(const double scale, bool center = true) override;
     LineSet &Rotate(const Eigen::Vector3d &rotation,
                     bool center = true,

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -354,6 +354,10 @@ Eigen::Vector3d Octree::GetMaxBound() const {
     }
 }
 
+Eigen::Vector3d Octree::GetCenter() const {
+    return origin_ + Eigen::Vector3d(size_, size_, size_) / 2;
+}
+
 AxisAlignedBoundingBox Octree::GetAxisAlignedBoundingBox() const {
     AxisAlignedBoundingBox box;
     box.min_bound_ = GetMinBound();
@@ -371,7 +375,7 @@ Octree& Octree::Transform(const Eigen::Matrix4d& transformation) {
     return *this;
 }
 
-Octree& Octree::Translate(const Eigen::Vector3d& translation) {
+Octree& Octree::Translate(const Eigen::Vector3d& translation, bool relative) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -153,10 +153,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     Octree& Transform(const Eigen::Matrix4d& transformation) override;
-    Octree& Translate(const Eigen::Vector3d& translation) override;
+    Octree& Translate(const Eigen::Vector3d& translation,
+                      bool relative = true) override;
     Octree& Scale(const double scale, bool center = true) override;
     Octree& Rotate(const Eigen::Vector3d& rotation,
                    bool center = true,

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -57,10 +57,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     PointCloud &Transform(const Eigen::Matrix4d &transformation) override;
-    PointCloud &Translate(const Eigen::Vector3d &translation) override;
+    PointCloud &Translate(const Eigen::Vector3d &translation,
+                          bool relative = true) override;
     PointCloud &Scale(const double scale, bool center = true) override;
     PointCloud &Rotate(const Eigen::Vector3d &rotation,
                        bool center = true,
@@ -192,7 +194,9 @@ public:
     /// in Large Spatial Databases with Noise", 1996
     /// Returns a vector of point labels, -1 indicates noise according to
     /// the algorithm.
-    std::vector<int> ClusterDBSCAN(double eps, size_t min_points) const;
+    std::vector<int> ClusterDBSCAN(double eps,
+                                   size_t min_points,
+                                   bool print_progress = false) const;
 
     /// Factory function to create a pointcloud from a depth image and a camera
     /// model (PointCloudFactory.cpp)

--- a/src/Open3D/Geometry/PointCloudCluster.cpp
+++ b/src/Open3D/Geometry/PointCloudCluster.cpp
@@ -32,13 +32,40 @@
 #include "Open3D/Geometry/KDTreeFlann.h"
 #include "Open3D/Utility/Console.h"
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace open3d {
 namespace geometry {
 
 std::vector<int> PointCloud::ClusterDBSCAN(double eps,
-                                           size_t min_points) const {
+                                           size_t min_points,
+                                           bool print_progress) const {
     KDTreeFlann kdtree(*this);
+
+    // precompute all neighbours
+    utility::LogDebug("Precompute Neighbours\n");
+    utility::ConsoleProgressBar progress_bar(
+            points_.size(), "Precompute Neighbours", print_progress);
+    std::vector<std::vector<int>> nbs(points_.size());
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (size_t idx = 0; idx < points_.size(); ++idx) {
+        std::vector<double> dists2;
+        kdtree.SearchRadius(points_[idx], eps, nbs[idx], dists2);
+
+#ifdef _OPENMP
+#pragma omp critical
+#endif
+        { ++progress_bar; }
+    }
+    utility::LogDebug("Done Precompute Neighbours\n");
+
     // set all labels to undefined (-2)
+    utility::LogDebug("Compute Clusters\n");
+    progress_bar.reset(points_.size(), "Clustering", print_progress);
     std::vector<int> labels(points_.size(), -2);
     int cluster_label = 0;
     for (size_t idx = 0; idx < points_.size(); ++idx) {
@@ -46,22 +73,18 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
             continue;
         }
 
-        // find neighbours
-        std::vector<int> nbs;
-        std::vector<double> dists2;
-        kdtree.SearchRadius(points_[idx], eps, nbs, dists2);
-
         // check density
-        if (nbs.size() < min_points) {
+        if (nbs[idx].size() < min_points) {
             labels[idx] = -1;
             continue;
         }
 
-        std::unordered_set<int> nbs_next(nbs.begin(), nbs.end());
+        std::unordered_set<int> nbs_next(nbs[idx].begin(), nbs[idx].end());
         std::unordered_set<int> nbs_visited;
         nbs_visited.insert(int(idx));
 
         labels[idx] = cluster_label;
+        ++progress_bar;
         while (!nbs_next.empty()) {
             int nb = *nbs_next.begin();
             nbs_next.erase(nbs_next.begin());
@@ -69,15 +92,16 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
 
             if (labels[nb] == -1) {  // noise label
                 labels[nb] = cluster_label;
+                ++progress_bar;
             }
             if (labels[nb] != -2) {  // not undefined label
                 continue;
             }
             labels[nb] = cluster_label;
+            ++progress_bar;
 
-            kdtree.SearchRadius(points_[nb], eps, nbs, dists2);
-            if (nbs.size() >= min_points) {
-                for (int qnb : nbs) {
+            if (nbs[nb].size() >= min_points) {
+                for (int qnb : nbs[nb]) {
                     if (nbs_visited.count(qnb) == 0) {
                         nbs_next.insert(qnb);
                     }
@@ -87,6 +111,8 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
 
         cluster_label++;
     }
+
+    utility::LogDebug("Done Compute Clusters: {:d}\n", cluster_label);
     return labels;
 }
 

--- a/src/Open3D/Geometry/PointCloudCluster.cpp
+++ b/src/Open3D/Geometry/PointCloudCluster.cpp
@@ -52,7 +52,7 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-    for (size_t idx = 0; idx < points_.size(); ++idx) {
+    for (int idx = 0; idx < int(points_.size()); ++idx) {
         std::vector<double> dists2;
         kdtree.SearchRadius(points_[idx], eps, nbs[idx], dists2);
 

--- a/src/Open3D/Geometry/TetraMesh.h
+++ b/src/Open3D/Geometry/TetraMesh.h
@@ -51,10 +51,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     TetraMesh &Transform(const Eigen::Matrix4d &transformation) override;
-    TetraMesh &Translate(const Eigen::Vector3d &translation) override;
+    TetraMesh &Translate(const Eigen::Vector3d &translation,
+                         bool relative = true) override;
     TetraMesh &Scale(const double scale, bool center = true) override;
     TetraMesh &Rotate(const Eigen::Vector3d &rotation,
                       bool center = true,

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -67,10 +67,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     TriangleMesh &Transform(const Eigen::Matrix4d &transformation) override;
-    TriangleMesh &Translate(const Eigen::Vector3d &translation) override;
+    TriangleMesh &Translate(const Eigen::Vector3d &translation,
+                            bool relative = true) override;
     TriangleMesh &Scale(const double scale, bool center = true) override;
     TriangleMesh &Rotate(const Eigen::Vector3d &rotation,
                          bool center = true,

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -26,6 +26,7 @@
 
 #include "Open3D/Geometry/VoxelGrid.h"
 
+#include <numeric>
 #include <unordered_map>
 
 #include "Open3D/Camera/PinholeCameraParameters.h"
@@ -78,6 +79,21 @@ Eigen::Vector3d VoxelGrid::GetMaxBound() const {
     }
 }
 
+Eigen::Vector3d VoxelGrid::GetCenter() const {
+    Eigen::Vector3d center(0, 0, 0);
+    if (!HasVoxels()) {
+        return center;
+    }
+    center = std::accumulate(
+            voxels_.begin(), voxels_.end(), center,
+            [this](const Eigen::Vector3d &vec, const Voxel &vox) {
+                return vec + vox.grid_index_.cast<double>() * voxel_size_ +
+                       origin_;
+            });
+    center /= double(voxels_.size());
+    return center;
+}
+
 AxisAlignedBoundingBox VoxelGrid::GetAxisAlignedBoundingBox() const {
     AxisAlignedBoundingBox box;
     box.min_bound_ = GetMinBound();
@@ -95,7 +111,8 @@ VoxelGrid &VoxelGrid::Transform(const Eigen::Matrix4d &transformation) {
     return *this;
 }
 
-VoxelGrid &VoxelGrid::Translate(const Eigen::Vector3d &translation) {
+VoxelGrid &VoxelGrid::Translate(const Eigen::Vector3d &translation,
+                                bool relative) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -84,11 +84,13 @@ Eigen::Vector3d VoxelGrid::GetCenter() const {
     if (!HasVoxels()) {
         return center;
     }
+    const Eigen::Vector3d half_voxel_size(0.5 * voxel_size_, 0.5 * voxel_size_,
+                                          0.5 * voxel_size_);
     center = std::accumulate(
             voxels_.begin(), voxels_.end(), center,
-            [this](const Eigen::Vector3d &vec, const Voxel &vox) {
+            [&](const Eigen::Vector3d &vec, const Voxel &vox) {
                 return vec + vox.grid_index_.cast<double>() * voxel_size_ +
-                       origin_;
+                       origin_ + half_voxel_size;
             });
     center /= double(voxels_.size());
     return center;

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -69,10 +69,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const override;
     Eigen::Vector3d GetMaxBound() const override;
+    Eigen::Vector3d GetCenter() const override;
     AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const override;
     OrientedBoundingBox GetOrientedBoundingBox() const override;
     VoxelGrid &Transform(const Eigen::Matrix4d &transformation) override;
-    VoxelGrid &Translate(const Eigen::Vector3d &translation) override;
+    VoxelGrid &Translate(const Eigen::Vector3d &translation,
+                         bool relative = true) override;
     VoxelGrid &Scale(const double scale, bool center = true) override;
     VoxelGrid &Rotate(const Eigen::Vector3d &rotation,
                       bool center = true,

--- a/src/Open3D/Utility/Console.h
+++ b/src/Open3D/Utility/Console.h
@@ -258,13 +258,13 @@ inline void LogDebugf(const char *format, const Args &... args) {
 class ConsoleProgressBar {
 public:
     ConsoleProgressBar(size_t expected_count,
-                       const std::string progress_info,
+                       const std::string &progress_info,
                        bool active = false) {
         reset(expected_count, progress_info, active);
     }
 
     void reset(size_t expected_count,
-               const std::string progress_info,
+               const std::string &progress_info,
                bool active) {
         expected_count_ = expected_count;
         current_count_ = -1;

--- a/src/Open3D/Utility/Console.h
+++ b/src/Open3D/Utility/Console.h
@@ -259,12 +259,18 @@ class ConsoleProgressBar {
 public:
     ConsoleProgressBar(size_t expected_count,
                        const std::string progress_info,
-                       bool active = false)
-        : expected_count_(expected_count),
-          current_count_(-1),
-          progress_info_(progress_info),
-          progress_pixel_(0),
-          active_(active) {
+                       bool active = false) {
+        reset(expected_count, progress_info, active);
+    }
+
+    void reset(size_t expected_count,
+               const std::string progress_info,
+               bool active) {
+        expected_count_ = expected_count;
+        current_count_ = -1;
+        progress_info_ = progress_info;
+        progress_pixel_ = 0;
+        active_ = active;
         operator++();
     }
 

--- a/src/Open3D/Utility/Helper.cpp
+++ b/src/Open3D/Utility/Helper.cpp
@@ -29,6 +29,12 @@
 #include <cctype>
 #include <unordered_set>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif  // _WIN32
+
 namespace open3d {
 namespace utility {
 
@@ -81,6 +87,14 @@ size_t WordLength(const std::string& doc,
         length++;
     }
     return length;
+}
+
+void Sleep(int milliseconds) {
+#ifdef _WIN32
+    Sleep(milliseconds);
+#else
+    usleep(milliseconds * 1000);
+#endif  // _WIN32
 }
 
 }  // namespace utility

--- a/src/Open3D/Utility/Helper.h
+++ b/src/Open3D/Utility/Helper.h
@@ -126,5 +126,7 @@ std::string& RightStripString(std::string& str,
 std::string& StripString(std::string& str,
                          const std::string& chars = "\t\n\v\f\r ");
 
+void Sleep(int milliseconds);
+
 }  // namespace utility
 }  // namespace open3d

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
@@ -58,6 +58,14 @@ Eigen::Vector3d PointCloudPicker::GetMaxBound() const {
     }
 }
 
+Eigen::Vector3d PointCloudPicker::GetCenter() const {
+    if (pointcloud_ptr_) {
+        return ((const geometry::PointCloud&)(*pointcloud_ptr_)).GetCenter();
+    } else {
+        return Eigen::Vector3d(0.0, 0.0, 0.0);
+    }
+}
+
 geometry::AxisAlignedBoundingBox PointCloudPicker::GetAxisAlignedBoundingBox()
         const {
     if (pointcloud_ptr_) {
@@ -84,7 +92,7 @@ PointCloudPicker& PointCloudPicker::Transform(
 }
 
 PointCloudPicker& PointCloudPicker::Translate(
-        const Eigen::Vector3d& translation) {
+        const Eigen::Vector3d& translation, bool relative) {
     // Do nothing
     return *this;
 }

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.h
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.h
@@ -51,10 +51,12 @@ public:
     bool IsEmpty() const override;
     Eigen::Vector3d GetMinBound() const final;
     Eigen::Vector3d GetMaxBound() const final;
+    Eigen::Vector3d GetCenter() const final;
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox() const final;
     geometry::OrientedBoundingBox GetOrientedBoundingBox() const final;
     PointCloudPicker& Transform(const Eigen::Matrix4d& transformation) override;
-    PointCloudPicker& Translate(const Eigen::Vector3d& translation) override;
+    PointCloudPicker& Translate(const Eigen::Vector3d& translation,
+                                bool relative = true) override;
     PointCloudPicker& Scale(const double scale, bool center = true) override;
     PointCloudPicker& Rotate(const Eigen::Vector3d& rotation,
                              bool center = true,

--- a/src/Python/geometry/geometry.cpp
+++ b/src/Python/geometry/geometry.cpp
@@ -92,6 +92,8 @@ void pybind_geometry_classes(py::module &m) {
                  "Returns min bounds for geometry coordinates.")
             .def("get_max_bound", &geometry::Geometry3D::GetMaxBound,
                  "Returns max bounds for geometry coordinates.")
+            .def("get_center", &geometry::Geometry3D::GetCenter,
+                 "Returns the center of the geometry coordinates.")
             .def("get_axis_aligned_bounding_box",
                  &geometry::Geometry3D::GetAxisAlignedBoundingBox,
                  "Returns an axis-aligned bounding box of the geometry.")
@@ -102,7 +104,8 @@ void pybind_geometry_classes(py::module &m) {
                  "Apply transformation (4x4 matrix) to the geometry "
                  "coordinates.")
             .def("translate", &geometry::Geometry3D::Translate,
-                 "Apply translation to the geometry coordinates.")
+                 "Apply translation to the geometry coordinates.",
+                 "translation"_a, "relative"_a = true)
             .def("scale", &geometry::Geometry3D::Scale,
                  "Apply scaling to the geometry coordinates.", "scale"_a,
                  "center"_a = true)
@@ -112,12 +115,20 @@ void pybind_geometry_classes(py::module &m) {
                  "type"_a = geometry::Geometry3D::RotationType::XYZ);
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_min_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_max_bound");
+    docstring::ClassMethodDocInject(m, "Geometry3D", "get_center");
     docstring::ClassMethodDocInject(m, "Geometry3D",
                                     "get_axis_aligned_bounding_box");
     docstring::ClassMethodDocInject(m, "Geometry3D",
                                     "get_oriented_bounding_box");
     docstring::ClassMethodDocInject(m, "Geometry3D", "transform");
-    docstring::ClassMethodDocInject(m, "Geometry3D", "translate");
+    docstring::ClassMethodDocInject(
+            m, "Geometry3D", "translate",
+            {{"translation", "A 3D vector to transform the geometry"},
+             {"relative",
+              "If true, the translation vector is directly added to the "
+              "geometry "
+              "coordinates. Otherwise, the center is moved to the translation "
+              "vector."}});
     docstring::ClassMethodDocInject(
             m, "Geometry3D", "scale",
             {{"scale",

--- a/src/Python/geometry/geometry_trampoline.h
+++ b/src/Python/geometry/geometry_trampoline.h
@@ -60,6 +60,9 @@ public:
     Eigen::Vector3d GetMaxBound() const override {
         PYBIND11_OVERLOAD_PURE(Eigen::Vector3d, Geometry3DBase, );
     }
+    Eigen::Vector3d GetCenter() const override {
+        PYBIND11_OVERLOAD_PURE(Eigen::Vector3d, Geometry3DBase, );
+    }
     geometry::AxisAlignedBoundingBox GetAxisAlignedBoundingBox()
             const override {
         PYBIND11_OVERLOAD_PURE(geometry::AxisAlignedBoundingBox,

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -149,7 +149,7 @@ void pybind_pointcloud(py::module &m) {
                  "'A Density-Based Algorithm for Discovering Clusters in Large "
                  "Spatial Databases with Noise', 1996. Returns a list of point "
                  "labels, -1 indicates noise according to the algorithm.",
-                 "eps"_a, "min_points"_a)
+                 "eps"_a, "min_points"_a, "print_progress"_a = false)
             .def_static(
                     "create_from_depth_image",
                     &geometry::PointCloud::CreateFromDepthImage,
@@ -264,7 +264,9 @@ void pybind_pointcloud(py::module &m) {
             m, "PointCloud", "cluster_dbscan",
             {{"eps",
               "Density parameter that is used to find neighbouring points."},
-             {"min_points", "Minimum number of points to form a cluster."}});
+             {"min_points", "Minimum number of points to form a cluster."},
+             {"print_progress",
+              "If true the progress is visualized in the console."}});
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_depth_image");
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_rgbd_image");
 }


### PR DESCRIPTION
This PR speeds up DBSCAN by pre-computing the neighbors using omp.

I further added a `GetCenter` method to `Geometry3D` and a `relative` parameter to `Translate` to allow to move the center to a specific position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1147)
<!-- Reviewable:end -->
