### PR TITLE
Geometry Code Simplification and PaintUniformColor Warning

### DIFF
--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -49,20 +49,12 @@ bool OrientedBoundingBox::IsEmpty() const { return Volume() == 0; }
 
 Eigen::Vector3d OrientedBoundingBox::GetMinBound() const {
     auto points = GetBoxPoints();
-    return std::accumulate(
-            points.begin(), points.end(), points[0],
-            [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
-                return a.array().min(b.array()).matrix();
-            });
+    return ComputeMinBound(points);
 }
 
 Eigen::Vector3d OrientedBoundingBox::GetMaxBound() const {
     auto points = GetBoxPoints();
-    return std::accumulate(
-            points.begin(), points.end(), points[0],
-            [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
-                return a.array().max(b.array()).matrix();
-            });
+    return ComputeMaxBound(points);
 }
 
 Eigen::Vector3d OrientedBoundingBox::GetCenter() const { return center_; }

--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -142,8 +142,8 @@ void Geometry3D::RotatePoints(const Eigen::Vector3d& rotation,
         points_center = ComputeCenter(points);
     }
     const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
-    for (auto& points : points) {
-        points = R * (points - points_center) + points_center;
+    for (auto& point : points) {
+        point = R * (point - points_center) + points_center;
     }
 }
 

--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -73,9 +73,19 @@ void Geometry3D::ResizeAndPaintUniformColor(
         const size_t size,
         const Eigen::Vector3d& color) const {
     colors.resize(size);
-    // TODO: print warning if wrong color value
+    Eigen::Vector3d clipped_color = color;
+    if (color.minCoeff() < 0 || color.maxCoeff() > 1) {
+        utility::LogWarning(
+                "invalid color in PaintUniformColor, clipping to [0, 1]\n");
+        clipped_color = clipped_color.array()
+                                .max(Eigen::Vector3d(0, 0, 0).array())
+                                .matrix();
+        clipped_color = clipped_color.array()
+                                .min(Eigen::Vector3d(1, 1, 1).array())
+                                .matrix();
+    }
     for (size_t i = 0; i < size; i++) {
-        colors[i] = color;
+        colors[i] = clipped_color;
     }
 }
 

