### PR TITLE
OrientedBoundingBox parameter update and crop

### DIFF
--- a/examples/Cpp/LineSet.cpp
+++ b/examples/Cpp/LineSet.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i < new_lineset_ptr->lines_.size(); i++) {
         auto point_pair = new_lineset_ptr->GetLineCoordinate(i);
         if ((point_pair.first - point_pair.second).norm() <
-            0.05 * bounding_box.GetMaxExtend()) {
+            0.05 * bounding_box.GetMaxExtent()) {
             new_lineset_ptr->colors_[i] = Eigen::Vector3d(1.0, 0.0, 0.0);
         } else {
             new_lineset_ptr->colors_[i] = Eigen::Vector3d(0.0, 0.0, 0.0);

--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
             mesh->ComputeVertexNormals();
             auto boundingbox = mesh->GetAxisAlignedBoundingBox();
             auto mesh_frame = geometry::TriangleMesh::CreateCoordinateFrame(
-                    boundingbox.GetMaxExtend() * 0.2, boundingbox.min_bound_);
+                    boundingbox.GetMaxExtent() * 0.2, boundingbox.min_bound_);
             visualization::DrawGeometries({mesh, mesh_frame});
         }
     } else if (option == "merge") {
@@ -127,12 +127,12 @@ int main(int argc, char *argv[]) {
         double scale1 = std::stod(argv[4]);
         double scale2 = std::stod(argv[5]);
         Eigen::Matrix4d trans = Eigen::Matrix4d::Identity();
-        trans(0, 0) = trans(1, 1) = trans(2, 2) = scale1 / bbox.GetMaxExtend();
+        trans(0, 0) = trans(1, 1) = trans(2, 2) = scale1 / bbox.GetMaxExtent();
         mesh->Transform(trans);
         trans.setIdentity();
         trans.block<3, 1>(0, 3) =
                 Eigen::Vector3d(scale2 / 2.0, scale2 / 2.0, scale2 / 2.0) -
-                bbox.GetCenter() * scale1 / bbox.GetMaxExtend();
+                bbox.GetCenter() * scale1 / bbox.GetMaxExtent();
         mesh->Transform(trans);
         io::WriteTriangleMesh(argv[3], *mesh);
     } else if (option == "distance") {

--- a/examples/Python/Basic/bounding_volume.py
+++ b/examples/Python/Basic/bounding_volume.py
@@ -9,8 +9,9 @@ import open3d as o3d
 import os
 
 import sys
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(dir_path, '../Misc'))
+sys.path.append(os.path.join(dir_path, "../Misc"))
 import meshes
 
 np.random.seed(42)
@@ -18,7 +19,7 @@ np.random.seed(42)
 
 def mesh_generator():
     mesh = o3d.geometry.TriangleMesh.create_box()
-    mesh.rotate((0.3, 0.5, 0.1))
+    mesh.rotate(mesh.get_rotation_matrix_from_xyz((0.3, 0.5, 0.1)))
     yield "rotated box mesh", mesh
     yield "rotated box pcd", mesh.sample_points_uniformly(500)
 
@@ -37,3 +38,33 @@ if __name__ == "__main__":
         aabox.color = [1, 0, 0]
         obox.color = [0, 1, 0]
         o3d.visualization.draw_geometries([geom, aabox, obox])
+
+    mesh = meshes.armadillo()
+
+    bbox = o3d.geometry.AxisAlignedBoundingBox()
+    bbox.min_bound = (-30, 0, -10)
+    bbox.max_bound = (10, 20, 10)
+    o3d.visualization.draw_geometries([mesh, bbox])
+    o3d.visualization.draw_geometries([mesh.crop(bbox), bbox])
+
+    bbox = o3d.geometry.OrientedBoundingBox()
+    bbox.center = (-10, 10, 0)
+    bbox.R = bbox.get_rotation_matrix_from_xyz((2, 1, 0))
+    bbox.extent = (40, 20, 20)
+    o3d.visualization.draw_geometries([mesh, bbox])
+    o3d.visualization.draw_geometries([mesh.crop(bbox), bbox])
+
+    pcd = mesh.sample_points_uniformly(500000)
+
+    bbox = o3d.geometry.AxisAlignedBoundingBox()
+    bbox.min_bound = (-30, 0, -10)
+    bbox.max_bound = (10, 20, 10)
+    o3d.visualization.draw_geometries([pcd, bbox])
+    o3d.visualization.draw_geometries([pcd.crop(bbox), bbox])
+
+    bbox = o3d.geometry.OrientedBoundingBox()
+    bbox.center = (-10, 10, 0)
+    bbox.R = bbox.get_rotation_matrix_from_xyz((2, 1, 0))
+    bbox.extent = (40, 20, 20)
+    o3d.visualization.draw_geometries([pcd, bbox])
+    o3d.visualization.draw_geometries([pcd.crop(bbox), bbox])

--- a/examples/Python/Basic/half_edge_mesh.py
+++ b/examples/Python/Basic/half_edge_mesh.py
@@ -22,7 +22,10 @@ def draw_geometries_with_back_face(geometries):
 if __name__ == "__main__":
     # Initialize a HalfEdgeTriangleMesh from TriangleMesh
     mesh = o3d.io.read_triangle_mesh("../../TestData/sphere.ply")
-    mesh = mesh.crop([-1, -1, -1], [1, 0.6, 1])
+    bbox = o3d.geometry.AxisAlignedBoundingBox()
+    bbox.min_bound = [-1, -1, -1]
+    bbox.max_bound = [1, 0.6, 1]
+    mesh = mesh.crop(bbox)
     het_mesh = o3d.geometry.HalfEdgeTriangleMesh.create_from_triangle_mesh(mesh)
     draw_geometries_with_back_face([het_mesh])
 

--- a/examples/Python/Basic/transformation.py
+++ b/examples/Python/Basic/transformation.py
@@ -31,7 +31,7 @@ def animate(geom):
     vis = o3d.visualization.Visualizer()
     vis.create_window()
 
-    geom.rotate(np.array((0.75, 0.5, 0)))
+    geom.rotate(geom.get_rotation_matrix_from_xyz((0.75, 0.5, 0)))
     vis.add_geometry(geom)
 
     scales = [0.9 for _ in range(30)] + [1 / 0.9 for _ in range(30)]
@@ -40,9 +40,8 @@ def animate(geom):
          ] + [(-0.1, -0.1, 0.1) for _ in range(30)]
 
     for scale, aa in zip(scales, axisangles):
-        geom.scale(scale).rotate(aa,
-                                 center=False,
-                                 type=o3d.geometry.RotationType.AxisAngle)
+        R = geom.get_rotation_matrix_from_axis_angle(aa)
+        geom.scale(scale).rotate(R, center=False)
         vis.update_geometry()
         vis.poll_events()
         vis.update_renderer()
@@ -56,8 +55,8 @@ def animate(geom):
         time.sleep(0.05)
 
     for scale, aa, t in zip(scales, axisangles, ts):
-        geom.scale(scale).translate(t).rotate(
-            aa, center=True, type=o3d.geometry.RotationType.AxisAngle)
+        R = geom.get_rotation_matrix_from_axis_angle(aa)
+        geom.scale(scale).translate(t).rotate(R, center=True)
         vis.update_geometry()
         vis.poll_events()
         vis.update_renderer()

