### PR TITLE
Add some Python init functions to geometry classes

### DIFF
--- a/docs/tutorial/Basic/visualization.rst
+++ b/docs/tutorial/Basic/visualization.rst
@@ -97,7 +97,7 @@ Geometry primitives
 .. literalinclude:: ../../../examples/Python/Basic/visualization.py
    :language: python
    :lineno-start: 16
-   :lines: 16-27
+   :lines: 16-30
    :linenos:
 
 This script generates a cubic, a sphere, and a cylinder using ``create_mesh_cubic``, ``create_mesh_sphere`` and
@@ -110,8 +110,8 @@ Draw multiple geometries
 
 .. literalinclude:: ../../../examples/Python/Basic/visualization.py
    :language: python
-   :lineno-start: 29
-   :lines: 29-35
+   :lineno-start: 32
+   :lines: 32-38
    :linenos:
 
 ``draw_geometries`` takes a list of geometries and renders them all together. Alternatively, ``TriangleMesh`` supports a ``+`` operator to combine multiple meshes into one. We recommend the first approach since it supports a combination of different geometries (e.g., a mesh can be rendered in tandem with a point cloud).
@@ -126,8 +126,8 @@ Draw line set
 
 .. literalinclude:: ../../../examples/Python/Basic/visualization.py
    :language: python
-   :lineno-start: 37
-   :lines: 37-47
+   :lineno-start: 40
+   :lines: 40-71
    :linenos:
 
 To draw lines, it is necessary to define ``LineSet`` and create a set of points and a set of edges. An edge is a pair of point indices. The above example creates custom ``points`` and edges (denoted as ``lines``) to make a cubic. Color is optional - red color ``[1,0,0]`` is assigned to each edge in this example. This script visualizes the following cubic.

--- a/examples/Python/Basic/bounding_volume.py
+++ b/examples/Python/Basic/bounding_volume.py
@@ -41,30 +41,30 @@ if __name__ == "__main__":
 
     mesh = meshes.armadillo()
 
-    bbox = o3d.geometry.AxisAlignedBoundingBox()
-    bbox.min_bound = (-30, 0, -10)
-    bbox.max_bound = (10, 20, 10)
+    bbox = o3d.geometry.AxisAlignedBoundingBox(min_bound=(-30, 0, -10),
+                                               max_bound=(10, 20, 10))
     o3d.visualization.draw_geometries([mesh, bbox])
     o3d.visualization.draw_geometries([mesh.crop(bbox), bbox])
 
-    bbox = o3d.geometry.OrientedBoundingBox()
-    bbox.center = (-10, 10, 0)
-    bbox.R = bbox.get_rotation_matrix_from_xyz((2, 1, 0))
-    bbox.extent = (40, 20, 20)
+    bbox = o3d.geometry.OrientedBoundingBox(
+        center=(-10, 10, 0),
+        R=bbox.get_rotation_matrix_from_xyz((2, 1, 0)),
+        extent=(40, 20, 20),
+    )
     o3d.visualization.draw_geometries([mesh, bbox])
     o3d.visualization.draw_geometries([mesh.crop(bbox), bbox])
 
     pcd = mesh.sample_points_uniformly(500000)
 
-    bbox = o3d.geometry.AxisAlignedBoundingBox()
-    bbox.min_bound = (-30, 0, -10)
-    bbox.max_bound = (10, 20, 10)
+    bbox = o3d.geometry.AxisAlignedBoundingBox(min_bound=(-30, 0, -10),
+                                               max_bound=(10, 20, 10))
     o3d.visualization.draw_geometries([pcd, bbox])
     o3d.visualization.draw_geometries([pcd.crop(bbox), bbox])
 
-    bbox = o3d.geometry.OrientedBoundingBox()
-    bbox.center = (-10, 10, 0)
-    bbox.R = bbox.get_rotation_matrix_from_xyz((2, 1, 0))
-    bbox.extent = (40, 20, 20)
+    bbox = o3d.geometry.OrientedBoundingBox(
+        center=(-10, 10, 0),
+        R=bbox.get_rotation_matrix_from_xyz((2, 1, 0)),
+        extent=(40, 20, 20),
+    )
     o3d.visualization.draw_geometries([pcd, bbox])
     o3d.visualization.draw_geometries([pcd.crop(bbox), bbox])

