### PR TITLE
Azure Kinect build from source on Ubuntu 16.04

### DIFF
--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -1,3 +1,9 @@
+if (BUILD_AZURE_KINECT AND APPLE)
+    message(WARNING "Azure Kinect is not supported on macOS, setting BUILD_AZURE_KINECT to OFF")
+    set(BUILD_AZURE_KINECT OFF)
+    set(BUILD_AZURE_KINECT OFF PARENT_SCOPE)
+endif()
+
 if (BUILD_AZURE_KINECT)
     # Conditionally include header files in Open3D.h
     set(BUILD_AZURE_KINECT_COMMENT "")
@@ -11,8 +17,6 @@ if (BUILD_AZURE_KINECT)
         else()
             set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\include")
         endif()
-    elseif(APPLE)
-        message(FATAL_ERROR "Azure Kinect is not supported on macOS")
     else()
         # Attempt 1: system-wide installed K4a
         # The property names are tested with k4a 1.2, future versions might work

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -4,6 +4,50 @@ if (BUILD_AZURE_KINECT AND APPLE)
     set(BUILD_AZURE_KINECT OFF PARENT_SCOPE)
 endif()
 
+function(find_k4a_with_ubuntu_1604_pip_package)
+    find_program(LSB_RELEASE_EXEC lsb_release)
+    if (LSB_RELEASE_EXEC)
+        execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
+            OUTPUT_VARIABLE LSB_DISTRIBUTION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(COMMAND ${LSB_RELEASE_EXEC} -cs
+            OUTPUT_VARIABLE LSB_CODENAME
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(LSB_DISTRIBUTION STREQUAL "Ubuntu" AND LSB_CODENAME STREQUAL "xenial")
+            message(STATUS "Ubuntu 16.04 detected, trying to load from open3d-azure-kinect-ubuntu1604 pip package")
+            if (NOT PYTHON_EXECUTABLE)
+                find_program(PYTHON_IN_PATH "python")
+                set(PYTHON_EXECUTABLE ${PYTHON_IN_PATH})
+            endif()
+            message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
+            execute_process(
+                COMMAND ${PYTHON_EXECUTABLE} -c "import imp; print(imp.find_module('open3d_azure_kinect_ubuntu1604_fix')[1])"
+                OUTPUT_VARIABLE AZURE_PACKAGE_FIX_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+            if (AZURE_PACKAGE_FIX_PATH)
+                message(STATUS "Found open3d_azure_kinect_ubuntu1604_fix pip package: ${AZURE_PACKAGE_FIX_PATH}")
+                set(k4a_INCLUDE_DIRS ${AZURE_PACKAGE_FIX_PATH}/include)
+                set(k4a_FOUND TRUE)
+            else()
+                message(STATUS "Cannot find open3d_azure_kinect_ubuntu1604_fix pip pacakge")
+            endif()
+        else()
+            message(STATUS "Not Ubuntu 16.04, skipping open3d-azure-kinect-ubuntu1604 pip package load")
+        endif()
+    else()
+        message(STATUS "Cannot find lsb_release command")
+    endif()
+
+    # Export variables to function caller
+    set(k4a_INCLUDE_DIRS ${k4a_INCLUDE_DIRS} PARENT_SCOPE)
+    set(k4a_FOUND ${k4a_FOUND} PARENT_SCOPE)
+endfunction()
+
+
 if (BUILD_AZURE_KINECT)
     # Conditionally include header files in Open3D.h
     set(BUILD_AZURE_KINECT_COMMENT "")
@@ -31,42 +75,7 @@ if (BUILD_AZURE_KINECT)
         # The Python package will provide headers and pre-compiled libs for
         # building k4a
         if (NOT k4a_FOUND)
-            find_program(LSB_RELEASE_EXEC lsb_release)
-            if (LSB_RELEASE_EXEC)
-                execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
-                    OUTPUT_VARIABLE LSB_DISTRIBUTION
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                )
-                execute_process(COMMAND ${LSB_RELEASE_EXEC} -cs
-                    OUTPUT_VARIABLE LSB_CODENAME
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                )
-                if(LSB_DISTRIBUTION STREQUAL "Ubuntu" AND LSB_CODENAME STREQUAL "xenial")
-                    message(STATUS "Ubuntu 16.04 detected, trying to load from open3d-azure-kinect-ubuntu1604 pip package")
-                    if (NOT PYTHON_EXECUTABLE)
-                        find_program(PYTHON_IN_PATH "python")
-                        set(PYTHON_EXECUTABLE ${PYTHON_IN_PATH})
-                    endif()
-                    message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
-                    execute_process(
-                        COMMAND ${PYTHON_EXECUTABLE} -c "import imp; print(imp.find_module('open3d_azure_kinect_ubuntu1604_fix')[1])"
-                        OUTPUT_VARIABLE AZURE_PACKAGE_FIX_PATH
-                        OUTPUT_STRIP_TRAILING_WHITESPACE
-                        ERROR_QUIET
-                    )
-                    if (AZURE_PACKAGE_FIX_PATH)
-                        message(STATUS "Found open3d_azure_kinect_ubuntu1604_fix pip package: ${AZURE_PACKAGE_FIX_PATH}")
-                        set(k4a_INCLUDE_DIRS ${AZURE_PACKAGE_FIX_PATH}/include)
-                        set(k4a_FOUND TRUE)
-                    else()
-                        message(STATUS "Cannot find open3d_azure_kinect_ubuntu1604_fix pip pacakge")
-                    endif()
-                else()
-                    message(STATUS "Not Ubuntu 16.04, skipping open3d-azure-kinect-ubuntu1604 pip package load")
-                endif()
-            else()
-                message(STATUS "Cannot find lsb_release command")
-            endif()
+            find_k4a_with_ubuntu_1604_pip_package()
         endif()
 
         if (k4a_FOUND)

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -22,41 +22,43 @@ if (BUILD_AZURE_KINECT)
         # User need to run `pip install open3d-azure-kinect-ubuntu1604` first.
         # The Python package will provide headers and pre-compiled libs for
         # building k4a
-        find_program(LSB_RELEASE_EXEC lsb_release)
-        if (LSB_RELEASE_EXEC)
-            execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
-                OUTPUT_VARIABLE LSB_DISTRIBUTION
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-            execute_process(COMMAND ${LSB_RELEASE_EXEC} -cs
-                OUTPUT_VARIABLE LSB_CODENAME
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-            if(LSB_DISTRIBUTION STREQUAL "Ubuntu" AND LSB_CODENAME STREQUAL "xenial")
-                message(STATUS "Ubuntu 16.04 detected, trying to load from open3d-azure-kinect-ubuntu1604 pip package")
-                if (NOT PYTHON_EXECUTABLE)
-                    find_program(PYTHON_IN_PATH "python")
-                    set(PYTHON_EXECUTABLE ${PYTHON_IN_PATH})
-                endif()
-                message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
-                execute_process(
-                    COMMAND ${PYTHON_EXECUTABLE} -c "import imp; print(imp.find_module('open3d_azure_kinect_ubuntu1604_fix')[1])"
-                    OUTPUT_VARIABLE AZURE_PACKAGE_FIX_PATH
+        if (NOT k4a_FOUND)
+            find_program(LSB_RELEASE_EXEC lsb_release)
+            if (LSB_RELEASE_EXEC)
+                execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
+                    OUTPUT_VARIABLE LSB_DISTRIBUTION
                     OUTPUT_STRIP_TRAILING_WHITESPACE
-                    ERROR_QUIET
                 )
-                if (AZURE_PACKAGE_FIX_PATH)
-                    message(STATUS "Found open3d_azure_kinect_ubuntu1604_fix pip package: ${AZURE_PACKAGE_FIX_PATH}")
-                    set(k4a_INCLUDE_DIRS ${AZURE_PACKAGE_FIX_PATH}/include)
-                    set(k4a_FOUND TRUE)
+                execute_process(COMMAND ${LSB_RELEASE_EXEC} -cs
+                    OUTPUT_VARIABLE LSB_CODENAME
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                )
+                if(LSB_DISTRIBUTION STREQUAL "Ubuntu" AND LSB_CODENAME STREQUAL "xenial")
+                    message(STATUS "Ubuntu 16.04 detected, trying to load from open3d-azure-kinect-ubuntu1604 pip package")
+                    if (NOT PYTHON_EXECUTABLE)
+                        find_program(PYTHON_IN_PATH "python")
+                        set(PYTHON_EXECUTABLE ${PYTHON_IN_PATH})
+                    endif()
+                    message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
+                    execute_process(
+                        COMMAND ${PYTHON_EXECUTABLE} -c "import imp; print(imp.find_module('open3d_azure_kinect_ubuntu1604_fix')[1])"
+                        OUTPUT_VARIABLE AZURE_PACKAGE_FIX_PATH
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+                        ERROR_QUIET
+                    )
+                    if (AZURE_PACKAGE_FIX_PATH)
+                        message(STATUS "Found open3d_azure_kinect_ubuntu1604_fix pip package: ${AZURE_PACKAGE_FIX_PATH}")
+                        set(k4a_INCLUDE_DIRS ${AZURE_PACKAGE_FIX_PATH}/include)
+                        set(k4a_FOUND TRUE)
+                    else()
+                        message(STATUS "Cannot find open3d_azure_kinect_ubuntu1604_fix pip pacakge")
+                    endif()
                 else()
-                    message(STATUS "Cannot find open3d_azure_kinect_ubuntu1604_fix pip pacakge")
+                    message(STATUS "Not Ubuntu 16.04, skipping open3d-azure-kinect-ubuntu1604 pip package load")
                 endif()
             else()
-                message(STATUS "Not Ubuntu 16.04, skipping open3d-azure-kinect-ubuntu1604 pip package load")
+                message(STATUS "Cannot find lsb_release command")
             endif()
-        else()
-            message(STATUS "Cannot find lsb_release command")
         endif()
 
         if (k4a_FOUND)
@@ -66,8 +68,6 @@ if (BUILD_AZURE_KINECT)
                     to https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md")
         endif()
     endif()
-
-    set(k4a_LIBRARIES k4a k4arecord)
 else()
     # Conditionally include header files in Open3D.h
     set(BUILD_AZURE_KINECT_COMMENT "//")

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -6,7 +6,11 @@ if (BUILD_AZURE_KINECT)
     # - k4a_INCLUDE_DIRS
     if (WIN32)
         # We assume k4a 1.2.0 is installed in the default directory
-        set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\include")
+        if (K4A_INCLUDE_DIR)
+            set(k4a_INCLUDE_DIRS ${K4A_INCLUDE_DIR})
+        else()
+            set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\include")
+        endif()
     elseif(APPLE)
         message(FATAL_ERROR "Azure Kinect is not supported on macOS")
     else()

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -4,48 +4,67 @@ if (BUILD_AZURE_KINECT)
 
     # Export the following variables:
     # - k4a_INCLUDE_DIRS
-    # - k4a_LIBRARY_DIRS
-    # - k4a_LIBRARIES
     if (WIN32)
         # We assume k4a 1.2.0 is installed in the default directory
         set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\include")
-        # On Windows, we need to
-        # 1) link with k4a.lib, k4arecord.lib
-        set(k4a_STATIC_LIBRARY_DIR
-            "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\windows-desktop\\amd64\\release\\lib"
-        )
-        # 2) copy depthengine_2_0.dll, k4a.dll, k4a.record.dll to executable location
-        set(k4a_DYNAMIC_LIBRARY_DIR
-            "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\windows-desktop\\amd64\\release\\bin"
-        )
-        set(k4a_LIBRARY_DIRS ${k4a_STATIC_LIBRARY_DIR} ${k4a_DYNAMIC_LIBRARY_DIR})
+    elseif(APPLE)
+        message(FATAL_ERROR "Azure Kinect is not supported on macOS")
     else()
+        # Attempt 1: system-wide installed K4a
         # The property names are tested with k4a 1.2, future versions might work
         find_package(k4a 1.2 QUIET)
         find_package(k4arecord 1.2 QUIET)
         if (k4a_FOUND)
-            get_target_property(k4a_INCLUDE_DIRS       k4a::k4a       INTERFACE_INCLUDE_DIRECTORIES)
-            get_target_property(k4a_LIBRARIES          k4a::k4a       IMPORTED_LOCATION_RELWITHDEBINFO)
-            get_target_property(k4arecord_INCLUDE_DIRS k4a::k4arecord INTERFACE_INCLUDE_DIRECTORIES)
-            get_target_property(k4arecord_LIBRARIES    k4a::k4arecord IMPORTED_LOCATION_RELWITHDEBINFO)
+            get_target_property(k4a_INCLUDE_DIRS k4a::k4a INTERFACE_INCLUDE_DIRECTORIES)
+        endif()
+
+        # Attempt 2: "open3d-azure-kinect-ubuntu1604"
+        # User need to run `pip install open3d-azure-kinect-ubuntu1604` first.
+        # The Python package will provide headers and pre-compiled libs for
+        # building k4a
+        find_program(LSB_RELEASE_EXEC lsb_release)
+        if (LSB_RELEASE_EXEC)
+            execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
+                OUTPUT_VARIABLE LSB_DISTRIBUTION
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            execute_process(COMMAND ${LSB_RELEASE_EXEC} -cs
+                OUTPUT_VARIABLE LSB_CODENAME
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            if(LSB_DISTRIBUTION STREQUAL "Ubuntu" AND LSB_CODENAME STREQUAL "xenial")
+                message(STATUS "Ubuntu 16.04 detected, trying to load from open3d-azure-kinect-ubuntu1604 pip package")
+                if (NOT PYTHON_EXECUTABLE)
+                    find_program(PYTHON_IN_PATH "python")
+                    set(PYTHON_EXECUTABLE ${PYTHON_IN_PATH})
+                endif()
+                message(STATUS "Using Python executable: ${PYTHON_EXECUTABLE}")
+                execute_process(
+                    COMMAND ${PYTHON_EXECUTABLE} -c "import imp; print(imp.find_module('open3d_azure_kinect_ubuntu1604_fix')[1])"
+                    OUTPUT_VARIABLE AZURE_PACKAGE_FIX_PATH
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET
+                )
+                if (AZURE_PACKAGE_FIX_PATH)
+                    message(STATUS "Found open3d_azure_kinect_ubuntu1604_fix pip package: ${AZURE_PACKAGE_FIX_PATH}")
+                    set(k4a_INCLUDE_DIRS ${AZURE_PACKAGE_FIX_PATH}/include)
+                    set(k4a_FOUND TRUE)
+                else()
+                    message(STATUS "Cannot find open3d_azure_kinect_ubuntu1604_fix pip pacakge")
+                endif()
+            else()
+                message(STATUS "Not Ubuntu 16.04, skipping open3d-azure-kinect-ubuntu1604 pip package load")
+            endif()
+        else()
+            message(STATUS "Cannot find lsb_release command")
+        endif()
+
+        if (k4a_FOUND)
             message(STATUS "k4a_INCLUDE_DIRS: ${k4a_INCLUDE_DIRS}")
-            message(STATUS "k4a_LIBRARIES: ${k4a_LIBRARIES}")
-            message(STATUS "k4arecord_INCLUDE_DIRS: ${k4arecord_INCLUDE_DIRS}")
-            message(STATUS "k4arecord_LIBRARIES: ${k4arecord_LIBRARIES}")
-
-            # Alias target to be consistent with windows
-            add_library(k4a INTERFACE)
-            add_library(k4arecord INTERFACE)
-
-            set(k4a_INCLUDE_DIRS k4a_INCLUDE_DIRS)
-
-            # Assume libk4a and libk4arecord are both in k4a_LIBRARY_DIR
-            get_filename_component(k4a_LIBRARY_DIR ${k4a_LIBRARIES} DIRECTORY)
-            set(k4a_LIBRARY_DIRS ${k4a_LIBRARY_DIR})
-        else ()
+        else()
             message(FATAL_ERROR "Kinect SDK NOT found. Please install according \
                     to https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md")
-        endif ()
+        endif()
     endif()
 
     set(k4a_LIBRARIES k4a k4arecord)

--- a/docs/tutorial/Basic/azure_kinect.rst
+++ b/docs/tutorial/Basic/azure_kinect.rst
@@ -183,6 +183,12 @@ flag.
 Unofficial Ubuntu 16.04 workaround
 ==================================
 
+The Azure Kinect SDK is not officially supported on Ubuntu 16.04. We provide
+unofficial support for experimental purposes.
+
+Using Open3D Python packages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 For Python Open3D, run
 
 .. code-block:: sh
@@ -200,7 +206,27 @@ The ``open3d_azure_kinect_ubuntu1604_fix`` will preload the shared libs and set
 ``LD_LIBRARY_PATH`` which are then used by ``dlopen`` when the Kinect library
 is loaded from the compiled module.
 
-To compile Open3D from source, you'll need to build and install K4A SDK
-manually. However, at runtime, you'll still need to ensure
-the 18.04 copy of ``libstdc++.so`` and ``libdepthengine.so`` are visible from
-``LD_LIBRARY_PATH``.
+After installing ``open3d_azure_kinect_ubuntu1604_fix``, import Open3D as usual
+with ``import open3d``, Open3D will try to load the shared libraries at
+initialization time in ``__init__.py``.
+
+Compiling Open3D from source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, install ``open3d_azure_kinect_ubuntu1604_fix`` package in your Python
+environment. This package contains the headers that are required for compiling
+Open3D with Azure Kinect support.
+
+When building Open3D from source, set the flag ``-DBUILD_AZURE_KINECT=ON``
+at CMake configure time. CMake will then try to detect the location of the
+``open3d_azure_kinect_ubuntu1604_fix`` package using the ``Python`` executable
+available from the current ``PATH``. Therefore, when running CMake, make sure
+that the same Python environment where ``open3d_azure_kinect_ubuntu1604_fix``
+was installed is activated.
+
+If you build a C++ binary, you'll still need to ensure that
+``LD_LIBRARY_PATH`` contains the directory which contains ``libstdc++.so`` and
+``libdepthengine.so`` at runtime. If you build the compiled Open3D Python
+module, Open3D's ``__init__.py`` will try to import
+``open3d_azure_kinect_ubuntu1604_fix`` to append the ``LD_LIBRARY_PATH``
+automatically.

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
@@ -28,6 +28,7 @@
 
 #include <json/json.h>
 #include <k4a/k4a.h>
+#include <map>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -38,20 +39,18 @@
 namespace open3d {
 namespace io {
 
-static std::unordered_map<k4a_image_format_t, std::string>
-        k4a_image_format_t_to_string({
-                {K4A_IMAGE_FORMAT_COLOR_MJPG, "K4A_IMAGE_FORMAT_COLOR_MJPG"},
-                {K4A_IMAGE_FORMAT_COLOR_NV12, "K4A_IMAGE_FORMAT_COLOR_NV12"},
-                {K4A_IMAGE_FORMAT_COLOR_YUY2, "K4A_IMAGE_FORMAT_COLOR_YUY2"},
-                {K4A_IMAGE_FORMAT_COLOR_BGRA32,
-                 "K4A_IMAGE_FORMAT_COLOR_BGRA32"},
-                {K4A_IMAGE_FORMAT_DEPTH16, "K4A_IMAGE_FORMAT_DEPTH16"},
-                {K4A_IMAGE_FORMAT_IR16, "K4A_IMAGE_FORMAT_IR16"},
-                {K4A_IMAGE_FORMAT_CUSTOM, "K4A_IMAGE_FORMAT_CUSTOM"},
-        });
+static std::map<k4a_image_format_t, std::string> k4a_image_format_t_to_string{
+        {K4A_IMAGE_FORMAT_COLOR_MJPG, "K4A_IMAGE_FORMAT_COLOR_MJPG"},
+        {K4A_IMAGE_FORMAT_COLOR_NV12, "K4A_IMAGE_FORMAT_COLOR_NV12"},
+        {K4A_IMAGE_FORMAT_COLOR_YUY2, "K4A_IMAGE_FORMAT_COLOR_YUY2"},
+        {K4A_IMAGE_FORMAT_COLOR_BGRA32, "K4A_IMAGE_FORMAT_COLOR_BGRA32"},
+        {K4A_IMAGE_FORMAT_DEPTH16, "K4A_IMAGE_FORMAT_DEPTH16"},
+        {K4A_IMAGE_FORMAT_IR16, "K4A_IMAGE_FORMAT_IR16"},
+        {K4A_IMAGE_FORMAT_CUSTOM, "K4A_IMAGE_FORMAT_CUSTOM"},
+};
 
-static std::unordered_map<k4a_color_resolution_t, std::string>
-        k4a_color_resolution_t_to_string({
+static std::map<k4a_color_resolution_t, std::string>
+        k4a_color_resolution_t_to_string{
                 {K4A_COLOR_RESOLUTION_OFF, "K4A_COLOR_RESOLUTION_OFF"},
                 {K4A_COLOR_RESOLUTION_720P, "K4A_COLOR_RESOLUTION_720P"},
                 {K4A_COLOR_RESOLUTION_1080P, "K4A_COLOR_RESOLUTION_1080P"},
@@ -59,49 +58,44 @@ static std::unordered_map<k4a_color_resolution_t, std::string>
                 {K4A_COLOR_RESOLUTION_1536P, "K4A_COLOR_RESOLUTION_1536P"},
                 {K4A_COLOR_RESOLUTION_2160P, "K4A_COLOR_RESOLUTION_2160P"},
                 {K4A_COLOR_RESOLUTION_3072P, "K4A_COLOR_RESOLUTION_3072P"},
-        });
+        };
 
-static std::unordered_map<k4a_depth_mode_t, std::string>
-        k4a_depth_mode_t_to_string({
-                {K4A_DEPTH_MODE_OFF, "K4A_DEPTH_MODE_OFF"},
-                {K4A_DEPTH_MODE_NFOV_2X2BINNED,
-                 "K4A_DEPTH_MODE_NFOV_2X2BINNED"},
-                {K4A_DEPTH_MODE_NFOV_UNBINNED, "K4A_DEPTH_MODE_NFOV_UNBINNED"},
-                {K4A_DEPTH_MODE_WFOV_2X2BINNED,
-                 "K4A_DEPTH_MODE_WFOV_2X2BINNED"},
-                {K4A_DEPTH_MODE_WFOV_UNBINNED, "K4A_DEPTH_MODE_WFOV_UNBINNED"},
-                {K4A_DEPTH_MODE_PASSIVE_IR, "K4A_DEPTH_MODE_PASSIVE_IR"},
-        });
+static std::map<k4a_depth_mode_t, std::string> k4a_depth_mode_t_to_string{
+        {K4A_DEPTH_MODE_OFF, "K4A_DEPTH_MODE_OFF"},
+        {K4A_DEPTH_MODE_NFOV_2X2BINNED, "K4A_DEPTH_MODE_NFOV_2X2BINNED"},
+        {K4A_DEPTH_MODE_NFOV_UNBINNED, "K4A_DEPTH_MODE_NFOV_UNBINNED"},
+        {K4A_DEPTH_MODE_WFOV_2X2BINNED, "K4A_DEPTH_MODE_WFOV_2X2BINNED"},
+        {K4A_DEPTH_MODE_WFOV_UNBINNED, "K4A_DEPTH_MODE_WFOV_UNBINNED"},
+        {K4A_DEPTH_MODE_PASSIVE_IR, "K4A_DEPTH_MODE_PASSIVE_IR"},
+};
 
-static std::unordered_map<k4a_fps_t, std::string> k4a_fps_t_to_string({
+static std::map<k4a_fps_t, std::string> k4a_fps_t_to_string{
         {K4A_FRAMES_PER_SECOND_5, "K4A_FRAMES_PER_SECOND_5"},
         {K4A_FRAMES_PER_SECOND_15, "K4A_FRAMES_PER_SECOND_15"},
         {K4A_FRAMES_PER_SECOND_30, "K4A_FRAMES_PER_SECOND_30"},
-});
+};
 
-static std::unordered_map<k4a_wired_sync_mode_t, std::string>
-        k4a_wired_sync_mode_t_to_string({
+static std::map<k4a_wired_sync_mode_t, std::string>
+        k4a_wired_sync_mode_t_to_string{
                 {K4A_WIRED_SYNC_MODE_STANDALONE,
                  "K4A_WIRED_SYNC_MODE_STANDALONE"},
                 {K4A_WIRED_SYNC_MODE_MASTER, "K4A_WIRED_SYNC_MODE_MASTER"},
                 {K4A_WIRED_SYNC_MODE_SUBORDINATE,
                  "K4A_WIRED_SYNC_MODE_SUBORDINATE"},
-        });
+        };
 
-static std::unordered_map<std::string, k4a_image_format_t>
-        string_to_k4a_image_format_t({
-                {"K4A_IMAGE_FORMAT_COLOR_MJPG", K4A_IMAGE_FORMAT_COLOR_MJPG},
-                {"K4A_IMAGE_FORMAT_COLOR_NV12", K4A_IMAGE_FORMAT_COLOR_NV12},
-                {"K4A_IMAGE_FORMAT_COLOR_YUY2", K4A_IMAGE_FORMAT_COLOR_YUY2},
-                {"K4A_IMAGE_FORMAT_COLOR_BGRA32",
-                 K4A_IMAGE_FORMAT_COLOR_BGRA32},
-                {"K4A_IMAGE_FORMAT_DEPTH16", K4A_IMAGE_FORMAT_DEPTH16},
-                {"K4A_IMAGE_FORMAT_IR16", K4A_IMAGE_FORMAT_IR16},
-                {"K4A_IMAGE_FORMAT_CUSTOM", K4A_IMAGE_FORMAT_CUSTOM},
-        });
+static std::map<std::string, k4a_image_format_t> string_to_k4a_image_format_t({
+        {"K4A_IMAGE_FORMAT_COLOR_MJPG", K4A_IMAGE_FORMAT_COLOR_MJPG},
+        {"K4A_IMAGE_FORMAT_COLOR_NV12", K4A_IMAGE_FORMAT_COLOR_NV12},
+        {"K4A_IMAGE_FORMAT_COLOR_YUY2", K4A_IMAGE_FORMAT_COLOR_YUY2},
+        {"K4A_IMAGE_FORMAT_COLOR_BGRA32", K4A_IMAGE_FORMAT_COLOR_BGRA32},
+        {"K4A_IMAGE_FORMAT_DEPTH16", K4A_IMAGE_FORMAT_DEPTH16},
+        {"K4A_IMAGE_FORMAT_IR16", K4A_IMAGE_FORMAT_IR16},
+        {"K4A_IMAGE_FORMAT_CUSTOM", K4A_IMAGE_FORMAT_CUSTOM},
+});
 
-static std::unordered_map<std::string, k4a_color_resolution_t>
-        string_to_k4a_color_resolution_t({
+static std::map<std::string, k4a_color_resolution_t>
+        string_to_k4a_color_resolution_t{
                 {"K4A_COLOR_RESOLUTION_OFF", K4A_COLOR_RESOLUTION_OFF},
                 {"K4A_COLOR_RESOLUTION_720P", K4A_COLOR_RESOLUTION_720P},
                 {"K4A_COLOR_RESOLUTION_1080P", K4A_COLOR_RESOLUTION_1080P},
@@ -109,34 +103,31 @@ static std::unordered_map<std::string, k4a_color_resolution_t>
                 {"K4A_COLOR_RESOLUTION_1536P", K4A_COLOR_RESOLUTION_1536P},
                 {"K4A_COLOR_RESOLUTION_2160P", K4A_COLOR_RESOLUTION_2160P},
                 {"K4A_COLOR_RESOLUTION_3072P", K4A_COLOR_RESOLUTION_3072P},
-        });
+        };
 
-static std::unordered_map<std::string, k4a_depth_mode_t>
-        string_to_k4a_depth_mode_t({
-                {"K4A_DEPTH_MODE_OFF", K4A_DEPTH_MODE_OFF},
-                {"K4A_DEPTH_MODE_NFOV_2X2BINNED",
-                 K4A_DEPTH_MODE_NFOV_2X2BINNED},
-                {"K4A_DEPTH_MODE_NFOV_UNBINNED", K4A_DEPTH_MODE_NFOV_UNBINNED},
-                {"K4A_DEPTH_MODE_WFOV_2X2BINNED",
-                 K4A_DEPTH_MODE_WFOV_2X2BINNED},
-                {"K4A_DEPTH_MODE_WFOV_UNBINNED", K4A_DEPTH_MODE_WFOV_UNBINNED},
-                {"K4A_DEPTH_MODE_PASSIVE_IR", K4A_DEPTH_MODE_PASSIVE_IR},
-        });
+static std::map<std::string, k4a_depth_mode_t> string_to_k4a_depth_mode_t{
+        {"K4A_DEPTH_MODE_OFF", K4A_DEPTH_MODE_OFF},
+        {"K4A_DEPTH_MODE_NFOV_2X2BINNED", K4A_DEPTH_MODE_NFOV_2X2BINNED},
+        {"K4A_DEPTH_MODE_NFOV_UNBINNED", K4A_DEPTH_MODE_NFOV_UNBINNED},
+        {"K4A_DEPTH_MODE_WFOV_2X2BINNED", K4A_DEPTH_MODE_WFOV_2X2BINNED},
+        {"K4A_DEPTH_MODE_WFOV_UNBINNED", K4A_DEPTH_MODE_WFOV_UNBINNED},
+        {"K4A_DEPTH_MODE_PASSIVE_IR", K4A_DEPTH_MODE_PASSIVE_IR},
+};
 
-static std::unordered_map<std::string, k4a_fps_t> string_to_k4a_fps_t({
+static std::map<std::string, k4a_fps_t> string_to_k4a_fps_t{
         {"K4A_FRAMES_PER_SECOND_5", K4A_FRAMES_PER_SECOND_5},
         {"K4A_FRAMES_PER_SECOND_15", K4A_FRAMES_PER_SECOND_15},
         {"K4A_FRAMES_PER_SECOND_30", K4A_FRAMES_PER_SECOND_30},
-});
+};
 
-static std::unordered_map<std::string, k4a_wired_sync_mode_t>
-        string_to_k4a_wired_sync_mode_t({
+static std::map<std::string, k4a_wired_sync_mode_t>
+        string_to_k4a_wired_sync_mode_t{
                 {"K4A_WIRED_SYNC_MODE_STANDALONE",
                  K4A_WIRED_SYNC_MODE_STANDALONE},
                 {"K4A_WIRED_SYNC_MODE_MASTER", K4A_WIRED_SYNC_MODE_MASTER},
                 {"K4A_WIRED_SYNC_MODE_SUBORDINATE",
                  K4A_WIRED_SYNC_MODE_SUBORDINATE},
-        });
+        };
 
 static std::unordered_map<std::string, std::string> standard_config{
         {"color_format", "K4A_IMAGE_FORMAT_COLOR_MJPG"},

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -50,12 +50,6 @@ namespace k4a_plugin {
 
 #ifdef _WIN32
 
-// clang-format off
-static const std::vector<std::string> k4a_lib_path_hints = {
-    "",
-    "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\windows-desktop\\amd64\\release\\bin\\"
-};
-// clang-format on
 static const std::string k4a_lib_name = "k4a.dll";
 static const std::string k4arecord_lib_name = "k4arecord.dll";
 
@@ -63,9 +57,29 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
     static std::unordered_map<std::string, HINSTANCE> map_lib_name_to_handle;
 
     if (map_lib_name_to_handle.count(lib_name) == 0) {
+        // clang-format off
+        // To use custom library path for K4a, set environment variable K4A_LIB_DIR
+        // Note that double qoutes and "\\" are not needed
+        // set K4A_LIB_DIR=C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\bin
+        std::string env_lib_dir = "";
+        char const* temp = std::getenv("K4A_LIB_DIR");
+        if (temp != nullptr) {
+            env_lib_dir = std::string(temp);
+        }
+        utility::LogInfo("K4A_LIB_DIR: {}\n", env_lib_dir);
+
+        static const std::vector<std::string> k4a_lib_path_hints = {
+            env_lib_dir,
+            "",
+            "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\windows-desktop\\amd64\\release\\bin"
+        };
+        // clang-format on
+
         HINSTANCE handle = NULL;
         for (const std::string& k4a_lib_path_hint : k4a_lib_path_hints) {
-            std::string full_path = k4a_lib_path_hint + lib_name;
+            utility::LogInfo("Trying k4a_lib_path_hint: {}\n",
+                             k4a_lib_path_hint);
+            std::string full_path = k4a_lib_path_hint + "\\" + lib_name;
             handle = LoadLibrary(TEXT(full_path.c_str()));
             if (handle != NULL) {
                 utility::LogDebug("Loaded {}\n", full_path);

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -59,14 +59,15 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
     if (map_lib_name_to_handle.count(lib_name) == 0) {
         // clang-format off
         // To use custom library path for K4a, set environment variable K4A_LIB_DIR
-        // Note that double qoutes and "\\" are not needed
+        // Exammple:
         // set K4A_LIB_DIR=C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\bin
+        // Note that double qoutes and "\\" are not needed
         std::string env_lib_dir = "";
         char const* temp = std::getenv("K4A_LIB_DIR");
         if (temp != nullptr) {
             env_lib_dir = std::string(temp);
         }
-        utility::LogInfo("K4A_LIB_DIR: {}\n", env_lib_dir);
+        utility::LogDebug("Environment variable K4A_LIB_DIR: {}\n", env_lib_dir);
 
         static const std::vector<std::string> k4a_lib_path_hints = {
             env_lib_dir,
@@ -77,8 +78,8 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
 
         HINSTANCE handle = NULL;
         for (const std::string& k4a_lib_path_hint : k4a_lib_path_hints) {
-            utility::LogInfo("Trying k4a_lib_path_hint: {}\n",
-                             k4a_lib_path_hint);
+            utility::LogDebug("Trying k4a_lib_path_hint: {}\n",
+                              k4a_lib_path_hint);
             std::string full_path = k4a_lib_path_hint + "\\" + lib_name;
             handle = LoadLibrary(TEXT(full_path.c_str()));
             if (handle != NULL) {
@@ -107,7 +108,7 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
             if (f == nullptr) {                                       \
                 utility::LogFatal("Cannot load func {}\n", #f_name);  \
             } else {                                                  \
-                utility::LogInfo("Loaded func {}\n", #f_name);        \
+                utility::LogDebug("Loaded func {}\n", #f_name);       \
             }                                                         \
         }                                                             \
         return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));              \
@@ -153,11 +154,11 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
         if (!handle) {
             utility::LogFatal("Cannot load {}\n", dlerror());
         } else {
-            utility::LogInfo("Loaded {}\n", full_path);
+            utility::LogDebug("Loaded {}\n", full_path);
             struct link_map* map = nullptr;
             if (!dlinfo(handle, RTLD_DI_LINKMAP, &map)) {
                 if (map != nullptr) {
-                    utility::LogInfo("Library path {}\n", map->l_name);
+                    utility::LogDebug("Library path {}\n", map->l_name);
                 } else {
                     utility::LogWarning("Cannot get link_map\n");
                 }

--- a/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
@@ -82,6 +82,11 @@
 // clang-format off
 #define EXTRACT_TYPES_PARAMS_0(...)
 
+// Workaround: with older compilers ##__VA_ARGS__ my not eliminate unnecessary
+// comma when __VA_ARGS__ is empty.
+// In this case, COUNT_ARGS() will be 1 where it should be 0.
+#define EXTRACT_TYPES_PARAMS_1(...)
+
 #define EXTRACT_TYPES_PARAMS_2(...) \
     EXPAND(ARGS_1(__VA_ARGS__)) EXPAND(ARGS_2(__VA_ARGS__))
 
@@ -169,6 +174,11 @@
 //     a1, a2, a3, a4
 // clang-format off
 #define EXTRACT_PARAMS_0(...)
+
+// Workaround: with older compilers ##__VA_ARGS__ my not eliminate unnecessary
+// comma when __VA_ARGS__ is empty.
+// In this case, COUNT_ARGS() will be 1 where it should be 0.
+#define EXTRACT_PARAMS_1(...)
 
 #define EXTRACT_PARAMS_2(...) \
     EXPAND(ARGS_2(__VA_ARGS__))

--- a/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
+++ b/src/Open3D/IO/Sensor/AzureKinect/PluginMacros.h
@@ -82,7 +82,7 @@
 // clang-format off
 #define EXTRACT_TYPES_PARAMS_0(...)
 
-// Workaround: with older compilers ##__VA_ARGS__ my not eliminate unnecessary
+// Workaround: with older compilers ##__VA_ARGS__ may not eliminate unnecessary
 // comma when __VA_ARGS__ is empty.
 // In this case, COUNT_ARGS() will be 1 where it should be 0.
 #define EXTRACT_TYPES_PARAMS_1(...)
@@ -175,7 +175,7 @@
 // clang-format off
 #define EXTRACT_PARAMS_0(...)
 
-// Workaround: with older compilers ##__VA_ARGS__ my not eliminate unnecessary
+// Workaround: with older compilers ##__VA_ARGS__ may not eliminate unnecessary
 // comma when __VA_ARGS__ is empty.
 // In this case, COUNT_ARGS() will be 1 where it should be 0.
 #define EXTRACT_PARAMS_1(...)


### PR DESCRIPTION
- Allow Ubuntu 16.04 to build azure kinect support when `open3d-azure-kinect-ubuntu1604` pip package is installed. This is useful since the released Open3D is built on Ubuntu 16.04 in order to be compatible with both 16.04 and 18.04. 
- Simplify `azure_kinect.cmake`: `k4a_INCLUDE_DIRS` is all we need at build time, no library or lib paths are needed
- Added the option for Windows users to specify `cmake -DK4A_INCLUDE_DIR=...` at at CMake config time
- Added the option for Windows user to specify `K4A_LIB_DIR` environment variable to point to K4a DLLs, e.g.
    ```
    set K4A_LIB_DIR=C:\Program Files\Azure Kinect SDK v1.2.0\sdk\windows-desktop\amd64\release\bin
    ```
- `std::map` instead dof `std::unorderd_map` for enum to string map, to be compatible with older compilers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1160)
<!-- Reviewable:end -->