--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -39,13 +39,13 @@ namespace geometry {
 
 OrientedBoundingBox& OrientedBoundingBox::Clear() {
     center_.setZero();
-    x_axis_.setZero();
-    y_axis_.setZero();
-    z_axis_.setZero();
+    extent_.setZero();
+    R_ = Eigen::Matrix3d::Identity();
+    color_.setZero();
     return *this;
 }
 
-bool OrientedBoundingBox::IsEmpty() const { return Volume() == 0; }
+bool OrientedBoundingBox::IsEmpty() const { return Volume() <= 0; }
 
 Eigen::Vector3d OrientedBoundingBox::GetMinBound() const {
     auto points = GetBoxPoints();
@@ -69,22 +69,10 @@ OrientedBoundingBox OrientedBoundingBox::GetOrientedBoundingBox() const {
 
 OrientedBoundingBox& OrientedBoundingBox::Transform(
         const Eigen::Matrix4d& transformation) {
-    Eigen::Vector4d c;
-    c << center_, 1;
-    Eigen::Vector4d x;
-    x << center_ + x_axis_, 1;
-    Eigen::Vector4d y;
-    y << center_ + y_axis_, 1;
-    Eigen::Vector4d z;
-    z << center_ + z_axis_, 1;
-    c = transformation * c;
-    x = transformation * x;
-    y = transformation * y;
-    z = transformation * z;
-    center_ = c.head<3>() / c(3);
-    x_axis_ = x.head<3>() / x(3) - center_;
-    y_axis_ = y.head<3>() / y(3) - center_;
-    z_axis_ = z.head<3>() / z(3) - center_;
+    utility::LogWarning(
+            "A general transform of an OrientedBoundingBox is not implemented. "
+            "Call Translate, "
+            "Scale, and Rotate.\n");
     return *this;
 }
 
@@ -101,65 +89,81 @@ OrientedBoundingBox& OrientedBoundingBox::Translate(
 OrientedBoundingBox& OrientedBoundingBox::Scale(const double scale,
                                                 bool center) {
     if (center) {
-        x_axis_ *= scale;
-        y_axis_ *= scale;
-        z_axis_ *= scale;
+        extent_ *= scale;
     } else {
-        Eigen::Vector3d x = scale * (center_ + x_axis_);
-        Eigen::Vector3d y = scale * (center_ + y_axis_);
-        Eigen::Vector3d z = scale * (center_ + z_axis_);
         center_ *= scale;
-        x_axis_ = x - center_;
-        y_axis_ = y - center_;
-        z_axis_ = z - center_;
+        extent_ *= scale;
     }
     return *this;
 }
 
-OrientedBoundingBox& OrientedBoundingBox::Rotate(
-        const Eigen::Vector3d& rotation, bool center, RotationType type) {
-    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
+OrientedBoundingBox& OrientedBoundingBox::Rotate(const Eigen::Matrix3d& R,
+                                                 bool center) {
     if (center) {
-        x_axis_ = R * x_axis_;
-        y_axis_ = R * y_axis_;
-        z_axis_ = R * z_axis_;
+        R_ *= R;
     } else {
-        Eigen::Vector3d x = R * (center_ + x_axis_);
-        Eigen::Vector3d y = R * (center_ + y_axis_);
-        Eigen::Vector3d z = R * (center_ + z_axis_);
         center_ = R * center_;
-        x_axis_ = x - center_;
-        y_axis_ = y - center_;
-        z_axis_ = z - center_;
+        R_ *= R;
     }
     return *this;
 }
 
 double OrientedBoundingBox::Volume() const {
-    return (2 * x_axis_.norm()) * (2 * y_axis_.norm()) * (2 * z_axis_.norm());
+    return extent_(0) * extent_(1) * extent_(2);
 }
 
 std::vector<Eigen::Vector3d> OrientedBoundingBox::GetBoxPoints() const {
+    Eigen::Vector3d x_axis = R_ * Eigen::Vector3d(extent_(0) / 2, 0, 0);
+    Eigen::Vector3d y_axis = R_ * Eigen::Vector3d(0, extent_(1) / 2, 0);
+    Eigen::Vector3d z_axis = R_ * Eigen::Vector3d(0, 0, extent_(2) / 2);
     std::vector<Eigen::Vector3d> points(8);
-    points[0] = center_ - x_axis_ - y_axis_ - z_axis_;
-    points[1] = center_ + x_axis_ - y_axis_ - z_axis_;
-    points[2] = center_ - x_axis_ + y_axis_ - z_axis_;
-    points[3] = center_ - x_axis_ - y_axis_ + z_axis_;
-    points[4] = center_ + x_axis_ + y_axis_ + z_axis_;
-    points[5] = center_ - x_axis_ + y_axis_ + z_axis_;
-    points[6] = center_ + x_axis_ - y_axis_ + z_axis_;
-    points[7] = center_ + x_axis_ + y_axis_ - z_axis_;
+    points[0] = center_ - x_axis - y_axis - z_axis;
+    points[1] = center_ + x_axis - y_axis - z_axis;
+    points[2] = center_ - x_axis + y_axis - z_axis;
+    points[3] = center_ - x_axis - y_axis + z_axis;
+    points[4] = center_ + x_axis + y_axis + z_axis;
+    points[5] = center_ - x_axis + y_axis + z_axis;
+    points[6] = center_ + x_axis - y_axis + z_axis;
+    points[7] = center_ + x_axis + y_axis - z_axis;
     return points;
+}
+
+std::vector<size_t> OrientedBoundingBox::GetPointIndicesWithinBoundingBox(
+        const std::vector<Eigen::Vector3d>& points) const {
+    auto box_points = GetBoxPoints();
+    auto TestPlane = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b,
+                        const Eigen::Vector3d c, const Eigen::Vector3d& x) {
+        Eigen::Matrix3d design;
+        design << (b - a), (c - a), (x - a);
+        return design.determinant();
+    };
+    std::vector<size_t> indices;
+    for (size_t idx = 0; idx < points.size(); idx++) {
+        const auto& point = points[idx];
+        if (TestPlane(box_points[0], box_points[1], box_points[3], point) <=
+                    0 &&
+            TestPlane(box_points[0], box_points[5], box_points[3], point) >=
+                    0 &&
+            TestPlane(box_points[2], box_points[5], box_points[7], point) <=
+                    0 &&
+            TestPlane(box_points[1], box_points[4], box_points[7], point) >=
+                    0 &&
+            TestPlane(box_points[3], box_points[4], box_points[5], point) <=
+                    0 &&
+            TestPlane(box_points[0], box_points[1], box_points[7], point) >=
+                    0) {
+            indices.push_back(idx);
+        }
+    }
+    return indices;
 }
 
 OrientedBoundingBox OrientedBoundingBox::CreateFromAxisAlignedBoundingBox(
         const AxisAlignedBoundingBox& aabox) {
-    Eigen::Vector3d half_extend = aabox.GetHalfExtend();
     OrientedBoundingBox obox;
     obox.center_ = aabox.GetCenter();
-    obox.x_axis_ << half_extend(0), 0, 0;
-    obox.y_axis_ << 0, half_extend(1), 0;
-    obox.z_axis_ << 0, 0, half_extend(2);
+    obox.extent_ = aabox.GetExtent();
+    obox.R_ = Eigen::Matrix3d::Identity();
     return obox;
 }
 
@@ -202,13 +206,11 @@ OrientedBoundingBox OrientedBoundingBox::CreateFromPoints(
         pt = R.transpose() * (pt - mean);
     }
     const auto aabox = hull_pcd.GetAxisAlignedBoundingBox();
-    const Eigen::Vector3d half_extend = aabox.GetHalfExtend();
 
     OrientedBoundingBox obox;
     obox.center_ = R * aabox.GetCenter() + mean;
-    obox.x_axis_ = R * Eigen::Vector3d(half_extend(0), 0, 0);
-    obox.y_axis_ = R * Eigen::Vector3d(0, half_extend(1), 0);
-    obox.z_axis_ = R * Eigen::Vector3d(0, 0, half_extend(2));
+    obox.R_ = R;
+    obox.extent_ = aabox.GetExtent();
 
     return obox;
 }
@@ -219,7 +221,7 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Clear() {
     return *this;
 }
 
-bool AxisAlignedBoundingBox::IsEmpty() const { return Volume() == 0; }
+bool AxisAlignedBoundingBox::IsEmpty() const { return Volume() <= 0; }
 Eigen::Vector3d AxisAlignedBoundingBox::GetMinBound() const {
     return min_bound_;
 }
@@ -255,9 +257,9 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Translate(
         min_bound_ += translation;
         max_bound_ += translation;
     } else {
-        const Eigen::Vector3d half_extend = GetHalfExtend();
-        min_bound_ = translation - half_extend;
-        max_bound_ = translation + half_extend;
+        const Eigen::Vector3d half_extent = GetHalfExtent();
+        min_bound_ = translation - half_extent;
+        max_bound_ = translation + half_extent;
     }
     return *this;
 }
@@ -276,10 +278,10 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Scale(const double scale,
 }
 
 AxisAlignedBoundingBox& AxisAlignedBoundingBox::Rotate(
-        const Eigen::Vector3d& rotation, bool center, RotationType type) {
+        const Eigen::Matrix3d& rotation, bool center) {
     utility::LogWarning(
             "A rotation of a AxisAlignedBoundingBox would not be axis aligned "
-            "anymore, convert it to a OrientedBoundingBox first\n");
+            "anymore, convert it to an OrientedBoundingBox first\n");
     return *this;
 }
 
@@ -322,20 +324,34 @@ AxisAlignedBoundingBox AxisAlignedBoundingBox::CreateFromPoints(
     return box;
 }
 
-double AxisAlignedBoundingBox::Volume() const { return GetExtend().prod(); }
+double AxisAlignedBoundingBox::Volume() const { return GetExtent().prod(); }
 
 std::vector<Eigen::Vector3d> AxisAlignedBoundingBox::GetBoxPoints() const {
     std::vector<Eigen::Vector3d> points(8);
-    Eigen::Vector3d extend = GetExtend();
+    Eigen::Vector3d extent = GetExtent();
     points[0] = min_bound_;
-    points[1] = min_bound_ + Eigen::Vector3d(extend(0), 0, 0);
-    points[2] = min_bound_ + Eigen::Vector3d(0, extend(1), 0);
-    points[3] = min_bound_ + Eigen::Vector3d(0, 0, extend(2));
+    points[1] = min_bound_ + Eigen::Vector3d(extent(0), 0, 0);
+    points[2] = min_bound_ + Eigen::Vector3d(0, extent(1), 0);
+    points[3] = min_bound_ + Eigen::Vector3d(0, 0, extent(2));
     points[4] = max_bound_;
-    points[5] = max_bound_ - Eigen::Vector3d(extend(0), 0, 0);
-    points[6] = max_bound_ - Eigen::Vector3d(0, extend(1), 0);
-    points[7] = max_bound_ - Eigen::Vector3d(0, 0, extend(2));
+    points[5] = max_bound_ - Eigen::Vector3d(extent(0), 0, 0);
+    points[6] = max_bound_ - Eigen::Vector3d(0, extent(1), 0);
+    points[7] = max_bound_ - Eigen::Vector3d(0, 0, extent(2));
     return points;
+}
+
+std::vector<size_t> AxisAlignedBoundingBox::GetPointIndicesWithinBoundingBox(
+        const std::vector<Eigen::Vector3d>& points) const {
+    std::vector<size_t> indices;
+    for (size_t idx = 0; idx < points.size(); idx++) {
+        const auto& point = points[idx];
+        if (point(0) >= min_bound_(0) && point(0) <= max_bound_(0) &&
+            point(1) >= min_bound_(1) && point(1) <= max_bound_(1) &&
+            point(2) >= min_bound_(2) && point(2) <= max_bound_(2)) {
+            indices.push_back(idx);
+        }
+    }
+    return indices;
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -27,6 +27,7 @@
 #include <numeric>
 #include <unordered_map>
 
+#include "Open3D/Geometry/BoundingVolume.h"
 #include "Open3D/Geometry/KDTreeFlann.h"
 #include "Open3D/Geometry/PointCloud.h"
 #include "Open3D/Geometry/TriangleMesh.h"
@@ -380,24 +381,26 @@ std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
 }
 
 std::shared_ptr<PointCloud> PointCloud::Crop(
-        const Eigen::Vector3d &min_bound,
-        const Eigen::Vector3d &max_bound) const {
-    if (min_bound(0) > max_bound(0) || min_bound(1) > max_bound(1) ||
-        min_bound(2) > max_bound(2)) {
+        const AxisAlignedBoundingBox &bbox) const {
+    if (bbox.IsEmpty()) {
         utility::LogWarning(
-                "[CropPointCloud] Illegal boundary clipped all points.\n");
+                "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
+                "size, or has wrong "
+                "bounds.\n");
         return std::make_shared<PointCloud>();
     }
-    std::vector<size_t> indices;
-    for (size_t i = 0; i < points_.size(); i++) {
-        const auto &point = points_[i];
-        if (point(0) >= min_bound(0) && point(0) <= max_bound(0) &&
-            point(1) >= min_bound(1) && point(1) <= max_bound(1) &&
-            point(2) >= min_bound(2) && point(2) <= max_bound(2)) {
-            indices.push_back(i);
-        }
+    return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
+}
+std::shared_ptr<PointCloud> PointCloud::Crop(
+        const OrientedBoundingBox &bbox) const {
+    if (bbox.IsEmpty()) {
+        utility::LogWarning(
+                "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
+                "size, or has wrong "
+                "bounds.\n");
+        return std::make_shared<PointCloud>();
     }
-    return SelectDownSample(indices);
+    return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
 }
 
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
@@ -493,24 +496,28 @@ PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
 }
 
 std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
-        const Eigen::Vector3d &min_bound,
-        const Eigen::Vector3d &max_bound) const {
-    if (min_bound(0) > max_bound(0) || min_bound(1) > max_bound(1) ||
-        min_bound(2) > max_bound(2)) {
+        const AxisAlignedBoundingBox &bbox) const {
+    if (bbox.IsEmpty()) {
         utility::LogWarning(
-                "[CropTriangleMesh] Illegal boundary clipped all points.\n");
+                "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
+                "size, or has wrong "
+                "bounds.\n");
         return std::make_shared<TriangleMesh>();
     }
-    std::vector<size_t> indices;
-    for (size_t i = 0; i < vertices_.size(); i++) {
-        const auto &point = vertices_[i];
-        if (point(0) >= min_bound(0) && point(0) <= max_bound(0) &&
-            point(1) >= min_bound(1) && point(1) <= max_bound(1) &&
-            point(2) >= min_bound(2) && point(2) <= max_bound(2)) {
-            indices.push_back(i);
-        }
-    }
-    return SelectDownSample(indices);
+    return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));
 }
