### PR TITLE
Fixes for Azure Kinect on Ubuntu 16.04

### DIFF
--- a/docs/tutorial/Basic/azure_kinect.rst
+++ b/docs/tutorial/Basic/azure_kinect.rst
@@ -8,11 +8,11 @@ Azure Kinect is only officially supported on Windows and Ubuntu 18.04.
 Installation
 ============
 
-Install Azure Kinect SDK (K4A)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install the Azure Kinect SDK
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Follow `the guide <https://github.com/microsoft/Azure-Kinect-Sensor-SDK>`_
-to install Azure Kinect SDK.
+to install the Azure Kinect SDK (K4A).
 
 On Ubuntu, you'll need to set up a udev rule to use the Kinect camera without
 ``sudo``, follow
@@ -21,11 +21,11 @@ On Ubuntu, you'll need to set up a udev rule to use the Kinect camera without
 After installation, you may run ``k4aviewer`` from the Linux terminal or
 ``k4aviewer.exe`` on Windows to make sure that the device is working.
 
-Currently, Open3D supports version ``v1.2.0`` Azure Kinect SDK, though future
+Currently, Open3D supports the Azure Kinect SDK version ``v1.2.0``, though future
 versions might also be compatible.
 
-If you're using Ubuntu 16.04, Azure Kinect is not officially supported. We
-have an unofficial workaround, see :ref:`azure_kinect_u1604_fix` for details.
+If you're using Ubuntu 16.04, the Azure Kinect SDK is not officially supported.
+We have an unofficial workaround, see :ref:`azure_kinect_u1604_fix` for details.
 
 
 Using Open3D from Pip or Conda

--- a/docs/tutorial/Basic/azure_kinect.rst
+++ b/docs/tutorial/Basic/azure_kinect.rst
@@ -21,10 +21,10 @@ On Ubuntu, you'll need to set up a udev rule to use the Kinect camera without
 After installation, you may run ``k4aviewer`` from the Linux terminal or
 ``k4aviewer.exe`` on Windows to make sure that the device is working.
 
-Currently, Open3D supports ``v1.2.0`` Azure Kinect SDK, though future version
-might also be compatible.
+Currently, Open3D supports version ``v1.2.0`` Azure Kinect SDK, though future
+versions might also be compatible.
 
-If you're using Ubuntu 16.04, Azure Kinect is not yet officially supported. We
+If you're using Ubuntu 16.04, Azure Kinect is not officially supported. We
 have an unofficial workaround, see :ref:`azure_kinect_u1604_fix` for details.
 
 
@@ -200,7 +200,7 @@ The ``open3d_azure_kinect_ubuntu1604_fix`` will preload the shared libs and set
 ``LD_LIBRARY_PATH`` which are then used by ``dlopen`` when the Kinect library
 is loaded from the compiled module.
 
-For compile Open3D from source, you'll need to build and install K4A SDK
+To compile Open3D from source, you'll need to build and install K4A SDK
 manually. However, at runtime, you'll still need to ensure
 the 18.04 copy of ``libstdc++.so`` and ``libdepthengine.so`` are visible from
 ``LD_LIBRARY_PATH``.

--- a/docs/tutorial/Basic/azure_kinect.rst
+++ b/docs/tutorial/Basic/azure_kinect.rst
@@ -1,4 +1,4 @@
-.. _azure_kinect_record:
+.. _azure_kinect:
 
 Azure Kinect with Open3D
 ------------------------
@@ -23,6 +23,10 @@ After installation, you may run ``k4aviewer`` from the Linux terminal or
 
 Currently, Open3D supports ``v1.2.0`` Azure Kinect SDK, though future version
 might also be compatible.
+
+If you're using Ubuntu 16.04, Azure Kinect is not yet officially supported. We
+have an unofficial workaround, see :ref:`azure_kinect_u1604_fix` for details.
+
 
 Using Open3D from Pip or Conda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -173,3 +177,30 @@ flag.
 
 .. image:: https://storage.googleapis.com/open3d-bin/docs/images/azure_kinect_mkv_reader_extract.png
     :alt: azure_kinect_mkv_reader_extract.png
