### PR TITLE
Improve numeric stability of TriangleTriangle3d

### DIFF
--- a/src/Open3D/Geometry/IntersectionTest.cpp
+++ b/src/Open3D/Geometry/IntersectionTest.cpp
@@ -60,7 +60,8 @@ bool IntersectionTest::TriangleTriangle3d(const Eigen::Vector3d& p0,
               (p2 - mu).array().square() + (q0 - mu).array().square() +
               (q1 - mu).array().square() + (q2 - mu).array().square()) /
              5)
-                    .sqrt();
+                    .sqrt() +
+            1e-12;
     Eigen::Vector3d p0m = (p0 - mu).array() / sigma.array();
     Eigen::Vector3d p1m = (p1 - mu).array() / sigma.array();
     Eigen::Vector3d p2m = (p2 - mu).array() / sigma.array();

--- a/src/Open3D/Geometry/IntersectionTest.cpp
+++ b/src/Open3D/Geometry/IntersectionTest.cpp
@@ -54,12 +54,21 @@ bool IntersectionTest::TriangleTriangle3d(const Eigen::Vector3d& p0,
                                           const Eigen::Vector3d& q0,
                                           const Eigen::Vector3d& q1,
                                           const Eigen::Vector3d& q2) {
-    return NoDivTriTriIsect(const_cast<double*>(p0.data()),
-                            const_cast<double*>(p1.data()),
-                            const_cast<double*>(p2.data()),
-                            const_cast<double*>(q0.data()),
-                            const_cast<double*>(q1.data()),
-                            const_cast<double*>(q2.data())) != 0;
+    const Eigen::Vector3d mu = (p0 + p1 + p2 + q0 + q1 + q2) / 6;
+    const Eigen::Vector3d sigma =
+            (((p0 - mu).array().square() + (p1 - mu).array().square() +
+              (p2 - mu).array().square() + (q0 - mu).array().square() +
+              (q1 - mu).array().square() + (q2 - mu).array().square()) /
+             5)
+                    .sqrt();
+    Eigen::Vector3d p0m = (p0 - mu).array() / sigma.array();
+    Eigen::Vector3d p1m = (p1 - mu).array() / sigma.array();
+    Eigen::Vector3d p2m = (p2 - mu).array() / sigma.array();
+    Eigen::Vector3d q0m = (q0 - mu).array() / sigma.array();
+    Eigen::Vector3d q1m = (q1 - mu).array() / sigma.array();
+    Eigen::Vector3d q2m = (q2 - mu).array() / sigma.array();
+    return NoDivTriTriIsect(p0m.data(), p1m.data(), p2m.data(), q0m.data(),
+                            q1m.data(), q2m.data()) != 0;
 }
 
 bool IntersectionTest::TriangleAABB(const Eigen::Vector3d& box_center,


### PR DESCRIPTION
It seems that the current triangle triangle intersection test has numerical issues (#1171). Therefore, this PR adds a normalization step to this collision test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1177)
<!-- Reviewable:end -->