+
+std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
+        const OrientedBoundingBox &bbox) const {
+    if (bbox.IsEmpty()) {
+        utility::LogWarning(
+                "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
+                "size, or has wrong "
+                "bounds.\n");
+        return std::make_shared<TriangleMesh>();
+    }
+    return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));
+}
+
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -133,62 +133,80 @@ void Geometry3D::ScalePoints(const double scale,
     }
 }
 
-void Geometry3D::RotatePoints(const Eigen::Vector3d& rotation,
+void Geometry3D::RotatePoints(const Eigen::Matrix3d& R,
                               std::vector<Eigen::Vector3d>& points,
-                              bool center,
-                              RotationType type) const {
+                              bool center) const {
     Eigen::Vector3d points_center(0, 0, 0);
     if (center && !points.empty()) {
         points_center = ComputeCenter(points);
     }
-    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
     for (auto& point : points) {
         point = R * (point - points_center) + points_center;
     }
 }
 
-void Geometry3D::RotateNormals(const Eigen::Vector3d& rotation,
+void Geometry3D::RotateNormals(const Eigen::Matrix3d& R,
                                std::vector<Eigen::Vector3d>& normals,
-                               bool center,
-                               RotationType type) const {
-    const Eigen::Matrix3d R = GetRotationMatrix(rotation, type);
+                               bool center) const {
     for (auto& normal : normals) {
         normal = R * normal;
     }
 }
 
-Eigen::Matrix3d Geometry3D::GetRotationMatrix(const Eigen::Vector3d& rotation,
-                                              RotationType type) const {
-    if (type == RotationType::XYZ) {
-        return open3d::utility::RotationMatrixX(rotation(0)) *
-               open3d::utility::RotationMatrixY(rotation(1)) *
-               open3d::utility::RotationMatrixZ(rotation(2));
-    } else if (type == RotationType::YZX) {
-        return open3d::utility::RotationMatrixY(rotation(0)) *
-               open3d::utility::RotationMatrixZ(rotation(1)) *
-               open3d::utility::RotationMatrixX(rotation(2));
-    } else if (type == RotationType::ZXY) {
-        return open3d::utility::RotationMatrixZ(rotation(0)) *
-               open3d::utility::RotationMatrixX(rotation(1)) *
-               open3d::utility::RotationMatrixY(rotation(2));
-    } else if (type == RotationType::XZY) {
-        return open3d::utility::RotationMatrixX(rotation(0)) *
-               open3d::utility::RotationMatrixZ(rotation(1)) *
-               open3d::utility::RotationMatrixY(rotation(2));
-    } else if (type == RotationType::ZYX) {
-        return open3d::utility::RotationMatrixZ(rotation(0)) *
-               open3d::utility::RotationMatrixY(rotation(1)) *
-               open3d::utility::RotationMatrixX(rotation(2));
-    } else if (type == RotationType::YXZ) {
-        return open3d::utility::RotationMatrixY(rotation(0)) *
-               open3d::utility::RotationMatrixX(rotation(1)) *
-               open3d::utility::RotationMatrixZ(rotation(2));
-    } else if (type == RotationType::AxisAngle) {
-        const double phi = rotation.norm();
-        return Eigen::AngleAxisd(phi, rotation / phi).toRotationMatrix();
-    } else {
-        return Eigen::Matrix3d::Identity();
-    }
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromXYZ(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixX(rotation(0)) *
+           open3d::utility::RotationMatrixY(rotation(1)) *
+           open3d::utility::RotationMatrixZ(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromYZX(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixY(rotation(0)) *
+           open3d::utility::RotationMatrixZ(rotation(1)) *
+           open3d::utility::RotationMatrixX(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromZXY(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixZ(rotation(0)) *
+           open3d::utility::RotationMatrixX(rotation(1)) *
+           open3d::utility::RotationMatrixY(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromXZY(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixX(rotation(0)) *
+           open3d::utility::RotationMatrixZ(rotation(1)) *
+           open3d::utility::RotationMatrixY(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromZYX(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixZ(rotation(0)) *
+           open3d::utility::RotationMatrixY(rotation(1)) *
+           open3d::utility::RotationMatrixX(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromYXZ(
+        const Eigen::Vector3d& rotation) {
+    return open3d::utility::RotationMatrixY(rotation(0)) *
+           open3d::utility::RotationMatrixX(rotation(1)) *
+           open3d::utility::RotationMatrixZ(rotation(2));
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromAxisAngle(
+        const Eigen::Vector3d& rotation) {
+    const double phi = rotation.norm();
+    return Eigen::AngleAxisd(phi, rotation / phi).toRotationMatrix();
+}
+
+Eigen::Matrix3d Geometry3D::GetRotationMatrixFromQuaternion(
+        const Eigen::Vector4d& rotation) {
+    return Eigen::Quaterniond(rotation(0), rotation(1), rotation(2),
+                              rotation(3))
+            .normalized()
+            .toRotationMatrix();
 }
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -40,8 +40,6 @@ class OrientedBoundingBox;
 
 class Geometry3D : public Geometry {
 public:
-    enum class RotationType { XYZ, YZX, ZXY, XZY, ZYX, YXZ, AxisAngle };
-
     ~Geometry3D() override {}
 
 protected:
@@ -59,9 +57,25 @@ public:
     virtual Geometry3D& Translate(const Eigen::Vector3d& translation,
                                   bool relative = true) = 0;
     virtual Geometry3D& Scale(const double scale, bool center = true) = 0;
-    virtual Geometry3D& Rotate(const Eigen::Vector3d& rotation,
-                               bool center = true,
-                               RotationType type = RotationType::XYZ) = 0;
+    virtual Geometry3D& Rotate(const Eigen::Matrix3d& R,
+                               bool center = true) = 0;
+
+    static Eigen::Matrix3d GetRotationMatrixFromXYZ(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromYZX(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromZXY(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromXZY(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromZYX(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromYXZ(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromAxisAngle(
+            const Eigen::Vector3d& rotation);
+    static Eigen::Matrix3d GetRotationMatrixFromQuaternion(
+            const Eigen::Vector4d& rotation);
 
 protected:
     Eigen::Vector3d ComputeMinBound(
@@ -85,18 +99,12 @@ protected:
     void ScalePoints(const double scale,
                      std::vector<Eigen::Vector3d>& points,
                      bool center) const;
-    void RotatePoints(const Eigen::Vector3d& rotation,
+    void RotatePoints(const Eigen::Matrix3d& R,
                       std::vector<Eigen::Vector3d>& points,
-                      bool center,
-                      RotationType type) const;
-    void RotateNormals(const Eigen::Vector3d& rotation,
+                      bool center) const;
+    void RotateNormals(const Eigen::Matrix3d& R,
                        std::vector<Eigen::Vector3d>& normals,
-                       bool center,
-                       RotationType type) const;
-
-    Eigen::Matrix3d GetRotationMatrix(
-            const Eigen::Vector3d& rotation,
-            RotationType type = RotationType::XYZ) const;
+                       bool center) const;
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/LineSet.cpp
+++ b/src/Open3D/Geometry/LineSet.cpp
@@ -74,10 +74,8 @@ LineSet &LineSet::Scale(const double scale, bool center) {
     return *this;
 }
 
-LineSet &LineSet::Rotate(const Eigen::Vector3d &rotation,
-                         bool center,
-                         RotationType type) {
-    RotatePoints(rotation, points_, center, type);
+LineSet &LineSet::Rotate(const Eigen::Matrix3d &R, bool center) {
+    RotatePoints(R, points_, center);
     return *this;
 }
 

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -58,9 +58,7 @@ public:
     LineSet &Translate(const Eigen::Vector3d &translation,
                        bool relative = true) override;
     LineSet &Scale(const double scale, bool center = true) override;
-    LineSet &Rotate(const Eigen::Vector3d &rotation,
-                    bool center = true,
-                    RotationType type = RotationType::XYZ) override;
+    LineSet &Rotate(const Eigen::Matrix3d &R, bool center = true) override;
 
     LineSet &operator+=(const LineSet &lineset);
     LineSet operator+(const LineSet &lineset) const;

--- a/src/Open3D/Geometry/MeshBase.cpp
+++ b/src/Open3D/Geometry/MeshBase.cpp
@@ -87,11 +87,9 @@ MeshBase &MeshBase::Scale(const double scale, bool center) {
     return *this;
 }
 
-MeshBase &MeshBase::Rotate(const Eigen::Vector3d &rotation,
-                           bool center,
-                           RotationType type) {
-    RotatePoints(rotation, vertices_, center, type);
-    RotateNormals(rotation, vertex_normals_, center, type);
+MeshBase &MeshBase::Rotate(const Eigen::Matrix3d &R, bool center) {
+    RotatePoints(R, vertices_, center);
+    RotateNormals(R, vertex_normals_, center);
     return *this;
 }
 

--- a/src/Open3D/Geometry/MeshBase.h
+++ b/src/Open3D/Geometry/MeshBase.h
@@ -76,9 +76,8 @@ public:
     virtual MeshBase &Translate(const Eigen::Vector3d &translation,
                                 bool relative = true) override;
     virtual MeshBase &Scale(const double scale, bool center = true) override;
-    virtual MeshBase &Rotate(const Eigen::Vector3d &rotation,
-                             bool center = true,
-                             RotationType type = RotationType::XYZ) override;
+    virtual MeshBase &Rotate(const Eigen::Matrix3d &R,
+                             bool center = true) override;
 
     MeshBase &operator+=(const MeshBase &mesh);
     MeshBase operator+(const MeshBase &mesh) const;

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -385,9 +385,7 @@ Octree& Octree::Scale(const double scale, bool center) {
     return *this;
 }
 
-Octree& Octree::Rotate(const Eigen::Vector3d& rotation,
-                       bool center,
-                       RotationType type) {
+Octree& Octree::Rotate(const Eigen::Matrix3d& R, bool center) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/Octree.h
+++ b/src/Open3D/Geometry/Octree.h
@@ -160,9 +160,7 @@ public:
     Octree& Translate(const Eigen::Vector3d& translation,
                       bool relative = true) override;
     Octree& Scale(const double scale, bool center = true) override;
-    Octree& Rotate(const Eigen::Vector3d& rotation,
-                   bool center = true,
-                   RotationType type = RotationType::XYZ) override;
+    Octree& Rotate(const Eigen::Matrix3d& R, bool center = true) override;
     bool ConvertToJsonValue(Json::Value& value) const override;
     bool ConvertFromJsonValue(const Json::Value& value) override;
 

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -82,11 +82,9 @@ PointCloud &PointCloud::Scale(const double scale, bool center) {
     return *this;
 }
 
-PointCloud &PointCloud::Rotate(const Eigen::Vector3d &rotation,
-                               bool center,
-                               RotationType type) {
-    RotatePoints(rotation, points_, center, type);
-    RotateNormals(rotation, normals_, center, type);
+PointCloud &PointCloud::Rotate(const Eigen::Matrix3d &R, bool center) {
+    RotatePoints(R, points_, center);
+    RotateNormals(R, normals_, center);
     return *this;
 }
 

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -64,9 +64,7 @@ public:
     PointCloud &Translate(const Eigen::Vector3d &translation,
                           bool relative = true) override;
     PointCloud &Scale(const double scale, bool center = true) override;
-    PointCloud &Rotate(const Eigen::Vector3d &rotation,
-                       bool center = true,
-                       RotationType type = RotationType::XYZ) override;
+    PointCloud &Rotate(const Eigen::Matrix3d &R, bool center = true) override;
 
     PointCloud &operator+=(const PointCloud &cloud);
     PointCloud operator+(const PointCloud &cloud) const;
@@ -124,11 +122,15 @@ public:
     /// uniformly \param every_k_points indicates the sample rate.
     std::shared_ptr<PointCloud> UniformDownSample(size_t every_k_points) const;
 
-    /// Function to crop \param input pointcloud into output pointcloud
-    /// All points with coordinates less than \param min_bound or larger than
-    /// \param max_bound are clipped.
-    std::shared_ptr<PointCloud> Crop(const Eigen::Vector3d &min_bound,
-                                     const Eigen::Vector3d &max_bound) const;
+    /// Function to crop pointcloud into output pointcloud
+    /// All points with coordinates outside the bounding box \param bbox are
+    /// clipped.
+    std::shared_ptr<PointCloud> Crop(const AxisAlignedBoundingBox &bbox) const;
+
+    /// Function to crop pointcloud into output pointcloud
+    /// All points with coordinates outside the bounding box \param bbox are
+    /// clipped.
+    std::shared_ptr<PointCloud> Crop(const OrientedBoundingBox &bbox) const;
 
     /// Function to remove points that have less than \param nb_points in a
     /// sphere of radius \param search_radius

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -58,11 +58,9 @@ TriangleMesh &TriangleMesh::Transform(const Eigen::Matrix4d &transformation) {
     return *this;
 }
 
-TriangleMesh &TriangleMesh::Rotate(const Eigen::Vector3d &rotation,
-                                   bool center,
-                                   RotationType type) {
-    MeshBase::Rotate(rotation, center, type);
-    RotateNormals(rotation, triangle_normals_, center, type);
+TriangleMesh &TriangleMesh::Rotate(const Eigen::Matrix3d &R, bool center) {
+    MeshBase::Rotate(R, center);
+    RotateNormals(R, triangle_normals_, center);
     return *this;
 }
 

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -51,10 +51,8 @@ public:
     virtual TriangleMesh &Clear() override;
     virtual TriangleMesh &Transform(
             const Eigen::Matrix4d &transformation) override;
-    virtual TriangleMesh &Rotate(
-            const Eigen::Vector3d &rotation,
-            bool center = true,
-            RotationType type = RotationType::XYZ) override;
+    virtual TriangleMesh &Rotate(const Eigen::Matrix3d &R,
+                                 bool center = true) override;
 
 public:
     TriangleMesh &operator+=(const TriangleMesh &mesh);
@@ -319,11 +317,16 @@ public:
     std::shared_ptr<TriangleMesh> SelectDownSample(
             const std::vector<size_t> &indices) const;
 
-    /// Function to crop \param input tringlemesh into output tringlemesh
-    /// All points with coordinates less than \param min_bound or larger than
-    /// \param max_bound are clipped.
-    std::shared_ptr<TriangleMesh> Crop(const Eigen::Vector3d &min_bound,
-                                       const Eigen::Vector3d &max_bound) const;
+    /// Function to crop pointcloud into output pointcloud
+    /// All points with coordinates outside the bounding box \param bbox are
+    /// clipped.
+    std::shared_ptr<TriangleMesh> Crop(
+            const AxisAlignedBoundingBox &bbox) const;
+
+    /// Function to crop pointcloud into output pointcloud
+    /// All points with coordinates outside the bounding box \param bbox are
+    /// clipped.
+    std::shared_ptr<TriangleMesh> Crop(const OrientedBoundingBox &bbox) const;
 
     /// Function that computes a triangle mesh from a oriented PointCloud \param
     /// pcd. This implements the Ball Pivoting algorithm proposed in F.

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -125,9 +125,7 @@ VoxelGrid &VoxelGrid::Scale(const double scale, bool center) {
     return *this;
 }
 
-VoxelGrid &VoxelGrid::Rotate(const Eigen::Vector3d &rotation,
-                             bool center,
-                             RotationType type) {
+VoxelGrid &VoxelGrid::Rotate(const Eigen::Matrix3d &R, bool center) {
     throw std::runtime_error("Not implemented");
     return *this;
 }

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -79,9 +79,7 @@ public:
     VoxelGrid &Translate(const Eigen::Vector3d &translation,
                          bool relative = true) override;
     VoxelGrid &Scale(const double scale, bool center = true) override;
-    VoxelGrid &Rotate(const Eigen::Vector3d &rotation,
-                      bool center = true,
-                      RotationType type = RotationType::XYZ) override;
+    VoxelGrid &Rotate(const Eigen::Matrix3d &R, bool center = true) override;
 
     VoxelGrid &operator+=(const VoxelGrid &voxelgrid);
     VoxelGrid operator+(const VoxelGrid &voxelgrid) const;

--- a/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
+++ b/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
@@ -411,7 +411,7 @@ bool PointCloudPickerRenderer::Render(const RenderOption &option,
         size_t index = picker.picked_indices_[i];
         if (index < pointcloud.points_.size()) {
             auto sphere = geometry::TriangleMesh::CreateSphere(
-                    view.GetBoundingBox().GetMaxExtend() *
+                    view.GetBoundingBox().GetMaxExtent() *
                     _option.pointcloud_picker_sphere_size_);
             sphere->ComputeVertexNormals();
             sphere->vertex_colors_.clear();

--- a/src/Open3D/Visualization/Shader/PhongShader.cpp
+++ b/src/Open3D/Visualization/Shader/PhongShader.cpp
@@ -155,7 +155,7 @@ void PhongShader::SetLighting(const ViewControl &view,
     for (int i = 0; i < 4; i++) {
         light_position_world_data_.block<3, 1>(0, i) =
                 box.GetCenter().cast<GLfloat>() +
-                (float)box.GetMaxExtend() *
+                (float)box.GetMaxExtent() *
                         ((float)option.light_position_relative_[i](0) *
                                  view.GetRight() +
                          (float)option.light_position_relative_[i](1) *

--- a/src/Open3D/Visualization/Shader/SimpleBlackShader.cpp
+++ b/src/Open3D/Visualization/Shader/SimpleBlackShader.cpp
@@ -136,7 +136,7 @@ bool SimpleBlackShaderForPointCloudNormal::PrepareBinding(
     }
     points.resize(pointcloud.points_.size() * 2);
     double line_length =
-            option.point_size_ * 0.01 * view.GetBoundingBox().GetMaxExtend();
+            option.point_size_ * 0.01 * view.GetBoundingBox().GetMaxExtent();
     for (size_t i = 0; i < pointcloud.points_.size(); i++) {
         const auto &point = pointcloud.points_[i];
         const auto &normal = pointcloud.normals_[i];

--- a/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
+++ b/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
@@ -169,7 +169,7 @@ void TexturePhongShader::SetLighting(const ViewControl &view,
     for (int i = 0; i < 4; i++) {
         light_position_world_data_.block<3, 1>(0, i) =
                 box.GetCenter().cast<GLfloat>() +
-                (float)box.GetMaxExtend() *
+                (float)box.GetMaxExtent() *
                         ((float)option.light_position_relative_[i](0) *
                                  view.GetRight() +
                          (float)option.light_position_relative_[i](1) *

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.cpp
@@ -102,9 +102,8 @@ PointCloudPicker& PointCloudPicker::Scale(const double scale, bool center) {
     return *this;
 }
 
-PointCloudPicker& PointCloudPicker::Rotate(const Eigen::Vector3d& rotation,
-                                           bool center,
-                                           RotationType type) {
+PointCloudPicker& PointCloudPicker::Rotate(const Eigen::Matrix3d& R,
+                                           bool center) {
     // Do nothing
     return *this;
 }

--- a/src/Open3D/Visualization/Utility/PointCloudPicker.h
+++ b/src/Open3D/Visualization/Utility/PointCloudPicker.h
@@ -58,9 +58,8 @@ public:
     PointCloudPicker& Translate(const Eigen::Vector3d& translation,
                                 bool relative = true) override;
     PointCloudPicker& Scale(const double scale, bool center = true) override;
-    PointCloudPicker& Rotate(const Eigen::Vector3d& rotation,
-                             bool center = true,
-                             RotationType type = RotationType::XYZ) override;
+    PointCloudPicker& Rotate(const Eigen::Matrix3d& R,
+                             bool center = true) override;
     bool SetPointCloud(std::shared_ptr<const geometry::Geometry> ptr);
 
 public:

--- a/src/Open3D/Visualization/Visualizer/ViewControl.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewControl.cpp
@@ -67,12 +67,12 @@ void ViewControl::SetViewMatrices(
         z_near_ =
                 constant_z_near_ > 0
                         ? constant_z_near_
-                        : std::max(0.01 * bounding_box_.GetMaxExtend(),
+                        : std::max(0.01 * bounding_box_.GetMaxExtent(),
                                    distance_ -
-                                           3.0 * bounding_box_.GetMaxExtend());
+                                           3.0 * bounding_box_.GetMaxExtent());
         z_far_ = constant_z_far_ > 0
                          ? constant_z_far_
-                         : distance_ + 3.0 * bounding_box_.GetMaxExtend();
+                         : distance_ + 3.0 * bounding_box_.GetMaxExtent();
         projection_matrix_ =
                 GLHelper::Perspective(field_of_view_, aspect_, z_near_, z_far_);
     } else {
@@ -80,10 +80,10 @@ void ViewControl::SetViewMatrices(
         // We use some black magic to support distance_ in orthogonal view
         z_near_ = constant_z_near_ > 0
                           ? constant_z_near_
-                          : distance_ - 3.0 * bounding_box_.GetMaxExtend();
+                          : distance_ - 3.0 * bounding_box_.GetMaxExtent();
         z_far_ = constant_z_far_ > 0
                          ? constant_z_far_
-                         : distance_ + 3.0 * bounding_box_.GetMaxExtend();
+                         : distance_ + 3.0 * bounding_box_.GetMaxExtent();
         projection_matrix_ =
                 GLHelper::Ortho(-aspect_ * view_ratio_, aspect_ * view_ratio_,
                                 -view_ratio_, view_ratio_, z_near_, z_far_);
@@ -204,9 +204,9 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
     double ideal_distance = (eye_ - bounding_box_.GetCenter()).dot(front_);
     double ideal_zoom = ideal_distance *
                         std::tan(field_of_view_ * 0.5 / 180.0 * M_PI) /
-                        bounding_box_.GetMaxExtend();
+                        bounding_box_.GetMaxExtent();
     zoom_ = std::max(std::min(ideal_zoom, ZOOM_MAX), ZOOM_MIN);
-    view_ratio_ = zoom_ * bounding_box_.GetMaxExtend();
+    view_ratio_ = zoom_ * bounding_box_.GetMaxExtent();
     distance_ = view_ratio_ / std::tan(field_of_view_ * 0.5 / 180.0 * M_PI);
     lookat_ = eye_ - front_ * distance_;
     return true;
@@ -234,11 +234,11 @@ void ViewControl::SetProjectionParameters() {
     right_ = up_.cross(front_).normalized();
     up_ = front_.cross(right_).normalized();  // todo: required?
     if (GetProjectionType() == ProjectionType::Perspective) {
-        view_ratio_ = zoom_ * bounding_box_.GetMaxExtend();
+        view_ratio_ = zoom_ * bounding_box_.GetMaxExtent();
         distance_ = view_ratio_ / std::tan(field_of_view_ * 0.5 / 180.0 * M_PI);
         eye_ = lookat_ + front_ * distance_;
     } else {
-        view_ratio_ = zoom_ * bounding_box_.GetMaxExtend();
+        view_ratio_ = zoom_ * bounding_box_.GetMaxExtent();
         distance_ =
                 view_ratio_ / std::tan(FIELD_OF_VIEW_STEP * 0.5 / 180.0 * M_PI);
         eye_ = lookat_ + front_ * distance_;

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -235,7 +235,7 @@ void Visualizer::BuildUtilities() {
     // 0. Build coordinate frame
     const auto boundingbox = GetViewControl().GetBoundingBox();
     coordinate_frame_mesh_ptr_ = geometry::TriangleMesh::CreateCoordinateFrame(
-            boundingbox.GetMaxExtend() * 0.2, boundingbox.min_bound_);
+            boundingbox.GetMaxExtent() * 0.2, boundingbox.min_bound_);
     coordinate_frame_mesh_renderer_ptr_ =
             std::make_shared<glsl::CoordinateFrameRenderer>();
     if (coordinate_frame_mesh_renderer_ptr_->AddGeometry(

--- a/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
@@ -97,7 +97,7 @@ void Visualizer::ResetViewPoint(bool reset_bounding_box /* = false*/) {
             const auto &boundingbox = view_control_ptr_->GetBoundingBox();
             *coordinate_frame_mesh_ptr_ =
                     *geometry::TriangleMesh::CreateCoordinateFrame(
-                            boundingbox.GetMaxExtend() * 0.2,
+                            boundingbox.GetMaxExtent() * 0.2,
                             boundingbox.min_bound_);
             coordinate_frame_mesh_renderer_ptr_->UpdateGeometry();
         }

--- a/src/Python/geometry/boundingvolume.cpp
+++ b/src/Python/geometry/boundingvolume.cpp
@@ -54,11 +54,9 @@ void pybind_boundingvolume(py::module &m) {
                  "Returns the eight points that define the bounding box.")
             .def_readwrite("center", &geometry::OrientedBoundingBox::center_,
                            "``float64`` array of shape ``(3, )``")
-            .def_readwrite("x_axis", &geometry::OrientedBoundingBox::x_axis_,
-                           "``float64`` array of shape ``(3, )``")
-            .def_readwrite("y_axis", &geometry::OrientedBoundingBox::y_axis_,
-                           "``float64`` array of shape ``(3, )``")
-            .def_readwrite("z_axis", &geometry::OrientedBoundingBox::z_axis_,
+            .def_readwrite("R", &geometry::OrientedBoundingBox::R_,
+                           "``float64`` array of shape ``(3,3 )``")
+            .def_readwrite("extent", &geometry::OrientedBoundingBox::extent_,
                            "``float64`` array of shape ``(3, )``")
             .def_readwrite("color", &geometry::OrientedBoundingBox::color_,
                            "``float64`` array of shape ``(3, )``");
@@ -87,6 +85,9 @@ void pybind_boundingvolume(py::module &m) {
             .def("get_box_points",
                  &geometry::AxisAlignedBoundingBox::GetBoxPoints,
                  "Returns the eight points that define the bounding box.")
+            .def("get_extent", &geometry::AxisAlignedBoundingBox::GetExtent,
+                 "get the extent/length of the bounding box in x, y, and z "
+                 "dimension.")
             .def_readwrite("min_bound",
                            &geometry::AxisAlignedBoundingBox::min_bound_,
                            "``float64`` array of shape ``(3, )``")
@@ -98,4 +99,5 @@ void pybind_boundingvolume(py::module &m) {
     docstring::ClassMethodDocInject(m, "AxisAlignedBoundingBox", "volume");
     docstring::ClassMethodDocInject(m, "AxisAlignedBoundingBox",
                                     "get_box_points");
+    docstring::ClassMethodDocInject(m, "AxisAlignedBoundingBox", "get_extent");
 }

--- a/src/Python/geometry/geometry.cpp
+++ b/src/Python/geometry/geometry.cpp
@@ -73,17 +73,6 @@ void pybind_geometry_classes(py::module &m) {
             .value("TetraMesh", geometry::Geometry::GeometryType::TetraMesh)
             .export_values();
 
-    // open3d.geometry.Geometry3D
-    py::enum_<geometry::Geometry3D::RotationType>(m, "RotationType")
-            .value("XYZ", geometry::Geometry3D::RotationType::XYZ)
-            .value("YZX", geometry::Geometry3D::RotationType::YZX)
-            .value("ZXY", geometry::Geometry3D::RotationType::ZXY)
-            .value("XZY", geometry::Geometry3D::RotationType::XZY)
-            .value("ZYX", geometry::Geometry3D::RotationType::ZYX)
-            .value("YXZ", geometry::Geometry3D::RotationType::YXZ)
-            .value("AxisAngle", geometry::Geometry3D::RotationType::AxisAngle)
-            .export_values();
-
     py::class_<geometry::Geometry3D, PyGeometry3D<geometry::Geometry3D>,
                std::shared_ptr<geometry::Geometry3D>, geometry::Geometry>
             geometry3d(m, "Geometry3D",
@@ -112,8 +101,31 @@ void pybind_geometry_classes(py::module &m) {
                  "center"_a = true)
             .def("rotate", &geometry::Geometry3D::Rotate,
                  "Apply rotation to the geometry coordinates and normals.",
-                 "rotation"_a, "center"_a = true,
-                 "type"_a = geometry::Geometry3D::RotationType::XYZ);
+                 "R"_a, "center"_a = true)
+            .def_static("get_rotation_matrix_from_xyz",
+                        &geometry::Geometry3D::GetRotationMatrixFromXYZ,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_yzx",
+                        &geometry::Geometry3D::GetRotationMatrixFromYZX,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_zxy",
+                        &geometry::Geometry3D::GetRotationMatrixFromZXY,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_xzy",
+                        &geometry::Geometry3D::GetRotationMatrixFromXZY,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_zyx",
+                        &geometry::Geometry3D::GetRotationMatrixFromZYX,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_yxz",
+                        &geometry::Geometry3D::GetRotationMatrixFromYXZ,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_axis_angle",
+                        &geometry::Geometry3D::GetRotationMatrixFromAxisAngle,
+                        "rotation"_a)
+            .def_static("get_rotation_matrix_from_quaternion",
+                        &geometry::Geometry3D::GetRotationMatrixFromQuaternion,
+                        "rotation"_a);
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_min_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_max_bound");
     docstring::ClassMethodDocInject(m, "Geometry3D", "get_center");
@@ -137,18 +149,11 @@ void pybind_geometry_classes(py::module &m) {
               "of the geometry"},
              {"center",
               "If true, then the scale is applied to the centered geometry"}});
-    docstring::ClassMethodDocInject(
-            m, "Geometry3D", "rotate",
-            {{"rotation",
-              "A 3D vector that either defines the three angles for "
-              "Euler rotation, or in the axis-angle representation "
-              "the normalized vector defines the axis of rotation and "
-              "the norm the angle around this axis."},
-             {"center",
-              "If true, then the rotation is applied to the centered geometry"},
-             {"type",
-              "Type of rotation, i.e., an Euler format, or "
-              "axis-angle."}});
+    docstring::ClassMethodDocInject(m, "Geometry3D", "rotate",
+                                    {{"R", "The rotation matrix"},
+                                     {"center",
+                                      "If true, then the rotation is applied "
+                                      "to the centered geometry"}});
 
     // open3d.geometry.Geometry2D
     py::class_<geometry::Geometry2D, PyGeometry2D<geometry::Geometry2D>,

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -90,9 +90,20 @@ void pybind_pointcloud(py::module &m) {
                  "points with "
                  "the 0-th point always chosen, not at random.",
                  "every_k_points"_a)
-            .def("crop", &geometry::PointCloud::Crop,
+            .def("crop",
+                 (std::shared_ptr<geometry::PointCloud>(
+                         geometry::PointCloud::*)(
+                         const geometry::AxisAlignedBoundingBox &) const) &
+                         geometry::PointCloud::Crop,
                  "Function to crop input pointcloud into output pointcloud",
-                 "min_bound"_a, "max_bound"_a)
+                 "bounding_box"_a)
+            .def("crop",
+                 (std::shared_ptr<geometry::PointCloud>(
+                         geometry::PointCloud::*)(
+                         const geometry::OrientedBoundingBox &) const) &
+                         geometry::PointCloud::Crop,
+                 "Function to crop input pointcloud into output pointcloud",
+                 "bounding_box"_a)
             .def("remove_none_finite_points",
                  &geometry::PointCloud::RemoveNoneFinitePoints,
                  "Function to remove none-finite points from the PointCloud",
@@ -225,8 +236,7 @@ void pybind_pointcloud(py::module &m) {
               "Sample rate, the selected point indices are [0, k, 2k, ...]"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "crop",
-            {{"min_bound", "Minimum bound for point coordinate"},
-             {"max_bound", "Maximum bound for point coordinate"}});
+            {{"bounding_box", "AxisAlignedBoundingBox to crop points"}});
     docstring::ClassMethodDocInject(
             m, "PointCloud", "remove_none_finite_points",
             {{"remove_nan", "Remove NaN values from the PointCloud"},

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -217,10 +217,20 @@ void pybind_trianglemesh(py::module &m) {
                  "``indices``: "
                  "Indices of vertices to be selected.",
                  "indices"_a)
-            .def("crop", &geometry::TriangleMesh::Crop,
-                 "Function to crop input triangle mesh into output triangle "
-                 "mesh",
-                 "min_bound"_a, "max_bound"_a)
+            .def("crop",
+                 (std::shared_ptr<geometry::TriangleMesh>(
+                         geometry::TriangleMesh::*)(
+                         const geometry::AxisAlignedBoundingBox &) const) &
+                         geometry::TriangleMesh::Crop,
+                 "Function to crop input TriangleMesh into output TriangleMesh",
+                 "bounding_box"_a)
+            .def("crop",
+                 (std::shared_ptr<geometry::TriangleMesh>(
+                         geometry::TriangleMesh::*)(
+                         const geometry::OrientedBoundingBox &) const) &
+                         geometry::TriangleMesh::Crop,
+                 "Function to crop input TriangleMesh into output TriangleMesh",
+                 "bounding_box"_a)
             .def("sample_points_uniformly",
                  &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",
@@ -469,8 +479,7 @@ void pybind_trianglemesh(py::module &m) {
             {{"indices", "Indices of vertices to be selected."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "crop",
-            {{"min_bound", "Minimum bound for vertex coordinate."},
-             {"max_bound", "Maximum bound for vertex coordinate."}});
+            {{"bounding_box", "AxisAlignedBoundingBox to crop points"}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_uniformly",
             {{"number_of_points",

--- a/src/Tools/ConvertPointCloud.cpp
+++ b/src/Tools/ConvertPointCloud.cpp
@@ -96,7 +96,8 @@ void convert(int argc,
                 argc, argv, "--clip_y_max", std::numeric_limits<double>::max());
         max_bound(2) = utility::GetProgramOptionAsDouble(
                 argc, argv, "--clip_z_max", std::numeric_limits<double>::max());
-        pointcloud_ptr = pointcloud_ptr->Crop(min_bound, max_bound);
+        pointcloud_ptr = pointcloud_ptr->Crop(
+                geometry::AxisAlignedBoundingBox(min_bound, max_bound));
         processed = true;
     }
 

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 
 #include "Open3D/Camera/PinholeCameraIntrinsic.h"
+#include "Open3D/Geometry/BoundingVolume.h"
 #include "Open3D/Geometry/Image.h"
 #include "Open3D/Geometry/PointCloud.h"
 #include "Open3D/Geometry/RGBDImage.h"
@@ -637,7 +638,8 @@ TEST(PointCloud, CropPointCloud) {
 
     Vector3d minBound(200.0, 200.0, 200.0);
     Vector3d maxBound(800.0, 800.0, 800.0);
-    auto output_pc = pc.Crop(minBound, maxBound);
+    auto output_pc =
+            pc.Crop(geometry::AxisAlignedBoundingBox(minBound, maxBound));
 
     ExpectLE(minBound, output_pc->points_);
     ExpectGE(maxBound, output_pc->points_);

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/Geometry/TriangleMesh.h"
+#include "Open3D/Geometry/BoundingVolume.h"
 #include "Open3D/Geometry/PointCloud.h"
 #include "TestUtility/UnitTest.h"
 
@@ -1334,7 +1335,8 @@ TEST(TriangleMesh, CropTriangleMesh) {
     Vector3d cropBoundMin(300.0, 300.0, 300.0);
     Vector3d cropBoundMax(800.0, 800.0, 800.0);
 
-    auto output_tm = tm.Crop(cropBoundMin, cropBoundMax);
+    auto output_tm = tm.Crop(
+            geometry::AxisAlignedBoundingBox(cropBoundMin, cropBoundMax));
 
     ExpectEQ(ref_vertices, output_tm->vertices_);
     ExpectEQ(ref_vertex_normals, output_tm->vertex_normals_);


### PR DESCRIPTION
Changed `OrientedBoundingBox` parameters from `*_axis` to `rotation`, `extent` and `center`, therefore avoiding situations where the bounding box could have non-orthogonal axis. 
I further implemented `crop` methods for `PointCloud` and `TriangleMesh` that accept an `OrientedBoundingBox` as argument. Example usage is shown in `bounding_volume.py`.
This should also address #1210.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1218)
<!-- Reviewable:end -->
