### PR TITLE
fopen wrapper to enable unicode paths in Windows

### DIFF
--- a/examples/Cpp/EvaluateFeatureMatch.cpp
+++ b/examples/Cpp/EvaluateFeatureMatch.cpp
@@ -37,7 +37,7 @@ public:
 
 public:
     bool LoadFromFile(const std::string &filename) {
-        FILE *fid = fopen(filename.c_str(), "rb");
+        FILE *fid = open3d::utility::filesystem::FOpen(filename, "rb");
         fread(&dataset_size_, sizeof(int), 1, fid);
         fread(&dimension_, sizeof(int), 1, fid);
         data_.resize(dataset_size_ * dimension_);
@@ -103,7 +103,7 @@ bool ReadLogFile(const std::string &filename,
     using namespace open3d;
     pair_ids.clear();
     transformations.clear();
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = open3d::utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
         utility::LogWarning("Read LOG failed: unable to open file.\n");
         return false;
@@ -154,7 +154,7 @@ bool ReadLogFile(const std::string &filename,
 }
 
 void WriteBinaryResult(const std::string &filename, std::vector<double> &data) {
-    FILE *f = fopen(filename.c_str(), "wb");
+    FILE *f = open3d::utility::filesystem::FOpen(filename, "wb");
     fwrite(data.data(), sizeof(double), data.size(), f);
     fclose(f);
 }

--- a/examples/Cpp/EvaluatePCDMatch.cpp
+++ b/examples/Cpp/EvaluatePCDMatch.cpp
@@ -54,7 +54,7 @@ bool ReadLogFile(const std::string &filename,
     using namespace open3d;
     pair_ids.clear();
     transformations.clear();
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
         utility::LogWarning("Read LOG failed: unable to open file.\n");
         return false;

--- a/examples/Cpp/IntegrateRGBD.cpp
+++ b/examples/Cpp/IntegrateRGBD.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
             io::CreatePinholeCameraTrajectoryFromFile(log_filename);
     std::string dir_name =
             utility::filesystem::GetFileParentDirectory(match_filename).c_str();
-    FILE *file = fopen(match_filename.c_str(), "r");
+    FILE *file = utility::filesystem::FOpen(match_filename, "r");
     if (file == NULL) {
         utility::LogError("Unable to open file {}\n", match_filename);
         fclose(file);

--- a/examples/Cpp/ViewDistances.cpp
+++ b/examples/Cpp/ViewDistances.cpp
@@ -67,16 +67,16 @@ int main(int argc, char *argv[]) {
     std::vector<double> distances(pcd->points_.size());
     if (utility::ProgramOptionExists(argc, argv, "--mahalanobis_distance")) {
         distances = pcd->ComputeMahalanobisDistance();
-        FILE *f = fopen(binname.c_str(), "wb");
+        FILE *f = utility::filesystem::FOpen(binname, "wb");
         fwrite(distances.data(), sizeof(double), distances.size(), f);
         fclose(f);
     } else if (utility::ProgramOptionExists(argc, argv, "--nn_distance")) {
         distances = pcd->ComputeNearestNeighborDistance();
-        FILE *f = fopen(binname.c_str(), "wb");
+        FILE *f = utility::filesystem::FOpen(binname, "wb");
         fwrite(distances.data(), sizeof(double), distances.size(), f);
         fclose(f);
     } else {
-        FILE *f = fopen(binname.c_str(), "rb");
+        FILE *f = utility::filesystem::FOpen(binname, "rb");
         if (f == NULL) {
             utility::LogWarning("Cannot open bin file.\n");
             return 1;

--- a/examples/Cpp/ViewPCDMatch.cpp
+++ b/examples/Cpp/ViewPCDMatch.cpp
@@ -36,7 +36,7 @@ bool ReadLogFile(const std::string &filename,
     using namespace open3d;
     metadata.clear();
     transformations.clear();
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
         utility::LogWarning("Read LOG failed: unable to open file.\n");
         return false;

--- a/src/Open3D/IO/FileFormat/FileBIN.cpp
+++ b/src/Open3D/IO/FileFormat/FileBIN.cpp
@@ -29,6 +29,7 @@
 
 #include "Open3D/IO/ClassIO/FeatureIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 
@@ -77,7 +78,7 @@ namespace io {
 
 bool ReadFeatureFromBIN(const std::string &filename,
                         registration::Feature &feature) {
-    FILE *fid = fopen(filename.c_str(), "rb");
+    FILE *fid = utility::filesystem::FOpen(filename, "rb");
     if (fid == NULL) {
         utility::LogWarning("Read BIN failed: unable to open file: {}\n",
                             filename);
@@ -90,7 +91,7 @@ bool ReadFeatureFromBIN(const std::string &filename,
 
 bool WriteFeatureToBIN(const std::string &filename,
                        const registration::Feature &feature) {
-    FILE *fid = fopen(filename.c_str(), "wb");
+    FILE *fid = utility::filesystem::FOpen(filename, "wb");
     if (fid == NULL) {
         utility::LogWarning("Write BIN failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/IO/FileFormat/FileJPG.cpp
+++ b/src/Open3D/IO/FileFormat/FileJPG.cpp
@@ -31,6 +31,7 @@
 
 #include "Open3D/IO/ClassIO/ImageIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 namespace io {
@@ -41,7 +42,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
     FILE *file_in;
     JSAMPARRAY buffer;
 
-    if ((file_in = fopen(filename.c_str(), "rb")) == NULL) {
+    if ((file_in = utility::filesystem::FOpen(filename, "rb")) == NULL) {
         utility::LogWarning("Read JPG failed: unable to open file: {}\n",
                             filename);
         return false;
@@ -111,7 +112,7 @@ bool WriteImageToJPG(const std::string &filename,
     FILE *file_out;
     JSAMPROW row_pointer[1];
 
-    if ((file_out = fopen(filename.c_str(), "wb")) == NULL) {
+    if ((file_out = utility::filesystem::FOpen(filename, "wb")) == NULL) {
         utility::LogWarning("Write JPG failed: unable to open file: {}\n",
                             filename);
         return false;

--- a/src/Open3D/IO/FileFormat/FileLOG.cpp
+++ b/src/Open3D/IO/FileFormat/FileLOG.cpp
@@ -28,6 +28,7 @@
 
 #include "Open3D/IO/ClassIO/PinholeCameraTrajectoryIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 // The log file is the redwood-data format for camera trajectories
 // See these pages for details:
@@ -49,7 +50,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
                 camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
     }
     trajectory.parameters_.clear();
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
         utility::LogWarning("Read LOG failed: unable to open file: {}\n",
                             filename.c_str());
@@ -110,7 +111,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
 bool WritePinholeCameraTrajectoryToLOG(
         const std::string &filename,
         const camera::PinholeCameraTrajectory &trajectory) {
-    FILE *f = fopen(filename.c_str(), "w");
+    FILE *f = utility::filesystem::FOpen(filename.c_str(), "w");
     if (f == NULL) {
         utility::LogWarning("Write LOG failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/IO/FileFormat/FilePCD.cpp
+++ b/src/Open3D/IO/FileFormat/FilePCD.cpp
@@ -31,6 +31,7 @@
 
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 #include "Open3D/Utility/Helper.h"
 
 // References for PCD file IO
@@ -714,7 +715,7 @@ bool ReadPointCloudFromPCD(const std::string &filename,
                            geometry::PointCloud &pointcloud,
                            bool print_progress) {
     PCDHeader header;
-    FILE *file = fopen(filename.c_str(), "rb");
+    FILE *file = utility::filesystem::FOpen(filename.c_str(), "rb");
     if (file == NULL) {
         utility::LogWarning("Read PCD failed: unable to open file: {}\n",
                             filename);
@@ -758,7 +759,7 @@ bool WritePointCloudToPCD(const std::string &filename,
         utility::LogWarning("Write PCD failed: unable to generate header.\n");
         return false;
     }
-    FILE *file = fopen(filename.c_str(), "wb");
+    FILE *file = utility::filesystem::FOpen(filename.c_str(), "wb");
     if (file == NULL) {
         utility::LogWarning("Write PCD failed: unable to open file.\n");
         return false;

--- a/src/Open3D/IO/FileFormat/FilePTS.cpp
+++ b/src/Open3D/IO/FileFormat/FilePTS.cpp
@@ -28,6 +28,7 @@
 
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 #include "Open3D/Utility/Helper.h"
 
 namespace open3d {
@@ -36,7 +37,7 @@ namespace io {
 bool ReadPointCloudFromPTS(const std::string &filename,
                            geometry::PointCloud &pointcloud,
                            bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "r");
+    FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
         utility::LogWarning("Read PTS failed: unable to open file.\n");
         return false;
@@ -97,7 +98,7 @@ bool WritePointCloudToPTS(const std::string &filename,
                           bool write_ascii /* = false*/,
                           bool compressed /* = false*/,
                           bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "w");
+    FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
         utility::LogWarning("Write PTS failed: unable to open file.\n");
         return false;

--- a/src/Open3D/IO/FileFormat/FileSTL.cpp
+++ b/src/Open3D/IO/FileFormat/FileSTL.cpp
@@ -29,6 +29,7 @@
 
 #include "Open3D/IO/ClassIO/TriangleMeshIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 namespace io {
@@ -36,7 +37,7 @@ namespace io {
 bool ReadTriangleMeshFromSTL(const std::string &filename,
                              geometry::TriangleMesh &mesh,
                              bool print_progress) {
-    FILE *myFile = fopen(filename.c_str(), "rb");
+    FILE *myFile = utility::filesystem::FOpen(filename.c_str(), "rb");
 
     if (!myFile) {
         utility::LogWarning("Read STL failed: unable to open file.\n");

--- a/src/Open3D/IO/FileFormat/FileTUM.cpp
+++ b/src/Open3D/IO/FileFormat/FileTUM.cpp
@@ -29,6 +29,7 @@
 
 #include "Open3D/IO/ClassIO/PinholeCameraTrajectoryIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 // The TUM format for camera trajectories as used in
 // "A Benchmark for the Evaluation of RGB-D SLAM Systems" by
@@ -53,7 +54,7 @@ bool ReadPinholeCameraTrajectoryFromTUM(
                 camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
     }
     trajectory.parameters_.clear();
-    FILE *f = fopen(filename.c_str(), "r");
+    FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
         utility::LogWarning("Read TUM failed: unable to open file: {}\n",
                             filename);
@@ -88,7 +89,7 @@ bool ReadPinholeCameraTrajectoryFromTUM(
 bool WritePinholeCameraTrajectoryToTUM(
         const std::string &filename,
         const camera::PinholeCameraTrajectory &trajectory) {
-    FILE *f = fopen(filename.c_str(), "w");
+    FILE *f = utility::filesystem::FOpen(filename, "w");
     if (f == NULL) {
         utility::LogWarning("Write TUM failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/IO/FileFormat/FileXYZ.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZ.cpp
@@ -28,6 +28,7 @@
 
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 namespace io {
@@ -35,7 +36,7 @@ namespace io {
 bool ReadPointCloudFromXYZ(const std::string &filename,
                            geometry::PointCloud &pointcloud,
                            bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "r");
+    FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
         utility::LogWarning("Read XYZ failed: unable to open file: {}\n",
                             filename);
@@ -61,7 +62,7 @@ bool WritePointCloudToXYZ(const std::string &filename,
                           bool write_ascii /* = false*/,
                           bool compressed /* = false*/,
                           bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "w");
+    FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
         utility::LogWarning("Write XYZ failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/IO/FileFormat/FileXYZN.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZN.cpp
@@ -28,6 +28,7 @@
 
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 namespace io {
@@ -35,7 +36,7 @@ namespace io {
 bool ReadPointCloudFromXYZN(const std::string &filename,
                             geometry::PointCloud &pointcloud,
                             bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "r");
+    FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
         utility::LogWarning("Read XYZN failed: unable to open file: {}\n",
                             filename);
@@ -67,7 +68,7 @@ bool WritePointCloudToXYZN(const std::string &filename,
         return false;
     }
 
-    FILE *file = fopen(filename.c_str(), "w");
+    FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
         utility::LogWarning("Write XYZN failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/IO/FileFormat/FileXYZRGB.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZRGB.cpp
@@ -28,6 +28,7 @@
 
 #include "Open3D/IO/ClassIO/PointCloudIO.h"
 #include "Open3D/Utility/Console.h"
+#include "Open3D/Utility/FileSystem.h"
 
 namespace open3d {
 namespace io {
@@ -35,7 +36,7 @@ namespace io {
 bool ReadPointCloudFromXYZRGB(const std::string &filename,
                               geometry::PointCloud &pointcloud,
                               bool print_progress) {
-    FILE *file = fopen(filename.c_str(), "r");
+    FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
         utility::LogWarning("Read XYZRGB failed: unable to open file: {}\n",
                             filename);
@@ -67,7 +68,7 @@ bool WritePointCloudToXYZRGB(const std::string &filename,
         return false;
     }
 
-    FILE *file = fopen(filename.c_str(), "w");
+    FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
         utility::LogWarning("Write XYZRGB failed: unable to open file: {}\n",
                             filename);

--- a/src/Open3D/Utility/FileSystem.cpp
+++ b/src/Open3D/Utility/FileSystem.cpp
@@ -199,6 +199,22 @@ bool ListFilesInDirectoryWithExtension(const std::string &directory,
     return true;
 }
 
+FILE *FOpen(const std::string &filename, const std::string &mode) {
+    FILE *fp;
+#ifndef _WIN32
+    fp = fopen(filename.c_str(), mode.c_str());
+#else
+    std::wstring filename_w;
+    filename_w.resize(filename.size());
+    int newSize = MultiByteToWideChar(
+            CP_UTF8, 0, filename.c_str(), filename.length(),
+            const_cast<wchar_t *>(filename_w.c_str()), filename.length());
+    filename_w.resize(newSize);
+    fp = _wfopen(filename_w.c_str(), mode.c_str());
+#endif
+    return fp;
+}
+
 }  // namespace filesystem
 }  // namespace utility
 }  // namespace open3d

--- a/src/Open3D/Utility/FileSystem.cpp
+++ b/src/Open3D/Utility/FileSystem.cpp
@@ -32,6 +32,7 @@
 #ifdef WINDOWS
 #include <direct.h>
 #include <dirent/dirent.h>
+#include <windows.h>
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif
@@ -210,7 +211,8 @@ FILE *FOpen(const std::string &filename, const std::string &mode) {
             CP_UTF8, 0, filename.c_str(), filename.length(),
             const_cast<wchar_t *>(filename_w.c_str()), filename.length());
     filename_w.resize(newSize);
-    fp = _wfopen(filename_w.c_str(), mode.c_str());
+    std::wstring mode_w(mode.begin(), mode.end());
+    fp = _wfopen(filename_w.c_str(), mode_w.c_str());
 #endif
     return fp;
 }

--- a/src/Open3D/Utility/FileSystem.h
+++ b/src/Open3D/Utility/FileSystem.h
@@ -66,6 +66,9 @@ bool ListFilesInDirectoryWithExtension(const std::string &directory,
                                        const std::string &extname,
                                        std::vector<std::string> &filenames);
 
+// wrapper for fopen that enables unicode paths on Windows
+FILE *FOpen(const std::string &filename, const std::string &mode);
+
 }  // namespace filesystem
 }  // namespace utility
 }  // namespace open3d

--- a/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
@@ -188,12 +188,12 @@ int main(int argc, char **argv) {
 
         io::WritePointCloud(source_filename, *source_ptr);
         auto source_dis = source_ptr->ComputePointCloudDistance(*target_ptr);
-        f = fopen(source_binname.c_str(), "wb");
+        f = utility::filesystem::FOpen(source_binname, "wb");
         fwrite(source_dis.data(), sizeof(double), source_dis.size(), f);
         fclose(f);
         io::WritePointCloud(target_filename, *target_ptr);
         auto target_dis = target_ptr->ComputePointCloudDistance(*source_ptr);
-        f = fopen(target_binname.c_str(), "wb");
+        f = utility::filesystem::FOpen(target_binname, "wb");
         fwrite(target_dis.data(), sizeof(double), target_dis.size(), f);
         fclose(f);
         return 1;

--- a/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
@@ -342,13 +342,13 @@ void VisualizerForAlignment::EvaluateAlignmentAndSave(
     io::WritePointCloud(source_filename, *source_copy_ptr_);
     auto source_dis =
             source_copy_ptr_->ComputePointCloudDistance(*target_copy_ptr_);
-    f = fopen(source_binname.c_str(), "wb");
+    f = utility::filesystem::FOpen(source_binname, "wb");
     fwrite(source_dis.data(), sizeof(double), source_dis.size(), f);
     fclose(f);
     io::WritePointCloud(target_filename, *target_copy_ptr_);
     auto target_dis =
             target_copy_ptr_->ComputePointCloudDistance(*source_copy_ptr_);
-    f = fopen(target_binname.c_str(), "wb");
+    f = utility::filesystem::FOpen(target_binname, "wb");
     fwrite(target_dis.data(), sizeof(double), target_dis.size(), f);
     fclose(f);
 }

--- a/src/UnitTest/Integration/UniformTSDFVolume.cpp
+++ b/src/UnitTest/Integration/UniformTSDFVolume.cpp
@@ -28,6 +28,7 @@
 #include "Open3D/Camera/PinholeCameraIntrinsic.h"
 #include "Open3D/Geometry/RGBDImage.h"
 #include "Open3D/IO/ClassIO/ImageIO.h"
+#include "Open3D/Utility/FileSystem.h"
 #include "Open3D/Visualization/Utility/DrawGeometry.h"
 #include "TestUtility/UnitTest.h"
 
@@ -38,7 +39,7 @@ using namespace unit_test;
 
 bool ReadPoses(const std::string& trajectory_path,
                std::vector<Eigen::Matrix4d>& poses) {
-    FILE* f = fopen(trajectory_path.c_str(), "r");
+    FILE* f = utility::filesystem::FOpen(trajectory_path, "r");
     if (f == NULL) {
         utility::LogWarning("Read poses failed: unable to open file: {}\n",
                             trajectory_path);


### PR DESCRIPTION
Addresses #1098. 
Implemenation of an fopen wrapper in `utility::filesystem` that should handle unicode paths in Windows. Note that some file types/extensions might still not work with unicode paths on Windows (ply, png?), because fopen is used within the 3rdparty lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1190)
<!-- Reviewable:end -->