--- a/examples/Python/Basic/mesh_properties.py
+++ b/examples/Python/Basic/mesh_properties.py
@@ -10,70 +10,70 @@ import time
 
 import os
 import sys
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(dir_path, '../Misc'))
+sys.path.append(os.path.join(dir_path, "../Misc"))
 import meshes
 
 
 def mesh_generator(edge_cases=True):
-    yield 'box', o3d.geometry.TriangleMesh.create_box()
-    yield 'sphere', o3d.geometry.TriangleMesh.create_sphere()
-    yield 'cone', o3d.geometry.TriangleMesh.create_cone()
-    yield 'torus', o3d.geometry.TriangleMesh.create_torus(radial_resolution=30,
+    yield "box", o3d.geometry.TriangleMesh.create_box()
+    yield "sphere", o3d.geometry.TriangleMesh.create_sphere()
+    yield "cone", o3d.geometry.TriangleMesh.create_cone()
+    yield "torus", o3d.geometry.TriangleMesh.create_torus(radial_resolution=30,
                                                           tubular_resolution=20)
-    yield 'moebius (twists=1)', o3d.geometry.TriangleMesh.create_moebius(
+    yield "moebius (twists=1)", o3d.geometry.TriangleMesh.create_moebius(
         twists=1)
-    yield 'moebius (twists=2)', o3d.geometry.TriangleMesh.create_moebius(
+    yield "moebius (twists=2)", o3d.geometry.TriangleMesh.create_moebius(
         twists=2)
-    yield 'moebius (twists=3)', o3d.geometry.TriangleMesh.create_moebius(
+    yield "moebius (twists=3)", o3d.geometry.TriangleMesh.create_moebius(
         twists=3)
 
-    yield 'knot', meshes.knot()
+    yield "knot", meshes.knot()
 
     if edge_cases:
-        yield 'non-manifold edge', meshes.non_manifold_edge()
-        yield 'non-manifold vertex', meshes.non_manifold_vertex()
-        yield 'open box', meshes.open_box()
-        yield 'boxes', meshes.intersecting_boxes()
+        yield "non-manifold edge", meshes.non_manifold_edge()
+        yield "non-manifold vertex", meshes.non_manifold_vertex()
+        yield "open box", meshes.open_box()
+        yield "boxes", meshes.intersecting_boxes()
 
 
 def check_properties(name, mesh):
 
     def fmt_bool(b):
-        return 'yes' if b else 'no'
+        return "yes" if b else "no"
 
     print(name)
     edge_manifold = mesh.is_edge_manifold(allow_boundary_edges=True)
-    print('  edge_manifold:          %s' % fmt_bool(edge_manifold))
+    print("  edge_manifold:          %s" % fmt_bool(edge_manifold))
     edge_manifold_boundary = mesh.is_edge_manifold(allow_boundary_edges=False)
-    print('  edge_manifold_boundary: %s' % fmt_bool(edge_manifold_boundary))
+    print("  edge_manifold_boundary: %s" % fmt_bool(edge_manifold_boundary))
     vertex_manifold = mesh.is_vertex_manifold()
-    print('  vertex_manifold:        %s' % fmt_bool(vertex_manifold))
+    print("  vertex_manifold:        %s" % fmt_bool(vertex_manifold))
     self_intersecting = mesh.is_self_intersecting()
-    print('  self_intersecting:      %s' % fmt_bool(self_intersecting))
+    print("  self_intersecting:      %s" % fmt_bool(self_intersecting))
     watertight = mesh.is_watertight()
-    print('  watertight:             %s' % fmt_bool(watertight))
+    print("  watertight:             %s" % fmt_bool(watertight))
     orientable = mesh.is_orientable()
-    print('  orientable:             %s' % fmt_bool(orientable))
+    print("  orientable:             %s" % fmt_bool(orientable))
 
     mesh.compute_vertex_normals()
 
     if not edge_manifold:
         edges = mesh.get_non_manifold_edges(allow_boundary_edges=True)
-        print('  # visualize non-manifold edges (allow_boundary_edges=True)')
+        print("  # visualize non-manifold edges (allow_boundary_edges=True)")
         o3d.visualization.draw_geometries(
             [mesh, meshes.edges_to_lineset(mesh, edges, (1, 0, 0))])
     if not edge_manifold_boundary:
         edges = mesh.get_non_manifold_edges(allow_boundary_edges=False)
-        print('  # visualize non-manifold edges (allow_boundary_edges=False)')
+        print("  # visualize non-manifold edges (allow_boundary_edges=False)")
         o3d.visualization.draw_geometries(
             [mesh, meshes.edges_to_lineset(mesh, edges, (0, 1, 0))])
     if not vertex_manifold:
         verts = np.asarray(mesh.get_non_manifold_vertices())
-        print('  # visualize non-manifold vertices')
-        pcl = o3d.geometry.PointCloud()
-        pcl.points = o3d.utility.Vector3dVector(
-            np.asarray(mesh.vertices)[verts])
+        print("  # visualize non-manifold vertices")
+        pcl = o3d.geometry.PointCloud(
+            points=o3d.utility.Vector3dVector(np.asarray(mesh.vertices)[verts]))
         pcl.paint_uniform_color((0, 0, 1))
         o3d.visualization.draw_geometries([mesh, pcl])
     if self_intersecting:
@@ -81,7 +81,7 @@ def check_properties(name, mesh):
             mesh.get_self_intersecting_triangles())
         intersecting_triangles = intersecting_triangles[0:1]
         intersecting_triangles = np.unique(intersecting_triangles)
-        print('  # visualize self-intersecting triangles')
+        print("  # visualize self-intersecting triangles")
         triangles = np.asarray(mesh.triangles)[intersecting_triangles]
         edges = [
             np.vstack((triangles[:, i], triangles[:, j]))
@@ -92,29 +92,29 @@ def check_properties(name, mesh):
         o3d.visualization.draw_geometries(
             [mesh, meshes.edges_to_lineset(mesh, edges, (1, 1, 0))])
     if watertight:
-        print('  # visualize watertight mesh')
+        print("  # visualize watertight mesh")
         o3d.visualization.draw_geometries([mesh])
 
     if not edge_manifold:
-        print('  # Remove non-manifold edges')
+        print("  # Remove non-manifold edges")
         mesh.remove_non_manifold_edges()
-        print('  # Is mesh now edge-manifold: {}'.format(
+        print("  # Is mesh now edge-manifold: {}".format(
             fmt_bool(mesh.is_edge_manifold())))
         o3d.visualization.draw_geometries([mesh])
 
 
 if __name__ == "__main__":
     # test mesh properties
-    print('#' * 80)
-    print('Test mesh properties')
-    print('#' * 80)
+    print("#" * 80)
+    print("Test mesh properties")
+    print("#" * 80)
     for name, mesh in mesh_generator(edge_cases=True):
         check_properties(name, mesh)
 
     # fix triangle orientation
-    print('#' * 80)
-    print('Fix triangle orientation')
-    print('#' * 80)
+    print("#" * 80)
+    print("Fix triangle orientation")
+    print("#" * 80)
     for name, mesh in mesh_generator(edge_cases=False):
         mesh.compute_vertex_normals()
         triangles = np.asarray(mesh.triangles)
@@ -124,13 +124,13 @@ if __name__ == "__main__":
         mesh.triangles = o3d.utility.Vector3iVector(triangles)
         o3d.visualization.draw_geometries([mesh])
         sucess = mesh.orient_triangles()
-        print('%s orientated: %s' % (name, 'yes' if sucess else 'no'))
+        print("%s orientated: %s" % (name, "yes" if sucess else "no"))
         o3d.visualization.draw_geometries([mesh])
 
     # intersection tests
-    print('#' * 80)
-    print('Intersection tests')
-    print('#' * 80)
+    print("#" * 80)
+    print("Intersection tests")
+    print("#" * 80)
     np.random.seed(30)
     bbox = o3d.geometry.TriangleMesh.create_box(20, 20, 20).translate(
         (-10, -10, -10))
@@ -155,8 +155,10 @@ if __name__ == "__main__":
             collision = False
             collision = collision or mesh0.is_intersecting(bbox)
             for idx1, mesh1 in enumerate(meshes):
-                if collision: break
-                if idx0 == idx1: continue
+                if collision:
+                    break
+                if idx0 == idx1:
+                    continue
                 collision = collision or mesh0.is_intersecting(mesh1)
             if collision:
                 mesh0.paint_uniform_color((1, 0, 0))

--- a/examples/Python/Basic/visualization.py
+++ b/examples/Python/Basic/visualization.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     pcd = o3d.io.read_point_cloud("../../TestData/fragment.ply")
     o3d.visualization.draw_geometries([pcd])
 
-    print("Let\'s draw some primitives")
+    print("Let's draw some primitives")
     mesh_box = o3d.geometry.TriangleMesh.create_box(width=1.0,
                                                     height=1.0,
                                                     depth=1.0)
@@ -37,15 +37,36 @@ if __name__ == "__main__":
     o3d.visualization.draw_geometries(
         [mesh_box + mesh_sphere + mesh_cylinder + mesh_frame])
 
-    print("Let\'s draw a cubic using o3d.geometry.LineSet.")
-    points = [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [0, 0, 1], [1, 0, 1],
-              [0, 1, 1], [1, 1, 1]]
-    lines = [[0, 1], [0, 2], [1, 3], [2, 3], [4, 5], [4, 6], [5, 7], [6, 7],
-             [0, 4], [1, 5], [2, 6], [3, 7]]
+    print("Let's draw a cubic using o3d.geometry.LineSet.")
+    points = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 0],
+        [0, 0, 1],
+        [1, 0, 1],
+        [0, 1, 1],
+        [1, 1, 1],
+    ]
+    lines = [
+        [0, 1],
+        [0, 2],
+        [1, 3],
+        [2, 3],
+        [4, 5],
+        [4, 6],
+        [5, 7],
+        [6, 7],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [3, 7],
+    ]
     colors = [[1, 0, 0] for i in range(len(lines))]
-    line_set = o3d.geometry.LineSet()
-    line_set.points = o3d.utility.Vector3dVector(points)
-    line_set.lines = o3d.utility.Vector2iVector(lines)
+    line_set = o3d.geometry.LineSet(
+        points=o3d.utility.Vector3dVector(points),
+        lines=o3d.utility.Vector2iVector(lines),
+    )
     line_set.colors = o3d.utility.Vector3dVector(colors)
     o3d.visualization.draw_geometries([line_set])
 

--- a/examples/Python/Misc/meshes.py
+++ b/examples/Python/Misc/meshes.py
@@ -32,28 +32,29 @@ def apply_noise(mesh, noise):
 
 
 def triangle():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array(
-            [
-                (np.sqrt(8 / 9), 0, -1 / 3),
-                (-np.sqrt(2 / 9), np.sqrt(2 / 3), -1 / 3),
-                (-np.sqrt(2 / 9), -np.sqrt(2 / 3), -1 / 3),
-            ],
-            dtype=np.float32,
-        ))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 1, 2]]))
+    mesh = o3d.geometry.TriangleMesh(
+        vertices=o3d.utility.Vector3dVector(
+            np.array(
+                [
+                    (np.sqrt(8 / 9), 0, -1 / 3),
+                    (-np.sqrt(2 / 9), np.sqrt(2 / 3), -1 / 3),
+                    (-np.sqrt(2 / 9), -np.sqrt(2 / 3), -1 / 3),
+                ],
+                dtype=np.float32,
+            )),
+        triangles=o3d.utility.Vector3iVector(np.array([[0, 1, 2]])),
+    )
     mesh.compute_vertex_normals()
     return mesh
 
 
 def plane():
