### PR TITLE
Support relative paths in ReconstructionSystem

### DIFF
--- a/examples/Python/ReconstructionSystem/run_system.py
+++ b/examples/Python/ReconstructionSystem/run_system.py
@@ -6,11 +6,17 @@
 
 import json
 import argparse
-import time, datetime
+import time
+import datetime
+import os
 import sys
-sys.path.append("../Utility")
-from file import check_folder_structure
-sys.path.append(".")
+
+_this_path = os.path.realpath(__file__)
+_this_dir = os.path.dirname(_this_path)
+sys.path.append(os.path.join(_this_dir))
+sys.path.append(os.path.join(_this_dir, "../Utility"))
+
+from file import check_folder_structure, resolve_relative_path
 from initialize_config import initialize_config
 
 if __name__ == "__main__":
@@ -43,12 +49,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # check folder structure
-    if args.config is not None:
-        with open(args.config) as json_file:
-            config = json.load(json_file)
-            initialize_config(config)
-            check_folder_structure(config["path_dataset"])
-    assert config is not None
+    with open(args.config) as json_file:
+        config = json.load(json_file)
+        initialize_config(config)
+        config["path_dataset"] = resolve_relative_path(args.config, config["path_dataset"])
+        config["path_intrinsic"] = resolve_relative_path(args.config, config["path_intrinsic"])
+        check_folder_structure(config["path_dataset"])
 
     if args.debug_mode:
         config['debug_mode'] = True

--- a/examples/Python/Utility/file.py
+++ b/examples/Python/Utility/file.py
@@ -3,9 +3,8 @@
 # See license file or visit www.open3d.org for details
 
 # examples/Python/Utility/file.py
-
 from os import listdir, makedirs
-from os.path import exists, isfile, join, splitext
+from os.path import exists, isfile, join, splitext, isabs, abspath, dirname
 import shutil
 import re
 
@@ -30,9 +29,16 @@ def get_file_list(path, extension=None):
 
 
 def add_if_exists(path_dataset, folder_names):
+    path = None
     for folder_name in folder_names:
-        if exists(join(path_dataset, folder_name)):
-            path = join(path_dataset, folder_name)
+        _path = join(path_dataset, folder_name)
+        if exists(_path):
+            path = _path
+
+    if path is None:
+        raise ValueError("Could not find any of {!r} in path {!r}".format(
+            folder_names, path_dataset))
+
     return path
 
 
@@ -78,3 +84,9 @@ def write_poses_to_log(filename, poses):
                 pose[2, 0], pose[2, 1], pose[2, 2], pose[2, 3]))
             f.write('{0:.8f} {1:.8f} {2:.8f} {3:.8f}\n'.format(
                 pose[3, 0], pose[3, 1], pose[3, 2], pose[3, 3]))
+
+
+def resolve_relative_path(relative_to, path):
+    if not isabs(path):
+        return abspath(join(dirname(relative_to), path))
+    return path


### PR DESCRIPTION
Allows `path_dataset` and `path_intrinsic` to be paths relative to the json file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1232)
<!-- Reviewable:end -->
