### PR TITLE
Implement image flip functions

### DIFF
--- a/src/Open3D/Geometry/Image.cpp
+++ b/src/Open3D/Geometry/Image.cpp
@@ -295,7 +295,7 @@ std::shared_ptr<Image> Image::Transpose() const {
     return output;
 }
 
-std::shared_ptr<Image> Image::FlipUD() const {
+std::shared_ptr<Image> Image::FlipVertical() const {
     auto output = std::make_shared<Image>();
     output->Prepare(width_, height_, num_of_channels_, bytes_per_channel_);
 
@@ -311,7 +311,7 @@ std::shared_ptr<Image> Image::FlipUD() const {
     return output;
 }
 
-std::shared_ptr<Image> Image::FlipLR() const {
+std::shared_ptr<Image> Image::FlipHorizontal() const {
     auto output = std::make_shared<Image>();
     output->Prepare(width_, height_, num_of_channels_, bytes_per_channel_);
 

--- a/src/Open3D/Geometry/Image.cpp
+++ b/src/Open3D/Geometry/Image.cpp
@@ -264,13 +264,13 @@ std::shared_ptr<Image> Image::Filter(const std::vector<double> &dx,
     }
 
     auto temp1 = FilterHorizontal(dx);
-    auto temp2 = temp1->Flip();
+    auto temp2 = temp1->Transpose();
     auto temp3 = temp2->FilterHorizontal(dy);
-    auto temp4 = temp3->Flip();
+    auto temp4 = temp3->Transpose();
     return temp4;
 }
 
-std::shared_ptr<Image> Image::Flip() const {
+std::shared_ptr<Image> Image::Transpose() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
         utility::LogWarning("[FilpImage] Unsupported image format.\n");
@@ -292,6 +292,48 @@ std::shared_ptr<Image> Image::Flip() const {
             *po = *pi;
         }
     }
+    return output;
+}
+
+std::shared_ptr<Image> Image::FlipUD() const {
+    auto output = std::make_shared<Image>();
+    output->Prepare(width_, height_, num_of_channels_, bytes_per_channel_);
+
+    int bytes_per_line = BytesPerLine();
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int y = 0; y < height_; y++) {
+        std::copy(data_.data() + y * bytes_per_line,
+                  data_.data() + (y + 1) * bytes_per_line,
+                  output->data_.data() + (height_ - y - 1) * bytes_per_line);
+    }
+    return output;
+}
+
+std::shared_ptr<Image> Image::FlipLR() const {
+    auto output = std::make_shared<Image>();
+    output->Prepare(width_, height_, num_of_channels_, bytes_per_channel_);
+
+    int bytes_per_line = BytesPerLine();
+    int bytes_per_pixel = num_of_channels_ * bytes_per_channel_;
+#ifdef _OPENMP
+#ifdef _WIN32
+#pragma omp parallel for schedule(static)
+#else
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
+#endif
+    for (int y = 0; y < height_; y++) {
+        for (int x = 0; x < width_; x++) {
+            std::copy(data_.data() + y * bytes_per_line + x * bytes_per_pixel,
+                      data_.data() + y * bytes_per_line +
+                              (x + 1) * bytes_per_pixel,
+                      output->data_.data() + y * bytes_per_line +
+                              (width_ - x - 1) * bytes_per_pixel);
+        }
+    }
+
     return output;
 }
 

--- a/src/Open3D/Geometry/Image.h
+++ b/src/Open3D/Geometry/Image.h
@@ -128,7 +128,12 @@ public:
     std::shared_ptr<Image> ConvertDepthToFloatImage(
             double depth_scale = 1000.0, double depth_trunc = 3.0) const;
 
-    std::shared_ptr<Image> Flip() const;
+    std::shared_ptr<Image> Transpose() const;
+
+    /// Function to flip image left and right
+    std::shared_ptr<Image> FlipLR() const;
+    /// Function to flip image up and down
+    std::shared_ptr<Image> FlipUD() const;
 
     /// Function to filter image with pre-defined filtering type
     std::shared_ptr<Image> Filter(Image::FilterType type) const;

--- a/src/Open3D/Geometry/Image.h
+++ b/src/Open3D/Geometry/Image.h
@@ -130,10 +130,10 @@ public:
 
     std::shared_ptr<Image> Transpose() const;
 
-    /// Function to flip image left and right
-    std::shared_ptr<Image> FlipLR() const;
-    /// Function to flip image up and down
-    std::shared_ptr<Image> FlipUD() const;
+    /// Function to flip image horizontally (from left to right)
+    std::shared_ptr<Image> FlipHorizontal() const;
+    /// Function to flip image vertically (upside down)
+    std::shared_ptr<Image> FlipVertical() const;
 
     /// Function to filter image with pre-defined filtering type
     std::shared_ptr<Image> Filter(Image::FilterType type) const;

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -177,9 +177,9 @@ void pybind_image(py::module &m) {
                      }
                  },
                  "Function to filter Image", "filter_type"_a)