-    mesh = o3d.geometry.TriangleMesh()
-    mesh.vertices = o3d.utility.Vector3dVector(
-        np.array([[0, 0, 0], [0, 0.2, 0], [1, 0.2, 0], [1, 0, 0]],
-                 dtype=np.float32))
-    mesh.triangles = o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0,
-                                                                      3]]))
+    mesh = o3d.geometry.TriangleMesh(
+        vertices=o3d.utility.Vector3dVector(
+            np.array([[0, 0, 0], [0, 0.2, 0], [1, 0.2, 0], [1, 0, 0]],
+                     dtype=np.float32)),
+        triangles=o3d.utility.Vector3iVector(np.array([[0, 2, 1], [2, 0, 3]])),
+    )
     mesh.compute_vertex_normals()
     return mesh
 

--- a/src/Open3D/Geometry/LineSet.h
+++ b/src/Open3D/Geometry/LineSet.h
@@ -44,6 +44,11 @@ class TetraMesh;
 class LineSet : public Geometry3D {
 public:
     LineSet() : Geometry3D(Geometry::GeometryType::LineSet) {}
+    LineSet(const std::vector<Eigen::Vector3d> &points,
+            const std::vector<Eigen::Vector2i> &lines)
+        : Geometry3D(Geometry::GeometryType::LineSet),
+          points_(points),
+          lines_(lines) {}
     ~LineSet() override {}
 
 public:

--- a/src/Open3D/Geometry/MeshBase.h
+++ b/src/Open3D/Geometry/MeshBase.h
@@ -117,6 +117,9 @@ public:
 protected:
     // Forward child class type to avoid indirect nonvirtual base
     MeshBase(Geometry::GeometryType type) : Geometry3D(type) {}
+    MeshBase(Geometry::GeometryType type,
+             const std::vector<Eigen::Vector3d> &vertices)
+        : Geometry3D(type), vertices_(vertices) {}
 
 public:
     std::vector<Eigen::Vector3d> vertices_;

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -50,6 +50,8 @@ class VoxelGrid;
 class PointCloud : public Geometry3D {
 public:
     PointCloud() : Geometry3D(Geometry::GeometryType::PointCloud) {}
+    PointCloud(const std::vector<Eigen::Vector3d> &points)
+        : Geometry3D(Geometry::GeometryType::PointCloud), points_(points) {}
     ~PointCloud() override {}
 
 public:

--- a/src/Open3D/Geometry/TetraMesh.h
+++ b/src/Open3D/Geometry/TetraMesh.h
@@ -44,6 +44,11 @@ class TriangleMesh;
 class TetraMesh : public MeshBase {
 public:
     TetraMesh() : MeshBase(Geometry::GeometryType::TetraMesh) {}
+    TetraMesh(const std::vector<Eigen::Vector3d> &vertices,
+              const std::vector<Eigen::Vector4i, utility::Vector4i_allocator>
+                      &tetras)
+        : MeshBase(Geometry::GeometryType::TetraMesh, vertices),
+          tetras_(tetras) {}
     ~TetraMesh() override {}
 
 public:

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -45,6 +45,10 @@ class PointCloud;
 class TriangleMesh : public MeshBase {
 public:
     TriangleMesh() : MeshBase(Geometry::GeometryType::TriangleMesh) {}
+    TriangleMesh(const std::vector<Eigen::Vector3d> &vertices,
+                 const std::vector<Eigen::Vector3i> &triangles)
+        : MeshBase(Geometry::GeometryType::TriangleMesh, vertices),
+          triangles_(triangles) {}
     ~TriangleMesh() override {}
 
 public:

--- a/src/Python/geometry/boundingvolume.cpp
+++ b/src/Python/geometry/boundingvolume.cpp
@@ -44,6 +44,12 @@ void pybind_boundingvolume(py::module &m) {
     py::detail::bind_copy_functions<geometry::OrientedBoundingBox>(
             oriented_bounding_box);
     oriented_bounding_box
+            .def(py::init<const Eigen::Vector3d &, const Eigen::Matrix3d &,
+                          const Eigen::Vector3d &>(),
+                 "Create OrientedBoudingBox from center, rotation R and extent "
+                 "in x, y and z "
+                 "direction",
+                 "center"_a, "R"_a, "extent"_a)
             .def("__repr__",
                  [](const geometry::OrientedBoundingBox &box) {
                      return std::string("geometry::OrientedBoundingBox");
@@ -76,6 +82,10 @@ void pybind_boundingvolume(py::module &m) {
     py::detail::bind_copy_functions<geometry::AxisAlignedBoundingBox>(
             axis_aligned_bounding_box);
     axis_aligned_bounding_box
+            .def(py::init<const Eigen::Vector3d &, const Eigen::Vector3d &>(),
+                 "Create an AxisAlignedBoundingBox from min bounds and max "
+                 "bounds in x, y and z",
+                 "min_bound"_a, "max_bound"_a)
             .def("__repr__",
                  [](const geometry::AxisAlignedBoundingBox &box) {
                      return std::string("geometry::AxisAlignedBoundingBox");

--- a/src/Python/geometry/lineset.cpp
+++ b/src/Python/geometry/lineset.cpp
@@ -41,11 +41,15 @@ void pybind_lineset(py::module &m) {
                     "pairs.");
     py::detail::bind_default_constructor<geometry::LineSet>(lineset);
     py::detail::bind_copy_functions<geometry::LineSet>(lineset);
-    lineset.def("__repr__",
-                [](const geometry::LineSet &lineset) {
-                    return std::string("geometry::LineSet with ") +
-                           std::to_string(lineset.lines_.size()) + " lines.";
-                })
+    lineset.def(py::init<const std::vector<Eigen::Vector3d> &,
+                         const std::vector<Eigen::Vector2i> &>(),
+                "Create a LineSet from given points and line indices",
+                "points"_a, "lines"_a)
+            .def("__repr__",
+                 [](const geometry::LineSet &lineset) {
+                     return std::string("geometry::LineSet with ") +
+                            std::to_string(lineset.lines_.size()) + " lines.";
+                 })
             .def(py::self + py::self)
             .def(py::self += py::self)
             .def("has_points", &geometry::LineSet::HasPoints,

--- a/src/Python/geometry/pointcloud.cpp
+++ b/src/Python/geometry/pointcloud.cpp
@@ -45,6 +45,8 @@ void pybind_pointcloud(py::module &m) {
     py::detail::bind_default_constructor<geometry::PointCloud>(pointcloud);
     py::detail::bind_copy_functions<geometry::PointCloud>(pointcloud);
     pointcloud
+            .def(py::init<const std::vector<Eigen::Vector3d> &>(),
+                 "Create a PointCloud from points", "points"_a)
             .def("__repr__",
                  [](const geometry::PointCloud &pcd) {
                      return std::string("geometry::PointCloud with ") +

--- a/src/Python/geometry/tetramesh.cpp
+++ b/src/Python/geometry/tetramesh.cpp
@@ -42,6 +42,11 @@ void pybind_tetramesh(py::module &m) {
     py::detail::bind_default_constructor<geometry::TetraMesh>(trianglemesh);
     py::detail::bind_copy_functions<geometry::TetraMesh>(trianglemesh);
     trianglemesh
+            .def(py::init<const std::vector<Eigen::Vector3d> &,
+                          const std::vector<Eigen::Vector4i,
+                                            utility::Vector4i_allocator> &>(),
+                 "Create a tetrahedra mesh from vertices and tetra indices",
+                 "vertices"_a, "tetras"_a)
             .def("__repr__",
                  [](const geometry::TetraMesh &mesh) {
                      return std::string("geometry::TetraMesh with ") +

--- a/src/Python/geometry/trianglemesh.cpp
+++ b/src/Python/geometry/trianglemesh.cpp
@@ -44,6 +44,10 @@ void pybind_trianglemesh(py::module &m) {
     py::detail::bind_default_constructor<geometry::TriangleMesh>(trianglemesh);
     py::detail::bind_copy_functions<geometry::TriangleMesh>(trianglemesh);
     trianglemesh
+            .def(py::init<const std::vector<Eigen::Vector3d> &,
+                          const std::vector<Eigen::Vector3i> &>(),
+                 "Create a triangle mesh from vertices and triangle indices",
+                 "vertices"_a, "triangles"_a)
             .def("__repr__",
                  [](const geometry::TriangleMesh &mesh) {
                      std::string info = fmt::format(


### PR DESCRIPTION
Added some init functions to the geometry classes. E.g., we can now directly create `AxisAlignedBoundingBox` with the parameters in the constructor.

Addresses comment https://reviewable.io/reviews/intel-isl/open3d/1218#-Lq_6SCRC82OKQcD6Y-5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1228)
<!-- Reviewable:end -->