--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -1,0 +1,185 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Geometry/Geometry3D.h"
+
+#include <Eigen/Dense>
+#include <numeric>
+
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+namespace geometry {
+
+Eigen::Vector3d Geometry3D::ComputeMinBound(
+        const std::vector<Eigen::Vector3d>& points) const {
+    if (points.empty()) {
+        return Eigen::Vector3d(0.0, 0.0, 0.0);
+    }
+    return std::accumulate(
+            points.begin(), points.end(), points[0],
+            [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+                return a.array().min(b.array()).matrix();
+            });
+}
+
+Eigen::Vector3d Geometry3D::ComputeMaxBound(
+        const std::vector<Eigen::Vector3d>& points) const {
+    if (points.empty()) {
+        return Eigen::Vector3d(0.0, 0.0, 0.0);
+    }
+    return std::accumulate(
+            points.begin(), points.end(), points[0],
+            [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+                return a.array().max(b.array()).matrix();
+            });
+}
+Eigen::Vector3d Geometry3D::ComputeCenter(
+        const std::vector<Eigen::Vector3d>& points) const {
+    Eigen::Vector3d center(0, 0, 0);
+    if (points.empty()) {
+        return center;
+    }
+    center = std::accumulate(points.begin(), points.end(), center);
+    center /= double(points.size());
+    return center;
+}
+
+void Geometry3D::ResizeAndPaintUniformColor(
+        std::vector<Eigen::Vector3d>& colors,
+        const size_t size,
+        const Eigen::Vector3d& color) const {
+    colors.resize(size);
+    // TODO: print warning if wrong color value
+    for (size_t i = 0; i < size; i++) {
+        colors[i] = color;
+    }
+}
+
+void Geometry3D::TransformPoints(const Eigen::Matrix4d& transformation,
+                                 std::vector<Eigen::Vector3d>& points) const {
+    for (auto& point : points) {
+        Eigen::Vector4d new_point =
+                transformation *
+                Eigen::Vector4d(point(0), point(1), point(2), 1.0);
+        point = new_point.head<3>() / new_point(3);
+    }
+}
+
+void Geometry3D::TransformNormals(const Eigen::Matrix4d& transformation,
+                                  std::vector<Eigen::Vector3d>& normals) const {
+    for (auto& normal : normals) {
+        Eigen::Vector4d new_normal =
+                transformation *
+                Eigen::Vector4d(normal(0), normal(1), normal(2), 0.0);
+        normal = new_normal.head<3>();
+    }
+}
+
+void Geometry3D::TranslatePoints(const Eigen::Vector3d& translation,
+                                 std::vector<Eigen::Vector3d>& points,
+                                 bool relative) const {
+    Eigen::Vector3d transform = translation;
+    if (!relative) {
+        transform -= ComputeCenter(points);
+    }
+    for (auto& point : points) {
+        point += transform;
+    }
+}
+
+void Geometry3D::ScalePoints(const double scale,
+                             std::vector<Eigen::Vector3d>& points,
+                             bool center) const {
+    Eigen::Vector3d points_center(0, 0, 0);
+    if (center && !points.empty()) {
+        points_center = ComputeCenter(points);
+    }
+    for (auto& point : points) {
+        point = (point - points_center) * scale + points_center;
+    }
+}
+
+void Geometry3D::RotatePoints(const Eigen::Vector3d& rotation,
+                              std::vector<Eigen::Vector3d>& points,
+                              bool center,
+                              RotationType type) const {
+    Eigen::Vector3d points_center(0, 0, 0);
+    if (center && !points.empty()) {
+        points_center = ComputeCenter(points);
+    }
+    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
+    for (auto& points : points) {
+        points = R * (points - points_center) + points_center;
+    }
+}
+
+void Geometry3D::RotateNormals(const Eigen::Vector3d& rotation,
+                               std::vector<Eigen::Vector3d>& normals,
+                               bool center,
+                               RotationType type) const {
+    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
+    for (auto& normal : normals) {
+        normal = R * normal;
+    }
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrix(const Eigen::Vector3d& rotation,
+                                              RotationType type) const {
+    if (type == RotationType::XYZ) {
+        return open3d::utility::RotationMatrixX(rotation(0)) *
+               open3d::utility::RotationMatrixY(rotation(1)) *
+               open3d::utility::RotationMatrixZ(rotation(2));
+    } else if (type == RotationType::YZX) {
+        return open3d::utility::RotationMatrixY(rotation(0)) *
+               open3d::utility::RotationMatrixZ(rotation(1)) *
+               open3d::utility::RotationMatrixX(rotation(2));
+    } else if (type == RotationType::ZXY) {
+        return open3d::utility::RotationMatrixZ(rotation(0)) *
+               open3d::utility::RotationMatrixX(rotation(1)) *
+               open3d::utility::RotationMatrixY(rotation(2));
+    } else if (type == RotationType::XZY) {
+        return open3d::utility::RotationMatrixX(rotation(0)) *
+               open3d::utility::RotationMatrixZ(rotation(1)) *
+               open3d::utility::RotationMatrixY(rotation(2));
+    } else if (type == RotationType::ZYX) {
+        return open3d::utility::RotationMatrixZ(rotation(0)) *
+               open3d::utility::RotationMatrixY(rotation(1)) *
+               open3d::utility::RotationMatrixX(rotation(2));
+    } else if (type == RotationType::YXZ) {
+        return open3d::utility::RotationMatrixY(rotation(0)) *
+               open3d::utility::RotationMatrixX(rotation(1)) *
+               open3d::utility::RotationMatrixZ(rotation(2));
+    } else if (type == RotationType::AxisAngle) {
+        const double phi = rotation.norm();
+        return Eigen::AngleAxisd(phi, rotation / phi).toRotationMatrix();
+    } else {
+        return Eigen::Matrix3d::Identity();
+    }
+}
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -64,40 +64,39 @@ public:
                                RotationType type = RotationType::XYZ) = 0;
 
 protected:
+    Eigen::Vector3d ComputeMinBound(
+            const std::vector<Eigen::Vector3d>& points) const;
+    Eigen::Vector3d ComputeMaxBound(
+            const std::vector<Eigen::Vector3d>& points) const;
+    Eigen::Vector3d ComputeCenter(
+            const std::vector<Eigen::Vector3d>& points) const;
+
+    void ResizeAndPaintUniformColor(std::vector<Eigen::Vector3d>& colors,
+                                    const size_t size,
+                                    const Eigen::Vector3d& color) const;
+
+    void TransformPoints(const Eigen::Matrix4d& transformation,
+                         std::vector<Eigen::Vector3d>& points) const;
+    void TransformNormals(const Eigen::Matrix4d& transformation,
+                          std::vector<Eigen::Vector3d>& normals) const;
+    void TranslatePoints(const Eigen::Vector3d& translation,
+                         std::vector<Eigen::Vector3d>& points,
+                         bool relative) const;
+    void ScalePoints(const double scale,
+                     std::vector<Eigen::Vector3d>& points,
+                     bool center) const;
+    void RotatePoints(const Eigen::Vector3d& rotation,
+                      std::vector<Eigen::Vector3d>& points,
+                      bool center,
+                      RotationType type) const;
+    void RotateNormals(const Eigen::Vector3d& rotation,
+                       std::vector<Eigen::Vector3d>& normals,
+                       bool center,
+                       RotationType type) const;
+
     Eigen::Matrix3d GetRotationMatrix(
             const Eigen::Vector3d& rotation,
-            RotationType type = RotationType::XYZ) const {
-        if (type == RotationType::XYZ) {
-            return open3d::utility::RotationMatrixX(rotation(0)) *
-                   open3d::utility::RotationMatrixY(rotation(1)) *
-                   open3d::utility::RotationMatrixZ(rotation(2));
-        } else if (type == RotationType::YZX) {
-            return open3d::utility::RotationMatrixY(rotation(0)) *
-                   open3d::utility::RotationMatrixZ(rotation(1)) *
-                   open3d::utility::RotationMatrixX(rotation(2));
-        } else if (type == RotationType::ZXY) {
-            return open3d::utility::RotationMatrixZ(rotation(0)) *
-                   open3d::utility::RotationMatrixX(rotation(1)) *
-                   open3d::utility::RotationMatrixY(rotation(2));
-        } else if (type == RotationType::XZY) {
-            return open3d::utility::RotationMatrixX(rotation(0)) *
-                   open3d::utility::RotationMatrixZ(rotation(1)) *
-                   open3d::utility::RotationMatrixY(rotation(2));
-        } else if (type == RotationType::ZYX) {
-            return open3d::utility::RotationMatrixZ(rotation(0)) *
-                   open3d::utility::RotationMatrixY(rotation(1)) *
-                   open3d::utility::RotationMatrixX(rotation(2));
-        } else if (type == RotationType::YXZ) {
-            return open3d::utility::RotationMatrixY(rotation(0)) *
-                   open3d::utility::RotationMatrixX(rotation(1)) *
-                   open3d::utility::RotationMatrixZ(rotation(2));
-        } else if (type == RotationType::AxisAngle) {
-            const double phi = rotation.norm();
-            return Eigen::AngleAxisd(phi, rotation / phi).toRotationMatrix();
-        } else {
-            return Eigen::Matrix3d::Identity();
-        }
-    }
+            RotationType type = RotationType::XYZ) const;
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -81,10 +81,7 @@ public:
 
     /// Assigns each line in the LineSet the same color \param color.
     LineSet &PaintUniformColor(const Eigen::Vector3d &color) {
-        colors_.resize(lines_.size());
-        for (size_t i = 0; i < lines_.size(); i++) {
-            colors_[i] = color;
-        }
+        ResizeAndPaintUniformColor(colors_, lines_.size(), color);
         return *this;
     }
 

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -47,36 +47,14 @@ PointCloud &PointCloud::Clear() {
 bool PointCloud::IsEmpty() const { return !HasPoints(); }
 
 Eigen::Vector3d PointCloud::GetMinBound() const {
-    if (!HasPoints()) {
-        return Eigen::Vector3d(0.0, 0.0, 0.0);
-    }
-    return std::accumulate(
-            points_.begin(), points_.end(), points_[0],
-            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
-                return a.array().min(b.array()).matrix();
-            });
+    return ComputeMinBound(points_);
 }
 
 Eigen::Vector3d PointCloud::GetMaxBound() const {
-    if (!HasPoints()) {
-        return Eigen::Vector3d(0.0, 0.0, 0.0);
-    }
-    return std::accumulate(
-            points_.begin(), points_.end(), points_[0],
-            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
-                return a.array().max(b.array()).matrix();
-            });
+    return ComputeMaxBound(points_);
 }
 
