### PR TITLE
Fix operator+ of AxisAlignedBoundingBox

### DIFF
--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -289,6 +289,18 @@ std::string AxisAlignedBoundingBox::GetPrintInfo() const {
                        max_bound_(0), max_bound_(1), max_bound_(2));
 }
 
+AxisAlignedBoundingBox& AxisAlignedBoundingBox::operator+=(
+        const AxisAlignedBoundingBox& other) {
+    if (IsEmpty()) {
+        min_bound_ = other.min_bound_;
+        max_bound_ = other.max_bound_;
+    } else if (!other.IsEmpty()) {
+        min_bound_ = min_bound_.array().min(other.min_bound_.array()).matrix();
+        max_bound_ = max_bound_.array().max(other.max_bound_.array()).matrix();
+    }
+    return *this;
+}
+
 AxisAlignedBoundingBox AxisAlignedBoundingBox::CreateFromPoints(
         const std::vector<Eigen::Vector3d>& points) {
     AxisAlignedBoundingBox box;

--- a/src/Open3D/Geometry/BoundingVolume.h
+++ b/src/Open3D/Geometry/BoundingVolume.h
@@ -115,11 +115,7 @@ public:
             bool center = true,
             RotationType type = RotationType::XYZ) override;
 
-    AxisAlignedBoundingBox& operator+=(const AxisAlignedBoundingBox& other) {
-        min_bound_ = min_bound_.array().min(other.min_bound_.array()).matrix();
-        max_bound_ = max_bound_.array().max(other.max_bound_.array()).matrix();
-        return *this;
-    }
+    AxisAlignedBoundingBox& operator+=(const AxisAlignedBoundingBox& other);
 
     double Volume() const;
     std::vector<Eigen::Vector3d> GetBoxPoints() const;


### PR DESCRIPTION
This fixes the `operator+` of `AxisAlignedBoundingBox` such that it ignores empty bounding boxes. This should address #1197.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1205)
<!-- Reviewable:end -->