+
+.. _azure_kinect_u1604_fix:
+
+Unofficial Ubuntu 16.04 workaround
+==================================
+
+For Python Open3D, run
+
+.. code-block:: sh
+
+    pip install open3d_azure_kinect_ubuntu1604_fix
+
+The ``open3d_azure_kinect_ubuntu1604_fix`` package contains 4 shared libs:
+
+- ``libstdc++.so``: copied from ubuntu 18.04, needed by ``libdepthengine.so``
+- ``libdepthengine.so``: copied from K4A installation on ubuntu 18.04
+- ``libk4a.so``: build from source on ubuntu 16.04
+- ``libk4arecord.so``: build from source on ubuntu 16.04
+
+The ``open3d_azure_kinect_ubuntu1604_fix`` will preload the shared libs and set
+``LD_LIBRARY_PATH`` which are then used by ``dlopen`` when the Kinect library
+is loaded from the compiled module.
+
+For compile Open3D from source, you'll need to build and install K4A SDK
+manually. However, at runtime, you'll still need to ensure
+the 18.04 copy of ``libstdc++.so`` and ``libdepthengine.so`` are visible from
+``LD_LIBRARY_PATH``.

--- a/docs/tutorial/Basic/index.rst
+++ b/docs/tutorial/Basic/index.rst
@@ -18,4 +18,4 @@ interface of Open3D.
     icp_registration
     working_with_numpy
     jupyter
-    azure_kinect_record
+    azure_kinect

--- a/examples/Python/ReconstructionSystem/sensors/azure_kinect_viewer.py
+++ b/examples/Python/ReconstructionSystem/sensors/azure_kinect_viewer.py
@@ -63,8 +63,6 @@ if __name__ == '__main__':
     else:
         config = o3d.io.AzureKinectSensorConfig()
 
-    o3d.io.write_azure_kinect_sensor_config("sensor_config.json", config)
-
     device = args.device
     if device < 0 or device > 255:
         print('Unsupported device id, fall back to 0')

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -68,7 +68,7 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
             std::string full_path = k4a_lib_path_hint + lib_name;
             handle = LoadLibrary(TEXT(full_path.c_str()));
             if (handle != NULL) {
-                utility::LogInfo("Loaded {}\n", full_path);
+                utility::LogDebug("Loaded {}\n", full_path);
                 break;
             }
         }

--- a/src/Python/package/open3d/__init__.py
+++ b/src/Python/package/open3d/__init__.py
@@ -25,7 +25,7 @@
 # ----------------------------------------------------------------------------
 
 try:
-    # Azure Kinect is not yet officially supported on Ubuntu 16.04, this is an
+    # Azure Kinect is not officially supported on Ubuntu 16.04, this is an
     # unofficial workaround. Install the fix package with
     # `pip install open3d_azure_kinect_ubuntu1604_fix`
     import open3d_azure_kinect_ubuntu1604_fix

--- a/src/Python/package/open3d/__init__.py
+++ b/src/Python/package/open3d/__init__.py
@@ -24,6 +24,14 @@
 # IN THE SOFTWARE.
 # ----------------------------------------------------------------------------
 
+try:
+    # Azure Kinect is not yet officially supported on Ubuntu 16.04, this is an
+    # unofficial workaround. Install the fix package with
+    # `pip install open3d_azure_kinect_ubuntu1604_fix`
+    import open3d_azure_kinect_ubuntu1604_fix
+except:
+    pass
+
 from .open3d import * # py2 py3 compatible
 
 __version__ = '@PROJECT_VERSION@'


### PR DESCRIPTION
MS Azure Kinect on Ubuntu 16.04 is not officially supported on Ubuntu 16.04. This PR is a fix for that.

On ubuntu 16.04, run
```shell
pip install open3d_azure_kinect_ubuntu1604_fix
pip install open3d-python # will be `pip install open3d` in the next release
```

Also see https://pypi.org/project/open3d-azure-kinect-ubuntu1604-fix/, https://github.com/yxlao/open3d_azure_kinect_ubuntu1604_fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1149)
<!-- Reviewable:end -->