-Eigen::Vector3d PointCloud::GetCenter() const {
-    Eigen::Vector3d center(0, 0, 0);
-    if (!HasPoints()) {
-        return center;
-    }
-    center = std::accumulate(points_.begin(), points_.end(), center);
-    center /= double(points_.size());
-    return center;
-}
+Eigen::Vector3d PointCloud::GetCenter() const { return ComputeCenter(points_); }
 
 AxisAlignedBoundingBox PointCloud::GetAxisAlignedBoundingBox() const {
     return AxisAlignedBoundingBox::CreateFromPoints(points_);
@@ -87,58 +65,27 @@ OrientedBoundingBox PointCloud::GetOrientedBoundingBox() const {
 }
 
 PointCloud &PointCloud::Transform(const Eigen::Matrix4d &transformation) {
-    for (auto &point : points_) {
-        Eigen::Vector4d new_point =
-                transformation *
-                Eigen::Vector4d(point(0), point(1), point(2), 1.0);
-        point = new_point.head<3>() / new_point(3);
-    }
-    for (auto &normal : normals_) {
-        Eigen::Vector4d new_normal =
-                transformation *
-                Eigen::Vector4d(normal(0), normal(1), normal(2), 0.0);
-        normal = new_normal.head<3>();
-    }
+    TransformPoints(transformation, points_);
+    TransformNormals(transformation, normals_);
     return *this;
 }
 
 PointCloud &PointCloud::Translate(const Eigen::Vector3d &translation,
                                   bool relative) {
-    Eigen::Vector3d transform = translation;
-    if (!relative) {
-        transform -= GetCenter();
-    }
-    for (auto &point : points_) {
-        point += transform;
-    }
+    TranslatePoints(translation, points_, relative);
     return *this;
 }
 
 PointCloud &PointCloud::Scale(const double scale, bool center) {
-    Eigen::Vector3d point_center(0, 0, 0);
-    if (center && !points_.empty()) {
-        point_center = GetCenter();
-    }
-    for (auto &point : points_) {
-        point = (point - point_center) * scale + point_center;
-    }
+    ScalePoints(scale, points_, center);
     return *this;
 }
 
 PointCloud &PointCloud::Rotate(const Eigen::Vector3d &rotation,
                                bool center,
                                RotationType type) {
-    Eigen::Vector3d point_center(0, 0, 0);
-    if (center && !points_.empty()) {
-        point_center = GetCenter();
-    }
-    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
-    for (auto &point : points_) {
-        point = R * (point - point_center) + point_center;
-    }
-    for (auto &normal : normals_) {
-        normal = R * normal;
-    }
+    RotatePoints(rotation, points_, center, type);
+    RotateNormals(rotation, normals_, center, type);
     return *this;
 }
 

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -90,10 +90,7 @@ public:
 
     /// Assigns each point in the PointCloud the same color \param color.
     PointCloud &PaintUniformColor(const Eigen::Vector3d &color) {
-        colors_.resize(points_.size());
-        for (size_t i = 0; i < points_.size(); i++) {
-            colors_[i] = color;
-        }
+        ResizeAndPaintUniformColor(colors_, points_.size(), color);
         return *this;
     }
 

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -55,35 +55,15 @@ TriangleMesh &TriangleMesh::Clear() {
 bool TriangleMesh::IsEmpty() const { return !HasVertices(); }
 
 Eigen::Vector3d TriangleMesh::GetMinBound() const {
-    if (!HasVertices()) {
-        return Eigen::Vector3d(0.0, 0.0, 0.0);
-    }
-    return std::accumulate(
-            vertices_.begin(), vertices_.end(), vertices_[0],
-            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
-                return a.array().min(b.array()).matrix();
-            });
+    return ComputeMinBound(vertices_);
 }
 
 Eigen::Vector3d TriangleMesh::GetMaxBound() const {
-    if (!HasVertices()) {
-        return Eigen::Vector3d(0.0, 0.0, 0.0);
-    }
-    return std::accumulate(
-            vertices_.begin(), vertices_.end(), vertices_[0],
-            [](const Eigen::Vector3d &a, const Eigen::Vector3d &b) {
-                return a.array().max(b.array()).matrix();
-            });
+    return ComputeMaxBound(vertices_);
 }
 
 Eigen::Vector3d TriangleMesh::GetCenter() const {
-    Eigen::Vector3d center(0, 0, 0);
-    if (!HasVertices()) {
-        return center;
-    }
-    center = std::accumulate(vertices_.begin(), vertices_.end(), center);
-    center /= double(vertices_.size());
-    return center;
+    return ComputeCenter(vertices_);
 }
 
 AxisAlignedBoundingBox TriangleMesh::GetAxisAlignedBoundingBox() const {
@@ -95,69 +75,29 @@ OrientedBoundingBox TriangleMesh::GetOrientedBoundingBox() const {
 }
 
 TriangleMesh &TriangleMesh::Transform(const Eigen::Matrix4d &transformation) {
-    for (auto &vertex : vertices_) {
-        Eigen::Vector4d new_point =
-                transformation *
-                Eigen::Vector4d(vertex(0), vertex(1), vertex(2), 1.0);
-        vertex = new_point.head<3>() / new_point(3);
-    }
-    for (auto &vertex_normal : vertex_normals_) {
-        Eigen::Vector4d new_normal =
-                transformation * Eigen::Vector4d(vertex_normal(0),
-                                                 vertex_normal(1),
-                                                 vertex_normal(2), 0.0);
-        vertex_normal = new_normal.head<3>();
-    }
-    for (auto &triangle_normal : triangle_normals_) {
-        Eigen::Vector4d new_normal =
-                transformation * Eigen::Vector4d(triangle_normal(0),
-                                                 triangle_normal(1),
-                                                 triangle_normal(2), 0.0);
-        triangle_normal = new_normal.head<3>();
-    }
+    TransformPoints(transformation, vertices_);
+    TransformNormals(transformation, vertex_normals_);
+    TransformNormals(transformation, triangle_normals_);
     return *this;
 }
 
 TriangleMesh &TriangleMesh::Translate(const Eigen::Vector3d &translation,
                                       bool relative) {
-    Eigen::Vector3d transform = translation;
-    if (!relative) {
-        transform -= GetCenter();
-    }
-    for (auto &vertex : vertices_) {
-        vertex += transform;
-    }
+    TranslatePoints(translation, vertices_, relative);
     return *this;
 }
 
 TriangleMesh &TriangleMesh::Scale(const double scale, bool center) {
-    Eigen::Vector3d vertex_center(0, 0, 0);
-    if (center && !vertices_.empty()) {
-        vertex_center = GetCenter();
-    }
-    for (auto &vertex : vertices_) {
-        vertex = (vertex - vertex_center) * scale + vertex_center;
-    }
+    ScalePoints(scale, vertices_, center);
     return *this;
 }
 
 TriangleMesh &TriangleMesh::Rotate(const Eigen::Vector3d &rotation,
                                    bool center,
                                    RotationType type) {
-    Eigen::Vector3d vertex_center(0, 0, 0);
-    if (center && !vertices_.empty()) {
-        vertex_center = GetCenter();
-    }
-    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
-    for (auto &vertex : vertices_) {
-        vertex = R * (vertex - vertex_center) + vertex_center;
-    }
-    for (auto &normal : vertex_normals_) {
-        normal = R * normal;
-    }
-    for (auto &normal : triangle_normals_) {
-        normal = R * normal;
-    }
+    RotatePoints(rotation, vertices_, center, type);
+    RotateNormals(rotation, vertex_normals_, center, type);
+    RotateNormals(rotation, triangle_normals_, center, type);
     return *this;
 }
 

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -203,10 +203,7 @@ public:
 
     /// Assigns each vertex in the TriangleMesh the same color \param color.
     TriangleMesh &PaintUniformColor(const Eigen::Vector3d &color) {
-        vertex_colors_.resize(vertices_.size());
-        for (size_t i = 0; i < vertices_.size(); i++) {
-            vertex_colors_[i] = color;
-        }
+        ResizeAndPaintUniformColor(vertex_colors_, vertices_.size(), color);
         return *this;
     }
 

--- a/src/UnitTest/Geometry/LineSet.cpp
+++ b/src/UnitTest/Geometry/LineSet.cpp
@@ -207,6 +207,35 @@ TEST(LineSet, Transform) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
+TEST(LineSet, PaintUniformColor) {
+    size_t size = 100;
+
+    Vector3d vmin(0.0, 0.0, 0.0);
+    Vector3d vmax(1000.0, 1000.0, 1000.0);
+
+    geometry::LineSet ls;
+
+    EXPECT_TRUE(ls.IsEmpty());
+
+    ls.points_.resize(size);
+    Rand(ls.points_, vmin, vmax, 0);
+    ls.lines_.resize(size);
+    Rand(ls.lines_, Zero2i, Vector2i(size - 1, size - 1), 0);
+
+    EXPECT_FALSE(ls.HasColors());
+
+    Vector3d color(233. / 255., 171. / 255., 53.0 / 255.);
+    ls.PaintUniformColor(color);
+
+    EXPECT_TRUE(ls.HasColors());
+
+    for (size_t i = 0; i < ls.colors_.size(); i++)
+        ExpectEQ(color, ls.colors_[i]);
+}
+
+// ----------------------------------------------------------------------------
+//
+// ----------------------------------------------------------------------------
 TEST(LineSet, OperatorAppend) {
     size_t size = 100;
 

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -309,12 +309,13 @@ TEST(PointCloud, PaintUniformColor) {
 
     EXPECT_FALSE(pc.HasColors());
 
-    pc.PaintUniformColor(Vector3d(233.0, 171.0, 53.0));
+    Vector3d color(233. / 255., 171. / 255., 53.0 / 255.);
+    pc.PaintUniformColor(color);
 
     EXPECT_TRUE(pc.HasColors());
 
     for (size_t i = 0; i < pc.colors_.size(); i++)
-        ExpectEQ(Vector3d(233.0, 171.0, 53.0), pc.colors_[i]);
+        ExpectEQ(color, pc.colors_[i]);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -946,10 +946,11 @@ TEST(TriangleMesh, PaintUniformColor) {
     tm.vertices_.resize(size);
     tm.vertex_colors_.resize(size);
 
-    tm.PaintUniformColor(Vector3d(31.0, 120.0, 205.0));
+    Vector3d color(233. / 255., 171. / 255., 53.0 / 255.);
+    tm.PaintUniformColor(color);
 
     for (size_t i = 0; i < tm.vertex_colors_.size(); i++)
-        ExpectEQ(Vector3d(31.0, 120.0, 205.0), tm.vertex_colors_[i]);
+        ExpectEQ(color, tm.vertex_colors_[i]);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
I simplified (and removed code duplication) from the `Geometry3D` classes. 
Additionally, I addressed issue #909. If `color` is outside the valid range of `[0, 1]` the method prints a warning and clips the color value to the valid range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1150)
<!-- Reviewable:end -->
