### PR TITLE
fix control may reach end warning for VFatal

### DIFF
--- a/src/Open3D/Utility/Console.h
+++ b/src/Open3D/Utility/Console.h
@@ -42,12 +42,11 @@ namespace open3d {
 namespace utility {
 
 enum class VerbosityLevel {
-    Off = 0,
-    Fatal = 1,
-    Error = 2,
-    Warning = 3,
-    Info = 4,
-    Debug = 5,
+    Fatal = 0,
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Debug = 4,
 };
 
 class Logger {
@@ -72,13 +71,11 @@ public:
         return instance;
     }
 
-    void VFatal(const char *format, fmt::format_args args) const {
-        if (verbosity_level_ >= VerbosityLevel::Fatal) {
-            std::string err_msg = fmt::vformat(format, args);
-            err_msg = fmt::format("[Open3D FATAL] {}", err_msg);
-            err_msg = ColorString(err_msg, TextColor::Red, 1);
-            throw std::runtime_error(err_msg);
-        }
+    void VFatal[[noreturn]](const char *format, fmt::format_args args) const {
+        std::string err_msg = fmt::vformat(format, args);
+        err_msg = fmt::format("[Open3D FATAL] {}", err_msg);
+        err_msg = ColorString(err_msg, TextColor::Red, 1);
+        throw std::runtime_error(err_msg);
     }
 
     void VError(const char *format, fmt::format_args args) const {
@@ -209,7 +206,7 @@ inline VerbosityLevel GetVerbosityLevel() {
 }
 
 template <typename... Args>
-inline void LogFatal(const char *format, const Args &... args) {
+inline void LogFatal[[noreturn]](const char *format, const Args &... args) {
     Logger::i().VFatal(format, fmt::make_format_args(args...));
 }
 

--- a/src/Python/utility/console.cpp
+++ b/src/Python/utility/console.cpp
@@ -33,8 +33,7 @@ using namespace open3d;
 void pybind_console(py::module &m) {
     py::enum_<utility::VerbosityLevel> vl(m, "VerbosityLevel", py::arithmetic(),
                                           "VerbosityLevel");
-    vl.value("Off", utility::VerbosityLevel::Off)
-            .value("Fatal", utility::VerbosityLevel::Fatal)
+    vl.value("Fatal", utility::VerbosityLevel::Fatal)
             .value("Error", utility::VerbosityLevel::Error)
             .value("Warning", utility::VerbosityLevel::Warning)
             .value("Info", utility::VerbosityLevel::Info)


### PR DESCRIPTION
Fixes
```
Tensor.cpp:104:1: warning: control may reach end of non-void function [-Wreturn-type]                     
}                                                                                                                                                       
^ 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1222)
<!-- Reviewable:end -->