-            .def("flipud", &geometry::Image::FlipUD,
+            .def("flip_vertical", &geometry::Image::FlipVertical,
                  "Function to flip image vertically (upside down)")
-            .def("fliplr", &geometry::Image::FlipLR,
+            .def("flip_horizontal", &geometry::Image::FlipHorizontal,
                  "Function to flip image horizontally (from left to right)")
             .def("create_pyramid",
                  [](const geometry::Image &input, size_t num_of_levels,

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -178,9 +178,9 @@ void pybind_image(py::module &m) {
                  },
                  "Function to filter Image", "filter_type"_a)
             .def("flipud", &geometry::Image::FlipUD,
-                 "Function to flip image upside down")
+                 "Function to flip image vertically (upside down)")
             .def("fliplr", &geometry::Image::FlipLR,
-                 "Function to flip image left to right")
+                 "Function to flip image horizontally (from left to right)")
             .def("create_pyramid",
                  [](const geometry::Image &input, size_t num_of_levels,
                     bool with_gaussian_filter) {

--- a/src/Python/geometry/image.cpp
+++ b/src/Python/geometry/image.cpp
@@ -177,6 +177,10 @@ void pybind_image(py::module &m) {
                      }
                  },
                  "Function to filter Image", "filter_type"_a)
+            .def("flipud", &geometry::Image::FlipUD,
+                 "Function to flip image upside down")
+            .def("fliplr", &geometry::Image::FlipLR,
+                 "Function to flip image left to right")
             .def("create_pyramid",
                  [](const geometry::Image &input, size_t num_of_levels,
                     bool with_gaussian_filter) {

--- a/src/UnitTest/Geometry/Image.cpp
+++ b/src/UnitTest/Geometry/Image.cpp
@@ -530,20 +530,87 @@ TEST(Image, TransposeImage) {
     int height = 5;
     int num_of_channels = 1;
     int bytes_per_channel = 4;
-    int flip_bytes_per_channel = 1;
 
     image.Prepare(width, height, num_of_channels, bytes_per_channel);
 
     Rand(image.data_, 0, 255, 0);
 
-    auto flip_image = image.ConvertDepthToFloatImage();
+    auto transpose_image = image.ConvertDepthToFloatImage();
 
+    EXPECT_FALSE(transpose_image->IsEmpty());
+    EXPECT_EQ(width, transpose_image->height_);
+    EXPECT_EQ(height, transpose_image->width_);
+    EXPECT_EQ(num_of_channels, transpose_image->num_of_channels_);
+    EXPECT_EQ(int(sizeof(float)), transpose_image->bytes_per_channel_);
+    ExpectEQ(ref, transpose_image->data_);
+}
+
+TEST(Image, FlipVerticalImage) {
+    // reference data used to validate the creation of the float image
+    // clang-format off
+    vector<uint8_t> input = {
+      0, 1, 2, 3, 4, 5,
+      6, 7, 8, 9, 10, 11,
+      12, 13, 14, 15, 16, 17
+    };
+    vector<uint8_t> flipped = {
+      12, 13, 14, 15, 16, 17,
+      6, 7, 8, 9, 10, 11,
+      0, 1, 2, 3, 4, 5,
+    };
+    // clang-format on
+
+    geometry::Image image;
+    // test image dimensions
+    int width = 6;
+    int height = 3;
+    int num_of_channels = 1;
+    int bytes_per_channel = 1;
+
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    image.data_ = input;
+
+    auto flip_image = image.FlipVertical();
     EXPECT_FALSE(flip_image->IsEmpty());
     EXPECT_EQ(width, flip_image->width_);
     EXPECT_EQ(height, flip_image->height_);
-    EXPECT_EQ(flip_bytes_per_channel, flip_image->num_of_channels_);
-    EXPECT_EQ(int(sizeof(float)), flip_image->bytes_per_channel_);
-    ExpectEQ(ref, flip_image->data_);
+    EXPECT_EQ(num_of_channels, flip_image->num_of_channels_);
+    EXPECT_EQ(int(sizeof(uint8_t)), flip_image->bytes_per_channel_);
+    ExpectEQ(flipped, flip_image->data_);
+}
+
+TEST(Image, FlipHorizontalImage) {
+    // reference data used to validate the creation of the float image
+    // clang-format off
+    vector<uint8_t> input = {
+      0, 1, 2, 3, 4, 5,
+      6, 7, 8, 9, 10, 11,
+      12, 13, 14, 15, 16, 17
+    };
+    vector<uint8_t> flipped = {
+      5, 4, 3, 2, 1, 0,
+      11, 10, 9, 8, 7, 6,
+      17, 16, 15, 14, 13, 12
+    };
+    // clang-format on
+
+    geometry::Image image;
+    // test image dimensions
+    int width = 6;
+    int height = 3;
+    int num_of_channels = 1;
+    int bytes_per_channel = 1;
+
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    image.data_ = input;
+
+    auto flip_image = image.FlipHorizontal();
+    EXPECT_FALSE(flip_image->IsEmpty());
+    EXPECT_EQ(width, flip_image->width_);
+    EXPECT_EQ(height, flip_image->height_);
+    EXPECT_EQ(num_of_channels, flip_image->num_of_channels_);
+    EXPECT_EQ(int(sizeof(uint8_t)), flip_image->bytes_per_channel_);
+    ExpectEQ(flipped, flip_image->data_);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/UnitTest/Geometry/Image.cpp
+++ b/src/UnitTest/Geometry/Image.cpp
@@ -511,7 +511,7 @@ TEST(Image, ConvertDepthToFloatImage) {
 // ----------------------------------------------------------------------------
 //
 // ----------------------------------------------------------------------------
-TEST(Image, FlipImage) {
+TEST(Image, TransposeImage) {
     // reference data used to validate the creation of the float image
     vector<uint8_t> ref = {
             233, 45,  204, 198, 205, 80,  90,  190, 133, 138, 127, 155, 87,


### PR DESCRIPTION
- Rename previous `Flip()` with `Transpose()` according to its semantics;
- Implement `FlipUD()` and `FlipLR()` to flip images. These are useful functions in loading textures.
- Python interface also supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1186)
<!-- Reviewable:end -->
