### PR TITLE
Proper LogError and LogWarning

### DIFF
--- a/docs/_static/C++/TestVisualizer.cpp
+++ b/docs/_static/C++/TestVisualizer.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -61,13 +61,14 @@ int main(int argc, char *argv[]) {
         if (io::ReadPointCloud(argv[2], *cloud_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         cloud_ptr->NormalizeNormals();
         visualization::DrawGeometries({cloud_ptr}, "PointCloud", 1600, 900);
     } else {
-        utility::LogError("Unrecognized option: {}\n", option);
+        utility::LogWarning("Unrecognized option: {}\n", option);
+        return 1;
     }
     utility::LogInfo("End of the test.\n");
 

--- a/examples/Cpp/AzureKinectMKVReader.cpp
+++ b/examples/Cpp/AzureKinectMKVReader.cpp
@@ -36,7 +36,7 @@ using namespace open3d;
 void WriteJsonToFile(const std::string &filename, const Json::Value &value) {
     std::ofstream out(filename);
     if (!out.is_open()) {
-        utility::LogError("Cannot write to {}\n", filename);
+        utility::LogFatal("Cannot write to {}", filename);
     }
 
     Json::StreamWriterBuilder builder;
@@ -49,10 +49,10 @@ void WriteJsonToFile(const std::string &filename, const Json::Value &value) {
 Json::Value GenerateDatasetConfig(const std::string &output_path) {
     Json::Value value;
 
-    utility::LogInfo("Writing to config.json\n");
+    utility::LogInfo("Writing to config.json");
     utility::LogInfo(
             "Please change path_dataset and path_intrinsic when you move the "
-            "dataset.\n");
+            "dataset.");
 
     if (output_path[0] == '/') {  // global dir
         value["path_dataset"] = output_path;
@@ -80,8 +80,8 @@ Json::Value GenerateDatasetConfig(const std::string &output_path) {
 void PrintUsage() {
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("AzureKinectMKVReader --input input.mkv [--output] [path]\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("AzureKinectMKVReader --input input.mkv [--output] [path]");
     // clang-format on
 }
 
@@ -98,25 +98,24 @@ int main(int argc, char **argv) {
     bool write_image = false;
     std::string output_path;
     if (!utility::ProgramOptionExists(argc, argv, "--output")) {
-        utility::LogInfo("No output image path, only play mkv.\n");
+        utility::LogInfo("No output image path, only play mkv.");
     } else {
         output_path = utility::GetProgramOptionAsString(argc, argv, "--output");
         if (output_path.empty()) {
-            utility::LogError("Output path {} is empty, only play mkv.\n",
+            utility::LogError("Output path {} is empty, only play mkv.",
                               output_path);
             return 1;
         }
         if (utility::filesystem::DirectoryExists(output_path)) {
-            utility::LogError(
-                    "Output path {} already existing, only play mkv.\n",
-                    output_path);
+            utility::LogError("Output path {} already existing, only play mkv.",
+                              output_path);
             return 1;
         } else if (!utility::filesystem::MakeDirectory(output_path)) {
-            utility::LogError("Unable to create path {}, only play mkv.\n",
+            utility::LogError("Unable to create path {}, only play mkv.",
                               output_path);
             return 1;
         } else {
-            utility::LogInfo("Decompress images to {}\n", output_path);
+            utility::LogInfo("Decompress images to {}", output_path);
             utility::filesystem::MakeDirectoryHierarchy(output_path + "/color");
             utility::filesystem::MakeDirectoryHierarchy(output_path + "/depth");
             write_image = true;
@@ -126,7 +125,7 @@ int main(int argc, char **argv) {
     io::MKVReader mkv_reader;
     mkv_reader.Open(mkv_filename);
     if (!mkv_reader.IsOpened()) {
-        utility::LogError("Unable to open {}\n", mkv_filename);
+        utility::LogError("Unable to open {}", mkv_filename);
         return 1;
     }
 
@@ -142,10 +141,10 @@ int main(int argc, char **argv) {
             GLFW_KEY_SPACE, [&](visualization::Visualizer *vis) {
                 if (flag_play) {
                     utility::LogInfo(
-                            "Playback paused, press [SPACE] to continue\n");
+                            "Playback paused, press [SPACE] to continue");
                 } else {
                     utility::LogInfo(
-                            "Playback resumed, press [SPACE] to pause\n");
+                            "Playback resumed, press [SPACE] to pause");
                 }
                 flag_play = !flag_play;
                 return true;
@@ -154,7 +153,7 @@ int main(int argc, char **argv) {
     vis.CreateVisualizerWindow("Open3D Azure Kinect MKV player", 1920, 540);
     utility::LogInfo(
             "Starting to play. Press [SPACE] to pause. Press [ESC] to "
-            "exit.\n");
+            "exit.");
 
     bool is_geometry_added = false;
     int idx = 0;
@@ -178,12 +177,12 @@ int main(int argc, char **argv) {
             if (write_image) {
                 auto color_file =
                         fmt::format("{0}/color/{1:05d}.jpg", output_path, idx);
-                utility::LogInfo("Writing to {}\n", color_file);
+                utility::LogInfo("Writing to {}", color_file);
                 io::WriteImage(color_file, im_rgbd->color_);
 
                 auto depth_file =
                         fmt::format("{0}/depth/{1:05d}.png", output_path, idx);
-                utility::LogInfo("Writing to {}\n", depth_file);
+                utility::LogInfo("Writing to {}", depth_file);
                 io::WriteImage(depth_file, im_rgbd->depth_);
 
                 ++idx;

--- a/examples/Cpp/AzureKinectMKVReader.cpp
+++ b/examples/Cpp/AzureKinectMKVReader.cpp
@@ -36,7 +36,7 @@ using namespace open3d;
 void WriteJsonToFile(const std::string &filename, const Json::Value &value) {
     std::ofstream out(filename);
     if (!out.is_open()) {
-        utility::LogFatal("Cannot write to {}\n", filename);
+        utility::LogError("Cannot write to {}\n", filename);
     }
 
     Json::StreamWriterBuilder builder;

--- a/examples/Cpp/AzureKinectRecord.cpp
+++ b/examples/Cpp/AzureKinectRecord.cpp
@@ -63,8 +63,8 @@ int main(int argc, char **argv) {
     int sensor_index =
             utility::GetProgramOptionAsInt(argc, argv, "--device", 0);
     if (sensor_index < 0 || sensor_index > 255) {
-        utility::LogError("Sensor index must between [0, 255]: {}\n",
-                          sensor_index);
+        utility::LogWarning("Sensor index must between [0, 255]: {}\n",
+                            sensor_index);
         return 1;
     }
 
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
     // Init recorder
     io::AzureKinectRecorder recorder(sensor_config, sensor_index);
     if (!recorder.InitSensor()) {
-        utility::LogError("Failed to connect to sensor, abort.\n");
+        utility::LogWarning("Failed to connect to sensor, abort.\n");
         return 1;
     }
 

--- a/examples/Cpp/AzureKinectRecord.cpp
+++ b/examples/Cpp/AzureKinectRecord.cpp
@@ -18,14 +18,14 @@ using namespace open3d;
 void PrintUsage() {
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage: \n");
-    utility::LogInfo("Options: \n");
-    utility::LogInfo("--config  Config .json file (default: none)\n");
-    utility::LogInfo("--list    List the currently connected K4A devices\n");
-    utility::LogInfo("--device  Specify the device index to use (default: 0)\n");
-    utility::LogInfo("--output  Output mkv file name (default: current_time.mkv)\n");
-    utility::LogInfo("-a        Align depth with color image (default: disabled)\n");
-    utility::LogInfo("-h        Print this helper\n");
+    utility::LogInfo("Usage: ");
+    utility::LogInfo("Options: ");
+    utility::LogInfo("--config  Config .json file (default: none)");
+    utility::LogInfo("--list    List the currently connected K4A devices");
+    utility::LogInfo("--device  Specify the device index to use (default: 0)");
+    utility::LogInfo("--output  Output mkv file name (default: current_time.mkv)");
+    utility::LogInfo("-a        Align depth with color image (default: disabled)");
+    utility::LogInfo("-h        Print this helper");
     // clang-format on
 }
 
@@ -53,17 +53,17 @@ int main(int argc, char **argv) {
         bool success = io::ReadIJsonConvertibleFromJSON(config_filename,
                                                         sensor_config);
         if (!success) {
-            utility::LogInfo("Invalid sensor config\n");
+            utility::LogInfo("Invalid sensor config");
             return 1;
         }
     } else {
-        utility::LogInfo("Use default sensor config\n");
+        utility::LogInfo("Use default sensor config");
     }
 
     int sensor_index =
             utility::GetProgramOptionAsInt(argc, argv, "--device", 0);
     if (sensor_index < 0 || sensor_index > 255) {
-        utility::LogWarning("Sensor index must between [0, 255]: {}\n",
+        utility::LogWarning("Sensor index must between [0, 255]: {}",
                             sensor_index);
         return 1;
     }
@@ -73,12 +73,12 @@ int main(int argc, char **argv) {
 
     std::string recording_filename = utility::GetProgramOptionAsString(
             argc, argv, "--output", utility::GetCurrentTimeStamp() + ".mkv");
-    utility::LogInfo("Prepare writing to {}\n", recording_filename);
+    utility::LogInfo("Prepare writing to {}", recording_filename);
 
     // Init recorder
     io::AzureKinectRecorder recorder(sensor_config, sensor_index);
     if (!recorder.InitSensor()) {
-        utility::LogWarning("Failed to connect to sensor, abort.\n");
+        utility::LogWarning("Failed to connect to sensor, abort.");
         return 1;
     }
 
@@ -92,21 +92,21 @@ int main(int argc, char **argv) {
                     utility::LogInfo(
                             "Recording paused. "
                             "Press [SPACE] to continue. "
-                            "Press [ESC] to save and exit.\n");
+                            "Press [ESC] to save and exit.");
                     flag_record = false;
                 } else if (!recorder.IsRecordCreated()) {
                     if (recorder.OpenRecord(recording_filename)) {
                         utility::LogInfo(
                                 "Recording started. "
                                 "Press [SPACE] to pause. "
-                                "Press [ESC] to save and exit.\n");
+                                "Press [ESC] to save and exit.");
                         flag_record = true;
                     }  // else flag_record keeps false
                 } else {
                     utility::LogInfo(
                             "Recording resumed, video may be discontinuous. "
                             "Press [SPACE] to pause. "
-                            "Press [ESC] to save and exit.\n");
+                            "Press [ESC] to save and exit.");
                     flag_record = true;
                 }
                 return false;
@@ -116,9 +116,9 @@ int main(int argc, char **argv) {
             GLFW_KEY_ESCAPE, [&](visualization::Visualizer *vis) {
                 flag_exit = true;
                 if (recorder.IsRecordCreated()) {
-                    utility::LogInfo("Recording finished.\n");
+                    utility::LogInfo("Recording finished.");
                 } else {
-                    utility::LogInfo("Nothing has been recorded.\n");
+                    utility::LogInfo("Nothing has been recorded.");
                 }
                 return false;
             });
@@ -126,14 +126,14 @@ int main(int argc, char **argv) {
     utility::LogInfo(
             "In the visulizer window, "
             "press [SPACE] to start recording, "
-            "press [ESC] to exit.\n");
+            "press [ESC] to exit.");
 
     vis.CreateVisualizerWindow("Open3D Azure Kinect Recorder", 1920, 540);
     do {
         auto im_rgbd =
                 recorder.RecordFrame(flag_record, enable_align_depth_to_color);
         if (im_rgbd == nullptr) {
-            utility::LogInfo("Invalid capture, skipping this frame\n");
+            utility::LogInfo("Invalid capture, skipping this frame");
             continue;
         }
 

--- a/examples/Cpp/AzureKinectViewer.cpp
+++ b/examples/Cpp/AzureKinectViewer.cpp
@@ -18,12 +18,12 @@ using namespace open3d;
 void PrintUsage() {
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Options: \n");
-    utility::LogInfo("--config  Config .json file (default: none)\n");
-    utility::LogInfo("--list    List the currently connected K4A devices\n");
-    utility::LogInfo("--device  Specify the device index to use (default: 0)\n");
-    utility::LogInfo("-a        Align depth with color image (default: disabled)\n");
-    utility::LogInfo("-h        Print this helper\n");
+    utility::LogInfo("Options: ");
+    utility::LogInfo("--config  Config .json file (default: none)");
+    utility::LogInfo("--list    List the currently connected K4A devices");
+    utility::LogInfo("--device  Specify the device index to use (default: 0)");
+    utility::LogInfo("-a        Align depth with color image (default: disabled)");
+    utility::LogInfo("-h        Print this helper");
     // clang-format on
 }
 
@@ -44,17 +44,17 @@ int main(int argc, char **argv) {
         auto config_filename =
                 utility::GetProgramOptionAsString(argc, argv, "--config", "");
         if (!io::ReadIJsonConvertibleFromJSON(config_filename, sensor_config)) {
-            utility::LogInfo("Invalid sensor config\n");
+            utility::LogInfo("Invalid sensor config");
             return 1;
         }
     } else {
-        utility::LogInfo("Use default sensor config\n");
+        utility::LogInfo("Use default sensor config");
     }
 
     int sensor_index =
             utility::GetProgramOptionAsInt(argc, argv, "--device", 0);
     if (sensor_index < 0 || sensor_index > 255) {
-        utility::LogWarning("Sensor index must between [0, 255]: {}\n",
+        utility::LogWarning("Sensor index must between [0, 255]: {}",
                             sensor_index);
         return 1;
     }
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     // Init sensor
     io::AzureKinectSensor sensor(sensor_config);
     if (!sensor.Connect(sensor_index)) {
-        utility::LogWarning("Failed to connect to sensor, abort.\n");
+        utility::LogWarning("Failed to connect to sensor, abort.");
         return 1;
     }
 
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     do {
         auto im_rgbd = sensor.CaptureFrame(enable_align_depth_to_color);
         if (im_rgbd == nullptr) {
-            utility::LogInfo("Invalid capture, skipping this frame\n");
+            utility::LogInfo("Invalid capture, skipping this frame");
             continue;
         }
 

--- a/examples/Cpp/AzureKinectViewer.cpp
+++ b/examples/Cpp/AzureKinectViewer.cpp
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
     int sensor_index =
             utility::GetProgramOptionAsInt(argc, argv, "--device", 0);
     if (sensor_index < 0 || sensor_index > 255) {
-        utility::LogError("Sensor index must between [0, 255]: {}\n",
-                          sensor_index);
+        utility::LogWarning("Sensor index must between [0, 255]: {}\n",
+                            sensor_index);
         return 1;
     }
 
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     // Init sensor
     io::AzureKinectSensor sensor(sensor_config);
     if (!sensor.Connect(sensor_index)) {
-        utility::LogError("Failed to connect to sensor, abort.\n");
+        utility::LogWarning("Failed to connect to sensor, abort.\n");
         return 1;
     }
 

--- a/examples/Cpp/CameraPoseTrajectory.cpp
+++ b/examples/Cpp/CameraPoseTrajectory.cpp
@@ -35,9 +35,8 @@ int main(int argc, char *argv[]) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
     if (argc != 3) {
-        utility::LogInfo("Usage :\n");
-        utility::LogInfo(
-                ">    CameraPoseTrajectory trajectory_file pcds_dir\n");
+        utility::LogInfo("Usage :");
+        utility::LogInfo(">    CameraPoseTrajectory trajectory_file pcds_dir");
         return 1;
     }
     const int NUM_OF_COLOR_PALETTE = 5;

--- a/examples/Cpp/ColorMapOptimization.cpp
+++ b/examples/Cpp/ColorMapOptimization.cpp
@@ -34,8 +34,8 @@ int main(int argc, char *argv[]) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
     if (argc != 2) {
-        utility::LogInfo("Usage :\n");
-        utility::LogInfo(">    ColorMapOptimization data_dir\n");
+        utility::LogInfo("Usage :");
+        utility::LogInfo(">    ColorMapOptimization data_dir");
         return 1;
     }
     // Read RGBD images
@@ -48,9 +48,9 @@ int main(int argc, char *argv[]) {
     assert(depth_filenames.size() == color_filenames.size());
     std::vector<std::shared_ptr<geometry::RGBDImage>> rgbd_images;
     for (size_t i = 0; i < depth_filenames.size(); i++) {
-        utility::LogDebug("reading {}...\n", depth_filenames[i]);
+        utility::LogDebug("reading {}...", depth_filenames[i]);
         auto depth = io::CreateImageFromFile(depth_filenames[i]);
-        utility::LogDebug("reading {}...\n", color_filenames[i]);
+        utility::LogDebug("reading {}...", color_filenames[i]);
         auto color = io::CreateImageFromFile(color_filenames[i]);
         auto rgbd_image = geometry::RGBDImage::CreateFromColorAndDepth(
                 *color, *depth, 1000.0, 3.0, false);

--- a/examples/Cpp/DepthCapture.cpp
+++ b/examples/Cpp/DepthCapture.cpp
@@ -88,14 +88,14 @@ int main(int argc, char *argv[]) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
     if (argc < 2) {
         PrintOpen3DVersion();
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > DepthCapture  [filename]\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > DepthCapture  [filename]");
         return 1;
     }
 
     auto mesh_ptr = io::CreateMeshFromFile(argv[1]);
     mesh_ptr->ComputeVertexNormals();
-    utility::LogInfo("Press S to capture a depth image.\n");
+    utility::LogInfo("Press S to capture a depth image.");
     VisualizerWithDepthCapture visualizer;
     visualizer.CreateVisualizerWindow("Depth Capture", 640, 480, 200, 200);
     visualizer.AddGeometry(mesh_ptr);
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 
     if (!utility::filesystem::FileExists("depth.png") ||
         !utility::filesystem::FileExists("camera.json")) {
-        utility::LogInfo("Depth has not been captured.\n");
+        utility::LogInfo("Depth has not been captured.");
         return 1;
     }
 
@@ -122,15 +122,15 @@ int main(int argc, char *argv[]) {
     visualizer1.Run();
     visualizer1.DestroyVisualizerWindow();
 
-    utility::LogInfo("Press L to validate the depth image.\n");
-    utility::LogInfo("Press P to load the capturing camera pose.\n");
+    utility::LogInfo("Press L to validate the depth image.");
+    utility::LogInfo("Press P to load the capturing camera pose.");
     VisualizerWithDepthCapture visualizer2;
     visualizer2.CreateVisualizerWindow("Depth Validation", 640, 480, 200, 200);
     visualizer2.AddGeometry(mesh_ptr);
     visualizer2.Run();
     visualizer2.DestroyVisualizerWindow();
 
-    utility::LogInfo("End of the test.\n");
+    utility::LogInfo("End of the test.");
 
     return 0;
 }

--- a/examples/Cpp/EvaluateFeatureMatch.cpp
+++ b/examples/Cpp/EvaluateFeatureMatch.cpp
@@ -84,16 +84,16 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > EvaluateFeatureMatch [options]\n");
-    utility::LogInfo("      Evaluate feature matching quality of point clouds.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.\n");
-    utility::LogInfo("    --dir directory           : The directory storing all data files. By default it is the parent directory of the log file + pcd/.\n");
-    utility::LogInfo("    --threshold t             : Threshold to determine if a match is good or not. Default: 0.075.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > EvaluateFeatureMatch [options]");
+    utility::LogInfo("      Evaluate feature matching quality of point clouds.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.");
+    utility::LogInfo("    --dir directory           : The directory storing all data files. By default it is the parent directory of the log file + pcd/.");
+    utility::LogInfo("    --threshold t             : Threshold to determine if a match is good or not. Default: 0.075.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
     // clang-format on
 }
 
@@ -105,7 +105,7 @@ bool ReadLogFile(const std::string &filename,
     transformations.clear();
     FILE *f = open3d::utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
-        utility::LogWarning("Read LOG failed: unable to open file.\n");
+        utility::LogWarning("Read LOG failed: unable to open file.");
         return false;
     }
     char line_buffer[DEFAULT_IO_BUFFER_SIZE];
@@ -114,32 +114,32 @@ bool ReadLogFile(const std::string &filename,
     while (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f)) {
         if (strlen(line_buffer) > 0 && line_buffer[0] != '#') {
             if (sscanf(line_buffer, "%d %d %d", &i, &j, &k) != 3) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(0, 0),
                        &trans(0, 1), &trans(0, 2), &trans(0, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(1, 0),
                        &trans(1, 1), &trans(1, 2), &trans(1, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(2, 0),
                        &trans(2, 1), &trans(2, 2), &trans(2, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(3, 0),
@@ -220,17 +220,17 @@ int main(int argc, char *argv[]) {
         }
         total_correspondence_num += correspondence_num;
         total_point_num += (int)source.points_.size();
-        utility::LogInfo("#{:d} <-- #{:d} : {:d} out of {:d} ({:.2f}%).\n",
+        utility::LogInfo("#{:d} <-- #{:d} : {:d} out of {:d} ({:.2f}%).",
                          pair_ids[k].first, pair_ids[k].second,
                          correspondence_num, (int)source.points_.size(),
                          correspondence_num * 100.0 / source.points_.size());
     }
-    utility::LogInfo("Total {:d} out of {:d} ({:.2f}% coverage).\n\n",
+    utility::LogInfo("Total {:d} out of {:d} ({:.2f}% coverage).",
                      total_correspondence_num, total_point_num,
                      total_correspondence_num * 100.0 / total_point_num);
 
     for (const auto feature : features) {
-        utility::LogInfo("Evaluate feature {}.\n", feature);
+        utility::LogInfo("Evaluate feature {}.", feature);
         std::vector<KDTreeFlannFeature> feature_trees(pcd_names.size());
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) num_threads(16)
@@ -239,7 +239,7 @@ int main(int argc, char *argv[]) {
             feature_trees[i].LoadFromFile(pcd_dirname + "cloud_bin_" +
                                           std::to_string(i) + "." + feature);
         }
-        utility::LogInfo("All KDTrees built.\n");
+        utility::LogInfo("All KDTrees built.");
         int total_point_num = 0;
         int total_correspondence_num = 0;
         int total_positive = 0;
@@ -300,14 +300,14 @@ int main(int argc, char *argv[]) {
             utility::LogInfo(
                     "#{:d} <-- #{:d} : {:d} out of {:d} out of {:d} ({:.2f}% "
                     "w.r.t. "
-                    "correspondences).\n",
+                    "correspondences).",
                     pair_ids[k].first, pair_ids[k].second, positive,
                     correspondence_num, (int)source.points_.size(),
                     positive * 100.0 / correspondence_num);
         }
         utility::LogInfo(
                 "Total {:d} out of {:d} out of {:d} ({:.2f}% w.r.t. "
-                "correspondences).\n\n",
+                "correspondences).",
                 total_positive, total_correspondence_num, total_point_num,
                 total_positive * 100.0 / total_correspondence_num);
         WriteBinaryResult(pcd_dirname + feature + ".bin", true_dis);

--- a/examples/Cpp/EvaluatePCDMatch.cpp
+++ b/examples/Cpp/EvaluatePCDMatch.cpp
@@ -33,18 +33,18 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > EvaluatePCDMatch [options]\n");
-    utility::LogInfo("      View pairwise matching result of point clouds.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.\n");
-    utility::LogInfo("    --gt file                 : A log file of the ground truth pairwise matching results. Must have.\n");
-    utility::LogInfo("    --threshold t             : Distance threshold. Must have.\n");
-    utility::LogInfo("    --threshold_rmse t        : Distance threshold to decide if a match is good or not. Default: 2t.\n");
-    utility::LogInfo("    --dir directory           : The directory storing all pcd files. By default it is the parent directory of the log file + pcd/.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > EvaluatePCDMatch [options]");
+    utility::LogInfo("      View pairwise matching result of point clouds.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.");
+    utility::LogInfo("    --gt file                 : A log file of the ground truth pairwise matching results. Must have.");
+    utility::LogInfo("    --threshold t             : Distance threshold. Must have.");
+    utility::LogInfo("    --threshold_rmse t        : Distance threshold to decide if a match is good or not. Default: 2t.");
+    utility::LogInfo("    --dir directory           : The directory storing all pcd files. By default it is the parent directory of the log file + pcd/.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
     // clang-format on
 }
 
@@ -56,7 +56,7 @@ bool ReadLogFile(const std::string &filename,
     transformations.clear();
     FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
-        utility::LogWarning("Read LOG failed: unable to open file.\n");
+        utility::LogWarning("Read LOG failed: unable to open file.");
         return false;
     }
     char line_buffer[DEFAULT_IO_BUFFER_SIZE];
@@ -65,32 +65,32 @@ bool ReadLogFile(const std::string &filename,
     while (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f)) {
         if (strlen(line_buffer) > 0 && line_buffer[0] != '#') {
             if (sscanf(line_buffer, "%d %d %d", &i, &j, &k) != 3) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(0, 0),
                        &trans(0, 1), &trans(0, 2), &trans(0, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(1, 0),
                        &trans(1, 1), &trans(1, 2), &trans(1, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(2, 0),
                        &trans(2, 1), &trans(2, 2), &trans(2, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(3, 0),
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
             }
         }
         rmse = std::sqrt(rmse / (double)correspondence_num);
-        utility::LogInfo("#{:d} < -- #{:d} : rmse {:.4f}\n", pair_ids[k].first,
+        utility::LogInfo("#{:d} < -- #{:d} : rmse {:.4f}", pair_ids[k].first,
                          pair_ids[k].second, rmse);
         total_rmse += rmse;
         if (rmse < threshold_rmse) {
@@ -182,12 +182,12 @@ int main(int argc, char *argv[]) {
             positive_rmse += rmse;
         }
     }
-    utility::LogInfo("Average rmse {:.8f} ({:.8f} / {:d})\n",
+    utility::LogInfo("Average rmse {:.8f} ({:.8f} / {:d})",
                      total_rmse / (double)pair_ids.size(), total_rmse,
                      (int)pair_ids.size());
-    utility::LogInfo("Average rmse of positives {:.8f} ({:.8f} / {:d})\n",
+    utility::LogInfo("Average rmse of positives {:.8f} ({:.8f} / {:d})",
                      positive_rmse / (double)positive, positive_rmse, positive);
-    utility::LogInfo("Accuracy {:.2f}% ({:d} / {:d})\n",
+    utility::LogInfo("Accuracy {:.2f}% ({:d} / {:d})",
                      (double)positive * 100.0 / (double)pair_ids.size(),
                      positive, (int)pair_ids.size());
     return 0;

--- a/examples/Cpp/FileDialog.cpp
+++ b/examples/Cpp/FileDialog.cpp
@@ -30,8 +30,8 @@
 
 void PrintHelp() {
     using namespace open3d;
-    utility::LogInfo("Usage :\n");
-    utility::LogInfo("    > FileDialog [save|load]\n");
+    utility::LogInfo("Usage :");
+    utility::LogInfo("    > FileDialog [save|load]");
 }
 
 int main(int argc, char *argv[]) {
@@ -45,11 +45,11 @@ int main(int argc, char *argv[]) {
     if (option == "load") {
         char const *str = tinyfd_openFileDialog("Find a file to load", "", 0,
                                                 NULL, NULL, 1);
-        utility::LogInfo("{}\n", str);
+        utility::LogInfo("{}", str);
     } else if (option == "save") {
         char const *str = tinyfd_saveFileDialog("Find a file to save", "", 1,
                                                 &pattern, NULL);
-        utility::LogInfo("{}\n", str);
+        utility::LogInfo("{}", str);
     }
     return 0;
 }

--- a/examples/Cpp/FileSystem.cpp
+++ b/examples/Cpp/FileSystem.cpp
@@ -30,12 +30,12 @@
 
 void PrintHelp() {
     using namespace open3d;
-    utility::LogInfo("Usage :\n");
-    utility::LogInfo("    > FileSystem ls [dir]\n");
-    utility::LogInfo("    > FileSystem mkdir [dir]\n");
-    utility::LogInfo("    > FileSystem rmdir [dir]\n");
-    utility::LogInfo("    > FileSystem rmfile [file]\n");
-    utility::LogInfo("    > FileSystem fileexists [file]\n");
+    utility::LogInfo("Usage :");
+    utility::LogInfo("    > FileSystem ls [dir]");
+    utility::LogInfo("    > FileSystem mkdir [dir]");
+    utility::LogInfo("    > FileSystem rmdir [dir]");
+    utility::LogInfo("    > FileSystem rmfile [file]");
+    utility::LogInfo("    > FileSystem fileexists [file]");
 }
 
 int main(int argc, char **args) {

--- a/examples/Cpp/Flann.cpp
+++ b/examples/Cpp/Flann.cpp
@@ -45,12 +45,12 @@ int main(int argc, char **argv) {
     if (io::ReadPointCloud(argv[1], *cloud_ptr)) {
         utility::LogInfo("Successfully read {}\n", argv[1]);
     } else {
-        utility::LogError("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}\n\n", argv[1]);
         return 1;
     }
 
     if ((int)cloud_ptr->points_.size() < 100) {
-        utility::LogError("Boring point cloud.\n");
+        utility::LogWarning("Boring point cloud.\n");
         return 1;
     }
 
@@ -98,14 +98,14 @@ int main(int argc, char **argv) {
 
     auto new_cloud_ptr = std::make_shared<geometry::PointCloud>();
     if (io::ReadPointCloud(argv[1], *new_cloud_ptr)) {
-        utility::LogWarning("Successfully read {}\n", argv[1]);
+        utility::LogInfo("Successfully read {}\n", argv[1]);
     } else {
-        utility::LogError("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}\n\n", argv[1]);
         return 1;
     }
 
     if ((int)new_cloud_ptr->points_.size() < 100) {
-        utility::LogError("Boring point cloud.\n");
+        utility::LogWarning("Boring point cloud.\n");
         return 1;
     }
 

--- a/examples/Cpp/Flann.cpp
+++ b/examples/Cpp/Flann.cpp
@@ -36,21 +36,21 @@ int main(int argc, char **argv) {
 
     if (argc < 2) {
         PrintOpen3DVersion();
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > Flann [filename]\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > Flann [filename]");
         return 1;
     }
 
     auto cloud_ptr = std::make_shared<geometry::PointCloud>();
     if (io::ReadPointCloud(argv[1], *cloud_ptr)) {
-        utility::LogInfo("Successfully read {}\n", argv[1]);
+        utility::LogInfo("Successfully read {}", argv[1]);
     } else {
-        utility::LogWarning("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}", argv[1]);
         return 1;
     }
 
     if ((int)cloud_ptr->points_.size() < 100) {
-        utility::LogWarning("Boring point cloud.\n");
+        utility::LogWarning("Boring point cloud.");
         return 1;
     }
 
@@ -74,8 +74,7 @@ int main(int argc, char **argv) {
     index.knnSearch(query, indices, dists, nn, SearchParams(-1, 0.0));
 
     for (size_t i = 0; i < indices_vec.size(); i++) {
-        utility::LogInfo("{:d}, {:f}\n", (int)indices_vec[i],
-                         sqrt(dists_vec[i]));
+        utility::LogInfo("{:d}, {:f}", (int)indices_vec[i], sqrt(dists_vec[i]));
         cloud_ptr->colors_[indices_vec[i]] = Eigen::Vector3d(1.0, 0.0, 0.0);
     }
 
@@ -86,10 +85,9 @@ int main(int argc, char **argv) {
     int k = index.radiusSearch(query1, indices, dists, r * r,
                                SearchParams(-1, 0.0));
 
-    utility::LogInfo("======== {:d}, {:f} ========\n", k, r);
+    utility::LogInfo("======== {:d}, {:f} ========", k, r);
     for (int i = 0; i < k; i++) {
-        utility::LogInfo("{:d}, {:f}\n", (int)indices_vec[i],
-                         sqrt(dists_vec[i]));
+        utility::LogInfo("{:d}, {:f}", (int)indices_vec[i], sqrt(dists_vec[i]));
         cloud_ptr->colors_[indices_vec[i]] = Eigen::Vector3d(0.0, 0.0, 1.0);
     }
     cloud_ptr->colors_[99] = Eigen::Vector3d(0.0, 1.0, 1.0);
@@ -98,14 +96,14 @@ int main(int argc, char **argv) {
 
     auto new_cloud_ptr = std::make_shared<geometry::PointCloud>();
     if (io::ReadPointCloud(argv[1], *new_cloud_ptr)) {
-        utility::LogInfo("Successfully read {}\n", argv[1]);
+        utility::LogInfo("Successfully read {}", argv[1]);
     } else {
-        utility::LogWarning("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}", argv[1]);
         return 1;
     }
 
     if ((int)new_cloud_ptr->points_.size() < 100) {
-        utility::LogWarning("Boring point cloud.\n");
+        utility::LogWarning("Boring point cloud.");
         return 1;
     }
 
@@ -124,7 +122,7 @@ int main(int argc, char **argv) {
                      new_dists_vec);
 
     for (size_t i = 0; i < new_indices_vec.size(); i++) {
-        utility::LogInfo("{:d}, {:f}\n", (int)new_indices_vec[i],
+        utility::LogInfo("{:d}, {:f}", (int)new_indices_vec[i],
                          sqrt(new_dists_vec[i]));
         new_cloud_ptr->colors_[new_indices_vec[i]] =
                 Eigen::Vector3d(1.0, 0.0, 0.0);
@@ -135,9 +133,9 @@ int main(int argc, char **argv) {
     k = kdtree.SearchRadius(new_cloud_ptr->points_[99], r, new_indices_vec,
                             new_dists_vec);
 
-    utility::LogInfo("======== {:d}, {:f} ========\n", k, r);
+    utility::LogInfo("======== {:d}, {:f} ========", k, r);
     for (int i = 0; i < k; i++) {
-        utility::LogInfo("{:d}, {:f}\n", (int)new_indices_vec[i],
+        utility::LogInfo("{:d}, {:f}", (int)new_indices_vec[i],
                          sqrt(new_dists_vec[i]));
         new_cloud_ptr->colors_[new_indices_vec[i]] =
                 Eigen::Vector3d(0.0, 0.0, 1.0);
@@ -148,9 +146,9 @@ int main(int argc, char **argv) {
                       geometry::KDTreeSearchParamRadius(r), new_indices_vec,
                       new_dists_vec);
 
-    utility::LogInfo("======== {:d}, {:f} ========\n", k, r);
+    utility::LogInfo("======== {:d}, {:f} ========", k, r);
     for (int i = 0; i < k; i++) {
-        utility::LogInfo("{:d}, {:f}\n", (int)new_indices_vec[i],
+        utility::LogInfo("{:d}, {:f}", (int)new_indices_vec[i],
                          sqrt(new_dists_vec[i]));
         new_cloud_ptr->colors_[new_indices_vec[i]] =
                 Eigen::Vector3d(0.0, 0.0, 1.0);

--- a/examples/Cpp/Image.cpp
+++ b/examples/Cpp/Image.cpp
@@ -100,6 +100,7 @@ int main(int argc, char **argv) {
         }
     } else {
         utility::LogWarning("Failed to read {}\n\n", filename_rgb);
+        return 1;
     }
 
     geometry::Image depth_image_16bit;
@@ -149,7 +150,8 @@ int main(int argc, char **argv) {
             io::WriteImage(outputname, *level_16bit);
         }
     } else {
-        utility::LogError("Failed to read {}\n\n", filename_depth);
+        utility::LogWarning("Failed to read {}\n\n", filename_depth);
+        return 1;
     }
 
     return 0;

--- a/examples/Cpp/Image.cpp
+++ b/examples/Cpp/Image.cpp
@@ -36,15 +36,15 @@ int main(int argc, char **argv) {
     if (argc != 3) {
         PrintOpen3DVersion();
         // clang-format off
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > Image [image filename] [depth filename]\n");
-        utility::LogInfo("    The program will :\n");
-        utility::LogInfo("    1) Read 8bit RGB and 16bit depth image\n");
-        utility::LogInfo("    2) Convert RGB image to single channel float image\n");
-        utility::LogInfo("    3) 3x3, 5x5, 7x7 Gaussian filters are applied\n");
-        utility::LogInfo("    4) 3x3 Sobel filter for x-and-y-directions are applied\n");
-        utility::LogInfo("    5) Make image pyramid that includes Gaussian blur and downsampling\n");
-        utility::LogInfo("    6) Will save all the layers in the image pyramid\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > Image [image filename] [depth filename]");
+        utility::LogInfo("    The program will :");
+        utility::LogInfo("    1) Read 8bit RGB and 16bit depth image");
+        utility::LogInfo("    2) Convert RGB image to single channel float image");
+        utility::LogInfo("    3) 3x3, 5x5, 7x7 Gaussian filters are applied");
+        utility::LogInfo("    4) 3x3 Sobel filter for x-and-y-directions are applied");
+        utility::LogInfo("    5) Make image pyramid that includes Gaussian blur and downsampling");
+        utility::LogInfo("    6) Will save all the layers in the image pyramid");
         // clang-format on
         return 1;
     }
@@ -54,13 +54,13 @@ int main(int argc, char **argv) {
 
     geometry::Image color_image_8bit;
     if (io::ReadImage(filename_rgb, color_image_8bit)) {
-        utility::LogDebug("RGB image size : {:d} x {:d}\n",
+        utility::LogDebug("RGB image size : {:d} x {:d}",
                           color_image_8bit.width_, color_image_8bit.height_);
         auto gray_image = color_image_8bit.CreateFloatImage();
         io::WriteImage("gray.png",
                        *gray_image->CreateImageFromFloatImage<uint8_t>());
 
-        utility::LogDebug("Gaussian Filtering\n");
+        utility::LogDebug("Gaussian Filtering");
         auto gray_image_b3 =
                 gray_image->Filter(geometry::Image::FilterType::Gaussian3);
         io::WriteImage("gray_blur3.png",
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
         io::WriteImage("gray_blur7.png",
                        *gray_image_b7->CreateImageFromFloatImage<uint8_t>());
 
-        utility::LogDebug("Sobel Filtering\n");
+        utility::LogDebug("Sobel Filtering");
         auto gray_image_dx =
                 gray_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-1,1] to [0,1].
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         io::WriteImage("gray_sobel_dy.png",
                        *gray_image_dy->CreateImageFromFloatImage<uint8_t>());
 
-        utility::LogDebug("Build Pyramid\n");
+        utility::LogDebug("Build Pyramid");
         auto pyramid = gray_image->CreatePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
@@ -99,19 +99,19 @@ int main(int argc, char **argv) {
             io::WriteImage(outputname, *level_8bit);
         }
     } else {
-        utility::LogWarning("Failed to read {}\n\n", filename_rgb);
+        utility::LogWarning("Failed to read {}", filename_rgb);
         return 1;
     }
 
     geometry::Image depth_image_16bit;
     if (io::ReadImage(filename_depth, depth_image_16bit)) {
-        utility::LogDebug("Depth image size : {:d} x {:d}\n",
+        utility::LogDebug("Depth image size : {:d} x {:d}",
                           depth_image_16bit.width_, depth_image_16bit.height_);
         auto depth_image = depth_image_16bit.CreateFloatImage();
         io::WriteImage("depth.png",
                        *depth_image->CreateImageFromFloatImage<uint16_t>());
 
-        utility::LogDebug("Gaussian Filtering\n");
+        utility::LogDebug("Gaussian Filtering");
         auto depth_image_b3 =
                 depth_image->Filter(geometry::Image::FilterType::Gaussian3);
         io::WriteImage("depth_blur3.png",
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
         io::WriteImage("depth_blur7.png",
                        *depth_image_b7->CreateImageFromFloatImage<uint16_t>());
 
-        utility::LogDebug("Sobel Filtering\n");
+        utility::LogDebug("Sobel Filtering");
         auto depth_image_dx =
                 depth_image->Filter(geometry::Image::FilterType::Sobel3Dx);
         // make [-65536,65536] to [0,13107.2]. // todo: need to test this
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
         io::WriteImage("depth_sobel_dy.png",
                        *depth_image_dy->CreateImageFromFloatImage<uint16_t>());
 
-        utility::LogDebug("Build Pyramid\n");
+        utility::LogDebug("Build Pyramid");
         auto pyramid = depth_image->CreatePyramid(4);
         for (int i = 0; i < 4; i++) {
             auto level = pyramid[i];
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
             io::WriteImage(outputname, *level_16bit);
         }
     } else {
-        utility::LogWarning("Failed to read {}\n\n", filename_depth);
+        utility::LogWarning("Failed to read {}", filename_depth);
         return 1;
     }
 

--- a/examples/Cpp/IntegrateRGBD.cpp
+++ b/examples/Cpp/IntegrateRGBD.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
             utility::filesystem::GetFileParentDirectory(match_filename).c_str();
     FILE *file = utility::filesystem::FOpen(match_filename, "r");
     if (file == NULL) {
-        utility::LogError("Unable to open file {}\n", match_filename);
+        utility::LogWarning("Unable to open file {}\n", match_filename);
         fclose(file);
         return 0;
     }

--- a/examples/Cpp/IntegrateRGBD.cpp
+++ b/examples/Cpp/IntegrateRGBD.cpp
@@ -33,22 +33,22 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > IntegrateRGBD [options]\n");
-    utility::LogInfo("      Integrate RGBD stream and extract geometry.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --match file              : The match file of an RGBD stream. Must have.\n");
-    utility::LogInfo("    --log file                : The log trajectory file. Must have.\n");
-    utility::LogInfo("    --save_pointcloud         : Save a point cloud created by marching cubes.\n");
-    utility::LogInfo("    --save_mesh               : Save a mesh created by marching cubes.\n");
-    utility::LogInfo("    --save_voxel              : Save a point cloud of the TSDF voxel.\n");
-    utility::LogInfo("    --every_k_frames k        : Save/reset every k frames. Default: 0 (none).\n");
-    utility::LogInfo("    --length l                : Length of the volume, in meters. Default: 4.0.\n");
-    utility::LogInfo("    --resolution r            : Resolution of the voxel grid. Default: 512.\n");
-    utility::LogInfo("    --sdf_trunc_percentage t  : TSDF truncation percentage, of the volume length. Default: 0.01.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > IntegrateRGBD [options]");
+    utility::LogInfo("      Integrate RGBD stream and extract geometry.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --match file              : The match file of an RGBD stream. Must have.");
+    utility::LogInfo("    --log file                : The log trajectory file. Must have.");
+    utility::LogInfo("    --save_pointcloud         : Save a point cloud created by marching cubes.");
+    utility::LogInfo("    --save_mesh               : Save a mesh created by marching cubes.");
+    utility::LogInfo("    --save_voxel              : Save a point cloud of the TSDF voxel.");
+    utility::LogInfo("    --every_k_frames k        : Save/reset every k frames. Default: 0 (none).");
+    utility::LogInfo("    --length l                : Length of the volume, in meters. Default: 4.0.");
+    utility::LogInfo("    --resolution r            : Resolution of the voxel grid. Default: 512.");
+    utility::LogInfo("    --sdf_trunc_percentage t  : TSDF truncation percentage, of the volume length. Default: 0.01.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
     // clang-format on
 }
 
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
             utility::filesystem::GetFileParentDirectory(match_filename).c_str();
     FILE *file = utility::filesystem::FOpen(match_filename, "r");
     if (file == NULL) {
-        utility::LogWarning("Unable to open file {}\n", match_filename);
+        utility::LogWarning("Unable to open file {}", match_filename);
         fclose(file);
         return 0;
     }
@@ -103,7 +103,7 @@ int main(int argc, char *argv[]) {
         std::vector<std::string> st;
         utility::SplitString(st, buffer, "\t\r\n ");
         if (st.size() >= 2) {
-            utility::LogInfo("Processing frame {:d} ...\n", index);
+            utility::LogInfo("Processing frame {:d} ...", index);
             io::ReadImage(dir_name + st[0], depth);
             io::ReadImage(dir_name + st[1], color);
             auto rgbd = geometry::RGBDImage::CreateFromColorAndDepth(
@@ -118,23 +118,22 @@ int main(int argc, char *argv[]) {
             index++;
             if (index == (int)camera_trajectory->parameters_.size() ||
                 (every_k_frames > 0 && index % every_k_frames == 0)) {
-                utility::LogInfo("Saving fragment {:d} ...\n", save_index);
+                utility::LogInfo("Saving fragment {:d} ...", save_index);
                 std::string save_index_str = std::to_string(save_index);
                 if (save_pointcloud) {
-                    utility::LogInfo("Saving pointcloud {:d} ...\n",
-                                     save_index);
+                    utility::LogInfo("Saving pointcloud {:d} ...", save_index);
                     auto pcd = volume.ExtractPointCloud();
                     io::WritePointCloud("pointcloud_" + save_index_str + ".ply",
                                         *pcd);
                 }
                 if (save_mesh) {
-                    utility::LogInfo("Saving mesh {:d} ...\n", save_index);
+                    utility::LogInfo("Saving mesh {:d} ...", save_index);
                     auto mesh = volume.ExtractTriangleMesh();
                     io::WriteTriangleMesh("mesh_" + save_index_str + ".ply",
                                           *mesh);
                 }
                 if (save_voxel) {
-                    utility::LogInfo("Saving voxel {:d} ...\n", save_index);
+                    utility::LogInfo("Saving voxel {:d} ...", save_index);
                     auto voxel = volume.ExtractVoxelPointCloud();
                     io::WritePointCloud("voxel_" + save_index_str + ".ply",
                                         *voxel);

--- a/examples/Cpp/LineSet.cpp
+++ b/examples/Cpp/LineSet.cpp
@@ -39,16 +39,16 @@ int main(int argc, char **argv) {
     if (argc < 2) {
         PrintOpen3DVersion();
         // clang-format off
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > LineSet [filename]\n");
-        utility::LogInfo("    The program will :\n");
-        utility::LogInfo("    1. load the pointcloud in [filename].\n");
-        utility::LogInfo("    2. use KDTreeFlann to compute 50 nearest neighbors of point0.\n");
-        utility::LogInfo("    3. convert the correspondences to LineSet and render it.\n");
-        utility::LogInfo("    4. rotate the point cloud slightly to get another point cloud.\n");
-        utility::LogInfo("    5. find closest point of the original point cloud on the new point cloud, mark as correspondences.\n");
-        utility::LogInfo("    6. convert to LineSet and render it.\n");
-        utility::LogInfo("    7. distance below 0.05 are rendered as red, others as black.\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > LineSet [filename]");
+        utility::LogInfo("    The program will :");
+        utility::LogInfo("    1. load the pointcloud in [filename].");
+        utility::LogInfo("    2. use KDTreeFlann to compute 50 nearest neighbors of point0.");
+        utility::LogInfo("    3. convert the correspondences to LineSet and render it.");
+        utility::LogInfo("    4. rotate the point cloud slightly to get another point cloud.");
+        utility::LogInfo("    5. find closest point of the original point cloud on the new point cloud, mark as correspondences.");
+        utility::LogInfo("    6. convert to LineSet and render it.");
+        utility::LogInfo("    7. distance below 0.05 are rendered as red, others as black.");
         // clang-format on
         return 1;
     }

--- a/examples/Cpp/Log.cpp
+++ b/examples/Cpp/Log.cpp
@@ -33,37 +33,37 @@ int main(int argc, char **argv) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    utility::LogDebug("This Debug message should be visible, {} {:.2f}\n",
+    utility::LogDebug("This Debug message should be visible, {} {:.2f}",
                       "format:", 0.42001);
-    utility::LogInfo("This Info message should be visible, {} {:.2f}\n",
+    utility::LogInfo("This Info message should be visible, {} {:.2f}",
                      "format:", 0.42001);
-    utility::LogWarning("This Warning message should be visible, {} {:.2f}\n",
+    utility::LogWarning("This Warning message should be visible, {} {:.2f}",
                         "format:", 0.42001);
 
-    utility::LogDebugf("This Debug message should be visible, %s %.2f\n",
+    utility::LogDebugf("This Debug message should be visible, %s %.2f",
                        "formatf:", 0.42001);
-    utility::LogInfof("This Info message should be visible, %s %.2f\n",
+    utility::LogInfof("This Info message should be visible, %s %.2f",
                       "formatf:", 0.42001);
-    utility::LogWarningf("This Warning message should be visible, %s %.2f\n",
+    utility::LogWarningf("This Warning message should be visible, %s %.2f",
                          "formatf:", 0.42001);
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Info);
 
-    utility::LogDebug("This Debug message should NOT be visible, {} {:.2f}\n",
+    utility::LogDebug("This Debug message should NOT be visible, {} {:.2f}",
                       "format:", 0.42001);
-    utility::LogInfo("This Info message should be visible, {} {:.2f}\n",
+    utility::LogInfo("This Info message should be visible, {} {:.2f}",
                      "format:", 0.42001);
-    utility::LogWarning("This Warning message should be visible, {} {:.2f}\n",
+    utility::LogWarning("This Warning message should be visible, {} {:.2f}",
                         "format:", 0.42001);
 
     try {
-        utility::LogError("This Error exception is catched\n");
+        utility::LogError("This Error exception is catched");
     } catch (const std::exception &e) {
         utility::LogInfo("Catched exception msg: {}", e.what());
     }
-    utility::LogInfo("This Info message shall print in regular color\n");
-    utility::LogError("This Error message terminates the program\n");
-    utility::LogError("This Error message should NOT be visible\n");
+    utility::LogInfo("This Info message shall print in regular color");
+    utility::LogError("This Error message terminates the program");
+    utility::LogError("This Error message should NOT be visible");
 
     return 0;
 }

--- a/examples/Cpp/Log.cpp
+++ b/examples/Cpp/Log.cpp
@@ -39,8 +39,6 @@ int main(int argc, char **argv) {
                      "format:", 0.42001);
     utility::LogWarning("This Warning message should be visible, {} {:.2f}\n",
                         "format:", 0.42001);
-    utility::LogError("This Error message should be visible, {} {:.2f}\n",
-                      "format:", 0.42001);
 
     utility::LogDebugf("This Debug message should be visible, %s %.2f\n",
                        "formatf:", 0.42001);
@@ -48,8 +46,6 @@ int main(int argc, char **argv) {
                       "formatf:", 0.42001);
     utility::LogWarningf("This Warning message should be visible, %s %.2f\n",
                          "formatf:", 0.42001);
-    utility::LogErrorf("This Error message should be visible, %s %.2f\n",
-                       "formatf:", 0.42001);
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Info);
 
@@ -59,17 +55,15 @@ int main(int argc, char **argv) {
                      "format:", 0.42001);
     utility::LogWarning("This Warning message should be visible, {} {:.2f}\n",
                         "format:", 0.42001);
-    utility::LogError("This Error message should be visible, {} {:.2f}\n",
-                      "format:", 0.42001);
 
     try {
-        utility::LogFatal("This Fatal exception is catched\n");
+        utility::LogError("This Error exception is catched\n");
     } catch (const std::exception &e) {
         utility::LogInfo("Catched exception msg: {}", e.what());
     }
     utility::LogInfo("This Info message shall print in regular color\n");
-    utility::LogFatal("This Fatal message terminates the program\n");
-    utility::LogFatal("This Fatal message should NOT be visible\n");
+    utility::LogError("This Error message terminates the program\n");
+    utility::LogError("This Error message should NOT be visible\n");
 
     return 0;
 }

--- a/examples/Cpp/OdometryRGBD.cpp
+++ b/examples/Cpp/OdometryRGBD.cpp
@@ -34,16 +34,16 @@ void PrintHelp(char* argv[]) {
 
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo(">    OdometryRGBD [color_source] [source_target] [color_target] [depth_target] [options]\n");
-    utility::LogInfo("     Given RGBD image pair, estimate 6D odometry.\n");
-    utility::LogInfo("     [options]\n");
-    utility::LogInfo("     --camera_intrinsic [intrinsic_path]\n");
-    utility::LogInfo("     --rgbd_type [number] (0:Redwood, 1:TUM, 2:SUN, 3:NYU)\n");
-    utility::LogInfo("     --verbose : indicate this to display detailed information\n");
-    utility::LogInfo("     --hybrid : compute odometry using hybrid objective\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo(">    OdometryRGBD [color_source] [source_target] [color_target] [depth_target] [options]");
+    utility::LogInfo("     Given RGBD image pair, estimate 6D odometry.");
+    utility::LogInfo("     [options]");
+    utility::LogInfo("     --camera_intrinsic [intrinsic_path]");
+    utility::LogInfo("     --rgbd_type [number] (0:Redwood, 1:TUM, 2:SUN, 3:NYU)");
+    utility::LogInfo("     --verbose : indicate this to display detailed information");
+    utility::LogInfo("     --hybrid : compute odometry using hybrid objective");
     // clang-NewPormat on
-    utility::LogInfo("\n");
+    utility::LogInfo("");
 }
 
 int main(int argc, char* argv[]) {
@@ -60,18 +60,18 @@ int main(int argc, char* argv[]) {
         intrinsic_path = utility::GetProgramOptionAsString(argc, argv,
                                                            "--camera_intrinsic")
                                  .c_str();
-        utility::LogInfo("Camera intrinsic path {}\n",
+        utility::LogInfo("Camera intrinsic path {}",
                            intrinsic_path.c_str());
     } else {
-        utility::LogWarning("Camera intrinsic path is not given\n");
+        utility::LogWarning("Camera intrinsic path is not given");
         return 1;
     }
     camera::PinholeCameraIntrinsic intrinsic;
     if (intrinsic_path.empty() ||
         !io::ReadIJsonConvertible(intrinsic_path, intrinsic)) {
         utility::LogWarning(
-                "Failed to read intrinsic parameters for depth image.\n");
-        utility::LogWarning("Using default value for Primesense camera.\n");
+                "Failed to read intrinsic parameters for depth image.");
+        utility::LogWarning("Using default value for Primesense camera.");
         intrinsic = camera::PinholeCameraIntrinsic(
                 camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
     }

--- a/examples/Cpp/OdometryRGBD.cpp
+++ b/examples/Cpp/OdometryRGBD.cpp
@@ -64,13 +64,14 @@ int main(int argc, char* argv[]) {
                            intrinsic_path.c_str());
     } else {
         utility::LogWarning("Camera intrinsic path is not given\n");
+        return 1;
     }
     camera::PinholeCameraIntrinsic intrinsic;
     if (intrinsic_path.empty() ||
         !io::ReadIJsonConvertible(intrinsic_path, intrinsic)) {
         utility::LogWarning(
                 "Failed to read intrinsic parameters for depth image.\n");
-        utility::LogWarning("Use default value for Primesense camera.\n");
+        utility::LogWarning("Using default value for Primesense camera.\n");
         intrinsic = camera::PinholeCameraIntrinsic(
                 camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
     }

--- a/examples/Cpp/OpenMP.cpp
+++ b/examples/Cpp/OpenMP.cpp
@@ -80,9 +80,9 @@ void TestMatrixMultiplication(int argc, char **argv) {
     }
 
 #ifdef _OPENMP
-    utility::LogInfo("OpenMP is supported.\n");
+    utility::LogInfo("OpenMP is supported.");
 #else
-    utility::LogInfo("OpenMP is not supported.\n");
+    utility::LogInfo("OpenMP is not supported.");
 #endif
 
 #ifdef _OPENMP
@@ -105,19 +105,19 @@ void TestMatrixMultiplication(int argc, char **argv) {
     }
 
     if (nThreads == NUM_THREADS) {
-        utility::LogInfo("{:d} OpenMP threads were used.\n", NUM_THREADS);
+        utility::LogInfo("{:d} OpenMP threads were used.", NUM_THREADS);
     } else {
-        utility::LogInfo("Expected {:d} OpenMP threads, but {:d} were used.\n",
+        utility::LogInfo("Expected {:d} OpenMP threads, but {:d} were used.",
                          NUM_THREADS, nThreads);
     }
 
     if (nSum != nSumCalc) {
         utility::LogInfo(
                 "The sum of {:d} through {:d} should be {:d}, "
-                "but {:d} was reported!\n",
+                "but {:d} was reported!",
                 NUM_START, NUM_END, nSumCalc, nSum);
     } else {
-        utility::LogInfo("The sum of {:d} through {:d} is {:d}\n", NUM_START,
+        utility::LogInfo("The sum of {:d} through {:d} is {:d}", NUM_START,
                          NUM_END, nSum);
     }
 
@@ -125,7 +125,7 @@ void TestMatrixMultiplication(int argc, char **argv) {
     if (argc > 1) {
         test_thread = std::stoi(argv[1]);
     }
-    open3d::utility::LogInfo("Benchmark multithreading up to {:d} threads.\n",
+    open3d::utility::LogInfo("Benchmark multithreading up to {:d} threads.",
                              test_thread);
 
     for (int i = 1; i <= test_thread; i *= 2) {

--- a/examples/Cpp/PCDFileFormat.cpp
+++ b/examples/Cpp/PCDFileFormat.cpp
@@ -35,12 +35,12 @@ int main(int argc, char **argv) {
     if (argc < 2) {
         PrintOpen3DVersion();
         // clang-format off
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > PCDFileFormat [filename] [ascii|binary|compressed]\n");
-        utility::LogInfo("    The program will :\n");
-        utility::LogInfo("    1. load the pointcloud in [filename].\n");
-        utility::LogInfo("    2. visualize the point cloud.\n");
-        utility::LogInfo("    3. if a save method is specified, write the point cloud into data.pcd.\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > PCDFileFormat [filename] [ascii|binary|compressed]");
+        utility::LogInfo("    The program will :");
+        utility::LogInfo("    1. load the pointcloud in [filename].");
+        utility::LogInfo("    2. visualize the point cloud.");
+        utility::LogInfo("    3. if a save method is specified, write the point cloud into data.pcd.");
         // clang-format on
         return 0;
     }

--- a/examples/Cpp/PointCloud.cpp
+++ b/examples/Cpp/PointCloud.cpp
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
         }
          */
     } else {
-        utility::LogError("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}\n\n", argv[1]);
     }
 
     // 3. test pointcloud visualization

--- a/examples/Cpp/PointCloud.cpp
+++ b/examples/Cpp/PointCloud.cpp
@@ -34,14 +34,14 @@ void PrintPointCloud(const open3d::geometry::PointCloud &pointcloud) {
     using namespace open3d;
 
     bool pointcloud_has_normal = pointcloud.HasNormals();
-    utility::LogInfo("Pointcloud has %d points.\n",
+    utility::LogInfo("Pointcloud has %d points.",
                      (int)pointcloud.points_.size());
 
     Eigen::Vector3d min_bound = pointcloud.GetMinBound();
     Eigen::Vector3d max_bound = pointcloud.GetMaxBound();
     utility::LogInfo(
             "Bounding box is: ({:.4f}, {:.4f}, {:.4f}) - ({:.4f}, {:.4f}, "
-            "{:.4f})\n",
+            "{:.4f})",
             min_bound(0), min_bound(1), min_bound(2), max_bound(0),
             max_bound(1), max_bound(2));
 
@@ -49,16 +49,16 @@ void PrintPointCloud(const open3d::geometry::PointCloud &pointcloud) {
         if (pointcloud_has_normal) {
             const Eigen::Vector3d &point = pointcloud.points_[i];
             const Eigen::Vector3d &normal = pointcloud.normals_[i];
-            utility::LogInfo("{:.6f} {:.6f} {:.6f} {:.6f} {:.6f} {:.6f}\n",
+            utility::LogInfo("{:.6f} {:.6f} {:.6f} {:.6f} {:.6f} {:.6f}",
                              point(0), point(1), point(2), normal(0), normal(1),
                              normal(2));
         } else {
             const Eigen::Vector3d &point = pointcloud.points_[i];
-            utility::LogInfo("{:.6f} {:.6f} {:.6f}\n", point(0), point(1),
+            utility::LogInfo("{:.6f} {:.6f} {:.6f}", point(0), point(1),
                              point(2));
         }
     }
-    utility::LogInfo("End of the list.\n\n");
+    utility::LogInfo("End of the list.");
 }
 
 int main(int argc, char *argv[]) {
@@ -123,26 +123,26 @@ int main(int argc, char *argv[]) {
     const std::string filename_ply("test.ply");
 
     if (io::ReadPointCloud(argv[1], pointcloud)) {
-        utility::LogInfo("Successfully read {}\n", argv[1]);
+        utility::LogInfo("Successfully read {}", argv[1]);
 
         /*
         geometry::PointCloud pointcloud_copy;
         pointcloud_copy.CloneFrom(pointcloud);
 
         if (io::WritePointCloud(filename_xyz, pointcloud)) {
-            utility::LogInfo("Successfully wrote {}\n\n",
+            utility::LogInfo("Successfully wrote {}",
         filename_xyz.c_str()); } else { utility::LogError("Failed to write
-        {}\n\n", filename_xyz);
+        {}", filename_xyz);
         }
 
         if (io::WritePointCloud(filename_ply, pointcloud_copy)) {
-            utility::LogInfo("Successfully wrote {}\n\n",
+            utility::LogInfo("Successfully wrote {}",
         filename_ply); } else { utility::LogError("Failed to write
-        {}\n\n", filename_ply);
+        {}", filename_ply);
         }
          */
     } else {
-        utility::LogWarning("Failed to read {}\n\n", argv[1]);
+        utility::LogWarning("Failed to read {}", argv[1]);
     }
 
     // 3. test pointcloud visualization
@@ -189,13 +189,13 @@ int main(int argc, char *argv[]) {
                   //        open3d::KDTreeSearchParamKNN(20));
                   pointcloud_ptr->EstimateNormals(
                           open3d::geometry::KDTreeSearchParamRadius(0.05));
-                  utility::LogInfo("Done.\n");
+                  utility::LogInfo("Done.");
                   return true;
               }}},
             "Press Space to Estimate Normal", 1600, 900);
 
     // n. test end
 
-    utility::LogInfo("End of the test.\n");
+    utility::LogInfo("End of the test.");
     return 0;
 }

--- a/examples/Cpp/PoseGraph.cpp
+++ b/examples/Cpp/PoseGraph.cpp
@@ -38,16 +38,16 @@ int main(int argc, char **argv) {
     if (argc != 2) {
         PrintOpen3DVersion();
         // clang-format off
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > PoseGraph [posegraph_for_optimization].json\n");
-        utility::LogInfo("    The program will :\n");
-        utility::LogInfo("    1) Generate random PoseGraph\n");
-        utility::LogInfo("    2) Save random PoseGraph as test_pose_graph.json\n");
-        utility::LogInfo("    3) Reads PoseGraph from test_pose_graph.json\n");
-        utility::LogInfo("    4) Save loaded PoseGraph as test_pose_graph_copy.json\n");
-        utility::LogInfo("    5) Load PoseGraph from [posegraph_for_optimization].json\n");
-        utility::LogInfo("    6) Optimize PoseGraph\n");
-        utility::LogInfo("    7) Save PoseGraph to pose_graph_optimized.json\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > PoseGraph [posegraph_for_optimization].json");
+        utility::LogInfo("    The program will :");
+        utility::LogInfo("    1) Generate random PoseGraph");
+        utility::LogInfo("    2) Save random PoseGraph as test_pose_graph.json");
+        utility::LogInfo("    3) Reads PoseGraph from test_pose_graph.json");
+        utility::LogInfo("    4) Save loaded PoseGraph as test_pose_graph_copy.json");
+        utility::LogInfo("    5) Load PoseGraph from [posegraph_for_optimization].json");
+        utility::LogInfo("    6) Optimize PoseGraph");
+        utility::LogInfo("    7) Save PoseGraph to pose_graph_optimized.json");
         // clang-format on
         return 1;
     }

--- a/examples/Cpp/ProgramOptions.cpp
+++ b/examples/Cpp/ProgramOptions.cpp
@@ -30,8 +30,8 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage :\n");
-    utility::LogInfo("    > ProgramOptions [--help] [--switch] [--int i] [--double d] [--string str] [--vector (x,y,z,...)]\n");
+    utility::LogInfo("Usage :");
+    utility::LogInfo("    > ProgramOptions [--help] [--switch] [--int i] [--double d] [--string str] [--vector (x,y,z,...)]");
     // clang-format on
 }
 
@@ -42,22 +42,22 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    utility::LogInfo("Switch is {}.\n",
+    utility::LogInfo("Switch is {}.",
                      utility::ProgramOptionExists(argc, argv, "--switch")
                              ? "ON"
                              : "OFF");
-    utility::LogInfo("Int is {:d}\n",
+    utility::LogInfo("Int is {:d}",
                      utility::GetProgramOptionAsInt(argc, argv, "--int"));
-    utility::LogInfo("Double is {:.10f}\n",
+    utility::LogInfo("Double is {:.10f}",
                      utility::GetProgramOptionAsDouble(argc, argv, "--double"));
-    utility::LogInfo("String is {}\n",
+    utility::LogInfo("String is {}",
                      utility::GetProgramOptionAsString(argc, argv, "--string"));
     std::vector<std::string> strs;
     utility::SplitString(
             strs, utility::GetProgramOptionAsString(argc, argv, "--string"),
             ",.", true);
     for (auto &str : strs) {
-        utility::LogInfo("\tSubstring : {}\n", str);
+        utility::LogInfo("\tSubstring : {}", str);
     }
     Eigen::VectorXd vec =
             utility::GetProgramOptionAsEigenVectorXd(argc, argv, "--vector");
@@ -69,6 +69,6 @@ int main(int argc, char *argv[]) {
             utility::LogInfo("{:.2f}", vec(i));
         }
     }
-    utility::LogInfo(")\n");
+    utility::LogInfo(")");
     return 0;
 }

--- a/examples/Cpp/RGBDOdometry.cpp
+++ b/examples/Cpp/RGBDOdometry.cpp
@@ -30,9 +30,8 @@ using namespace open3d;
 
 void PrintHelp() {
     PrintOpen3DVersion();
-    utility::LogInfo("Usage :\n");
-    utility::LogInfo(
-            "    > RGBDOdometry [color1] [depth1] [color2] [depth2]\n");
+    utility::LogInfo("Usage :");
+    utility::LogInfo("    > RGBDOdometry [color1] [depth1] [color2] [depth2]");
 }
 
 std::shared_ptr<geometry::RGBDImage> ReadRGBDImage(
@@ -43,15 +42,13 @@ std::shared_ptr<geometry::RGBDImage> ReadRGBDImage(
     geometry::Image color, depth;
     io::ReadImage(color_filename, color);
     io::ReadImage(depth_filename, depth);
-    utility::LogInfo("Reading RGBD image : \n");
-    utility::LogInfo(
-            "     Color : {:d} x {:d} x {:d} ({:d} bits per channel)\n",
-            color.width_, color.height_, color.num_of_channels_,
-            color.bytes_per_channel_ * 8);
-    utility::LogInfo(
-            "     Depth : {:d} x {:d} x {:d} ({:d} bits per channel)\n",
-            depth.width_, depth.height_, depth.num_of_channels_,
-            depth.bytes_per_channel_ * 8);
+    utility::LogInfo("Reading RGBD image : ");
+    utility::LogInfo("     Color : {:d} x {:d} x {:d} ({:d} bits per channel)",
+                     color.width_, color.height_, color.num_of_channels_,
+                     color.bytes_per_channel_ * 8);
+    utility::LogInfo("     Depth : {:d} x {:d} x {:d} ({:d} bits per channel)",
+                     depth.width_, depth.height_, depth.num_of_channels_,
+                     depth.bytes_per_channel_ * 8);
     double depth_scale = 1000.0, depth_trunc = 3.0;
     bool convert_rgb_to_intensity = true;
     std::shared_ptr<geometry::RGBDImage> rgbd_image =

--- a/examples/Cpp/RealSense.cpp
+++ b/examples/Cpp/RealSense.cpp
@@ -34,17 +34,16 @@ using namespace open3d;
 
 int main(int argc, char **args) {
     rs::context ctx;
-    utility::LogInfo("There are {:d} connected RealSense devices.\n",
+    utility::LogInfo("There are {:d} connected RealSense devices.",
                      ctx.get_device_count());
     if (ctx.get_device_count() == 0) {
         return 1;
     }
 
     rs::device *dev = ctx.get_device(0);
-    utility::LogInfo("Using device 0, an {}\n", dev->get_name());
-    utility::LogInfo("    Serial number: {}\n", dev->get_serial());
-    utility::LogInfo("    Firmware version: {}\n\n",
-                     dev->get_firmware_version());
+    utility::LogInfo("Using device 0, an {}", dev->get_name());
+    utility::LogInfo("    Serial number: {}", dev->get_serial());
+    utility::LogInfo("    Firmware version: {}", dev->get_firmware_version());
 
     dev->set_option(rs::option::color_enable_auto_exposure, 0.0);
     dev->set_option(rs::option::color_exposure, 625);
@@ -68,39 +67,39 @@ int main(int argc, char **args) {
     for (int i = 0; i < 9; i++) {
         utility::LogInfo("{:.6f} ", extrinsics.rotation[i]);
     }
-    utility::LogInfo("\n");
+    utility::LogInfo("");
     for (int i = 0; i < 3; i++) {
         utility::LogInfo("{:.6f} ", extrinsics.translation[i]);
     }
-    utility::LogInfo("\n");
+    utility::LogInfo("");
 
     rs::intrinsics depth_intr = dev->get_stream_intrinsics(rs::stream::depth);
-    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}\n",
-                     depth_intr.width, depth_intr.height, depth_intr.fx,
-                     depth_intr.fy, depth_intr.ppx, depth_intr.ppy);
+    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}", depth_intr.width,
+                     depth_intr.height, depth_intr.fx, depth_intr.fy,
+                     depth_intr.ppx, depth_intr.ppy);
     for (int i = 0; i < 5; i++) {
         utility::LogInfo("{:.6f} ", depth_intr.coeffs[i]);
     }
-    utility::LogInfo("\n\n");
+    utility::LogInfo("");
 
     rs::intrinsics color_intr = dev->get_stream_intrinsics(rs::stream::color);
-    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}\n",
-                     color_intr.width, color_intr.height, color_intr.fx,
-                     color_intr.fy, color_intr.ppx, color_intr.ppy);
+    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}", color_intr.width,
+                     color_intr.height, color_intr.fx, color_intr.fy,
+                     color_intr.ppx, color_intr.ppy);
     for (int i = 0; i < 5; i++) {
         utility::LogInfo("{:.6f} ", color_intr.coeffs[i]);
     }
-    utility::LogInfo("\n\n");
+    utility::LogInfo("");
 
     rs::intrinsics rect_intr =
             dev->get_stream_intrinsics(rs::stream::rectified_color);
-    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}\n", rect_intr.width,
+    utility::LogInfo("{:d} {:d} {:.6f} {:.6f} {:.6f} {:.6f}", rect_intr.width,
                      rect_intr.height, rect_intr.fx, rect_intr.fy,
                      rect_intr.ppx, rect_intr.ppy);
     for (int i = 0; i < 5; i++) {
         utility::LogInfo("{:.6f} ", rect_intr.coeffs[i]);
     }
-    utility::LogInfo("\n\n");
+    utility::LogInfo("");
 
     visualization::Visualizer depth_vis, color_vis;
     if (depth_vis.CreateVisualizerWindow("Depth", 640, 480, 15, 50) == false ||
@@ -122,7 +121,7 @@ int main(int argc, char **args) {
         depth_vis.UpdateGeometry();
         color_vis.UpdateGeometry();
 
-        utility::LogInfo("{:.2f}\n",
+        utility::LogInfo("{:.2f}",
                          dev->get_option(rs::option::color_white_balance));
 
         /*
@@ -142,7 +141,7 @@ int main(int argc, char **args) {
         dev->get_options((const rs::option *)opts, 10, (double *)value);
         utility::LogInfo("{:.2f} {:.2f} {:.2f} {:.2f} {:.2f} {:.2f} {:.2f}
         {:.2f} {:.2f}
-        {:.2f}\n", value[0], value[1], value[2], value[3], value[4], value[5],
+        {:.2f}", value[0], value[1], value[2], value[3], value[4], value[5],
         value[6], value[7], value[8], value[9]);
         */
     }

--- a/examples/Cpp/RegistrationRANSAC.cpp
+++ b/examples/Cpp/RegistrationRANSAC.cpp
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
     if (argc != 3 && argc != 4) {
         utility::LogInfo(
                 "Usage : RegistrationRANSAC [path_to_first_point_cloud] "
-                "[path_to_second_point_cloud] --visualize\n");
+                "[path_to_second_point_cloud] --visualize");
         return 1;
     }
 

--- a/examples/Cpp/TriangleMesh.cpp
+++ b/examples/Cpp/TriangleMesh.cpp
@@ -30,10 +30,10 @@
 
 void PrintHelp() {
     using namespace open3d;
-    utility::LogInfo("Usage :\n");
-    utility::LogInfo("    > TriangleMesh sphere\n");
-    utility::LogInfo("    > TriangleMesh merge <file1> <file2>\n");
-    utility::LogInfo("    > TriangleMesh normal <file1> <file2>\n");
+    utility::LogInfo("Usage :");
+    utility::LogInfo("    > TriangleMesh sphere");
+    utility::LogInfo("    > TriangleMesh merge <file1> <file2>");
+    utility::LogInfo("    > TriangleMesh normal <file1> <file2>");
 }
 
 void PaintMesh(open3d::geometry::TriangleMesh &mesh,
@@ -91,13 +91,13 @@ int main(int argc, char *argv[]) {
     } else if (option == "merge") {
         auto mesh1 = io::CreateMeshFromFile(argv[2]);
         auto mesh2 = io::CreateMeshFromFile(argv[3]);
-        utility::LogInfo("Mesh1 has {:d} vertices, {:d} triangles.\n",
+        utility::LogInfo("Mesh1 has {:d} vertices, {:d} triangles.",
                          mesh1->vertices_.size(), mesh1->triangles_.size());
-        utility::LogInfo("Mesh2 has {:d} vertices, {:d} triangles.\n",
+        utility::LogInfo("Mesh2 has {:d} vertices, {:d} triangles.",
                          mesh2->vertices_.size(), mesh2->triangles_.size());
         *mesh1 += *mesh2;
         utility::LogInfo(
-                "After merge, Mesh1 has {:d} vertices, {:d} triangles.\n",
+                "After merge, Mesh1 has {:d} vertices, {:d} triangles.",
                 mesh1->vertices_.size(), mesh1->triangles_.size());
         mesh1->RemoveDuplicatedVertices();
         mesh1->RemoveDuplicatedTriangles();
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
         mesh1->RemoveUnreferencedVertices();
         utility::LogInfo(
                 "After purge vertices, Mesh1 has {:d} vertices, {:d} "
-                "triangles.\n",
+                "triangles.",
                 mesh1->vertices_.size(), mesh1->triangles_.size());
         visualization::DrawGeometries({mesh1});
         io::WriteTriangleMesh("temp.ply", *mesh1, true, true);
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
             mesh1->vertex_colors_[i] = Eigen::Vector3d(color, color, color);
             r += sqrt(dists[0]);
         }
-        utility::LogInfo("Average distance is {:.6f}.\n",
+        utility::LogInfo("Average distance is {:.6f}.",
                          r / (double)mesh1->vertices_.size());
         if (argc > 5) {
             io::WriteTriangleMesh(argv[5], *mesh1);
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]) {
         camera::PinholeCameraTrajectory trajectory;
         io::ReadIJsonConvertible(argv[3], trajectory);
         if (utility::filesystem::DirectoryExists("image") == false) {
-            utility::LogWarning("No image!\n");
+            utility::LogWarning("No image!");
             return 0;
         }
         int idx = 3000;
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
             std::cout << pt_in_plane / pt_in_plane(2) << std::endl;
             auto result = fimage->FloatValueAt(uv(0), uv(1));
             if (result.first) {
-                utility::LogInfo("{:.6f}\n", result.second);
+                utility::LogInfo("{:.6f}", result.second);
             }
             visualization::DrawGeometries({fimage}, "Test", 1920, 1080);
         }

--- a/examples/Cpp/TrimMeshBasedOnPointCloud.cpp
+++ b/examples/Cpp/TrimMeshBasedOnPointCloud.cpp
@@ -30,17 +30,17 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > TrimMeshBasedOnPointCloud [options]\n");
-    utility::LogInfo("      Trim a mesh baesd on distance to a point cloud.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
-    utility::LogInfo("    --in_mesh mesh_file       : Input mesh file. MUST HAVE.\n");
-    utility::LogInfo("    --out_mesh mesh_file      : Output mesh file. MUST HAVE.\n");
-    utility::LogInfo("    --pointcloud pcd_file     : Reference pointcloud file. MUST HAVE.\n");
-    utility::LogInfo("    --distance d              : Maximum distance. MUST HAVE.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > TrimMeshBasedOnPointCloud [options]");
+    utility::LogInfo("      Trim a mesh baesd on distance to a point cloud.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
+    utility::LogInfo("    --in_mesh mesh_file       : Input mesh file. MUST HAVE.");
+    utility::LogInfo("    --out_mesh mesh_file      : Output mesh file. MUST HAVE.");
+    utility::LogInfo("    --pointcloud pcd_file     : Reference pointcloud file. MUST HAVE.");
+    utility::LogInfo("    --distance d              : Maximum distance. MUST HAVE.");
     // clang-format on
 }
 
@@ -62,17 +62,17 @@ int main(int argc, char *argv[]) {
             utility::GetProgramOptionAsString(argc, argv, "--pointcloud");
     auto distance = utility::GetProgramOptionAsDouble(argc, argv, "--distance");
     if (distance <= 0.0) {
-        utility::LogWarning("Illegal distance.\n");
+        utility::LogWarning("Illegal distance.");
         return 1;
     }
     if (in_mesh_file.empty() || out_mesh_file.empty() || pcd_file.empty()) {
-        utility::LogWarning("Missing file names.\n");
+        utility::LogWarning("Missing file names.");
         return 1;
     }
     auto mesh = io::CreateMeshFromFile(in_mesh_file);
     auto pcd = io::CreatePointCloudFromFile(pcd_file);
     if (mesh->IsEmpty() || pcd->IsEmpty()) {
-        utility::LogWarning("Empty geometry.\n");
+        utility::LogWarning("Empty geometry.");
         return 1;
     }
 
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
     }
     utility::LogInfo(
             "[TrimMeshBasedOnPointCloud] {:d} vertices and {:d} triangles have "
-            "been removed.\n",
+            "been removed.",
             old_vertex_num - k, old_triangle_num - kt);
     io::WriteTriangleMesh(out_mesh_file, *mesh);
     return 0;

--- a/examples/Cpp/ViewDistances.cpp
+++ b/examples/Cpp/ViewDistances.cpp
@@ -30,18 +30,18 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ViewDistances source_file [options]\n");
-    utility::LogInfo("      View color coded distances of a point cloud.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
-    utility::LogInfo("    --max_distance d          : Set max distance. Must be positive.\n");
-    utility::LogInfo("    --mahalanobis_distance    : Compute the Mahalanobis distance.\n");
-    utility::LogInfo("    --nn_distance             : Compute the NN distance.\n");
-    utility::LogInfo("    --write_color_back        : Write color back to source_file.\n");
-    utility::LogInfo("    --without_gui             : Without GUI.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ViewDistances source_file [options]");
+    utility::LogInfo("      View color coded distances of a point cloud.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
+    utility::LogInfo("    --max_distance d          : Set max distance. Must be positive.");
+    utility::LogInfo("    --mahalanobis_distance    : Compute the Mahalanobis distance.");
+    utility::LogInfo("    --nn_distance             : Compute the NN distance.");
+    utility::LogInfo("    --write_color_back        : Write color back to source_file.");
+    utility::LogInfo("    --without_gui             : Without GUI.");
     // clang-format on
 }
 
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
             argc, argv, "--max_distance", 0.0);
     auto pcd = io::CreatePointCloudFromFile(argv[1]);
     if (pcd->IsEmpty()) {
-        utility::LogWarning("Empty point cloud.\n");
+        utility::LogWarning("Empty point cloud.");
         return 1;
     }
     std::string binname =
@@ -78,17 +78,17 @@ int main(int argc, char *argv[]) {
     } else {
         FILE *f = utility::filesystem::FOpen(binname, "rb");
         if (f == NULL) {
-            utility::LogWarning("Cannot open bin file.\n");
+            utility::LogWarning("Cannot open bin file.");
             return 1;
         }
         if (fread(distances.data(), sizeof(double), pcd->points_.size(), f) !=
             pcd->points_.size()) {
-            utility::LogWarning("Cannot open bin file.\n");
+            utility::LogWarning("Cannot open bin file.");
             return 1;
         }
     }
     if (max_distance <= 0.0) {
-        utility::LogWarning("Max distance must be a positive value.\n");
+        utility::LogWarning("Max distance must be a positive value.");
         return 1;
     }
     pcd->colors_.resize(pcd->points_.size());

--- a/examples/Cpp/ViewPCDMatch.cpp
+++ b/examples/Cpp/ViewPCDMatch.cpp
@@ -38,7 +38,7 @@ bool ReadLogFile(const std::string &filename,
     transformations.clear();
     FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
-        utility::LogWarning("Read LOG failed: unable to open file.\n");
+        utility::LogWarning("Read LOG failed: unable to open file.");
         return false;
     }
     char line_buffer[DEFAULT_IO_BUFFER_SIZE];
@@ -47,32 +47,32 @@ bool ReadLogFile(const std::string &filename,
     while (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f)) {
         if (strlen(line_buffer) > 0 && line_buffer[0] != '#') {
             if (sscanf(line_buffer, "%d %d %d", &i, &j, &k) != 3) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(0, 0),
                        &trans(0, 1), &trans(0, 2), &trans(0, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(1, 0),
                        &trans(1, 1), &trans(1, 2), &trans(1, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(2, 0),
                        &trans(2, 1), &trans(2, 2), &trans(2, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 return false;
             } else {
                 sscanf(line_buffer, "%lf %lf %lf %lf", &trans(3, 0),
@@ -90,15 +90,15 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ViewPCDMatch [options]\n");
-    utility::LogInfo("      View pairwise matching result of point clouds.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.\n");
-    utility::LogInfo("    --dir directory           : The directory storing all pcd files. By default it is the parent directory of the log file + pcd/.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ViewPCDMatch [options]");
+    utility::LogInfo("      View pairwise matching result of point clouds.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --log file                : A log file of the pairwise matching results. Must have.");
+    utility::LogInfo("    --dir directory           : The directory storing all pcd files. By default it is the parent directory of the log file + pcd/.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
     // clang-format on
 }
 
@@ -137,8 +137,7 @@ int main(int argc, char *argv[]) {
 
     for (size_t k = 0; k < metadata.size(); k++) {
         auto i = std::get<0>(metadata[k]), j = std::get<1>(metadata[k]);
-        utility::LogInfo("Showing matched point cloud #{:d} and #{:d}.\n", i,
-                         j);
+        utility::LogInfo("Showing matched point cloud #{:d} and #{:d}.", i, j);
         auto pcd_target = io::CreatePointCloudFromFile(
                 pcd_dirname + "cloud_bin_" + std::to_string(i) + ".pcd");
         pcd_target->colors_.clear();

--- a/examples/Cpp/Visualizer.cpp
+++ b/examples/Cpp/Visualizer.cpp
@@ -34,10 +34,10 @@ void PrintUsage() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > Visualizer [mesh|spin|slowspin|pointcloud|rainbow|image|depth|editing] [filename]\n");
-    utility::LogInfo("    > Visualizer [animation] [filename] [trajectoryfile]\n");
-    utility::LogInfo("    > Visualizer [rgbd] [color] [depth] [--rgbd_type]\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > Visualizer [mesh|spin|slowspin|pointcloud|rainbow|image|depth|editing] [filename]");
+    utility::LogInfo("    > Visualizer [animation] [filename] [trajectoryfile]");
+    utility::LogInfo("    > Visualizer [rgbd] [color] [depth] [--rgbd_type]");
     // clang-format on
 }
 int main(int argc, char *argv[]) {
@@ -53,9 +53,9 @@ int main(int argc, char *argv[]) {
     if (option == "mesh") {
         auto mesh_ptr = std::make_shared<geometry::TriangleMesh>();
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -63,9 +63,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "spin") {
         auto mesh_ptr = std::make_shared<geometry::TriangleMesh>();
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -80,9 +80,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "slowspin") {
         auto mesh_ptr = std::make_shared<geometry::TriangleMesh>();
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -99,9 +99,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "pointcloud") {
         auto cloud_ptr = std::make_shared<geometry::PointCloud>();
         if (io::ReadPointCloud(argv[2], *cloud_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         cloud_ptr->NormalizeNormals();
@@ -109,9 +109,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "rainbow") {
         auto cloud_ptr = std::make_shared<geometry::PointCloud>();
         if (io::ReadPointCloud(argv[2], *cloud_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         cloud_ptr->NormalizeNormals();
@@ -140,9 +140,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "image") {
         auto image_ptr = std::make_shared<geometry::Image>();
         if (io::ReadImage(argv[2], *image_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         visualization::DrawGeometries({image_ptr}, "Image", image_ptr->width_,
@@ -159,16 +159,16 @@ int main(int argc, char *argv[]) {
         auto depth_ptr = std::make_shared<geometry::Image>();
 
         if (io::ReadImage(argv[2], *color_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
 
         if (io::ReadImage(argv[3], *depth_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[3]);
+            utility::LogInfo("Successfully read {}", argv[3]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[3]);
+            utility::LogWarning("Failed to read {}", argv[3]);
             return 1;
         }
 
@@ -203,9 +203,9 @@ int main(int argc, char *argv[]) {
     } else if (option == "animation") {
         auto mesh_ptr = std::make_shared<geometry::TriangleMesh>();
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
-            utility::LogInfo("Successfully read {}\n", argv[2]);
+            utility::LogInfo("Successfully read {}", argv[2]);
         } else {
-            utility::LogWarning("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -218,7 +218,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    utility::LogInfo("End of the test.\n");
+    utility::LogInfo("End of the test.");
 
     return 0;
 }

--- a/examples/Cpp/Visualizer.cpp
+++ b/examples/Cpp/Visualizer.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadPointCloud(argv[2], *cloud_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         cloud_ptr->NormalizeNormals();
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadPointCloud(argv[2], *cloud_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         cloud_ptr->NormalizeNormals();
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadImage(argv[2], *image_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         visualization::DrawGeometries({image_ptr}, "Image", image_ptr->width_,
@@ -161,14 +161,14 @@ int main(int argc, char *argv[]) {
         if (io::ReadImage(argv[2], *color_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
 
         if (io::ReadImage(argv[3], *depth_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[3]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[3]);
+            utility::LogWarning("Failed to read {}\n\n", argv[3]);
             return 1;
         }
 
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
         if (io::ReadTriangleMesh(argv[2], *mesh_ptr)) {
             utility::LogInfo("Successfully read {}\n", argv[2]);
         } else {
-            utility::LogError("Failed to read {}\n\n", argv[2]);
+            utility::LogWarning("Failed to read {}\n\n", argv[2]);
             return 1;
         }
         mesh_ptr->ComputeVertexNormals();

--- a/examples/Cpp/Voxelization.cpp
+++ b/examples/Cpp/Voxelization.cpp
@@ -29,13 +29,12 @@
 using namespace open3d;
 
 void PrintVoxelGridInformation(const geometry::VoxelGrid& voxel_grid) {
-    utility::LogInfo("geometry::VoxelGrid with {:d} voxels\n",
+    utility::LogInfo("geometry::VoxelGrid with {:d} voxels",
                      voxel_grid.voxels_.size());
-    utility::LogInfo("               origin: [{:f} {:f} {:f}]\n",
+    utility::LogInfo("               origin: [{:f} {:f} {:f}]",
                      voxel_grid.origin_(0), voxel_grid.origin_(1),
                      voxel_grid.origin_(2));
-    utility::LogInfo("               voxel_size: {:f}\n",
-                     voxel_grid.voxel_size_);
+    utility::LogInfo("               voxel_size: {:f}", voxel_grid.voxel_size_);
     return;
 }
 
@@ -46,8 +45,8 @@ int main(int argc, char** args) {
     if (argc < 3) {
         PrintOpen3DVersion();
         // clang-format off
-        utility::LogInfo("Usage:\n");
-        utility::LogInfo("    > Voxelization [pointcloud_filename] [voxel_filename_ply]\n");
+        utility::LogInfo("Usage:");
+        utility::LogInfo("    > Voxelization [pointcloud_filename] [voxel_filename_ply]");
         // clang-format on
         return 1;
     }

--- a/src/Open3D/Camera/PinholeCameraIntrinsic.cpp
+++ b/src/Open3D/Camera/PinholeCameraIntrinsic.cpp
@@ -70,7 +70,7 @@ bool PinholeCameraIntrinsic::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "PinholeCameraParameters read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     width_ = value.get("width", -1).asInt();
@@ -78,7 +78,7 @@ bool PinholeCameraIntrinsic::ConvertFromJsonValue(const Json::Value &value) {
     if (EigenMatrix3dFromJsonArray(intrinsic_matrix_,
                                    value["intrinsic_matrix"]) == false) {
         utility::LogWarning(
-                "PinholeCameraParameters read JSON failed: wrong format.\n");
+                "PinholeCameraParameters read JSON failed: wrong format.");
         return false;
     }
     return true;

--- a/src/Open3D/Camera/PinholeCameraParameters.cpp
+++ b/src/Open3D/Camera/PinholeCameraParameters.cpp
@@ -54,7 +54,7 @@ bool PinholeCameraParameters::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "PinholeCameraParameters read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "PinholeCameraParameters" ||
@@ -62,7 +62,7 @@ bool PinholeCameraParameters::ConvertFromJsonValue(const Json::Value &value) {
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
                 "PinholeCameraParameters read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (intrinsic_.ConvertFromJsonValue(value["intrinsic"]) == false) {

--- a/src/Open3D/Camera/PinholeCameraTrajectory.cpp
+++ b/src/Open3D/Camera/PinholeCameraTrajectory.cpp
@@ -57,7 +57,7 @@ bool PinholeCameraTrajectory::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "PinholeCameraTrajectory read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "PinholeCameraTrajectory" ||
@@ -65,7 +65,7 @@ bool PinholeCameraTrajectory::ConvertFromJsonValue(const Json::Value &value) {
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
                 "PinholeCameraTrajectory read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
 
@@ -74,7 +74,7 @@ bool PinholeCameraTrajectory::ConvertFromJsonValue(const Json::Value &value) {
     if (parameter_array.size() == 0) {
         utility::LogWarning(
                 "PinholeCameraTrajectory read JSON failed: empty "
-                "trajectory.\n");
+                "trajectory.");
         return false;
     }
     parameters_.resize(parameter_array.size());

--- a/src/Open3D/ColorMap/ColorMapOptimization.cpp
+++ b/src/Open3D/ColorMap/ColorMapOptimization.cpp
@@ -135,7 +135,7 @@ void OptimizeImageCoorNonrigid(
                 residual_reg += rr_reg;
             }
         }
-        utility::LogDebug("Residual error : {:.6f}, reg : {:.6f}\n", residual,
+        utility::LogDebug("Residual error : {:.6f}, reg : {:.6f}", residual,
                           residual_reg);
         SetProxyIntensityForVertex(mesh, images_gray, warping_fields, camera,
                                    visiblity_vertex_to_image, proxy_intensity,
@@ -206,7 +206,7 @@ void OptimizeImageCoorRigid(
                 total_num_ += int(visiblity_image_to_vertex[c].size());
             }
         }
-        utility::LogDebug("Residual error : {:.6f} (avg : {:.6f})\n", residual,
+        utility::LogDebug("Residual error : {:.6f} (avg : {:.6f})", residual,
                           residual / total_num_);
         SetProxyIntensityForVertex(mesh, images_gray, camera,
                                    visiblity_vertex_to_image, proxy_intensity,
@@ -250,7 +250,7 @@ std::vector<std::shared_ptr<geometry::Image>> CreateDepthBoundaryMasks(
     auto n_images = images_depth.size();
     std::vector<std::shared_ptr<geometry::Image>> masks;
     for (size_t i = 0; i < n_images; i++) {
-        utility::LogDebug("[MakeDepthMasks] geometry::Image {:d}/{:d}\n", i,
+        utility::LogDebug("[MakeDepthMasks] geometry::Image {:d}/{:d}", i,
                           n_images);
         masks.push_back(images_depth[i]->CreateDepthBoundaryMask(
                 option.depth_threshold_for_discontinuity_check_,
@@ -281,16 +281,16 @@ void ColorMapOptimization(
         camera::PinholeCameraTrajectory& camera,
         const ColorMapOptimizationOption& option
         /* = ColorMapOptimizationOption()*/) {
-    utility::LogDebug("[ColorMapOptimization]\n");
+    utility::LogDebug("[ColorMapOptimization]");
     std::vector<std::shared_ptr<geometry::Image>> images_gray, images_dx,
             images_dy, images_color, images_depth;
     std::tie(images_gray, images_dx, images_dy, images_color, images_depth) =
             CreateGradientImages(images_rgbd);
 
-    utility::LogDebug("[ColorMapOptimization] :: MakingMasks\n");
+    utility::LogDebug("[ColorMapOptimization] :: MakingMasks");
     auto images_mask = CreateDepthBoundaryMasks(images_depth, option);
 
-    utility::LogDebug("[ColorMapOptimization] :: VisibilityCheck\n");
+    utility::LogDebug("[ColorMapOptimization] :: VisibilityCheck");
     std::vector<std::vector<int>> visiblity_vertex_to_image;
     std::vector<std::vector<int>> visiblity_image_to_vertex;
     std::tie(visiblity_vertex_to_image, visiblity_image_to_vertex) =
@@ -301,7 +301,7 @@ void ColorMapOptimization(
 
     std::vector<double> proxy_intensity;
     if (option.non_rigid_camera_coordinate_) {
-        utility::LogDebug("[ColorMapOptimization] :: Non-Rigid Optimization\n");
+        utility::LogDebug("[ColorMapOptimization] :: Non-Rigid Optimization");
         auto warping_uv_ = CreateWarpingFields(images_gray, option);
         auto warping_uv_init_ = CreateWarpingFields(images_gray, option);
         OptimizeImageCoorNonrigid(
@@ -313,7 +313,7 @@ void ColorMapOptimization(
                                 option.image_boundary_margin_,
                                 option.invisible_vertex_color_knn_);
     } else {
-        utility::LogDebug("[ColorMapOptimization] :: Rigid Optimization\n");
+        utility::LogDebug("[ColorMapOptimization] :: Rigid Optimization");
         OptimizeImageCoorRigid(mesh, images_gray, images_dx, images_dy, camera,
                                visiblity_vertex_to_image,
                                visiblity_image_to_vertex, proxy_intensity,

--- a/src/Open3D/ColorMap/EigenHelperForNonRigidOptimization.cpp
+++ b/src/Open3D/ColorMap/EigenHelperForNonRigidOptimization.cpp
@@ -84,7 +84,7 @@ std::tuple<MatOutType, VecOutType, double> ComputeJTJandJTrNonRigid(
     }
 #endif
     if (verbose) {
-        utility::LogDebug("Residual : {:.2e} (# of elements : {:d})\n",
+        utility::LogDebug("Residual : {:.2e} (# of elements : {:d})",
                           r2_sum / (double)iteration_num, iteration_num);
     }
     return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);

--- a/src/Open3D/ColorMap/ImageWarpingField.cpp
+++ b/src/Open3D/ColorMap/ImageWarpingField.cpp
@@ -95,7 +95,7 @@ bool ImageWarpingField::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "ImageWarpingField read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "ImageWarpingField" ||
@@ -103,7 +103,7 @@ bool ImageWarpingField::ConvertFromJsonValue(const Json::Value &value) {
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
                 "ImageWarpingField read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     anchor_w_ = value.get("anchor_w", 1).asInt();
@@ -113,7 +113,7 @@ bool ImageWarpingField::ConvertFromJsonValue(const Json::Value &value) {
     if (flow_array.size() == 0 ||
         int(flow_array.size()) != (anchor_w_ * anchor_h_ * 2)) {
         utility::LogWarning(
-                "ImageWarpingField read JSON failed: invalid flow.\n");
+                "ImageWarpingField read JSON failed: invalid flow.");
         return false;
     }
     flow_.resize(anchor_w_ * anchor_h_ * 2, 1);

--- a/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.cpp
+++ b/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.cpp
@@ -92,7 +92,7 @@ CreateVertexAndImageVisibility(
                 }
             }
         }
-        utility::LogDebug("[cam {:d}] {:.5f} percents are visible\n", c,
+        utility::LogDebug("[cam {:d}] {:.5f} percents are visible", c,
                           double(viscnt) / n_vertex * 100);
         fflush(stdout);
     }

--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -71,8 +71,7 @@ OrientedBoundingBox& OrientedBoundingBox::Transform(
         const Eigen::Matrix4d& transformation) {
     utility::LogError(
             "A general transform of an OrientedBoundingBox is not implemented. "
-            "Call Translate, "
-            "Scale, and Rotate.\n");
+            "Call Translate, Scale, and Rotate.");
     return *this;
 }
 
@@ -247,7 +246,7 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Transform(
         const Eigen::Matrix4d& transformation) {
     utility::LogError(
             "A general transform of a AxisAlignedBoundingBox would not be axis "
-            "aligned anymore, convert it to a OrientedBoundingBox first\n");
+            "aligned anymore, convert it to a OrientedBoundingBox first");
     return *this;
 }
 
@@ -281,7 +280,7 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Rotate(
         const Eigen::Matrix3d& rotation, bool center) {
     utility::LogError(
             "A rotation of a AxisAlignedBoundingBox would not be axis aligned "
-            "anymore, convert it to an OrientedBoundingBox first\n");
+            "anymore, convert it to an OrientedBoundingBox first");
     return *this;
 }
 

--- a/src/Open3D/Geometry/BoundingVolume.cpp
+++ b/src/Open3D/Geometry/BoundingVolume.cpp
@@ -69,7 +69,7 @@ OrientedBoundingBox OrientedBoundingBox::GetOrientedBoundingBox() const {
 
 OrientedBoundingBox& OrientedBoundingBox::Transform(
         const Eigen::Matrix4d& transformation) {
-    utility::LogWarning(
+    utility::LogError(
             "A general transform of an OrientedBoundingBox is not implemented. "
             "Call Translate, "
             "Scale, and Rotate.\n");
@@ -245,7 +245,7 @@ OrientedBoundingBox AxisAlignedBoundingBox::GetOrientedBoundingBox() const {
 
 AxisAlignedBoundingBox& AxisAlignedBoundingBox::Transform(
         const Eigen::Matrix4d& transformation) {
-    utility::LogWarning(
+    utility::LogError(
             "A general transform of a AxisAlignedBoundingBox would not be axis "
             "aligned anymore, convert it to a OrientedBoundingBox first\n");
     return *this;
@@ -279,7 +279,7 @@ AxisAlignedBoundingBox& AxisAlignedBoundingBox::Scale(const double scale,
 
 AxisAlignedBoundingBox& AxisAlignedBoundingBox::Rotate(
         const Eigen::Matrix3d& rotation, bool center) {
-    utility::LogWarning(
+    utility::LogError(
             "A rotation of a AxisAlignedBoundingBox would not be axis aligned "
             "anymore, convert it to an OrientedBoundingBox first\n");
     return *this;

--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -171,8 +171,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectDownSample(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SelectDownSample] This mesh contains triangle uvs that are "
-                "not handled "
-                "in this function\n");
+                "not handled in this function\n");
     }
     auto output = std::make_shared<TriangleMesh>();
     bool has_triangle_normals = HasTriangleNormals();
@@ -257,8 +256,7 @@ std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
         double voxel_size) const {
     auto output = std::make_shared<PointCloud>();
     if (voxel_size <= 0.0) {
-        utility::LogWarning("[VoxelDownSample] voxel_size <= 0.\n");
-        return output;
+        utility::LogError("[VoxelDownSample] voxel_size <= 0.\n");
     }
     Eigen::Vector3d voxel_size3 =
             Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
@@ -266,8 +264,7 @@ std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
     Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogWarning("[VoxelDownSample] voxel_size is too small.\n");
-        return output;
+        utility::LogError("[VoxelDownSample] voxel_size is too small.\n");
     }
     std::unordered_map<Eigen::Vector3i, AccumulatedPoint,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -306,8 +303,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
     auto output = std::make_shared<PointCloud>();
     Eigen::MatrixXi cubic_id;
     if (voxel_size <= 0.0) {
-        utility::LogWarning("[VoxelDownSample] voxel_size <= 0.\n");
-        return std::make_tuple(output, cubic_id);
+        utility::LogError("[VoxelDownSample] voxel_size <= 0.\n");
     }
     // Note: this is different from VoxelDownSample.
     // It is for fixing coordinate for multiscale voxel space
@@ -315,8 +311,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
     auto voxel_max_bound = max_bound;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogWarning("[VoxelDownSample] voxel_size is too small.\n");
-        return std::make_tuple(output, cubic_id);
+        utility::LogError("[VoxelDownSample] voxel_size is too small.\n");
     }
     std::unordered_map<Eigen::Vector3i, AccumulatedPointForTrace,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -370,8 +365,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
 std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
         size_t every_k_points) const {
     if (every_k_points == 0) {
-        utility::LogWarning("[UniformDownSample] Illegal sample rate.\n");
-        return std::make_shared<PointCloud>();
+        utility::LogError("[UniformDownSample] Illegal sample rate.\n");
     }
     std::vector<size_t> indices;
     for (size_t i = 0; i < points_.size(); i += every_k_points) {
@@ -383,22 +377,19 @@ std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
 std::shared_ptr<PointCloud> PointCloud::Crop(
         const AxisAlignedBoundingBox &bbox) const {
     if (bbox.IsEmpty()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong "
-                "bounds.\n");
-        return std::make_shared<PointCloud>();
+                "size, or has wrong bounds.\n");
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
 }
 std::shared_ptr<PointCloud> PointCloud::Crop(
         const OrientedBoundingBox &bbox) const {
     if (bbox.IsEmpty()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
                 "size, or has wrong "
                 "bounds.\n");
-        return std::make_shared<PointCloud>();
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
 }
@@ -406,11 +397,9 @@ std::shared_ptr<PointCloud> PointCloud::Crop(
 std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
 PointCloud::RemoveRadiusOutliers(size_t nb_points, double search_radius) const {
     if (nb_points < 1 || search_radius <= 0) {
-        utility::LogWarning(
+        utility::LogError(
                 "[RemoveRadiusOutliers] Illegal input parameters,"
                 "number of points and radius must be positive\n");
-        return std::make_tuple(std::make_shared<PointCloud>(),
-                               std::vector<size_t>());
     }
     KDTreeFlann kdtree;
     kdtree.SetGeometry(*this);
@@ -438,12 +427,9 @@ std::tuple<std::shared_ptr<PointCloud>, std::vector<size_t>>
 PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
                                       double std_ratio) const {
     if (nb_neighbors < 1 || std_ratio <= 0) {
-        utility::LogWarning(
+        utility::LogError(
                 "[RemoveStatisticalOutliers] Illegal input parameters, number "
-                "of neighbors"
-                "and standard deviation ratio must be positive\n");
-        return std::make_tuple(std::make_shared<PointCloud>(),
-                               std::vector<size_t>());
+                "of neighbors and standard deviation ratio must be positive\n");
     }
     if (points_.size() == 0) {
         return std::make_tuple(std::make_shared<PointCloud>(),
@@ -498,11 +484,9 @@ PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
 std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
         const AxisAlignedBoundingBox &bbox) const {
     if (bbox.IsEmpty()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong "
-                "bounds.\n");
-        return std::make_shared<TriangleMesh>();
+                "size, or has wrong bounds.\n");
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));
 }
@@ -510,10 +494,9 @@ std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
 std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
         const OrientedBoundingBox &bbox) const {
     if (bbox.IsEmpty()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong "
-                "bounds.\n");
+                "size, or has wrong bounds.\n");
         return std::make_shared<TriangleMesh>();
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));

--- a/src/Open3D/Geometry/DownSample.cpp
+++ b/src/Open3D/Geometry/DownSample.cpp
@@ -161,7 +161,7 @@ std::shared_ptr<PointCloud> PointCloud::SelectDownSample(
         }
     }
     utility::LogDebug(
-            "Pointcloud down sampled from {:d} points to {:d} points.\n",
+            "Pointcloud down sampled from {:d} points to {:d} points.",
             (int)points_.size(), (int)output->points_.size());
     return output;
 }
@@ -171,7 +171,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectDownSample(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SelectDownSample] This mesh contains triangle uvs that are "
-                "not handled in this function\n");
+                "not handled in this function");
     }
     auto output = std::make_shared<TriangleMesh>();
     bool has_triangle_normals = HasTriangleNormals();
@@ -245,8 +245,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectDownSample(
     output->RemoveDegenerateTriangles();
     utility::LogDebug(
             "Triangle mesh sampled from {:d} vertices and {:d} triangles to "
-            "{:d} "
-            "vertices and {:d} triangles.\n",
+            "{:d} vertices and {:d} triangles.",
             (int)vertices_.size(), (int)triangles_.size(),
             (int)output->vertices_.size(), (int)output->triangles_.size());
     return output;
@@ -256,7 +255,7 @@ std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
         double voxel_size) const {
     auto output = std::make_shared<PointCloud>();
     if (voxel_size <= 0.0) {
-        utility::LogError("[VoxelDownSample] voxel_size <= 0.\n");
+        utility::LogError("[VoxelDownSample] voxel_size <= 0.");
     }
     Eigen::Vector3d voxel_size3 =
             Eigen::Vector3d(voxel_size, voxel_size, voxel_size);
@@ -264,7 +263,7 @@ std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
     Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogError("[VoxelDownSample] voxel_size is too small.\n");
+        utility::LogError("[VoxelDownSample] voxel_size is too small.");
     }
     std::unordered_map<Eigen::Vector3i, AccumulatedPoint,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -290,7 +289,7 @@ std::shared_ptr<PointCloud> PointCloud::VoxelDownSample(
         }
     }
     utility::LogDebug(
-            "Pointcloud down sampled from {:d} points to {:d} points.\n",
+            "Pointcloud down sampled from {:d} points to {:d} points.",
             (int)points_.size(), (int)output->points_.size());
     return output;
 }
@@ -303,7 +302,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
     auto output = std::make_shared<PointCloud>();
     Eigen::MatrixXi cubic_id;
     if (voxel_size <= 0.0) {
-        utility::LogError("[VoxelDownSample] voxel_size <= 0.\n");
+        utility::LogError("[VoxelDownSample] voxel_size <= 0.");
     }
     // Note: this is different from VoxelDownSample.
     // It is for fixing coordinate for multiscale voxel space
@@ -311,7 +310,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
     auto voxel_max_bound = max_bound;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogError("[VoxelDownSample] voxel_size is too small.\n");
+        utility::LogError("[VoxelDownSample] voxel_size is too small.");
     }
     std::unordered_map<Eigen::Vector3i, AccumulatedPointForTrace,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -357,7 +356,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
         cnt++;
     }
     utility::LogDebug(
-            "Pointcloud down sampled from {:d} points to {:d} points.\n",
+            "Pointcloud down sampled from {:d} points to {:d} points.",
             (int)points_.size(), (int)output->points_.size());
     return std::make_tuple(output, cubic_id);
 }
@@ -365,7 +364,7 @@ PointCloud::VoxelDownSampleAndTrace(double voxel_size,
 std::shared_ptr<PointCloud> PointCloud::UniformDownSample(
         size_t every_k_points) const {
     if (every_k_points == 0) {
-        utility::LogError("[UniformDownSample] Illegal sample rate.\n");
+        utility::LogError("[UniformDownSample] Illegal sample rate.");
     }
     std::vector<size_t> indices;
     for (size_t i = 0; i < points_.size(); i += every_k_points) {
@@ -379,7 +378,7 @@ std::shared_ptr<PointCloud> PointCloud::Crop(
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong bounds.\n");
+                "size, or has wrong bounds.");
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
 }
@@ -388,8 +387,7 @@ std::shared_ptr<PointCloud> PointCloud::Crop(
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "[CropPointCloud] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong "
-                "bounds.\n");
+                "size, or has wrong bounds.");
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(points_));
 }
@@ -399,7 +397,7 @@ PointCloud::RemoveRadiusOutliers(size_t nb_points, double search_radius) const {
     if (nb_points < 1 || search_radius <= 0) {
         utility::LogError(
                 "[RemoveRadiusOutliers] Illegal input parameters,"
-                "number of points and radius must be positive\n");
+                "number of points and radius must be positive");
     }
     KDTreeFlann kdtree;
     kdtree.SetGeometry(*this);
@@ -429,7 +427,7 @@ PointCloud::RemoveStatisticalOutliers(size_t nb_neighbors,
     if (nb_neighbors < 1 || std_ratio <= 0) {
         utility::LogError(
                 "[RemoveStatisticalOutliers] Illegal input parameters, number "
-                "of neighbors and standard deviation ratio must be positive\n");
+                "of neighbors and standard deviation ratio must be positive");
     }
     if (points_.size() == 0) {
         return std::make_tuple(std::make_shared<PointCloud>(),
@@ -486,7 +484,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong bounds.\n");
+                "size, or has wrong bounds.");
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));
 }
@@ -496,7 +494,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::Crop(
     if (bbox.IsEmpty()) {
         utility::LogError(
                 "[CropTriangleMesh] AxisAlignedBoundingBox either has zeros "
-                "size, or has wrong bounds.\n");
+                "size, or has wrong bounds.");
         return std::make_shared<TriangleMesh>();
     }
     return SelectDownSample(bbox.GetPointIndicesWithinBoundingBox(vertices_));

--- a/src/Open3D/Geometry/EstimateNormals.cpp
+++ b/src/Open3D/Geometry/EstimateNormals.cpp
@@ -305,7 +305,7 @@ bool PointCloud::OrientNormalsToAlignWithDirection(
     if (HasNormals() == false) {
         utility::LogWarning(
                 "[OrientNormalsToAlignWithDirection] No normals in the "
-                "PointCloud. Call EstimateNormals() first.\n");
+                "PointCloud. Call EstimateNormals() first.");
     }
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -326,7 +326,7 @@ bool PointCloud::OrientNormalsTowardsCameraLocation(
     if (HasNormals() == false) {
         utility::LogWarning(
                 "[OrientNormalsTowardsCameraLocation] No normals in the "
-                "PointCloud. Call EstimateNormals() first.\n");
+                "PointCloud. Call EstimateNormals() first.");
     }
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)

--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -76,7 +76,7 @@ void Geometry3D::ResizeAndPaintUniformColor(
     Eigen::Vector3d clipped_color = color;
     if (color.minCoeff() < 0 || color.maxCoeff() > 1) {
         utility::LogWarning(
-                "invalid color in PaintUniformColor, clipping to [0, 1]\n");
+                "invalid color in PaintUniformColor, clipping to [0, 1]");
         clipped_color = clipped_color.array()
                                 .max(Eigen::Vector3d(0, 0, 0).array())
                                 .matrix();

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -72,8 +72,7 @@ std::vector<int> HalfEdgeTriangleMesh::BoundaryHalfEdgesFromVertex(
     const HalfEdge &init_he = half_edges_[init_he_index];
 
     if (!init_he.IsBoundary()) {
-        utility::LogError("The vertex {:d} is not on boundary.\n",
-                          vertex_index);
+        utility::LogError("The vertex {:d} is not on boundary.", vertex_index);
     }
 
     std::vector<int> boundary_half_edge_indices;
@@ -128,13 +127,13 @@ int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
     if (!HasHalfEdges() || curr_half_edge_index >= int(half_edges_.size()) ||
         curr_half_edge_index == -1) {
         utility::LogWarning(
-                "edge index {:d} out of range or half-edges not available.\n",
+                "edge index {:d} out of range or half-edges not available.",
                 curr_half_edge_index);
         return -1;
     }
     if (!half_edges_[curr_half_edge_index].IsBoundary()) {
         utility::LogWarning(
-                "The currented half-edge index {:d} is on boundary.\n",
+                "The currented half-edge index {:d} is on boundary.",
                 curr_half_edge_index);
         return -1;
     }
@@ -147,7 +146,7 @@ int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
     if (!half_edges_[next_half_edge_index].IsBoundary()) {
         utility::LogWarning(
                 "[NextHalfEdgeOnBoundary] The next half-edge along the "
-                "boundary is not a boundary edge.\n");
+                "boundary is not a boundary edge.");
         return -1;
     }
     return next_half_edge_index;
@@ -200,7 +199,7 @@ HalfEdgeTriangleMesh::CreateFromTriangleMesh(const TriangleMesh &mesh) {
             vertex_indices_to_half_edge_index.find(he_2.vertex_indices_) !=
                     vertex_indices_to_half_edge_index.end()) {
             utility::LogError(
-                    "ComputeHalfEdges failed. Duplicated half-edges.\n");
+                    "ComputeHalfEdges failed. Duplicated half-edges.");
         }
 
         het_mesh->half_edges_.push_back(he_0);
@@ -256,7 +255,7 @@ HalfEdgeTriangleMesh::CreateFromTriangleMesh(const TriangleMesh &mesh) {
             }
         }
         if (num_boundaries > 1) {
-            utility::LogError("ComputeHalfEdges failed. Invalid vertex.\n");
+            utility::LogError("ComputeHalfEdges failed. Invalid vertex.");
         }
         // If there is a boundary edge, start from that; otherwise start
         // with any half-edge (default 0) started from this vertex.

--- a/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/Open3D/Geometry/HalfEdgeTriangleMesh.cpp
@@ -72,9 +72,8 @@ std::vector<int> HalfEdgeTriangleMesh::BoundaryHalfEdgesFromVertex(
     const HalfEdge &init_he = half_edges_[init_he_index];
 
     if (!init_he.IsBoundary()) {
-        utility::LogWarning("The vertex {:d} is not on boundary.\n",
-                            vertex_index);
-        return {};
+        utility::LogError("The vertex {:d} is not on boundary.\n",
+                          vertex_index);
     }
 
     std::vector<int> boundary_half_edge_indices;
@@ -146,8 +145,8 @@ int HalfEdgeTriangleMesh::NextHalfEdgeOnBoundary(
     int vertex_index = half_edges_[curr_half_edge_index].vertex_indices_(1);
     int next_half_edge_index = ordered_half_edge_from_vertex_[vertex_index][0];
     if (!half_edges_[next_half_edge_index].IsBoundary()) {
-        utility::LogError(
-                "Internal algorithm error. The next half-edge along the "
+        utility::LogWarning(
+                "[NextHalfEdgeOnBoundary] The next half-edge along the "
                 "boundary is not a boundary edge.\n");
         return -1;
     }
@@ -200,9 +199,8 @@ HalfEdgeTriangleMesh::CreateFromTriangleMesh(const TriangleMesh &mesh) {
                     vertex_indices_to_half_edge_index.end() ||
             vertex_indices_to_half_edge_index.find(he_2.vertex_indices_) !=
                     vertex_indices_to_half_edge_index.end()) {
-            utility::LogWarning(
+            utility::LogError(
                     "ComputeHalfEdges failed. Duplicated half-edges.\n");
-            return het_mesh;
         }
 
         het_mesh->half_edges_.push_back(he_0);
@@ -258,8 +256,7 @@ HalfEdgeTriangleMesh::CreateFromTriangleMesh(const TriangleMesh &mesh) {
             }
         }
         if (num_boundaries > 1) {
-            utility::LogWarning("ComputeHalfEdges failed. Invalid vertex.\n");
-            return het_mesh;
+            utility::LogError("ComputeHalfEdges failed. Invalid vertex.\n");
         }
         // If there is a boundary edge, start from that; otherwise start
         // with any half-edge (default 0) started from this vertex.

--- a/src/Open3D/Geometry/Image.cpp
+++ b/src/Open3D/Geometry/Image.cpp
@@ -120,7 +120,7 @@ std::shared_ptr<Image> Image::ConvertDepthToFloatImage(
 
 Image &Image::ClipIntensity(double min /* = 0.0*/, double max /* = 1.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogError("[ClipIntensity] Unsupported image format.\n");
+        utility::LogError("[ClipIntensity] Unsupported image format.");
     }
     for (int y = 0; y < height_; y++) {
         for (int x = 0; x < width_; x++) {
@@ -134,7 +134,7 @@ Image &Image::ClipIntensity(double min /* = 0.0*/, double max /* = 1.0*/) {
 
 Image &Image::LinearTransform(double scale, double offset /* = 0.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogError("[LinearTransform] Unsupported image format.\n");
+        utility::LogError("[LinearTransform] Unsupported image format.");
     }
     for (int y = 0; y < height_; y++) {
         for (int x = 0; x < width_; x++) {
@@ -148,7 +148,7 @@ Image &Image::LinearTransform(double scale, double offset /* = 0.0*/) {
 std::shared_ptr<Image> Image::Downsample() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogError("[Downsample] Unsupported image format.\n");
+        utility::LogError("[Downsample] Unsupported image format.");
     }
     int half_width = (int)floor((double)width_ / 2.0);
     int half_height = (int)floor((double)height_ / 2.0);
@@ -181,7 +181,7 @@ std::shared_ptr<Image> Image::FilterHorizontal(
         kernel.size() % 2 != 1) {
         utility::LogError(
                 "[FilterHorizontal] Unsupported image format or kernel "
-                "size.\n");
+                "size.");
     }
     output->Prepare(width_, height_, 1, 4);
 
@@ -214,7 +214,7 @@ std::shared_ptr<Image> Image::FilterHorizontal(
 std::shared_ptr<Image> Image::Filter(Image::FilterType type) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogError("[Filter] Unsupported image format.\n");
+        utility::LogError("[Filter] Unsupported image format.");
     }
 
     switch (type) {
@@ -234,7 +234,7 @@ std::shared_ptr<Image> Image::Filter(Image::FilterType type) const {
             output = Filter(Sobel32, Sobel31);
             break;
         default:
-            utility::LogError("[Filter] Unsupported filter type.\n");
+            utility::LogError("[Filter] Unsupported filter type.");
             break;
     }
     return output;
@@ -254,7 +254,7 @@ std::shared_ptr<Image> Image::Filter(const std::vector<double> &dx,
                                      const std::vector<double> &dy) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogError("[Filter] Unsupported image format.\n");
+        utility::LogError("[Filter] Unsupported image format.");
     }
 
     auto temp1 = FilterHorizontal(dx);
@@ -338,7 +338,7 @@ std::shared_ptr<Image> Image::FlipHorizontal() const {
 std::shared_ptr<Image> Image::Dilate(int half_kernel_size /* = 1 */) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 1) {
-        utility::LogError("[Dilate] Unsupported image format.\n");
+        utility::LogError("[Dilate] Unsupported image format.");
     }
     output->Prepare(width_, height_, 1, 1);
 

--- a/src/Open3D/Geometry/Image.cpp
+++ b/src/Open3D/Geometry/Image.cpp
@@ -120,8 +120,7 @@ std::shared_ptr<Image> Image::ConvertDepthToFloatImage(
 
 Image &Image::ClipIntensity(double min /* = 0.0*/, double max /* = 1.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning("[ClipIntensity] Unsupported image format.\n");
-        return *this;
+        utility::LogError("[ClipIntensity] Unsupported image format.\n");
     }
     for (int y = 0; y < height_; y++) {
         for (int x = 0; x < width_; x++) {
@@ -135,8 +134,7 @@ Image &Image::ClipIntensity(double min /* = 0.0*/, double max /* = 1.0*/) {
 
 Image &Image::LinearTransform(double scale, double offset /* = 0.0*/) {
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning("[LinearTransform] Unsupported image format.\n");
-        return *this;
+        utility::LogError("[LinearTransform] Unsupported image format.\n");
     }
     for (int y = 0; y < height_; y++) {
         for (int x = 0; x < width_; x++) {
@@ -150,8 +148,7 @@ Image &Image::LinearTransform(double scale, double offset /* = 0.0*/) {
 std::shared_ptr<Image> Image::Downsample() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning("[Downsample] Unsupported image format.\n");
-        return output;
+        utility::LogError("[Downsample] Unsupported image format.\n");
     }
     int half_width = (int)floor((double)width_ / 2.0);
     int half_height = (int)floor((double)height_ / 2.0);
@@ -182,10 +179,9 @@ std::shared_ptr<Image> Image::FilterHorizontal(
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4 ||
         kernel.size() % 2 != 1) {
-        utility::LogWarning(
+        utility::LogError(
                 "[FilterHorizontal] Unsupported image format or kernel "
                 "size.\n");
-        return output;
     }
     output->Prepare(width_, height_, 1, 4);
 
@@ -218,8 +214,7 @@ std::shared_ptr<Image> Image::FilterHorizontal(
 std::shared_ptr<Image> Image::Filter(Image::FilterType type) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning("[Filter] Unsupported image format.\n");
-        return output;
+        utility::LogError("[Filter] Unsupported image format.\n");
     }
 
     switch (type) {
@@ -239,7 +234,7 @@ std::shared_ptr<Image> Image::Filter(Image::FilterType type) const {
             output = Filter(Sobel32, Sobel31);
             break;
         default:
-            utility::LogWarning("[Filter] Unsupported filter type.\n");
+            utility::LogError("[Filter] Unsupported filter type.\n");
             break;
     }
     return output;
@@ -259,8 +254,7 @@ std::shared_ptr<Image> Image::Filter(const std::vector<double> &dx,
                                      const std::vector<double> &dy) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning("[Filter] Unsupported image format.\n");
-        return output;
+        utility::LogError("[Filter] Unsupported image format.\n");
     }
 
     auto temp1 = FilterHorizontal(dx);
@@ -344,8 +338,7 @@ std::shared_ptr<Image> Image::FlipHorizontal() const {
 std::shared_ptr<Image> Image::Dilate(int half_kernel_size /* = 1 */) const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 1) {
-        utility::LogWarning("[Dilate] Unsupported image format.\n");
-        return output;
+        utility::LogError("[Dilate] Unsupported image format.\n");
     }
     output->Prepare(width_, height_, 1, 1);
 

--- a/src/Open3D/Geometry/ImageFactory.cpp
+++ b/src/Open3D/Geometry/ImageFactory.cpp
@@ -123,9 +123,8 @@ template <typename T>
 std::shared_ptr<Image> Image::CreateImageFromFloatImage() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateImageFromFloatImage] Unsupported image format.\n");
-        return output;
     }
 
     output->Prepare(width_, height_, num_of_channels_, sizeof(T));
@@ -148,8 +147,7 @@ ImagePyramid Image::CreatePyramid(size_t num_of_levels,
     std::vector<std::shared_ptr<Image>> pyramid_image;
     pyramid_image.clear();
     if ((num_of_channels_ != 1) || (bytes_per_channel_ != 4)) {
-        utility::LogWarning("[CreateImagePyramid] Unsupported image format.\n");
-        return pyramid_image;
+        utility::LogError("[CreateImagePyramid] Unsupported image format.\n");
     }
 
     for (size_t i = 0; i < num_of_levels; i++) {

--- a/src/Open3D/Geometry/ImageFactory.cpp
+++ b/src/Open3D/Geometry/ImageFactory.cpp
@@ -124,7 +124,7 @@ std::shared_ptr<Image> Image::CreateImageFromFloatImage() const {
     auto output = std::make_shared<Image>();
     if (num_of_channels_ != 1 || bytes_per_channel_ != 4) {
         utility::LogError(
-                "[CreateImageFromFloatImage] Unsupported image format.\n");
+                "[CreateImageFromFloatImage] Unsupported image format.");
     }
 
     output->Prepare(width_, height_, num_of_channels_, sizeof(T));
@@ -147,7 +147,7 @@ ImagePyramid Image::CreatePyramid(size_t num_of_levels,
     std::vector<std::shared_ptr<Image>> pyramid_image;
     pyramid_image.clear();
     if ((num_of_channels_ != 1) || (bytes_per_channel_ != 4)) {
-        utility::LogError("[CreateImagePyramid] Unsupported image format.\n");
+        utility::LogError("[CreateImagePyramid] Unsupported image format.");
     }
 
     for (size_t i = 0; i < num_of_levels; i++) {

--- a/src/Open3D/Geometry/KDTreeFlann.cpp
+++ b/src/Open3D/Geometry/KDTreeFlann.cpp
@@ -75,7 +75,7 @@ bool KDTreeFlann::SetGeometry(const Geometry &geometry) {
         case Geometry::GeometryType::Unspecified:
         default:
             utility::LogWarning(
-                    "[KDTreeFlann::SetGeometry] Unsupported Geometry type.\n");
+                    "[KDTreeFlann::SetGeometry] Unsupported Geometry type.");
             return false;
     }
 }
@@ -190,8 +190,7 @@ bool KDTreeFlann::SetRawData(const Eigen::Map<const Eigen::MatrixXd> &data) {
     dimension_ = data.rows();
     dataset_size_ = data.cols();
     if (dimension_ == 0 || dataset_size_ == 0) {
-        utility::LogWarning(
-                "[KDTreeFlann::SetRawData] Failed due to no data.\n");
+        utility::LogWarning("[KDTreeFlann::SetRawData] Failed due to no data.");
         return false;
     }
     data_.resize(dataset_size_ * dimension_);

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<OctreeNode> OctreeNode::ConstructFromJsonValue(
         } else if (class_name == "OctreeColorLeafNode") {
             node = std::make_shared<OctreeColorLeafNode>();
         } else {
-            utility::LogError("Unhandled class name {}\n", class_name);
+            utility::LogError("Unhandled class name {}", class_name);
         }
     }
     // Convert from json
@@ -106,13 +106,12 @@ bool OctreeInternalNode::ConvertFromJsonValue(const Json::Value& value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "ConvertFromJsonValue read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     std::string class_name = value.get("class_name", "").asString();
     if (class_name != "OctreeInternalNode") {
-        utility::LogWarning("class_name {} != OctreeInternalNode\n",
-                            class_name);
+        utility::LogWarning("class_name {} != OctreeInternalNode", class_name);
         return false;
     }
     bool rc = true;
@@ -171,7 +170,7 @@ bool OctreeColorLeafNode::ConvertFromJsonValue(const Json::Value& value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "OctreeColorLeafNode read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "") != "OctreeColorLeafNode") {
@@ -590,7 +589,7 @@ bool Octree::ConvertToJsonValue(Json::Value& value) const {
 bool Octree::ConvertFromJsonValue(const Json::Value& value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "Octree read JSON failed: unsupported json format.\n");
+                "Octree read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "") != "Octree") {

--- a/src/Open3D/Geometry/Octree.cpp
+++ b/src/Open3D/Geometry/Octree.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<OctreeNode> OctreeNode::ConstructFromJsonValue(
         } else if (class_name == "OctreeColorLeafNode") {
             node = std::make_shared<OctreeColorLeafNode>();
         } else {
-            utility::LogWarning("Unhandled class name {}\n", class_name);
+            utility::LogError("Unhandled class name {}\n", class_name);
         }
     }
     // Convert from json
@@ -67,7 +67,7 @@ std::shared_ptr<OctreeNodeInfo> OctreeInternalNode::GetInsertionNodeInfo(
         const std::shared_ptr<OctreeNodeInfo>& node_info,
         const Eigen::Vector3d& point) {
     if (!Octree::IsPointInBound(point, node_info->origin_, node_info->size_)) {
-        throw std::runtime_error(
+        utility::LogError(
                 "Internal error: cannot insert to child since point not in "
                 "parent node bound.");
     }
@@ -140,7 +140,7 @@ OctreeColorLeafNode::GetUpdateFunction(const Eigen::Vector3d& color) {
                             node)) {
             color_leaf_node->color_ = color;
         } else {
-            throw std::runtime_error(
+            utility::LogError(
                     "Internal error: leaf node must be OctreeLeafNode");
         }
     };
@@ -202,7 +202,7 @@ Octree::Octree(const Octree& src_octree)
                                    src_node)) {
             map_src_to_dst_node[src_leaf_node] = src_leaf_node->Clone();
         } else {
-            throw std::runtime_error("Internal error: unknown node type");
+            utility::LogError("Internal error: unknown node type");
         }
     };
     src_octree.Traverse(f_build_map);
@@ -371,29 +371,29 @@ OrientedBoundingBox Octree::GetOrientedBoundingBox() const {
 }
 
 Octree& Octree::Transform(const Eigen::Matrix4d& transformation) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 Octree& Octree::Translate(const Eigen::Vector3d& translation, bool relative) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 Octree& Octree::Scale(const double scale, bool center) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 Octree& Octree::Rotate(const Eigen::Matrix3d& R, bool center) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 void Octree::ConvertFromPointCloud(const geometry::PointCloud& point_cloud,
                                    double size_expand) {
     if (size_expand > 1 || size_expand < 0) {
-        throw std::runtime_error("size_expand shall be between 0 and 1");
+        utility::LogError("size_expand shall be between 0 and 1");
     }
 
     // Set bounds
@@ -450,7 +450,7 @@ void Octree::InsertPointRecurse(
         if (auto leaf_node = std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
             f_update(leaf_node);
         } else {
-            throw std::runtime_error(
+            utility::LogError(
                     "Internal error: leaf node must be OctreeLeafNode");
         }
     } else {
@@ -475,7 +475,7 @@ void Octree::InsertPointRecurse(
             InsertPointRecurse(internal_node->children_[child_index],
                                child_node_info, point, f_init, f_update);
         } else {
-            throw std::runtime_error(
+            utility::LogError(
                     "Internal error: internal node must be "
                     "OctreeInternalNode");
         }
@@ -539,7 +539,7 @@ void Octree::TraverseRecurse(
                        std::dynamic_pointer_cast<OctreeLeafNode>(node)) {
         f(leaf_node, node_info);
     } else {
-        throw std::runtime_error("Internal error: unknown node type");
+        utility::LogError("Internal error: unknown node type");
     }
 }
 

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -254,10 +254,8 @@ std::tuple<std::shared_ptr<TriangleMesh>, std::vector<size_t>>
 PointCloud::HiddenPointRemoval(const Eigen::Vector3d &camera_location,
                                const double radius) const {
     if (radius <= 0) {
-        utility::LogWarning(
+        utility::LogError(
                 "[HiddenPointRemoval] radius must be larger than zero.\n");
-        return std::make_tuple(std::make_shared<TriangleMesh>(),
-                               std::vector<size_t>());
     }
 
     // perform spherical projection

--- a/src/Open3D/Geometry/PointCloud.cpp
+++ b/src/Open3D/Geometry/PointCloud.cpp
@@ -133,7 +133,7 @@ std::vector<double> PointCloud::ComputePointCloudDistance(
         if (kdtree.SearchKNN(points_[i], 1, indices, dists) == 0) {
             utility::LogDebug(
                     "[ComputePointCloudToPointCloudDistance] Found a point "
-                    "without neighbors.\n");
+                    "without neighbors.");
             distances[i] = 0.0;
         } else {
             distances[i] = std::sqrt(dists[0]);
@@ -166,7 +166,7 @@ PointCloud &PointCloud::RemoveNoneFinitePoints(bool remove_nan,
     if (has_normal) normals_.resize(k);
     if (has_color) colors_.resize(k);
     utility::LogDebug(
-            "[RemoveNoneFinitePoints] {:d} nan points have been removed.\n",
+            "[RemoveNoneFinitePoints] {:d} nan points have been removed.",
             (int)(old_point_num - k));
     return *this;
 }
@@ -236,7 +236,7 @@ std::vector<double> PointCloud::ComputeNearestNeighborDistance() const {
         if (kdtree.SearchKNN(points_[i], 2, indices, dists) <= 1) {
             utility::LogDebug(
                     "[ComputePointCloudNearestNeighborDistance] Found a point "
-                    "without neighbors.\n");
+                    "without neighbors.");
             nn_dis[i] = 0.0;
         } else {
             nn_dis[i] = std::sqrt(dists[1]);
@@ -255,7 +255,7 @@ PointCloud::HiddenPointRemoval(const Eigen::Vector3d &camera_location,
                                const double radius) const {
     if (radius <= 0) {
         utility::LogError(
-                "[HiddenPointRemoval] radius must be larger than zero.\n");
+                "[HiddenPointRemoval] radius must be larger than zero.");
     }
 
     // perform spherical projection

--- a/src/Open3D/Geometry/PointCloudCluster.cpp
+++ b/src/Open3D/Geometry/PointCloudCluster.cpp
@@ -45,7 +45,7 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
     KDTreeFlann kdtree(*this);
 
     // precompute all neighbours
-    utility::LogDebug("Precompute Neighbours\n");
+    utility::LogDebug("Precompute Neighbours");
     utility::ConsoleProgressBar progress_bar(
             points_.size(), "Precompute Neighbours", print_progress);
     std::vector<std::vector<int>> nbs(points_.size());
@@ -61,10 +61,10 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
 #endif
         { ++progress_bar; }
     }
-    utility::LogDebug("Done Precompute Neighbours\n");
+    utility::LogDebug("Done Precompute Neighbours");
 
     // set all labels to undefined (-2)
-    utility::LogDebug("Compute Clusters\n");
+    utility::LogDebug("Compute Clusters");
     progress_bar.reset(points_.size(), "Clustering", print_progress);
     std::vector<int> labels(points_.size(), -2);
     int cluster_label = 0;
@@ -112,7 +112,7 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
         cluster_label++;
     }
 
-    utility::LogDebug("Done Compute Clusters: {:d}\n", cluster_label);
+    utility::LogDebug("Done Compute Clusters: {:d}", cluster_label);
     return labels;
 }
 

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
                                                        extrinsic, stride);
         }
     }
-    utility::LogWarning(
+    utility::LogError(
             "[CreatePointCloudFromDepthImage] Unsupported image format.\n");
     return std::make_shared<PointCloud>();
 }
@@ -157,7 +157,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
                                                             extrinsic);
         }
     }
-    utility::LogWarning(
+    utility::LogError(
             "[CreatePointCloudFromRGBDImage] Unsupported image format.\n");
     return std::make_shared<PointCloud>();
 }

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
         }
     }
     utility::LogError(
-            "[CreatePointCloudFromDepthImage] Unsupported image format.\n");
+            "[CreatePointCloudFromDepthImage] Unsupported image format.");
     return std::make_shared<PointCloud>();
 }
 
@@ -158,7 +158,7 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
         }
     }
     utility::LogError(
-            "[CreatePointCloudFromRGBDImage] Unsupported image format.\n");
+            "[CreatePointCloudFromRGBDImage] Unsupported image format.");
     return std::make_shared<PointCloud>();
 }
 

--- a/src/Open3D/Geometry/Qhull.cpp
+++ b/src/Open3D/Geometry/Qhull.cpp
@@ -111,7 +111,7 @@ Qhull::ComputeDelaunayTetrahedralization(
     if (points.size() < 4) {
         utility::LogError(
                 "[ComputeDelaunayTriangulation3D] not enough points to create "
-                "a tetrahedral mesh.\n");
+                "a tetrahedral mesh.");
     }
 
     // qhull cannot deal with this case

--- a/src/Open3D/Geometry/Qhull.cpp
+++ b/src/Open3D/Geometry/Qhull.cpp
@@ -109,10 +109,9 @@ Qhull::ComputeDelaunayTetrahedralization(
     std::vector<size_t> pt_map;
 
     if (points.size() < 4) {
-        utility::LogWarning(
+        utility::LogError(
                 "[ComputeDelaunayTriangulation3D] not enough points to create "
                 "a tetrahedral mesh.\n");
-        return std::make_tuple(delaunay_triangulation, pt_map);
     }
 
     // qhull cannot deal with this case

--- a/src/Open3D/Geometry/RGBDImageFactory.cpp
+++ b/src/Open3D/Geometry/RGBDImageFactory.cpp
@@ -37,10 +37,9 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromColorAndDepth(
         bool convert_rgb_to_intensity /* = true*/) {
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateFromColorAndDepth] Unsupported image "
                 "format.\n");
-        return rgbd_image;
     }
     rgbd_image->depth_ =
             *depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
@@ -77,9 +76,8 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromSUNFormat(
         bool convert_rgb_to_intensity /* = true*/) {
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateRGBDImageFromSUNFormat] Unsupported image format.\n");
-        return rgbd_image;
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {
@@ -99,9 +97,8 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromNYUFormat(
         bool convert_rgb_to_intensity /* = true*/) {
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateRGBDImageFromNYUFormat] Unsupported image format.\n");
-        return rgbd_image;
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {

--- a/src/Open3D/Geometry/RGBDImageFactory.cpp
+++ b/src/Open3D/Geometry/RGBDImageFactory.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromColorAndDepth(
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
         utility::LogError(
                 "[CreateFromColorAndDepth] Unsupported image "
-                "format.\n");
+                "format.");
     }
     rgbd_image->depth_ =
             *depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
@@ -77,7 +77,7 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromSUNFormat(
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
         utility::LogError(
-                "[CreateRGBDImageFromSUNFormat] Unsupported image format.\n");
+                "[CreateRGBDImageFromSUNFormat] Unsupported image format.");
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {
@@ -98,7 +98,7 @@ std::shared_ptr<RGBDImage> RGBDImage::CreateFromNYUFormat(
     std::shared_ptr<RGBDImage> rgbd_image = std::make_shared<RGBDImage>();
     if (color.height_ != depth.height_ || color.width_ != depth.width_) {
         utility::LogError(
-                "[CreateRGBDImageFromNYUFormat] Unsupported image format.\n");
+                "[CreateRGBDImageFromNYUFormat] Unsupported image format.");
     }
     for (int v = 0; v < depth.height_; v++) {
         for (int u = 0; u < depth.width_; u++) {

--- a/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
+++ b/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
@@ -136,7 +136,7 @@ void BallPivotingEdge::AddAdjacentTriangle(BallPivotingTrianglePtr triangle) {
             triangle1_ = triangle;
             type_ = Type::Inner;
         } else {
-            utility::LogDebug("!!! This case should not happen\n");
+            utility::LogDebug("!!! This case should not happen");
         }
     }
 }
@@ -242,7 +242,7 @@ public:
                         const BallPivotingVertexPtr& v2,
                         const Eigen::Vector3d& center) {
         utility::LogDebug(
-                "[CreateTriangle] with v0.idx={}, v1.idx={}, v2.idx={}\n",
+                "[CreateTriangle] with v0.idx={}, v1.idx={}, v2.idx={}",
                 v0->idx_, v1->idx_, v2->idx_);
         BallPivotingTrianglePtr triangle =
                 std::make_shared<BallPivotingTriangle>(v0, v1, v2, center);
@@ -301,7 +301,7 @@ public:
     bool IsCompatible(const BallPivotingVertexPtr& v0,
                       const BallPivotingVertexPtr& v1,
                       const BallPivotingVertexPtr& v2) {
-        utility::LogDebug("[IsCompatible] v0.idx={}, v1.idx={}, v2.idx={}\n",
+        utility::LogDebug("[IsCompatible] v0.idx={}, v1.idx={}, v2.idx={}",
                           v0->idx_, v1->idx_, v2->idx_);
         Eigen::Vector3d normal =
                 ComputeFaceNormal(v0->point_, v1->point_, v2->point_);
@@ -311,7 +311,7 @@ public:
         bool ret = normal.dot(v0->normal_) > -1e-16 &&
                    normal.dot(v1->normal_) > -1e-16 &&
                    normal.dot(v2->normal_) > -1e-16;
-        utility::LogDebug("[IsCompatible] retuns = {}\n", ret);
+        utility::LogDebug("[IsCompatible] retuns = {}", ret);
         return ret;
     }
 
@@ -319,29 +319,29 @@ public:
             const BallPivotingEdgePtr& edge,
             double radius,
             Eigen::Vector3d& candidate_center) {
-        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), radius={}\n",
+        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), radius={}",
                           edge->source_->idx_, edge->target_->idx_, radius);
         BallPivotingVertexPtr src = edge->source_;
         BallPivotingVertexPtr tgt = edge->target_;
 
         const BallPivotingVertexPtr opp = edge->GetOppositeVertex();
-        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), opp={}\n",
+        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), opp={}",
                           src->idx_, tgt->idx_, opp->idx_);
-        utility::LogDebug("[FindCandidateVertex] src={} => {}\n", src->idx_,
+        utility::LogDebug("[FindCandidateVertex] src={} => {}", src->idx_,
                           src->point_.transpose());
-        utility::LogDebug("[FindCandidateVertex] tgt={} => {}\n", tgt->idx_,
+        utility::LogDebug("[FindCandidateVertex] tgt={} => {}", tgt->idx_,
                           tgt->point_.transpose());
-        utility::LogDebug("[FindCandidateVertex] src={} => {}\n", opp->idx_,
+        utility::LogDebug("[FindCandidateVertex] src={} => {}", opp->idx_,
                           opp->point_.transpose());
 
         Eigen::Vector3d mp = 0.5 * (src->point_ + tgt->point_);
-        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), mp={}\n",
+        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), mp={}",
                           edge->source_->idx_, edge->target_->idx_,
                           mp.transpose());
 
         BallPivotingTrianglePtr triangle = edge->triangle0_;
         const Eigen::Vector3d& center = triangle->ball_center_;
-        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), center={}\n",
+        utility::LogDebug("[FindCandidateVertex] edge=({}, {}), center={}",
                           edge->source_->idx_, edge->target_->idx_,
                           center.transpose());
 
@@ -354,24 +354,23 @@ public:
         std::vector<int> indices;
         std::vector<double> dists2;
         kdtree_.SearchRadius(mp, 2 * radius, indices, dists2);
-        utility::LogDebug(
-                "[FindCandidateVertex] found {} potential candidates\n",
-                indices.size());
+        utility::LogDebug("[FindCandidateVertex] found {} potential candidates",
+                          indices.size());
 
         BallPivotingVertexPtr min_candidate = nullptr;
         double min_angle = 2 * M_PI;
         for (auto nbidx : indices) {
-            utility::LogDebug("[FindCandidateVertex] nbidx {:d}\n", nbidx);
+            utility::LogDebug("[FindCandidateVertex] nbidx {:d}", nbidx);
             const BallPivotingVertexPtr& candidate = vertices[nbidx];
             if (candidate->idx_ == src->idx_ || candidate->idx_ == tgt->idx_ ||
                 candidate->idx_ == opp->idx_) {
                 utility::LogDebug(
                         "[FindCandidateVertex] candidate {:d} is a triangle "
-                        "vertex of the edge\n",
+                        "vertex of the edge",
                         candidate->idx_);
                 continue;
             }
-            utility::LogDebug("[FindCandidateVertex] candidate={:d} => {}\n",
+            utility::LogDebug("[FindCandidateVertex] candidate={:d} => {}",
                               candidate->idx_, candidate->point_.transpose());
 
             bool coplanar = IntersectionTest::PointsCoplanar(
@@ -384,7 +383,7 @@ public:
                                      opp->point_) < 1e-12)) {
                 utility::LogDebug(
                         "[FindCandidateVertex] candidate {:d} is interesecting "
-                        "the existing triangle\n",
+                        "the existing triangle",
                         candidate->idx_);
                 continue;
             }
@@ -394,18 +393,17 @@ public:
                                    radius, new_center)) {
                 utility::LogDebug(
                         "[FindCandidateVertex] candidate {:d} can not compute "
-                        "ball\n",
+                        "ball",
                         candidate->idx_);
                 continue;
             }
-            utility::LogDebug(
-                    "[FindCandidateVertex] candidate {:d} center={}\n",
-                    candidate->idx_, new_center.transpose());
+            utility::LogDebug("[FindCandidateVertex] candidate {:d} center={}",
+                              candidate->idx_, new_center.transpose());
 
             Eigen::Vector3d b = new_center - mp;
             b /= b.norm();
             utility::LogDebug(
-                    "[FindCandidateVertex] candidate {:d} v={}, a={}, b={}\n",
+                    "[FindCandidateVertex] candidate {:d} v={}, a={}, b={}",
                     candidate->idx_, v.transpose(), a.transpose(),
                     b.transpose());
 
@@ -413,7 +411,7 @@ public:
             cosinus = std::min(cosinus, 1.0);
             cosinus = std::max(cosinus, -1.0);
             utility::LogDebug(
-                    "[FindCandidateVertex] candidate {:d} cosinus={:f}\n",
+                    "[FindCandidateVertex] candidate {:d} cosinus={:f}",
                     candidate->idx_, cosinus);
 
             double angle = std::acos(cosinus);
@@ -426,7 +424,7 @@ public:
             if (angle >= min_angle) {
                 utility::LogDebug(
                         "[FindCandidateVertex] candidate {:d} angle {:f} > "
-                        "min_angle {:f}\n",
+                        "min_angle {:f}",
                         candidate->idx_, angle, min_angle);
                 continue;
             }
@@ -441,7 +439,7 @@ public:
                 if ((new_center - nb->point_).norm() < radius - 1e-16) {
                     utility::LogDebug(
                             "[FindCandidateVertex] candidate {:d} not an empty "
-                            "ball\n",
+                            "ball",
                             candidate->idx_);
                     empty_ball = false;
                     break;
@@ -449,9 +447,8 @@ public:
             }
 
             if (empty_ball) {
-                utility::LogDebug(
-                        "[FindCandidateVertex] candidate {:d} works\n",
-                        candidate->idx_);
+                utility::LogDebug("[FindCandidateVertex] candidate {:d} works",
+                                  candidate->idx_);
                 min_angle = angle;
                 min_candidate = vertices[nbidx];
                 candidate_center = new_center;
@@ -459,16 +456,16 @@ public:
         }
 
         if (min_candidate == nullptr) {
-            utility::LogDebug("[FindCandidateVertex] returns nullptr\n");
+            utility::LogDebug("[FindCandidateVertex] returns nullptr");
         } else {
-            utility::LogDebug("[FindCandidateVertex] returns {:d}\n",
+            utility::LogDebug("[FindCandidateVertex] returns {:d}",
                               min_candidate->idx_);
         }
         return min_candidate;
     }
 
     void ExpandTriangulation(double radius) {
-        utility::LogDebug("[ExpandTriangulation] radius={}\n", radius);
+        utility::LogDebug("[ExpandTriangulation] radius={}", radius);
         while (!edge_front_.empty()) {
             BallPivotingEdgePtr edge = edge_front_.front();
             edge_front_.pop_front();
@@ -517,7 +514,7 @@ public:
                          Eigen::Vector3d& center) {
         utility::LogDebug(
                 "[TryTriangleSeed] v0.idx={}, v1.idx={}, v2.idx={}, "
-                "radius={}\n",
+                "radius={}",
                 v0->idx_, v1->idx_, v2->idx_, radius);
 
         if (!IsCompatible(v0, v1, v2)) {
@@ -528,13 +525,13 @@ public:
         BallPivotingEdgePtr e1 = GetLinkingEdge(v1, v2);
         if (e0 != nullptr && e0->type_ == BallPivotingEdge::Type::Inner) {
             utility::LogDebug(
-                    "[TryTriangleSeed] returns {} because e0 is inner edge\n",
+                    "[TryTriangleSeed] returns {} because e0 is inner edge",
                     false);
             return false;
         }
         if (e1 != nullptr && e1->type_ == BallPivotingEdge::Type::Inner) {
             utility::LogDebug(
-                    "[TryTriangleSeed] returns {} because e1 is inner edge\n",
+                    "[TryTriangleSeed] returns {} because e1 is inner edge",
                     false);
             return false;
         }
@@ -542,7 +539,7 @@ public:
         if (!ComputeBallCenter(v0->idx_, v1->idx_, v2->idx_, radius, center)) {
             utility::LogDebug(
                     "[TryTriangleSeed] returns {} could not compute ball "
-                    "center\n",
+                    "center",
                     false);
             return false;
         }
@@ -557,18 +554,18 @@ public:
             if ((center - v->point_).norm() < radius - 1e-16) {
                 utility::LogDebug(
                         "[TryTriangleSeed] returns {} computed ball is not "
-                        "empty\n",
+                        "empty",
                         false);
                 return false;
             }
         }
 
-        utility::LogDebug("[TryTriangleSeed] returns {}\n", true);
+        utility::LogDebug("[TryTriangleSeed] returns {}", true);
         return true;
     }
 
     bool TrySeed(BallPivotingVertexPtr& v, double radius) {
-        utility::LogDebug("[TrySeed] with v.idx={}, radius={}\n", v->idx_,
+        utility::LogDebug("[TrySeed] with v.idx={}, radius={}", v->idx_,
                           radius);
         std::vector<int> indices;
         std::vector<double> dists2;
@@ -640,19 +637,19 @@ public:
                 if (edge_front_.size() > 0) {
                     utility::LogDebug(
                             "[TrySeed] edge_front_.size() > 0 => return "
-                            "true\n");
+                            "true");
                     return true;
                 }
             }
         }
 
-        utility::LogDebug("[TrySeed] return false\n");
+        utility::LogDebug("[TrySeed] return false");
         return false;
     }
 
     void FindSeedTriangle(double radius) {
         for (size_t vidx = 0; vidx < vertices.size(); ++vidx) {
-            utility::LogDebug("[FindSeedTriangle] with radius={}, vidx={}\n",
+            utility::LogDebug("[FindSeedTriangle] with radius={}, vidx={}",
                               radius, vidx);
             if (vertices[vidx]->type_ == BallPivotingVertex::Type::Orphan) {
                 if (TrySeed(vertices[vidx], radius)) {
@@ -664,17 +661,17 @@ public:
 
     std::shared_ptr<TriangleMesh> Run(const std::vector<double>& radii) {
         if (!has_normals_) {
-            utility::LogError("ReconstructBallPivoting requires normals\n");
+            utility::LogError("ReconstructBallPivoting requires normals");
         }
 
         mesh_->triangles_.clear();
 
         for (double radius : radii) {
-            utility::LogDebug("[Run] ################################\n");
-            utility::LogDebug("[Run] change to radius {:.4f}\n", radius);
+            utility::LogDebug("[Run] ################################");
+            utility::LogDebug("[Run] change to radius {:.4f}", radius);
             if (radius <= 0) {
                 utility::LogError(
-                        "got an invalid, negative radius as parameter\n");
+                        "got an invalid, negative radius as parameter");
             }
 
             // update radius => update border edges
@@ -682,7 +679,7 @@ public:
                 BallPivotingEdgePtr edge = *it;
                 BallPivotingTrianglePtr triangle = edge->triangle0_;
                 utility::LogDebug(
-                        "[Run] try edge {:d}-{:d} of triangle {:d}-{:d}-{:d}\n",
+                        "[Run] try edge {:d}-{:d} of triangle {:d}-{:d}-{:d}",
                         edge->source_->idx_, edge->target_->idx_,
                         triangle->vert0_->idx_, triangle->vert1_->idx_,
                         triangle->vert2_->idx_);
@@ -691,7 +688,7 @@ public:
                 if (ComputeBallCenter(triangle->vert0_->idx_,
                                       triangle->vert1_->idx_,
                                       triangle->vert2_->idx_, radius, center)) {
-                    utility::LogDebug("[Run]   yes, we can work on this\n");
+                    utility::LogDebug("[Run]   yes, we can work on this");
                     std::vector<int> indices;
                     std::vector<double> dists2;
                     kdtree_.SearchRadius(center, radius, indices, dists2);
@@ -701,7 +698,7 @@ public:
                             idx != triangle->vert1_->idx_ &&
                             idx != triangle->vert2_->idx_) {
                             utility::LogDebug(
-                                    "[Run]   but no, the ball is not empty\n");
+                                    "[Run]   but no, the ball is not empty");
                             empty_ball = false;
                             break;
                         }
@@ -709,7 +706,7 @@ public:
 
                     if (empty_ball) {
                         utility::LogDebug(
-                                "[Run]   yeah, add edge to edge_front_: {:d}\n",
+                                "[Run]   yeah, add edge to edge_front_: {:d}",
                                 edge_front_.size());
                         edge->type_ = BallPivotingEdge::Type::Front;
                         edge_front_.push_back(edge);
@@ -727,9 +724,9 @@ public:
                 ExpandTriangulation(radius);
             }
 
-            utility::LogDebug("[Run] mesh_ has {:d} triangles\n",
+            utility::LogDebug("[Run] mesh_ has {:d} triangles",
                               mesh_->triangles_.size());
-            utility::LogDebug("[Run] ################################\n");
+            utility::LogDebug("[Run] ################################");
         }
         return mesh_;
     }

--- a/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
+++ b/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
@@ -664,8 +664,7 @@ public:
 
     std::shared_ptr<TriangleMesh> Run(const std::vector<double>& radii) {
         if (!has_normals_) {
-            utility::LogWarning("ReconstructBallPivoting requires normals\n");
-            return mesh_;
+            utility::LogError("ReconstructBallPivoting requires normals\n");
         }
 
         mesh_->triangles_.clear();
@@ -674,9 +673,8 @@ public:
             utility::LogDebug("[Run] ################################\n");
             utility::LogDebug("[Run] change to radius {:.4f}\n", radius);
             if (radius <= 0) {
-                utility::LogWarning(
+                utility::LogError(
                         "got an invalid, negative radius as parameter\n");
-                return mesh_;
             }
 
             // update radius => update border edges

--- a/src/Open3D/Geometry/TetraMesh.cpp
+++ b/src/Open3D/Geometry/TetraMesh.cpp
@@ -95,7 +95,7 @@ TetraMesh &TetraMesh::RemoveDuplicatedVertices() {
         }
     }
     utility::LogDebug(
-            "[RemoveDuplicatedVertices] {:d} vertices have been removed.\n",
+            "[RemoveDuplicatedVertices] {:d} vertices have been removed.",
             (int)(old_vertex_num - k));
 
     return *this;
@@ -125,9 +125,8 @@ TetraMesh &TetraMesh::RemoveDuplicatedTetras() {
         }
     }
     tetras_.resize(k);
-    utility::LogDebug(
-            "[RemoveDuplicatedTetras] {:d} tetras have been removed.\n",
-            (int)(old_tetra_num - k));
+    utility::LogDebug("[RemoveDuplicatedTetras] {:d} tetras have been removed.",
+                      (int)(old_tetra_num - k));
 
     return *this;
 }
@@ -163,7 +162,7 @@ TetraMesh &TetraMesh::RemoveUnreferencedVertices() {
         }
     }
     utility::LogDebug(
-            "[RemoveUnreferencedVertices] {:d} vertices have been removed.\n",
+            "[RemoveUnreferencedVertices] {:d} vertices have been removed.",
             (int)(old_vertex_num - k));
 
     return *this;
@@ -184,7 +183,7 @@ TetraMesh &TetraMesh::RemoveDegenerateTetras() {
     tetras_.resize(k);
     utility::LogDebug(
             "[RemoveDegenerateTetras] {:d} tetras have been "
-            "removed.\n",
+            "removed.",
             (int)(old_tetra_num - k));
     return *this;
 }
@@ -200,7 +199,7 @@ std::shared_ptr<TriangleMesh> TetraMesh::ExtractTriangleMesh(
     if (values.size() != vertices_.size()) {
         utility::LogError(
                 "[ExtractTriangleMesh] number of values does not match the "
-                "number of vertices.\n");
+                "number of vertices.");
     }
 
     auto SurfaceIntersectionTest = [](double v0, double v1, double level) {
@@ -349,13 +348,13 @@ std::shared_ptr<TriangleMesh> TetraMesh::ExtractTriangleMesh(
                 utility::LogWarning(
                         "[ExtractTriangleMesh] failed to create triangles for "
                         "tetrahedron {:d}: invalid edge configuration for "
-                        "tetrahedron\n",
+                        "tetrahedron",
                         int(tetra_i));
             }
         } else if (0 != num_verts) {
             utility::LogWarning(
                     "[ExtractTriangleMesh] failed to create triangles for "
-                    "tetrahedron {:d}: unexpected number of vertices {:d}\n",
+                    "tetrahedron {:d}: unexpected number of vertices {:d}",
                     int(tetra_i), num_verts);
         }
     }

--- a/src/Open3D/Geometry/TetraMesh.cpp
+++ b/src/Open3D/Geometry/TetraMesh.cpp
@@ -198,10 +198,9 @@ std::shared_ptr<TriangleMesh> TetraMesh::ExtractTriangleMesh(
     auto triangle_mesh = std::make_shared<TriangleMesh>();
 
     if (values.size() != vertices_.size()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[ExtractTriangleMesh] number of values does not match the "
                 "number of vertices.\n");
-        return triangle_mesh;
     }
 
     auto SurfaceIntersectionTest = [](double v0, double v1, double level) {

--- a/src/Open3D/Geometry/TetraMeshFactory.cpp
+++ b/src/Open3D/Geometry/TetraMeshFactory.cpp
@@ -35,10 +35,9 @@ namespace geometry {
 std::shared_ptr<TetraMesh> TetraMesh::CreateFromPointCloud(
         const PointCloud& point_cloud) {
     if (point_cloud.points_.size() < 4) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateFromPointCloud] not enough points to create a "
                 "tetrahedral mesh.\n");
-        return std::make_shared<TetraMesh>();
     }
     return std::get<0>(
             Qhull::ComputeDelaunayTetrahedralization(point_cloud.points_));

--- a/src/Open3D/Geometry/TetraMeshFactory.cpp
+++ b/src/Open3D/Geometry/TetraMeshFactory.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<TetraMesh> TetraMesh::CreateFromPointCloud(
     if (point_cloud.points_.size() < 4) {
         utility::LogError(
                 "[CreateFromPointCloud] not enough points to create a "
-                "tetrahedral mesh.\n");
+                "tetrahedral mesh.");
     }
     return std::get<0>(
             Qhull::ComputeDelaunayTetrahedralization(point_cloud.points_));

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -90,7 +90,9 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     }
     if (HasTriangleUvs() || HasTexture()) {
         // TODO: implement copy
-        utility::LogWarning("copy of uvs and texture is not implemented yet\n");
+        utility::LogWarning(
+                "[TriangleMesh] copy of uvs and texture is not implemented "
+                "yet\n");
     }
     return (*this);
 }
@@ -479,13 +481,11 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
         size_t number_of_points) const {
     if (number_of_points <= 0) {
-        utility::LogWarning("[SamplePointsUniformly] number_of_points <= 0");
-        return std::make_shared<PointCloud>();
+        utility::LogError("[SamplePointsUniformly] number_of_points <= 0");
     }
     if (triangles_.size() == 0) {
-        utility::LogWarning(
+        utility::LogError(
                 "[SamplePointsUniformly] input mesh has no triangles");
-        return std::make_shared<PointCloud>();
     }
 
     // Compute area of each triangle and sum surface area
@@ -501,27 +501,21 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
         double init_factor /* = 5 */,
         const std::shared_ptr<PointCloud> pcl_init /* = nullptr */) const {
     if (number_of_points <= 0) {
-        utility::LogWarning("[SamplePointsPoissonDisk] number_of_points <= 0");
-        return std::make_shared<PointCloud>();
+        utility::LogError("[SamplePointsPoissonDisk] number_of_points <= 0");
     }
     if (triangles_.size() == 0) {
-        utility::LogWarning(
+        utility::LogError(
                 "[SamplePointsPoissonDisk] input mesh has no triangles");
-        return std::make_shared<PointCloud>();
     }
     if (pcl_init == nullptr && init_factor < 1) {
-        utility::LogWarning(
+        utility::LogError(
                 "[SamplePointsPoissonDisk] either pass pcl_init with #points "
-                "> "
-                "number_of_points or init_factor > 1");
-        return std::make_shared<PointCloud>();
+                "> number_of_points or init_factor > 1");
     }
     if (pcl_init != nullptr && pcl_init->points_.size() < number_of_points) {
-        utility::LogWarning(
+        utility::LogError(
                 "[SamplePointsPoissonDisk] either pass pcl_init with #points "
-                "> "
-                "number_of_points, or init_factor > 1");
-        return std::make_shared<PointCloud>();
+                "> number_of_points, or init_factor > 1");
     }
 
     // Compute area of each triangle and sum surface area
@@ -693,8 +687,7 @@ TriangleMesh &TriangleMesh::RemoveDuplicatedTriangles() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveDuplicatedTriangles] This mesh contains triangle uvs "
-                "that are not handled "
-                "in this function\n");
+                "that are not handled in this function\n");
     }
     typedef std::tuple<int, int, int> Index3;
     std::unordered_map<Index3, size_t, utility::hash_tuple::hash<Index3>>
@@ -789,8 +782,7 @@ TriangleMesh &TriangleMesh::RemoveDegenerateTriangles() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveDegenerateTriangles] This mesh contains triangle uvs "
-                "that are not handled "
-                "in this function\n");
+                "that are not handled in this function\n");
     }
     bool has_tri_normal = HasTriangleNormals();
     size_t old_triangle_num = triangles_.size();
@@ -820,8 +812,7 @@ TriangleMesh &TriangleMesh::RemoveNonManifoldEdges() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveNonManifoldEdges] This mesh contains triangle uvs that "
-                "are not handled "
-                "in this function\n");
+                "are not handled in this function\n");
     }
     std::vector<double> triangle_areas;
     GetSurfaceArea(triangle_areas);

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -92,7 +92,7 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
         // TODO: implement copy
         utility::LogWarning(
                 "[TriangleMesh] copy of uvs and texture is not implemented "
-                "yet\n");
+                "yet");
     }
     return (*this);
 }
@@ -677,7 +677,7 @@ TriangleMesh &TriangleMesh::RemoveDuplicatedVertices() {
         }
     }
     utility::LogDebug(
-            "[RemoveDuplicatedVertices] {:d} vertices have been removed.\n",
+            "[RemoveDuplicatedVertices] {:d} vertices have been removed.",
             (int)(old_vertex_num - k));
 
     return *this;
@@ -687,7 +687,7 @@ TriangleMesh &TriangleMesh::RemoveDuplicatedTriangles() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveDuplicatedTriangles] This mesh contains triangle uvs "
-                "that are not handled in this function\n");
+                "that are not handled in this function");
     }
     typedef std::tuple<int, int, int> Index3;
     std::unordered_map<Index3, size_t, utility::hash_tuple::hash<Index3>>
@@ -729,7 +729,7 @@ TriangleMesh &TriangleMesh::RemoveDuplicatedTriangles() {
         ComputeAdjacencyList();
     }
     utility::LogDebug(
-            "[RemoveDuplicatedTriangles] {:d} triangles have been removed.\n",
+            "[RemoveDuplicatedTriangles] {:d} triangles have been removed.",
             (int)(old_triangle_num - k));
 
     return *this;
@@ -772,7 +772,7 @@ TriangleMesh &TriangleMesh::RemoveUnreferencedVertices() {
         }
     }
     utility::LogDebug(
-            "[RemoveUnreferencedVertices] {:d} vertices have been removed.\n",
+            "[RemoveUnreferencedVertices] {:d} vertices have been removed.",
             (int)(old_vertex_num - k));
 
     return *this;
@@ -782,7 +782,7 @@ TriangleMesh &TriangleMesh::RemoveDegenerateTriangles() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveDegenerateTriangles] This mesh contains triangle uvs "
-                "that are not handled in this function\n");
+                "that are not handled in this function");
     }
     bool has_tri_normal = HasTriangleNormals();
     size_t old_triangle_num = triangles_.size();
@@ -803,7 +803,7 @@ TriangleMesh &TriangleMesh::RemoveDegenerateTriangles() {
     }
     utility::LogDebug(
             "[RemoveDegenerateTriangles] {:d} triangles have been "
-            "removed.\n",
+            "removed.",
             (int)(old_triangle_num - k));
     return *this;
 }
@@ -812,7 +812,7 @@ TriangleMesh &TriangleMesh::RemoveNonManifoldEdges() {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[RemoveNonManifoldEdges] This mesh contains triangle uvs that "
-                "are not handled in this function\n");
+                "are not handled in this function");
     }
     std::vector<double> triangle_areas;
     GetSurfaceArea(triangle_areas);
@@ -891,7 +891,7 @@ TriangleMesh &TriangleMesh::RemoveNonManifoldEdges() {
 TriangleMesh &TriangleMesh::MergeCloseVertices(double eps) {
     KDTreeFlann kdtree(*this);
     // precompute all neighbours
-    utility::LogDebug("Precompute Neighbours\n");
+    utility::LogDebug("Precompute Neighbours");
     std::vector<std::vector<int>> nbs(vertices_.size());
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -900,7 +900,7 @@ TriangleMesh &TriangleMesh::MergeCloseVertices(double eps) {
         std::vector<double> dists2;
         kdtree.SearchRadius(vertices_[idx], eps, nbs[idx], dists2);
     }
-    utility::LogDebug("Done Precompute Neighbours\n");
+    utility::LogDebug("Done Precompute Neighbours");
 
     bool has_vertex_normals = HasVertexNormals();
     bool has_vertex_colors = HasVertexColors();
@@ -948,7 +948,7 @@ TriangleMesh &TriangleMesh::MergeCloseVertices(double eps) {
             new_vertex_colors.push_back(color / n);
         }
     }
-    utility::LogDebug("Merged {} vertices\n",
+    utility::LogDebug("Merged {} vertices",
                       vertices_.size() - new_vertices.size());
 
     std::swap(vertices_, new_vertices);

--- a/src/Open3D/Geometry/TriangleMeshFactory.cpp
+++ b/src/Open3D/Geometry/TriangleMeshFactory.cpp
@@ -34,8 +34,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateTetrahedron(
         double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateTetrahedron] radius <= 0");
-        return mesh;
+        utility::LogError("[CreateTetrahedron] radius <= 0");
     }
     mesh->vertices_.push_back(radius *
                               Eigen::Vector3d(std::sqrt(8. / 9.), 0, -1. / 3.));
@@ -57,8 +56,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateOctahedron(
         double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateOctahedron] radius <= 0");
-        return mesh;
+        utility::LogError("[CreateOctahedron] radius <= 0");
     }
     mesh->vertices_.push_back(radius * Eigen::Vector3d(1, 0, 0));
     mesh->vertices_.push_back(radius * Eigen::Vector3d(0, 1, 0));
@@ -81,8 +79,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateIcosahedron(
         double radius /* = 1.0*/) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateIcosahedron] radius <= 0");
-        return mesh;
+        utility::LogError("[CreateIcosahedron] radius <= 0");
     }
     const double p = (1. + std::sqrt(5.)) / 2.;
     mesh->vertices_.push_back(radius * Eigen::Vector3d(-1, 0, p));
@@ -125,16 +122,13 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateBox(double width /* = 1.0*/,
                                                       double depth /* = 1.0*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (width <= 0) {
-        utility::LogWarning("[CreateBox] width <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateBox] width <= 0");
     }
     if (height <= 0) {
-        utility::LogWarning("[CreateBox] height <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateBox] height <= 0");
     }
     if (depth <= 0) {
-        utility::LogWarning("[CreateBox] depth <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateBox] depth <= 0");
     }
     mesh_ptr->vertices_.resize(8);
     mesh_ptr->vertices_[0] = Eigen::Vector3d(0.0, 0.0, 0.0);
@@ -164,12 +158,10 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateSphere(
         double radius /* = 1.0*/, int resolution /* = 20*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateSphere] radius <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateSphere] radius <= 0");
     }
     if (resolution <= 0) {
-        utility::LogWarning("[CreateSphere] resolution <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateSphere] resolution <= 0");
     }
     mesh_ptr->vertices_.resize(2 * resolution * (resolution - 1) + 2);
     mesh_ptr->vertices_[0] = Eigen::Vector3d(0.0, 0.0, radius);
@@ -214,20 +206,16 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateCylinder(
         int split /* = 4*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateCylinder] radius <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCylinder] radius <= 0");
     }
     if (height <= 0) {
-        utility::LogWarning("[CreateCylinder] height <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCylinder] height <= 0");
     }
     if (resolution <= 0) {
-        utility::LogWarning("[CreateCylinder] resolution <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCylinder] resolution <= 0");
     }
     if (split <= 0) {
-        utility::LogWarning("[CreateCylinder] split <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCylinder] split <= 0");
     }
     mesh_ptr->vertices_.resize(resolution * (split + 1) + 2);
     mesh_ptr->vertices_[0] = Eigen::Vector3d(0.0, 0.0, height * 0.5);
@@ -269,20 +257,16 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateCone(double radius /* = 1.0*/,
                                                        int split /* = 4*/) {
     auto mesh_ptr = std::make_shared<TriangleMesh>();
     if (radius <= 0) {
-        utility::LogWarning("[CreateCone] radius <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCone] radius <= 0");
     }
     if (height <= 0) {
-        utility::LogWarning("[CreateCone] height <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCone] height <= 0");
     }
     if (resolution <= 0) {
-        utility::LogWarning("[CreateCone] resolution <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCone] resolution <= 0");
     }
     if (split <= 0) {
-        utility::LogWarning("[CreateCone] split <= 0");
-        return mesh_ptr;
+        utility::LogError("[CreateCone] split <= 0");
     }
     mesh_ptr->vertices_.resize(resolution * split + 2);
     mesh_ptr->vertices_[0] = Eigen::Vector3d(0.0, 0.0, 0.0);
@@ -327,20 +311,16 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateTorus(
         int tubular_resolution /* = 20 */) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (torus_radius <= 0) {
-        utility::LogWarning("[CreateTorus] torus_radius <= 0");
-        return mesh;
+        utility::LogError("[CreateTorus] torus_radius <= 0");
     }
     if (tube_radius <= 0) {
-        utility::LogWarning("[CreateTorus] tube_radius <= 0");
-        return mesh;
+        utility::LogError("[CreateTorus] tube_radius <= 0");
     }
     if (radial_resolution <= 0) {
-        utility::LogWarning("[CreateTorus] radial_resolution <= 0");
-        return mesh;
+        utility::LogError("[CreateTorus] radial_resolution <= 0");
     }
     if (tubular_resolution <= 0) {
-        utility::LogWarning("[CreateTorus] tubular_resolution <= 0");
-        return mesh;
+        utility::LogError("[CreateTorus] tubular_resolution <= 0");
     }
 
     mesh->vertices_.resize(radial_resolution * tubular_resolution);
@@ -385,32 +365,25 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateArrow(
         int cylinder_split /* = 4*/,
         int cone_split /* = 1*/) {
     if (cylinder_radius <= 0) {
-        utility::LogWarning("[CreateArrow] cylinder_radius <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cylinder_radius <= 0");
     }
     if (cone_radius <= 0) {
-        utility::LogWarning("[CreateArrow] cone_radius <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cone_radius <= 0");
     }
     if (cylinder_height <= 0) {
-        utility::LogWarning("[CreateArrow] cylinder_height <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cylinder_height <= 0");
     }
     if (cone_height <= 0) {
-        utility::LogWarning("[CreateArrow] cone_height <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cone_height <= 0");
     }
     if (resolution <= 0) {
-        utility::LogWarning("[CreateArrow] resolution <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] resolution <= 0");
     }
     if (cylinder_split <= 0) {
-        utility::LogWarning("[CreateArrow] cylinder_split <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cylinder_split <= 0");
     }
     if (cone_split <= 0) {
-        utility::LogWarning("[CreateArrow] cone_split <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateArrow] cone_split <= 0");
     }
     Eigen::Matrix4d transformation = Eigen::Matrix4d::Identity();
     auto mesh_cylinder = CreateCylinder(cylinder_radius, cylinder_height,
@@ -430,8 +403,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateCoordinateFrame(
         double size /* = 1.0*/,
         const Eigen::Vector3d &origin /* = Eigen::Vector3d(0.0, 0.0, 0.0)*/) {
     if (size <= 0) {
-        utility::LogWarning("[CreateCoordinateFrame] size <= 0");
-        return std::make_shared<TriangleMesh>();
+        utility::LogError("[CreateCoordinateFrame] size <= 0");
     }
     auto mesh_frame = CreateSphere(0.06 * size);
     mesh_frame->ComputeVertexNormals();
@@ -478,32 +450,25 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateMoebius(
         double scale /* = 1 */) {
     auto mesh = std::make_shared<TriangleMesh>();
     if (length_split <= 0) {
-        utility::LogWarning("[CreateMoebius] length_split <= 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] length_split <= 0");
     }
     if (width_split <= 0) {
-        utility::LogWarning("[CreateMoebius] width_split <= 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] width_split <= 0");
     }
     if (twists < 0) {
-        utility::LogWarning("[CreateMoebius] twists < 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] twists < 0");
     }
     if (radius <= 0) {
-        utility::LogWarning("[CreateMoebius] radius <= 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] radius <= 0");
     }
     if (flatness == 0) {
-        utility::LogWarning("[CreateMoebius] flatness == 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] flatness == 0");
     }
     if (width <= 0) {
-        utility::LogWarning("[CreateMoebius] width <= 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] width <= 0");
     }
     if (scale <= 0) {
-        utility::LogWarning("[CreateMoebius] scale <= 0");
-        return mesh;
+        utility::LogError("[CreateMoebius] scale <= 0");
     }
 
     mesh->vertices_.resize(length_split * width_split);

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -96,13 +96,11 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyVertexClustering] This mesh contains triangle uvs "
-                "that are not handled "
-                "in this function\n");
+                "that are not handled in this function\n");
     }
     auto mesh = std::make_shared<TriangleMesh>();
     if (voxel_size <= 0.0) {
-        utility::LogWarning("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
-        return mesh;
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
     }
 
     Eigen::Vector3d voxel_size3 =
@@ -111,9 +109,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
     Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[VoxelGridFromPointCloud] voxel_size is too small.\n");
-        return mesh;
     }
 
     auto GetVoxelIdx = [&](const Eigen::Vector3d& vert) {
@@ -273,8 +270,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "
-                "that are not handled "
-                "in this function\n");
+                "that are not handled in this function\n");
     }
     typedef std::tuple<double, int, int> CostEdge;
 

--- a/src/Open3D/Geometry/TriangleMeshSimplification.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSimplification.cpp
@@ -96,11 +96,11 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyVertexClustering] This mesh contains triangle uvs "
-                "that are not handled in this function\n");
+                "that are not handled in this function");
     }
     auto mesh = std::make_shared<TriangleMesh>();
     if (voxel_size <= 0.0) {
-        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.0");
     }
 
     Eigen::Vector3d voxel_size3 =
@@ -109,8 +109,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
     Eigen::Vector3d voxel_max_bound = GetMaxBound() + voxel_size3 * 0.5;
     if (voxel_size * std::numeric_limits<int>::max() <
         (voxel_max_bound - voxel_min_bound).maxCoeff()) {
-        utility::LogError(
-                "[VoxelGridFromPointCloud] voxel_size is too small.\n");
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size is too small.");
     }
 
     auto GetVoxelIdx = [&](const Eigen::Vector3d& vert) {
@@ -270,7 +269,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "
-                "that are not handled in this function\n");
+                "that are not handled in this function");
     }
     typedef std::tuple<double, int, int> CostEdge;
 

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -40,8 +40,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideMidpoint(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SubdivideMidpoint] This mesh contains triangle uvs that are "
-                "not handled "
-                "in this function\n");
+                "not handled in this function\n");
     }
     auto mesh = std::make_shared<TriangleMesh>();
     mesh->vertices_ = vertices_;
@@ -119,8 +118,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideLoop(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SubdivideLoop] This mesh contains triangle uvs that are not "
-                "handled "
-                "in this function\n");
+                "handled in this function\n");
     }
     typedef std::unordered_map<Eigen::Vector2i, int,
                                utility::hash_eigen::hash<Eigen::Vector2i>>

--- a/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
+++ b/src/Open3D/Geometry/TriangleMeshSubdivide.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideMidpoint(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SubdivideMidpoint] This mesh contains triangle uvs that are "
-                "not handled in this function\n");
+                "not handled in this function");
     }
     auto mesh = std::make_shared<TriangleMesh>();
     mesh->vertices_ = vertices_;
@@ -118,7 +118,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideLoop(
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SubdivideLoop] This mesh contains triangle uvs that are not "
-                "handled in this function\n");
+                "handled in this function");
     }
     typedef std::unordered_map<Eigen::Vector2i, int,
                                utility::hash_eigen::hash<Eigen::Vector2i>>
@@ -153,7 +153,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideLoop(
         if (boundary_nbs.size() > 2) {
             utility::LogWarning(
                     "[SubdivideLoop] boundary edge with > 2 neighbours, maybe "
-                    "mesh is not manifold.\n");
+                    "mesh is not manifold.");
         }
 
         double beta, alpha;
@@ -305,7 +305,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SubdivideLoop(
         if (edge_to_triangles[e0].size() > 2 ||
             edge_to_triangles[e1].size() > 2 ||
             edge_to_triangles[e2].size() > 2) {
-            utility::LogWarning("[SubdivideLoop] non-manifold edge.\n");
+            utility::LogWarning("[SubdivideLoop] non-manifold edge.");
         }
 
         vertex_neighbours[tria(0)].insert(tria(1));

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -134,20 +134,20 @@ VoxelGrid &VoxelGrid::operator+=(const VoxelGrid &voxelgrid) {
     if (voxel_size_ != voxelgrid.voxel_size_) {
         utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid because voxel_size "
-                "differs (this=%f, other=%f.\n",
+                "differs (this=%f, other=%f)",
                 voxel_size_, voxelgrid.voxel_size_);
     }
     if (origin_ != voxelgrid.origin_) {
         utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid because origin "
-                "differs (this=%f,%f,%f, other=%f,%f,%f.\n",
+                "differs (this=%f,%f,%f, other=%f,%f,%f)",
                 origin_(0), origin_(1), origin_(2), voxelgrid.origin_(0),
                 voxelgrid.origin_(1), voxelgrid.origin_(2));
     }
     if (this->HasColors() != voxelgrid.HasColors()) {
         utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid one has colors and "
-                "the other not.\n");
+                "the other not.");
     }
     std::unordered_map<Eigen::Vector3i, AvgColorVoxel,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -275,7 +275,7 @@ VoxelGrid &VoxelGrid::CarveDepthMap(
         depth_map.width_ != camera_parameter.intrinsic_.width_) {
         utility::LogError(
                 "[VoxelGrid] provided depth_map dimensions are not compatible "
-                "with the provided camera_parameters\n");
+                "with the provided camera_parameters");
     }
 
     auto rot = camera_parameter.extrinsic_.block<3, 3>(0, 0);
@@ -317,7 +317,7 @@ VoxelGrid &VoxelGrid::CarveSilhouette(
         silhouette_mask.width_ != camera_parameter.intrinsic_.width_) {
         utility::LogError(
                 "[VoxelGrid] provided silhouette_mask dimensions are not "
-                "compatible with the provided camera_parameters\n");
+                "compatible with the provided camera_parameters");
     }
 
     auto rot = camera_parameter.extrinsic_.block<3, 3>(0, 0);

--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -110,47 +110,44 @@ OrientedBoundingBox VoxelGrid::GetOrientedBoundingBox() const {
 }
 
 VoxelGrid &VoxelGrid::Transform(const Eigen::Matrix4d &transformation) {
-    throw std::runtime_error("VoxelGrid::Transform is not supported");
+    utility::LogError("VoxelGrid::Transform is not supported");
     return *this;
 }
 
 VoxelGrid &VoxelGrid::Translate(const Eigen::Vector3d &translation,
                                 bool relative) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 VoxelGrid &VoxelGrid::Scale(const double scale, bool center) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 VoxelGrid &VoxelGrid::Rotate(const Eigen::Matrix3d &R, bool center) {
-    throw std::runtime_error("Not implemented");
+    utility::LogError("Not implemented");
     return *this;
 }
 
 VoxelGrid &VoxelGrid::operator+=(const VoxelGrid &voxelgrid) {
     if (voxel_size_ != voxelgrid.voxel_size_) {
-        utility::LogWarningf(
+        utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid because voxel_size "
                 "differs (this=%f, other=%f.\n",
                 voxel_size_, voxelgrid.voxel_size_);
-        return *this;
     }
     if (origin_ != voxelgrid.origin_) {
-        utility::LogWarningf(
+        utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid because origin "
                 "differs (this=%f,%f,%f, other=%f,%f,%f.\n",
                 origin_(0), origin_(1), origin_(2), voxelgrid.origin_(0),
                 voxelgrid.origin_(1), voxelgrid.origin_(2));
-        return *this;
     }
     if (this->HasColors() != voxelgrid.HasColors()) {
-        utility::LogWarningf(
+        utility::LogError(
                 "[VoxelGrid] Could not combine VoxelGrid one has colors and "
                 "the other not.\n");
-        return *this;
     }
     std::unordered_map<Eigen::Vector3i, AvgColorVoxel,
                        utility::hash_eigen::hash<Eigen::Vector3i>>
@@ -276,10 +273,9 @@ VoxelGrid &VoxelGrid::CarveDepthMap(
         const camera::PinholeCameraParameters &camera_parameter) {
     if (depth_map.height_ != camera_parameter.intrinsic_.height_ ||
         depth_map.width_ != camera_parameter.intrinsic_.width_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[VoxelGrid] provided depth_map dimensions are not compatible "
                 "with the provided camera_parameters\n");
-        return *this;
     }
 
     auto rot = camera_parameter.extrinsic_.block<3, 3>(0, 0);
@@ -319,10 +315,9 @@ VoxelGrid &VoxelGrid::CarveSilhouette(
         const camera::PinholeCameraParameters &camera_parameter) {
     if (silhouette_mask.height_ != camera_parameter.intrinsic_.height_ ||
         silhouette_mask.width_ != camera_parameter.intrinsic_.width_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[VoxelGrid] provided silhouette_mask dimensions are not "
                 "compatible with the provided camera_parameters\n");
-        return *this;
     }
 
     auto rot = camera_parameter.extrinsic_.block<3, 3>(0, 0);

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -196,7 +196,7 @@ public:
         if (num_of_points_ > 0 && voxel_index != voxel_index_) {
             utility::LogWarning(
                     "Tried to aggregate ColorVoxel with different "
-                    "voxel_index\n");
+                    "voxel_index");
         }
         voxel_index_ = voxel_index;
     }

--- a/src/Open3D/Geometry/VoxelGridFactory.cpp
+++ b/src/Open3D/Geometry/VoxelGridFactory.cpp
@@ -66,15 +66,13 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloudWithinBounds(
         const Eigen::Vector3d &max_bound) {
     auto output = std::make_shared<VoxelGrid>();
     if (voxel_size <= 0.0) {
-        utility::LogWarning("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
-        return output;
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
     }
 
     if (voxel_size * std::numeric_limits<int>::max() <
         (max_bound - min_bound).maxCoeff()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[VoxelGridFromPointCloud] voxel_size is too small.\n");
-        return output;
     }
     output->voxel_size_ = voxel_size;
     output->origin_ = min_bound;
@@ -124,15 +122,13 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
         const Eigen::Vector3d &max_bound) {
     auto output = std::make_shared<VoxelGrid>();
     if (voxel_size <= 0.0) {
-        utility::LogWarning("[CreateFromTriangleMesh] voxel_size <= 0.\n");
-        return output;
+        utility::LogError("[CreateFromTriangleMesh] voxel_size <= 0.\n");
     }
 
     if (voxel_size * std::numeric_limits<int>::max() <
         (max_bound - min_bound).maxCoeff()) {
-        utility::LogWarning(
+        utility::LogError(
                 "[CreateFromTriangleMesh] voxel_size is too small.\n");
-        return output;
     }
     output->voxel_size_ = voxel_size;
     output->origin_ = min_bound;

--- a/src/Open3D/Geometry/VoxelGridFactory.cpp
+++ b/src/Open3D/Geometry/VoxelGridFactory.cpp
@@ -66,13 +66,12 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloudWithinBounds(
         const Eigen::Vector3d &max_bound) {
     auto output = std::make_shared<VoxelGrid>();
     if (voxel_size <= 0.0) {
-        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.\n");
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size <= 0.");
     }
 
     if (voxel_size * std::numeric_limits<int>::max() <
         (max_bound - min_bound).maxCoeff()) {
-        utility::LogError(
-                "[VoxelGridFromPointCloud] voxel_size is too small.\n");
+        utility::LogError("[VoxelGridFromPointCloud] voxel_size is too small.");
     }
     output->voxel_size_ = voxel_size;
     output->origin_ = min_bound;
@@ -101,7 +100,7 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromPointCloudWithinBounds(
         output->AddVoxel(geometry::Voxel(grid_index, color));
     }
     utility::LogDebug(
-            "Pointcloud is voxelized from {:d} points to {:d} voxels.\n",
+            "Pointcloud is voxelized from {:d} points to {:d} voxels.",
             (int)input.points_.size(), (int)output->voxels_.size());
     return output;
 }
@@ -122,13 +121,12 @@ std::shared_ptr<VoxelGrid> VoxelGrid::CreateFromTriangleMeshWithinBounds(
         const Eigen::Vector3d &max_bound) {
     auto output = std::make_shared<VoxelGrid>();
     if (voxel_size <= 0.0) {
-        utility::LogError("[CreateFromTriangleMesh] voxel_size <= 0.\n");
+        utility::LogError("[CreateFromTriangleMesh] voxel_size <= 0.");
     }
 
     if (voxel_size * std::numeric_limits<int>::max() <
         (max_bound - min_bound).maxCoeff()) {
-        utility::LogError(
-                "[CreateFromTriangleMesh] voxel_size is too small.\n");
+        utility::LogError("[CreateFromTriangleMesh] voxel_size is too small.");
     }
     output->voxel_size_ = voxel_size;
     output->origin_ = min_bound;

--- a/src/Open3D/IO/ClassIO/IJsonConvertibleIO.cpp
+++ b/src/Open3D/IO/ClassIO/IJsonConvertibleIO.cpp
@@ -62,7 +62,7 @@ bool ReadIJsonConvertible(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Read utility::IJsonConvertible failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -70,7 +70,7 @@ bool ReadIJsonConvertible(const std::string &filename,
     if (map_itr == file_extension_to_ijsonconvertible_read_function.end()) {
         utility::LogWarning(
                 "Read utility::IJsonConvertible failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, object);
@@ -83,7 +83,7 @@ bool WriteIJsonConvertible(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Write utility::IJsonConvertible failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr = file_extension_to_ijsonconvertible_write_function.find(
@@ -91,7 +91,7 @@ bool WriteIJsonConvertible(const std::string &filename,
     if (map_itr == file_extension_to_ijsonconvertible_write_function.end()) {
         utility::LogWarning(
                 "Write utility::IJsonConvertible failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, object);

--- a/src/Open3D/IO/ClassIO/ImageIO.cpp
+++ b/src/Open3D/IO/ClassIO/ImageIO.cpp
@@ -70,13 +70,13 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Read geometry::Image failed: unknown file extension.\n");
+                "Read geometry::Image failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_image_read_function.find(filename_ext);
     if (map_itr == file_extension_to_image_read_function.end()) {
         utility::LogWarning(
-                "Read geometry::Image failed: unknown file extension.\n");
+                "Read geometry::Image failed: unknown file extension.");
         return false;
     }
     return map_itr->second(filename, image);
@@ -89,13 +89,13 @@ bool WriteImage(const std::string &filename,
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Write geometry::Image failed: unknown file extension.\n");
+                "Write geometry::Image failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_image_write_function.find(filename_ext);
     if (map_itr == file_extension_to_image_write_function.end()) {
         utility::LogWarning(
-                "Write geometry::Image failed: unknown file extension.\n");
+                "Write geometry::Image failed: unknown file extension.");
         return false;
     }
     return map_itr->second(filename, image, quality);

--- a/src/Open3D/IO/ClassIO/ImageWarpingFieldIO.cpp
+++ b/src/Open3D/IO/ClassIO/ImageWarpingFieldIO.cpp
@@ -83,7 +83,7 @@ bool ReadImageWarpingField(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Read color_map::ImageWarpingField failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -91,7 +91,7 @@ bool ReadImageWarpingField(const std::string &filename,
     if (map_itr == file_extension_to_warping_field_read_function.end()) {
         utility::LogWarning(
                 "Read color_map::ImageWarpingField failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, warping_field);
@@ -104,7 +104,7 @@ bool WriteImageWarpingField(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Write color_map::ImageWarpingField failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -112,7 +112,7 @@ bool WriteImageWarpingField(const std::string &filename,
     if (map_itr == file_extension_to_warping_field_write_function.end()) {
         utility::LogWarning(
                 "Write color_map::ImageWarpingField failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, trajectory);

--- a/src/Open3D/IO/ClassIO/LineSetIO.cpp
+++ b/src/Open3D/IO/ClassIO/LineSetIO.cpp
@@ -78,17 +78,17 @@ bool ReadLineSet(const std::string &filename,
     }
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Read geometry::LineSet failed: unknown file extension.\n");
+                "Read geometry::LineSet failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_lineset_read_function.find(filename_ext);
     if (map_itr == file_extension_to_lineset_read_function.end()) {
         utility::LogWarning(
-                "Read geometry::LineSet failed: unknown file extension.\n");
+                "Read geometry::LineSet failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, lineset, print_progress);
-    utility::LogDebug("Read geometry::LineSet: {:d} vertices.\n",
+    utility::LogDebug("Read geometry::LineSet: {:d} vertices.",
                       (int)lineset.points_.size());
     return success;
 }
@@ -102,18 +102,18 @@ bool WriteLineSet(const std::string &filename,
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Write geometry::LineSet failed: unknown file extension.\n");
+                "Write geometry::LineSet failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_lineset_write_function.find(filename_ext);
     if (map_itr == file_extension_to_lineset_write_function.end()) {
         utility::LogWarning(
-                "Write geometry::LineSet failed: unknown file extension.\n");
+                "Write geometry::LineSet failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, lineset, write_ascii, compressed,
                                    print_progress);
-    utility::LogDebug("Write geometry::LineSet: {:d} vertices.\n",
+    utility::LogDebug("Write geometry::LineSet: {:d} vertices.",
                       (int)lineset.points_.size());
     return success;
 }

--- a/src/Open3D/IO/ClassIO/OctreeIO.cpp
+++ b/src/Open3D/IO/ClassIO/OctreeIO.cpp
@@ -68,17 +68,17 @@ bool ReadOctree(const std::string &filename,
     }
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Read geometry::Octree failed: unknown file extension.\n");
+                "Read geometry::Octree failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_octree_read_function.find(filename_ext);
     if (map_itr == file_extension_to_octree_read_function.end()) {
         utility::LogWarning(
-                "Read geometry::Octree failed: unknown file extension.\n");
+                "Read geometry::Octree failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, octree);
-    utility::LogDebug("Read geometry::Octree.\n");
+    utility::LogDebug("Read geometry::Octree.");
     return success;
 }
 
@@ -87,17 +87,17 @@ bool WriteOctree(const std::string &filename, const geometry::Octree &octree) {
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Write geometry::Octree failed: unknown file extension.\n");
+                "Write geometry::Octree failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_octree_write_function.find(filename_ext);
     if (map_itr == file_extension_to_octree_write_function.end()) {
         utility::LogWarning(
-                "Write geometry::Octree failed: unknown file extension.\n");
+                "Write geometry::Octree failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, octree);
-    utility::LogDebug("Write geometry::Octree.\n");
+    utility::LogDebug("Write geometry::Octree.");
     return success;
 }
 

--- a/src/Open3D/IO/ClassIO/PinholeCameraTrajectoryIO.cpp
+++ b/src/Open3D/IO/ClassIO/PinholeCameraTrajectoryIO.cpp
@@ -87,7 +87,7 @@ bool ReadPinholeCameraTrajectory(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Read camera::PinholeCameraTrajectory failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -95,7 +95,7 @@ bool ReadPinholeCameraTrajectory(const std::string &filename,
     if (map_itr == file_extension_to_trajectory_read_function.end()) {
         utility::LogWarning(
                 "Read camera::PinholeCameraTrajectory failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, trajectory);
@@ -109,7 +109,7 @@ bool WritePinholeCameraTrajectory(
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Write camera::PinholeCameraTrajectory failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -117,7 +117,7 @@ bool WritePinholeCameraTrajectory(
     if (map_itr == file_extension_to_trajectory_write_function.end()) {
         utility::LogWarning(
                 "Write camera::PinholeCameraTrajectory failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, trajectory);

--- a/src/Open3D/IO/ClassIO/PointCloudIO.cpp
+++ b/src/Open3D/IO/ClassIO/PointCloudIO.cpp
@@ -90,18 +90,18 @@ bool ReadPointCloud(const std::string &filename,
     }
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Read geometry::PointCloud failed: unknown file extension.\n");
+                "Read geometry::PointCloud failed: unknown file extension.");
         return false;
     }
     auto map_itr =
             file_extension_to_pointcloud_read_function.find(filename_ext);
     if (map_itr == file_extension_to_pointcloud_read_function.end()) {
         utility::LogWarning(
-                "Read geometry::PointCloud failed: unknown file extension.\n");
+                "Read geometry::PointCloud failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, pointcloud, print_progress);
-    utility::LogDebug("Read geometry::PointCloud: {:d} vertices.\n",
+    utility::LogDebug("Read geometry::PointCloud: {:d} vertices.",
                       (int)pointcloud.points_.size());
     if (remove_nan_points || remove_infinite_points) {
         pointcloud.RemoveNoneFinitePoints(remove_nan_points,
@@ -119,19 +119,19 @@ bool WritePointCloud(const std::string &filename,
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Write geometry::PointCloud failed: unknown file extension.\n");
+                "Write geometry::PointCloud failed: unknown file extension.");
         return false;
     }
     auto map_itr =
             file_extension_to_pointcloud_write_function.find(filename_ext);
     if (map_itr == file_extension_to_pointcloud_write_function.end()) {
         utility::LogWarning(
-                "Write geometry::PointCloud failed: unknown file extension.\n");
+                "Write geometry::PointCloud failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, pointcloud, write_ascii,
                                    compressed, print_progress);
-    utility::LogDebug("Write geometry::PointCloud: {:d} vertices.\n",
+    utility::LogDebug("Write geometry::PointCloud: {:d} vertices.",
                       (int)pointcloud.points_.size());
     return success;
 }

--- a/src/Open3D/IO/ClassIO/PoseGraphIO.cpp
+++ b/src/Open3D/IO/ClassIO/PoseGraphIO.cpp
@@ -79,7 +79,7 @@ bool ReadPoseGraph(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Read registration::PoseGraph failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -87,7 +87,7 @@ bool ReadPoseGraph(const std::string &filename,
     if (map_itr == file_extension_to_pose_graph_read_function.end()) {
         utility::LogWarning(
                 "Read registration::PoseGraph failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, pose_graph);
@@ -100,7 +100,7 @@ bool WritePoseGraph(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Write registration::PoseGraph failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -108,7 +108,7 @@ bool WritePoseGraph(const std::string &filename,
     if (map_itr == file_extension_to_pose_graph_write_function.end()) {
         utility::LogWarning(
                 "Write registration::PoseGraph failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     return map_itr->second(filename, pose_graph);

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
@@ -87,7 +87,7 @@ bool ReadTriangleMesh(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Read geometry::TriangleMesh failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -95,17 +95,17 @@ bool ReadTriangleMesh(const std::string &filename,
     if (map_itr == file_extension_to_trianglemesh_read_function.end()) {
         utility::LogWarning(
                 "Read geometry::TriangleMesh failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     bool success = map_itr->second(filename, mesh, print_progress);
     utility::LogDebug(
-            "Read geometry::TriangleMesh: {:d} triangles and {:d} vertices.\n",
+            "Read geometry::TriangleMesh: {:d} triangles and {:d} vertices.",
             (int)mesh.triangles_.size(), (int)mesh.vertices_.size());
     if (mesh.HasVertices() && !mesh.HasTriangles()) {
         utility::LogWarning(
                 "geometry::TriangleMesh appears to be a geometry::PointCloud "
-                "(only contains vertices, but no triangles).\n");
+                "(only contains vertices, but no triangles).");
     }
     return success;
 }
@@ -123,7 +123,7 @@ bool WriteTriangleMesh(const std::string &filename,
     if (filename_ext.empty()) {
         utility::LogWarning(
                 "Write geometry::TriangleMesh failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     auto map_itr =
@@ -131,14 +131,14 @@ bool WriteTriangleMesh(const std::string &filename,
     if (map_itr == file_extension_to_trianglemesh_write_function.end()) {
         utility::LogWarning(
                 "Write geometry::TriangleMesh failed: unknown file "
-                "extension.\n");
+                "extension.");
         return false;
     }
     bool success = map_itr->second(filename, mesh, write_ascii, compressed,
                                    write_vertex_normals, write_vertex_colors,
                                    write_triangle_uvs, print_progress);
     utility::LogDebug(
-            "Write geometry::TriangleMesh: {:d} triangles and {:d} vertices.\n",
+            "Write geometry::TriangleMesh: {:d} triangles and {:d} vertices.",
             (int)mesh.triangles_.size(), (int)mesh.vertices_.size());
     return success;
 }

--- a/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
+++ b/src/Open3D/IO/ClassIO/TriangleMeshIO.cpp
@@ -105,8 +105,7 @@ bool ReadTriangleMesh(const std::string &filename,
     if (mesh.HasVertices() && !mesh.HasTriangles()) {
         utility::LogWarning(
                 "geometry::TriangleMesh appears to be a geometry::PointCloud "
-                "(only contains "
-                "vertices, but no triangles).\n");
+                "(only contains vertices, but no triangles).\n");
     }
     return success;
 }

--- a/src/Open3D/IO/ClassIO/VoxelGridIO.cpp
+++ b/src/Open3D/IO/ClassIO/VoxelGridIO.cpp
@@ -78,17 +78,17 @@ bool ReadVoxelGrid(const std::string &filename,
     }
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Read geometry::VoxelGrid failed: unknown file extension.\n");
+                "Read geometry::VoxelGrid failed: unknown file extension.");
         return false;
     }
     auto map_itr = file_extension_to_voxelgrid_read_function.find(filename_ext);
     if (map_itr == file_extension_to_voxelgrid_read_function.end()) {
         utility::LogWarning(
-                "Read geometry::VoxelGrid failed: unknown file extension.\n");
+                "Read geometry::VoxelGrid failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, voxelgrid, print_progress);
-    utility::LogDebug("Read geometry::VoxelGrid: {:d} voxels.\n",
+    utility::LogDebug("Read geometry::VoxelGrid: {:d} voxels.",
                       (int)voxelgrid.voxels_.size());
     return success;
 }
@@ -102,19 +102,19 @@ bool WriteVoxelGrid(const std::string &filename,
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {
         utility::LogWarning(
-                "Write geometry::VoxelGrid failed: unknown file extension.\n");
+                "Write geometry::VoxelGrid failed: unknown file extension.");
         return false;
     }
     auto map_itr =
             file_extension_to_voxelgrid_write_function.find(filename_ext);
     if (map_itr == file_extension_to_voxelgrid_write_function.end()) {
         utility::LogWarning(
-                "Write geometry::VoxelGrid failed: unknown file extension.\n");
+                "Write geometry::VoxelGrid failed: unknown file extension.");
         return false;
     }
     bool success = map_itr->second(filename, voxelgrid, write_ascii, compressed,
                                    print_progress);
-    utility::LogDebug("Write geometry::VoxelGrid: {:d} voxels.\n",
+    utility::LogDebug("Write geometry::VoxelGrid: {:d} voxels.",
                       (int)voxelgrid.voxels_.size());
     return success;
 }

--- a/src/Open3D/IO/FileFormat/FileBIN.cpp
+++ b/src/Open3D/IO/FileFormat/FileBIN.cpp
@@ -39,16 +39,16 @@ using namespace io;
 bool ReadMatrixXdFromBINFile(FILE *file, Eigen::MatrixXd &mat) {
     uint32_t rows, cols;
     if (fread(&rows, sizeof(uint32_t), 1, file) < 1) {
-        utility::LogWarning("Read BIN failed: unexpected EOF.\n");
+        utility::LogWarning("Read BIN failed: unexpected EOF.");
         return false;
     }
     if (fread(&cols, sizeof(uint32_t), 1, file) < 1) {
-        utility::LogWarning("Read BIN failed: unexpected EOF.\n");
+        utility::LogWarning("Read BIN failed: unexpected EOF.");
         return false;
     }
     mat.resize(rows, cols);
     if (fread(mat.data(), sizeof(double), rows * cols, file) < rows * cols) {
-        utility::LogWarning("Read BIN failed: unexpected EOF.\n");
+        utility::LogWarning("Read BIN failed: unexpected EOF.");
         return false;
     }
     return true;
@@ -58,15 +58,15 @@ bool WriteMatrixXdToBINFile(FILE *file, const Eigen::MatrixXd &mat) {
     uint32_t rows = (uint32_t)mat.rows();
     uint32_t cols = (uint32_t)mat.cols();
     if (fwrite(&rows, sizeof(uint32_t), 1, file) < 1) {
-        utility::LogWarning("Write BIN failed: unexpected error.\n");
+        utility::LogWarning("Write BIN failed: unexpected error.");
         return false;
     }
     if (fwrite(&cols, sizeof(uint32_t), 1, file) < 1) {
-        utility::LogWarning("Write BIN failed: unexpected error.\n");
+        utility::LogWarning("Write BIN failed: unexpected error.");
         return false;
     }
     if (fwrite(mat.data(), sizeof(double), rows * cols, file) < rows * cols) {
-        utility::LogWarning("Write BIN failed: unexpected error.\n");
+        utility::LogWarning("Write BIN failed: unexpected error.");
         return false;
     }
     return true;
@@ -80,7 +80,7 @@ bool ReadFeatureFromBIN(const std::string &filename,
                         registration::Feature &feature) {
     FILE *fid = utility::filesystem::FOpen(filename, "rb");
     if (fid == NULL) {
-        utility::LogWarning("Read BIN failed: unable to open file: {}\n",
+        utility::LogWarning("Read BIN failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -93,7 +93,7 @@ bool WriteFeatureToBIN(const std::string &filename,
                        const registration::Feature &feature) {
     FILE *fid = utility::filesystem::FOpen(filename, "wb");
     if (fid == NULL) {
-        utility::LogWarning("Write BIN failed: unable to open file: {}\n",
+        utility::LogWarning("Write BIN failed: unable to open file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FileGLTF.cpp
+++ b/src/Open3D/IO/FileFormat/FileGLTF.cpp
@@ -107,7 +107,7 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
     }
 
     if (!warn.empty() || !err.empty()) {
-        utility::LogWarning("Read GLTF failed: unable to open file {}\n",
+        utility::LogWarning("Read GLTF failed: unable to open file {}",
                             filename);
     }
     if (!ret) {
@@ -117,7 +117,7 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
     if (model.meshes.size() > 1) {
         utility::LogInfo(
                 "The file contains more than one mesh. All meshes will be "
-                "loaded as a single mesh.\n");
+                "loaded as a single mesh.");
     }
 
     mesh.Clear();
@@ -237,7 +237,7 @@ bool ReadTriangleMeshFromGLTF(const std::string& filename,
                             default: {
                                 utility::LogWarning(
                                         "Unrecognized component type for "
-                                        "vertex colors\n");
+                                        "vertex colors");
                                 break;
                             }
                         }
@@ -397,7 +397,7 @@ bool WriteTriangleMeshToGLTF(const std::string& filename,
     if (write_triangle_uvs && mesh.HasTriangleUvs()) {
         utility::LogWarning(
                 "This file format does not support writing textures and uv "
-                "coordinates. Consider using .obj\n");
+                "coordinates. Consider using .obj");
     }
     tinygltf::Model model;
     model.asset.generator = "Open3D";
@@ -594,13 +594,13 @@ bool WriteTriangleMeshToGLTF(const std::string& filename,
     if (filename_ext == "glb") {
         if (!loader.WriteGltfSceneToFile(&model, filename, false, true, true,
                                          true)) {
-            utility::LogWarning("Write GLTF failed.\n");
+            utility::LogWarning("Write GLTF failed.");
             return false;
         }
     } else {
         if (!loader.WriteGltfSceneToFile(&model, filename, false, true, true,
                                          false)) {
-            utility::LogWarning("Write GLTF failed.\n");
+            utility::LogWarning("Write GLTF failed.");
             return false;
         }
     }

--- a/src/Open3D/IO/FileFormat/FileJPG.cpp
+++ b/src/Open3D/IO/FileFormat/FileJPG.cpp
@@ -43,7 +43,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
     JSAMPARRAY buffer;
 
     if ((file_in = utility::filesystem::FOpen(filename, "rb")) == NULL) {
-        utility::LogWarning("Read JPG failed: unable to open file: {}\n",
+        utility::LogWarning("Read JPG failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -71,8 +71,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
         case JCS_CMYK:
         case JCS_YCCK:
         default:
-            utility::LogWarning(
-                    "Read JPG failed: color space not supported.\n");
+            utility::LogWarning("Read JPG failed: color space not supported.");
             jpeg_destroy_decompress(&cinfo);
             fclose(file_in);
             return false;
@@ -99,12 +98,12 @@ bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,
                      int quality /* = 90*/) {
     if (image.HasData() == false) {
-        utility::LogWarning("Write JPG failed: image has no data.\n");
+        utility::LogWarning("Write JPG failed: image has no data.");
         return false;
     }
     if (image.bytes_per_channel_ != 1 ||
         (image.num_of_channels_ != 1 && image.num_of_channels_ != 3)) {
-        utility::LogWarning("Write JPG failed: unsupported image data.\n");
+        utility::LogWarning("Write JPG failed: unsupported image data.");
         return false;
     }
     struct jpeg_compress_struct cinfo;
@@ -113,7 +112,7 @@ bool WriteImageToJPG(const std::string &filename,
     JSAMPROW row_pointer[1];
 
     if ((file_out = utility::filesystem::FOpen(filename, "wb")) == NULL) {
-        utility::LogWarning("Write JPG failed: unable to open file: {}\n",
+        utility::LogWarning("Write JPG failed: unable to open file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FileJSON.cpp
+++ b/src/Open3D/IO/FileFormat/FileJSON.cpp
@@ -45,7 +45,7 @@ bool ReadIJsonConvertibleFromJSONStream(std::istream &json_stream,
     bool is_parse_successful =
             parseFromStream(builder, json_stream, &root_object, &errs);
     if (is_parse_successful == false) {
-        utility::LogWarning("Read JSON failed: {}.\n", errs);
+        utility::LogWarning("Read JSON failed: {}.", errs);
         return false;
     }
     return object.ConvertFromJsonValue(root_object);
@@ -73,7 +73,7 @@ bool ReadIJsonConvertibleFromJSON(const std::string &filename,
                                   utility::IJsonConvertible &object) {
     std::ifstream file_in(filename);
     if (file_in.is_open() == false) {
-        utility::LogWarning("Read JSON failed: unable to open file: {}\n",
+        utility::LogWarning("Read JSON failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -86,7 +86,7 @@ bool WriteIJsonConvertibleToJSON(const std::string &filename,
                                  const utility::IJsonConvertible &object) {
     std::ofstream file_out(filename);
     if (file_out.is_open() == false) {
-        utility::LogWarning("Write JSON failed: unable to open file: {}\n",
+        utility::LogWarning("Write JSON failed: unable to open file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FileLOG.cpp
+++ b/src/Open3D/IO/FileFormat/FileLOG.cpp
@@ -52,7 +52,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
     trajectory.parameters_.clear();
     FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
-        utility::LogWarning("Read LOG failed: unable to open file: {}\n",
+        utility::LogWarning("Read LOG failed: unable to open file: {}",
                             filename.c_str());
         return false;
     }
@@ -62,12 +62,12 @@ bool ReadPinholeCameraTrajectoryFromLOG(
     while (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f)) {
         if (strlen(line_buffer) > 0 && line_buffer[0] != '#') {
             if (sscanf(line_buffer, "%d %d %d", &i, &j, &k) != 3) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 fclose(f);
                 return false;
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 fclose(f);
                 return false;
             } else {
@@ -75,7 +75,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
                        &trans(0, 1), &trans(0, 2), &trans(0, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 fclose(f);
                 return false;
             } else {
@@ -83,7 +83,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
                        &trans(1, 1), &trans(1, 2), &trans(1, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 fclose(f);
                 return false;
             } else {
@@ -91,7 +91,7 @@ bool ReadPinholeCameraTrajectoryFromLOG(
                        &trans(2, 1), &trans(2, 2), &trans(2, 3));
             }
             if (fgets(line_buffer, DEFAULT_IO_BUFFER_SIZE, f) == 0) {
-                utility::LogWarning("Read LOG failed: unrecognized format.\n");
+                utility::LogWarning("Read LOG failed: unrecognized format.");
                 fclose(f);
                 return false;
             } else {
@@ -113,7 +113,7 @@ bool WritePinholeCameraTrajectoryToLOG(
         const camera::PinholeCameraTrajectory &trajectory) {
     FILE *f = utility::filesystem::FOpen(filename.c_str(), "w");
     if (f == NULL) {
-        utility::LogWarning("Write LOG failed: unable to open file: {}\n",
+        utility::LogWarning("Write LOG failed: unable to open file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -54,10 +54,10 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
                                 filename.c_str(), mtl_base_path.c_str());
 
     if (!warn.empty()) {
-        utility::LogWarning("Read OBJ failed: {}\n", warn);
+        utility::LogWarning("Read OBJ failed: {}", warn);
     }
     if (!err.empty()) {
-        utility::LogWarning("Read OBJ failed: {}\n", err);
+        utility::LogWarning("Read OBJ failed: {}", err);
     }
 
     if (!ret) {
@@ -94,7 +94,7 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
             if (fv != 3) {
                 utility::LogWarning(
                         "Read OBJ failed: facet with number of vertices not "
-                        "equal to 3\n");
+                        "equal to 3");
                 return false;
             }
 
@@ -172,22 +172,22 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
 
     std::ofstream file(filename.c_str(), std::ios::out | std::ios::binary);
     if (!file) {
-        utility::LogWarning("Write OBJ failed: unable to open file.\n");
+        utility::LogWarning("Write OBJ failed: unable to open file.");
         return false;
     }
 
     if (mesh.HasTriangleNormals()) {
-        utility::LogWarning("Write OBJ can not include triangle normals.\n");
+        utility::LogWarning("Write OBJ can not include triangle normals.");
     }
 
-    file << "# Created by Open3D \n";
-    file << "# object name: " << object_name << "\n";
-    file << "# number of vertices: " << mesh.vertices_.size() << "\n";
-    file << "# number of triangles: " << mesh.triangles_.size() << "\n";
+    file << "# Created by Open3D " << std::endl;
+    file << "# object name: " << object_name << std::endl;
+    file << "# number of vertices: " << mesh.vertices_.size() << std::endl;
+    file << "# number of triangles: " << mesh.triangles_.size() << std::endl;
 
     // always write material name in obj file, regardless of uvs or textures
-    file << "mtllib " << object_name << ".mtl\n";
-    file << "usemtl " << object_name << "\n";
+    file << "mtllib " << object_name << ".mtl" << std::endl;
+    file << "usemtl " << object_name << std::endl;
 
     utility::ConsoleProgressBar progress_bar(
             mesh.vertices_.size() + mesh.triangles_.size(),
@@ -202,12 +202,12 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
             const Eigen::Vector3d& color = mesh.vertex_colors_[vidx];
             file << " " << color(0) << " " << color(1) << " " << color(2);
         }
-        file << "\n";
+        file << std::endl;
 
         if (write_vertex_normals) {
             const Eigen::Vector3d& normal = mesh.vertex_normals_[vidx];
             file << "vn " << normal(0) << " " << normal(1) << " " << normal(2)
-                 << "\n";
+                 << std::endl;
         }
 
         ++progress_bar;
@@ -221,7 +221,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     // loose triangle-wise representation is provided
     if (write_triangle_uvs) {
         for (auto& uv : mesh.triangle_uvs_) {
-            file << "vt " << uv(0) << " " << uv(1) << "\n";
+            file << "vt " << uv(0) << " " << uv(1) << std::endl;
         }
     }
 
@@ -234,19 +234,19 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
             file << triangle(1) + 1 << "/" << 3 * tidx + 2 << "/"
                  << triangle(1) + 1 << " ";
             file << triangle(2) + 1 << "/" << 3 * tidx + 3 << "/"
-                 << triangle(2) + 1 << "\n";
+                 << triangle(2) + 1 << std::endl;
         } else if (!write_vertex_normals && write_triangle_uvs) {
             file << "f ";
             file << triangle(0) + 1 << "/" << 3 * tidx + 1 << " ";
             file << triangle(1) + 1 << "/" << 3 * tidx + 2 << " ";
-            file << triangle(2) + 1 << "/" << 3 * tidx + 3 << "\n";
+            file << triangle(2) + 1 << "/" << 3 * tidx + 3 << std::endl;
         } else if (write_vertex_normals && !write_triangle_uvs) {
             file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1 << " "
                  << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
-                 << triangle(2) + 1 << "//" << triangle(2) + 1 << "\n";
+                 << triangle(2) + 1 << "//" << triangle(2) + 1 << std::endl;
         } else {
             file << "f " << triangle(0) + 1 << " " << triangle(1) + 1 << " "
-                 << triangle(2) + 1 << "\n";
+                 << triangle(2) + 1 << std::endl;
         }
         ++progress_bar;
     }
@@ -265,21 +265,21 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     std::ofstream mtl_file(mtl_filename.c_str(), std::ios::out);
     if (!mtl_file) {
         utility::LogWarning(
-                "Write OBJ successful, but failed to write material file.\n");
+                "Write OBJ successful, but failed to write material file.");
         return true;
     }
-    mtl_file << "# Created by Open3D \n";
-    mtl_file << "# object name: " << object_name << "\n";
-    mtl_file << "newmtl " << object_name << "\n";
-    mtl_file << "Ka 1.000 1.000 1.000\n";
-    mtl_file << "Kd 1.000 1.000 1.000\n";
-    mtl_file << "Ks 0.000 0.000 0.000\n";
+    mtl_file << "# Created by Open3D " << std::endl;
+    mtl_file << "# object name: " << object_name << std::endl;
+    mtl_file << "newmtl " << object_name << std::endl;
+    mtl_file << "Ka 1.000 1.000 1.000" << std::endl;
+    mtl_file << "Kd 1.000 1.000 1.000" << std::endl;
+    mtl_file << "Ks 0.000 0.000 0.000" << std::endl;
 
     if (write_triangle_uvs && mesh.HasTexture()) {
         if (!io::WriteImage(tex_filename, *mesh.texture_.FlipVertical())) {
             utility::LogWarning(
                     "Write OBJ successful, but failed to write texture "
-                    "file.\n");
+                    "file.");
             return true;
         }
         mtl_file << "map_Kd " << object_name << ".png";

--- a/src/Open3D/IO/FileFormat/FileOFF.cpp
+++ b/src/Open3D/IO/FileFormat/FileOFF.cpp
@@ -38,7 +38,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
                              bool print_progress) {
     std::ifstream file(filename.c_str(), std::ios::in);
     if (!file) {
-        utility::LogWarning("Read OFF failed: unable to open file: {}\n",
+        utility::LogWarning("Read OFF failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -57,8 +57,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
     if (header != "OFF" && header != "COFF" && header != "NOFF" &&
         header != "CNOFF") {
         utility::LogWarning(
-                "Read OFF failed: header keyword '{}' not supported.\n",
-                header);
+                "Read OFF failed: header keyword '{}' not supported.", header);
         return false;
     }
 
@@ -66,13 +65,12 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
     unsigned int num_of_vertices, num_of_faces, num_of_edges;
     std::istringstream iss(info);
     if (!(iss >> num_of_vertices >> num_of_faces >> num_of_edges)) {
-        utility::LogWarning("Read OFF failed: could not read file info.\n");
+        utility::LogWarning("Read OFF failed: could not read file info.");
         return false;
     }
 
     if (num_of_vertices == 0 || num_of_faces == 0) {
-        utility::LogWarning(
-                "Read OFF failed: mesh has no vertices or faces.\n");
+        utility::LogWarning("Read OFF failed: mesh has no vertices or faces.");
         return false;
     }
 
@@ -100,7 +98,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
         std::istringstream iss(line);
         if (!(iss >> vx >> vy >> vz)) {
             utility::LogWarning(
-                    "Read OFF failed: could not read all vertex values.\n");
+                    "Read OFF failed: could not read all vertex values.");
             return false;
         }
         mesh.vertices_[vidx] = Eigen::Vector3d(vx, vy, vz);
@@ -109,7 +107,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
             if (!(iss >> nx >> ny >> nz)) {
                 utility::LogWarning(
                         "Read OFF failed: could not read all vertex normal "
-                        "values.\n");
+                        "values.");
                 return false;
             }
             mesh.vertex_normals_[vidx](0) = nx;
@@ -120,7 +118,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
             if (!(iss >> r >> g >> b >> alpha)) {
                 utility::LogWarning(
                         "Read OFF failed: could not read all vertex color "
-                        "values.\n");
+                        "values.");
                 return false;
             }
             mesh.vertex_colors_[vidx] =
@@ -141,7 +139,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
             if (!(iss >> vertex_index)) {
                 utility::LogWarning(
                         "Read OFF failed: could not read all vertex "
-                        "indices.\n");
+                        "indices.");
                 return false;
             }
             indices.push_back(vertex_index);
@@ -149,7 +147,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
         if (!AddTrianglesByEarClipping(mesh, indices)) {
             utility::LogWarning(
                     "Read OFF failed: A polygon in the mesh could not be "
-                    "decomposed into triangles. Vertex indices: {}\n",
+                    "decomposed into triangles. Vertex indices: {}",
                     indices);
             return false;
         }
@@ -171,23 +169,23 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
     if (write_triangle_uvs && mesh.HasTriangleUvs()) {
         utility::LogWarning(
                 "This file format does not support writing textures and uv "
-                "coordinates. Consider using .obj\n");
+                "coordinates. Consider using .obj");
     }
 
     std::ofstream file(filename.c_str(), std::ios::out);
     if (!file) {
-        utility::LogWarning("Write OFF failed: unable to open file.\n");
+        utility::LogWarning("Write OFF failed: unable to open file.");
         return false;
     }
 
     if (mesh.HasTriangleNormals()) {
-        utility::LogWarning("Write OFF cannot include triangle normals.\n");
+        utility::LogWarning("Write OFF cannot include triangle normals.");
     }
 
     size_t num_of_vertices = mesh.vertices_.size();
     size_t num_of_triangles = mesh.triangles_.size();
     if (num_of_vertices == 0 || num_of_triangles == 0) {
-        utility::LogWarning("Write OFF failed: empty file.\n");
+        utility::LogWarning("Write OFF failed: empty file.");
         return false;
     }
 
@@ -199,8 +197,8 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
     if (write_vertex_normals) {
         file << "N";
     }
-    file << "OFF\n";
-    file << num_of_vertices << " " << num_of_triangles << " 0\n";
+    file << "OFF" << std::endl;
+    file << num_of_vertices << " " << num_of_triangles << " 0" << std::endl;
 
     utility::ConsoleProgressBar progress_bar(num_of_vertices + num_of_triangles,
                                              "Writing OFF: ", print_progress);
@@ -217,14 +215,14 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
                  << std::round(color(1) * 255.0) << " "
                  << std::round(color(2) * 255.0) << " 255";
         }
-        file << "\n";
+        file << std::endl;
         ++progress_bar;
     }
 
     for (size_t tidx = 0; tidx < num_of_triangles; ++tidx) {
         const Eigen::Vector3i &triangle = mesh.triangles_[tidx];
         file << "3 " << triangle(0) << " " << triangle(1) << " " << triangle(2)
-             << "\n";
+             << std::endl;
         ++progress_bar;
     }
 

--- a/src/Open3D/IO/FileFormat/FilePCD.cpp
+++ b/src/Open3D/IO/FileFormat/FilePCD.cpp
@@ -80,11 +80,11 @@ public:
 
 bool CheckHeader(PCDHeader &header) {
     if (header.points <= 0 || header.pointsize <= 0) {
-        utility::LogWarning("[CheckHeader] PCD has no data.\n");
+        utility::LogWarning("[CheckHeader] PCD has no data.");
         return false;
     }
     if (header.fields.size() == 0 || header.pointsize <= 0) {
-        utility::LogWarning("[CheckHeader] PCD has no fields.\n");
+        utility::LogWarning("[CheckHeader] PCD has no fields.");
         return false;
     }
     header.has_points = false;
@@ -122,7 +122,7 @@ bool CheckHeader(PCDHeader &header) {
     header.has_colors = (has_rgb || has_rgba);
     if (header.has_points == false) {
         utility::LogWarning(
-                "[CheckHeader] Fields for point data are not complete.\n");
+                "[CheckHeader] Fields for point data are not complete.");
         return false;
     }
     return true;
@@ -152,7 +152,7 @@ bool ReadPCDHeader(FILE *file, PCDHeader &header) {
                    line_type.substr(0, 7) == "COLUMNS") {
             specified_channel_count = st.size() - 1;
             if (specified_channel_count == 0) {
-                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.\n");
+                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.");
                 return false;
             }
             header.fields.resize(specified_channel_count);
@@ -170,7 +170,7 @@ bool ReadPCDHeader(FILE *file, PCDHeader &header) {
             header.pointsize = offset;
         } else if (line_type.substr(0, 4) == "SIZE") {
             if (specified_channel_count != st.size() - 1) {
-                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.\n");
+                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.");
                 return false;
             }
             int offset = 0, col_type = 0;
@@ -183,7 +183,7 @@ bool ReadPCDHeader(FILE *file, PCDHeader &header) {
             header.pointsize = offset;
         } else if (line_type.substr(0, 4) == "TYPE") {
             if (specified_channel_count != st.size() - 1) {
-                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.\n");
+                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.");
                 return false;
             }
             for (size_t i = 0; i < specified_channel_count; i++) {
@@ -191,7 +191,7 @@ bool ReadPCDHeader(FILE *file, PCDHeader &header) {
             }
         } else if (line_type.substr(0, 5) == "COUNT") {
             if (specified_channel_count != st.size() - 1) {
-                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.\n");
+                utility::LogWarning("[ReadPCDHeader] Bad PCD file format.");
                 return false;
             }
             int count_offset = 0, offset = 0, col_count = 0;
@@ -340,7 +340,7 @@ bool ReadPCDData(FILE *file,
         pointcloud.points_.resize(header.points);
     } else {
         utility::LogWarning(
-                "[ReadPCDData] Fields for point data are not complete.\n");
+                "[ReadPCDData] Fields for point data are not complete.");
         return false;
     }
     if (header.has_normals) {
@@ -399,7 +399,7 @@ bool ReadPCDData(FILE *file,
         for (int i = 0; i < header.points; i++) {
             if (fread(buffer.get(), header.pointsize, 1, file) != 1) {
                 utility::LogWarning(
-                        "[ReadPCDData] Failed to read data record.\n");
+                        "[ReadPCDData] Failed to read data record.");
                 pointcloud.Clear();
                 return false;
             }
@@ -439,24 +439,24 @@ bool ReadPCDData(FILE *file,
         std::uint32_t compressed_size;
         std::uint32_t uncompressed_size;
         if (fread(&compressed_size, sizeof(compressed_size), 1, file) != 1) {
-            utility::LogWarning("[ReadPCDData] Failed to read data record.\n");
+            utility::LogWarning("[ReadPCDData] Failed to read data record.");
             pointcloud.Clear();
             return false;
         }
         if (fread(&uncompressed_size, sizeof(uncompressed_size), 1, file) !=
             1) {
-            utility::LogWarning("[ReadPCDData] Failed to read data record.\n");
+            utility::LogWarning("[ReadPCDData] Failed to read data record.");
             pointcloud.Clear();
             return false;
         }
         utility::LogDebug(
                 "PCD data with {:d} compressed size, and {:d} uncompressed "
-                "size.\n",
+                "size.",
                 compressed_size, uncompressed_size);
         std::unique_ptr<char[]> buffer_compressed(new char[compressed_size]);
         if (fread(buffer_compressed.get(), 1, compressed_size, file) !=
             compressed_size) {
-            utility::LogWarning("[ReadPCDData] Failed to read data record.\n");
+            utility::LogWarning("[ReadPCDData] Failed to read data record.");
             pointcloud.Clear();
             return false;
         }
@@ -465,7 +465,7 @@ bool ReadPCDData(FILE *file,
                            (unsigned int)compressed_size, buffer.get(),
                            (unsigned int)uncompressed_size) !=
             uncompressed_size) {
-            utility::LogWarning("[ReadPCDData] Uncompression failed.\n");
+            utility::LogWarning("[ReadPCDData] Uncompression failed.");
             pointcloud.Clear();
             return false;
         }
@@ -695,11 +695,11 @@ bool WritePCDData(FILE *file,
                 lzf_compress(buffer.get(), buffer_size_in_bytes,
                              buffer_compressed.get(), buffer_size_in_bytes * 2);
         if (size_compressed == 0) {
-            utility::LogWarning("[WritePCDData] Failed to compress data.\n");
+            utility::LogWarning("[WritePCDData] Failed to compress data.");
             return false;
         }
         utility::LogDebug(
-                "[WritePCDData] {:d} bytes data compressed into {:d} bytes.\n",
+                "[WritePCDData] {:d} bytes data compressed into {:d} bytes.",
                 buffer_size_in_bytes, size_compressed);
         fwrite(&size_compressed, sizeof(size_compressed), 1, file);
         fwrite(&buffer_size_in_bytes, sizeof(buffer_size_in_bytes), 1, file);
@@ -717,31 +717,30 @@ bool ReadPointCloudFromPCD(const std::string &filename,
     PCDHeader header;
     FILE *file = utility::filesystem::FOpen(filename.c_str(), "rb");
     if (file == NULL) {
-        utility::LogWarning("Read PCD failed: unable to open file: {}\n",
+        utility::LogWarning("Read PCD failed: unable to open file: {}",
                             filename);
         return false;
     }
     if (ReadPCDHeader(file, header) == false) {
-        utility::LogWarning("Read PCD failed: unable to parse header.\n");
+        utility::LogWarning("Read PCD failed: unable to parse header.");
         fclose(file);
         return false;
     }
     utility::LogDebug(
             "PCD header indicates {:d} fields, {:d} bytes per point, and {:d} "
-            "points "
-            "in total.\n",
+            "points in total.",
             (int)header.fields.size(), header.pointsize, header.points);
     for (const auto &field : header.fields) {
-        utility::LogDebug("{}, {}, {:d}, {:d}, {:d}\n", field.name.c_str(),
+        utility::LogDebug("{}, {}, {:d}, {:d}, {:d}", field.name.c_str(),
                           field.type, field.size, field.count, field.offset);
     }
-    utility::LogDebug("Compression method is {:d}.\n", (int)header.datatype);
-    utility::LogDebug("Points: {};  normals: {};  colors: {}\n",
+    utility::LogDebug("Compression method is {:d}.", (int)header.datatype);
+    utility::LogDebug("Points: {};  normals: {};  colors: {}",
                       header.has_points ? "yes" : "no",
                       header.has_normals ? "yes" : "no",
                       header.has_colors ? "yes" : "no");
     if (ReadPCDData(file, header, pointcloud) == false) {
-        utility::LogWarning("Read PCD failed: unable to read data.\n");
+        utility::LogWarning("Read PCD failed: unable to read data.");
         fclose(file);
         return false;
     }
@@ -756,21 +755,21 @@ bool WritePointCloudToPCD(const std::string &filename,
                           bool print_progress) {
     PCDHeader header;
     if (GenerateHeader(pointcloud, write_ascii, compressed, header) == false) {
-        utility::LogWarning("Write PCD failed: unable to generate header.\n");
+        utility::LogWarning("Write PCD failed: unable to generate header.");
         return false;
     }
     FILE *file = utility::filesystem::FOpen(filename.c_str(), "wb");
     if (file == NULL) {
-        utility::LogWarning("Write PCD failed: unable to open file.\n");
+        utility::LogWarning("Write PCD failed: unable to open file.");
         return false;
     }
     if (WritePCDHeader(file, header) == false) {
-        utility::LogWarning("Write PCD failed: unable to write header.\n");
+        utility::LogWarning("Write PCD failed: unable to write header.");
         fclose(file);
         return false;
     }
     if (WritePCDData(file, header, pointcloud) == false) {
-        utility::LogWarning("Write PCD failed: unable to write data.\n");
+        utility::LogWarning("Write PCD failed: unable to write data.");
         fclose(file);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FilePCD.cpp
+++ b/src/Open3D/IO/FileFormat/FilePCD.cpp
@@ -449,7 +449,7 @@ bool ReadPCDData(FILE *file,
             pointcloud.Clear();
             return false;
         }
-        utility::LogWarning(
+        utility::LogDebug(
                 "PCD data with {:d} compressed size, and {:d} uncompressed "
                 "size.\n",
                 compressed_size, uncompressed_size);

--- a/src/Open3D/IO/FileFormat/FilePLY.cpp
+++ b/src/Open3D/IO/FileFormat/FilePLY.cpp
@@ -195,7 +195,7 @@ int ReadFaceCallBack(p_ply_argument argument) {
         if (!AddTrianglesByEarClipping(*state_ptr->mesh_ptr, state_ptr->face)) {
             utility::LogWarning(
                     "Read PLY failed: A polygon in the mesh could not be "
-                    "decomposed into triangles.\n");
+                    "decomposed into triangles.");
             return 0;
         }
         state_ptr->face_index++;
@@ -362,12 +362,12 @@ bool ReadPointCloudFromPLY(const std::string &filename,
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Read PLY failed: unable to open file: %s\n",
+        utility::LogWarning("Read PLY failed: unable to open file: %s",
                             filename.c_str());
         return false;
     }
     if (!ply_read_header(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to parse header.\n");
+        utility::LogWarning("Read PLY failed: unable to parse header.");
         ply_close(ply_file);
         return false;
     }
@@ -390,7 +390,7 @@ bool ReadPointCloudFromPLY(const std::string &filename,
     ply_set_read_cb(ply_file, "vertex", "blue", ReadColorCallback, &state, 2);
 
     if (state.vertex_num <= 0) {
-        utility::LogWarning("Read PLY failed: number of vertex <= 0.\n");
+        utility::LogWarning("Read PLY failed: number of vertex <= 0.");
         ply_close(ply_file);
         return false;
     }
@@ -409,7 +409,7 @@ bool ReadPointCloudFromPLY(const std::string &filename,
     state.progress_bar = &progress_bar;
 
     if (!ply_read(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to read file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to read file: {}",
                             filename);
         ply_close(ply_file);
         return false;
@@ -426,7 +426,7 @@ bool WritePointCloudToPLY(const std::string &filename,
                           bool compressed /* = false*/,
                           bool print_progress) {
     if (pointcloud.IsEmpty()) {
-        utility::LogWarning("Write PLY failed: point cloud has 0 points.\n");
+        utility::LogWarning("Write PLY failed: point cloud has 0 points.");
         return false;
     }
 
@@ -434,7 +434,7 @@ bool WritePointCloudToPLY(const std::string &filename,
                                 write_ascii ? PLY_ASCII : PLY_LITTLE_ENDIAN,
                                 NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Write PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Write PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -455,7 +455,7 @@ bool WritePointCloudToPLY(const std::string &filename,
         ply_add_property(ply_file, "blue", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
     }
     if (!ply_write_header(ply_file)) {
-        utility::LogWarning("Write PLY failed: unable to write header.\n");
+        utility::LogWarning("Write PLY failed: unable to write header.");
         ply_close(ply_file);
         return false;
     }
@@ -498,12 +498,12 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Read PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
     if (!ply_read_header(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to parse header.\n");
+        utility::LogWarning("Read PLY failed: unable to parse header.");
         ply_close(ply_file);
         return false;
     }
@@ -526,7 +526,7 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
     ply_set_read_cb(ply_file, "vertex", "blue", ReadColorCallback, &state, 2);
 
     if (state.vertex_num <= 0) {
-        utility::LogWarning("Read PLY failed: number of vertex <= 0.\n");
+        utility::LogWarning("Read PLY failed: number of vertex <= 0.");
         ply_close(ply_file);
         return false;
     }
@@ -553,7 +553,7 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
     state.progress_bar = &progress_bar;
 
     if (!ply_read(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to read file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to read file: {}",
                             filename);
         ply_close(ply_file);
         return false;
@@ -574,11 +574,11 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
     if (write_triangle_uvs && mesh.HasTriangleUvs()) {
         utility::LogWarning(
                 "This file format currently does not support writing textures "
-                "and uv coordinates. Consider using .obj\n");
+                "and uv coordinates. Consider using .obj");
     }
 
     if (mesh.IsEmpty()) {
-        utility::LogWarning("Write PLY failed: mesh has 0 vertices.\n");
+        utility::LogWarning("Write PLY failed: mesh has 0 vertices.");
         return false;
     }
 
@@ -586,7 +586,7 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
                                 write_ascii ? PLY_ASCII : PLY_LITTLE_ENDIAN,
                                 NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Write PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Write PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -614,7 +614,7 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
                     static_cast<long>(mesh.triangles_.size()));
     ply_add_property(ply_file, "vertex_indices", PLY_LIST, PLY_UCHAR, PLY_UINT);
     if (!ply_write_header(ply_file)) {
-        utility::LogWarning("Write PLY failed: unable to write header.\n");
+        utility::LogWarning("Write PLY failed: unable to write header.");
         ply_close(ply_file);
         return false;
     }
@@ -661,12 +661,12 @@ bool ReadLineSetFromPLY(const std::string &filename,
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Read PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
     if (!ply_read_header(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to parse header.\n");
+        utility::LogWarning("Read PLY failed: unable to parse header.");
         ply_close(ply_file);
         return false;
     }
@@ -688,12 +688,12 @@ bool ReadLineSetFromPLY(const std::string &filename,
     ply_set_read_cb(ply_file, "edge", "blue", ReadColorCallback, &state, 2);
 
     if (state.vertex_num <= 0) {
-        utility::LogWarning("Read PLY failed: number of vertex <= 0.\n");
+        utility::LogWarning("Read PLY failed: number of vertex <= 0.");
         ply_close(ply_file);
         return false;
     }
     if (state.line_num <= 0) {
-        utility::LogWarning("Read PLY failed: number of edges <= 0.\n");
+        utility::LogWarning("Read PLY failed: number of edges <= 0.");
         ply_close(ply_file);
         return false;
     }
@@ -713,7 +713,7 @@ bool ReadLineSetFromPLY(const std::string &filename,
     state.progress_bar = &progress_bar;
 
     if (!ply_read(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to read file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to read file: {}",
                             filename);
         ply_close(ply_file);
         return false;
@@ -729,11 +729,11 @@ bool WriteLineSetToPLY(const std::string &filename,
                        bool compressed /* = false*/,
                        bool print_progress) {
     if (lineset.IsEmpty()) {
-        utility::LogWarning("Write PLY failed: line set has 0 points.\n");
+        utility::LogWarning("Write PLY failed: line set has 0 points.");
         return false;
     }
     if (!lineset.HasLines()) {
-        utility::LogWarning("Write PLY failed: line set has 0 lines.\n");
+        utility::LogWarning("Write PLY failed: line set has 0 lines.");
         return false;
     }
 
@@ -741,7 +741,7 @@ bool WriteLineSetToPLY(const std::string &filename,
                                 write_ascii ? PLY_ASCII : PLY_LITTLE_ENDIAN,
                                 NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Write PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Write PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -760,7 +760,7 @@ bool WriteLineSetToPLY(const std::string &filename,
         ply_add_property(ply_file, "blue", PLY_UCHAR, PLY_UCHAR, PLY_UCHAR);
     }
     if (!ply_write_header(ply_file)) {
-        utility::LogWarning("Write PLY failed: unable to write header.\n");
+        utility::LogWarning("Write PLY failed: unable to write header.");
         ply_close(ply_file);
         return false;
     }
@@ -803,12 +803,12 @@ bool ReadVoxelGridFromPLY(const std::string &filename,
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Read PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
     if (!ply_read_header(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to parse header.\n");
+        utility::LogWarning("Read PLY failed: unable to parse header.");
         ply_close(ply_file);
         return false;
     }
@@ -822,7 +822,7 @@ bool ReadVoxelGridFromPLY(const std::string &filename,
     ply_set_read_cb(ply_file, "vertex", "z", ReadVoxelCallback, &state, 2);
 
     if (state.voxel_num <= 0) {
-        utility::LogWarning("Read PLY failed: number of vertex <= 0.\n");
+        utility::LogWarning("Read PLY failed: number of vertex <= 0.");
         ply_close(ply_file);
         return false;
     }
@@ -848,7 +848,7 @@ bool ReadVoxelGridFromPLY(const std::string &filename,
     state.progress_bar = &progress_bar;
 
     if (!ply_read(ply_file)) {
-        utility::LogWarning("Read PLY failed: unable to read file: {}\n",
+        utility::LogWarning("Read PLY failed: unable to read file: {}",
                             filename);
         ply_close(ply_file);
         return false;
@@ -874,7 +874,7 @@ bool WriteVoxelGridToPLY(const std::string &filename,
                          bool compressed /* = false*/,
                          bool print_progress) {
     if (voxelgrid.IsEmpty()) {
-        utility::LogWarning("Write PLY failed: voxelgrid has 0 voxels.\n");
+        utility::LogWarning("Write PLY failed: voxelgrid has 0 voxels.");
         return false;
     }
 
@@ -882,7 +882,7 @@ bool WriteVoxelGridToPLY(const std::string &filename,
                                 write_ascii ? PLY_ASCII : PLY_LITTLE_ENDIAN,
                                 NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Write PLY failed: unable to open file: {}\n",
+        utility::LogWarning("Write PLY failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -908,7 +908,7 @@ bool WriteVoxelGridToPLY(const std::string &filename,
     }
 
     if (!ply_write_header(ply_file)) {
-        utility::LogWarning("Write PLY failed: unable to write header.\n");
+        utility::LogWarning("Write PLY failed: unable to write header.");
         ply_close(ply_file);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FilePLY.cpp
+++ b/src/Open3D/IO/FileFormat/FilePLY.cpp
@@ -574,8 +574,7 @@ bool WriteTriangleMeshToPLY(const std::string &filename,
     if (write_triangle_uvs && mesh.HasTriangleUvs()) {
         utility::LogWarning(
                 "This file format currently does not support writing textures "
-                "and uv "
-                "coordinates. Consider using .obj\n");
+                "and uv coordinates. Consider using .obj\n");
     }
 
     if (mesh.IsEmpty()) {

--- a/src/Open3D/IO/FileFormat/FilePNG.cpp
+++ b/src/Open3D/IO/FileFormat/FilePNG.cpp
@@ -55,7 +55,7 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
     if (png_image_begin_read_from_file(&pngimage, filename.c_str()) == 0) {
-        utility::LogWarning("Read PNG failed: unable to parse header.\n");
+        utility::LogWarning("Read PNG failed: unable to parse header.");
         return false;
     }
 
@@ -68,7 +68,7 @@ bool ReadImageFromPNG(const std::string &filename, geometry::Image &image) {
     SetPNGImageFromImage(image, pngimage);
     if (png_image_finish_read(&pngimage, NULL, image.data_.data(), 0, NULL) ==
         0) {
-        utility::LogWarning("Read PNG failed: unable to read file: {}\n",
+        utility::LogWarning("Read PNG failed: unable to read file: {}",
                             filename);
         return false;
     }
@@ -79,7 +79,7 @@ bool WriteImageToPNG(const std::string &filename,
                      const geometry::Image &image,
                      int quality) {
     if (image.HasData() == false) {
-        utility::LogWarning("Write PNG failed: image has no data.\n");
+        utility::LogWarning("Write PNG failed: image has no data.");
         return false;
     }
     png_image pngimage;
@@ -88,7 +88,7 @@ bool WriteImageToPNG(const std::string &filename,
     SetPNGImageFromImage(image, pngimage);
     if (png_image_write_to_file(&pngimage, filename.c_str(), 0,
                                 image.data_.data(), 0, NULL) == 0) {
-        utility::LogWarning("Write PNG failed: unable to write file: {}\n",
+        utility::LogWarning("Write PNG failed: unable to write file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FilePTS.cpp
+++ b/src/Open3D/IO/FileFormat/FilePTS.cpp
@@ -39,7 +39,7 @@ bool ReadPointCloudFromPTS(const std::string &filename,
                            bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
-        utility::LogWarning("Read PTS failed: unable to open file.\n");
+        utility::LogWarning("Read PTS failed: unable to open file.");
         return false;
     }
     char line_buffer[DEFAULT_IO_BUFFER_SIZE];
@@ -48,7 +48,7 @@ bool ReadPointCloudFromPTS(const std::string &filename,
         sscanf(line_buffer, "%d", &num_of_pts);
     }
     if (num_of_pts <= 0) {
-        utility::LogWarning("Read PTS failed: unable to read header.\n");
+        utility::LogWarning("Read PTS failed: unable to read header.");
         fclose(file);
         return false;
     }
@@ -63,7 +63,7 @@ bool ReadPointCloudFromPTS(const std::string &filename,
             num_of_fields = (int)st.size();
             if (num_of_fields < 3) {
                 utility::LogWarning(
-                        "Read PTS failed: insufficient data fields.\n");
+                        "Read PTS failed: insufficient data fields.");
                 fclose(file);
                 return false;
             }
@@ -100,7 +100,7 @@ bool WritePointCloudToPTS(const std::string &filename,
                           bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
-        utility::LogWarning("Write PTS failed: unable to open file.\n");
+        utility::LogWarning("Write PTS failed: unable to open file.");
         return false;
     }
     fprintf(file, "%d\r\n", (int)pointcloud.points_.size());

--- a/src/Open3D/IO/FileFormat/FileSTL.cpp
+++ b/src/Open3D/IO/FileFormat/FileSTL.cpp
@@ -40,7 +40,7 @@ bool ReadTriangleMeshFromSTL(const std::string &filename,
     FILE *myFile = utility::filesystem::FOpen(filename.c_str(), "rb");
 
     if (!myFile) {
-        utility::LogWarning("Read STL failed: unable to open file.\n");
+        utility::LogWarning("Read STL failed: unable to open file.");
         fclose(myFile);
         return false;
     }
@@ -51,13 +51,13 @@ bool ReadTriangleMeshFromSTL(const std::string &filename,
         fread(header, sizeof(char), 80, myFile);
         fread(&num_of_triangles, sizeof(unsigned int), 1, myFile);
     } else {
-        utility::LogWarning("Read STL failed: unable to read header.\n");
+        utility::LogWarning("Read STL failed: unable to read header.");
         fclose(myFile);
         return false;
     }
 
     if (num_of_triangles == 0) {
-        utility::LogWarning("Read STL failed: empty file.\n");
+        utility::LogWarning("Read STL failed: empty file.");
         fclose(myFile);
         return false;
     }
@@ -90,7 +90,7 @@ bool ReadTriangleMeshFromSTL(const std::string &filename,
             // ignore buffer[48] and buffer [49] because it is rarely used.
 
         } else {
-            utility::LogWarning("Read STL failed: not enough triangles.\n");
+            utility::LogWarning("Read STL failed: not enough triangles.");
             fclose(myFile);
             return false;
         }
@@ -112,24 +112,24 @@ bool WriteTriangleMeshToSTL(const std::string &filename,
     if (write_triangle_uvs && mesh.HasTriangleUvs()) {
         utility::LogWarning(
                 "This file format does not support writing textures and uv "
-                "coordinates. Consider using .obj\n");
+                "coordinates. Consider using .obj");
     }
 
     std::ofstream myFile(filename.c_str(), std::ios::out | std::ios::binary);
 
     if (!myFile) {
-        utility::LogWarning("Write STL failed: unable to open file.\n");
+        utility::LogWarning("Write STL failed: unable to open file.");
         return false;
     }
 
     if (!mesh.HasTriangleNormals()) {
-        utility::LogWarning("Write STL failed: compute normals first.\n");
+        utility::LogWarning("Write STL failed: compute normals first.");
         return false;
     }
 
     size_t num_of_triangles = mesh.triangles_.size();
     if (num_of_triangles == 0) {
-        utility::LogWarning("Write STL failed: empty file.\n");
+        utility::LogWarning("Write STL failed: empty file.");
         return false;
     }
     char header[80] = "Created by Open3D";

--- a/src/Open3D/IO/FileFormat/FileTUM.cpp
+++ b/src/Open3D/IO/FileFormat/FileTUM.cpp
@@ -56,7 +56,7 @@ bool ReadPinholeCameraTrajectoryFromTUM(
     trajectory.parameters_.clear();
     FILE *f = utility::filesystem::FOpen(filename, "r");
     if (f == NULL) {
-        utility::LogWarning("Read TUM failed: unable to open file: {}\n",
+        utility::LogWarning("Read TUM failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -67,7 +67,7 @@ bool ReadPinholeCameraTrajectoryFromTUM(
         if (strlen(line_buffer) > 0 && line_buffer[0] != '#') {
             if (sscanf(line_buffer, "%lf %lf %lf %lf %lf %lf %lf %lf", &ts, &x,
                        &y, &z, &qx, &qy, &qz, &qw) != 8) {
-                utility::LogWarning("Read TUM failed: unrecognized format.\n");
+                utility::LogWarning("Read TUM failed: unrecognized format.");
                 fclose(f);
                 return false;
             }
@@ -91,7 +91,7 @@ bool WritePinholeCameraTrajectoryToTUM(
         const camera::PinholeCameraTrajectory &trajectory) {
     FILE *f = utility::filesystem::FOpen(filename, "w");
     if (f == NULL) {
-        utility::LogWarning("Write TUM failed: unable to open file: {}\n",
+        utility::LogWarning("Write TUM failed: unable to open file: {}",
                             filename);
         return false;
     }

--- a/src/Open3D/IO/FileFormat/FileXYZ.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZ.cpp
@@ -38,7 +38,7 @@ bool ReadPointCloudFromXYZ(const std::string &filename,
                            bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
-        utility::LogWarning("Read XYZ failed: unable to open file: {}\n",
+        utility::LogWarning("Read XYZ failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -64,7 +64,7 @@ bool WritePointCloudToXYZ(const std::string &filename,
                           bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
-        utility::LogWarning("Write XYZ failed: unable to open file: {}\n",
+        utility::LogWarning("Write XYZ failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -73,7 +73,7 @@ bool WritePointCloudToXYZ(const std::string &filename,
         const Eigen::Vector3d &point = pointcloud.points_[i];
         if (fprintf(file, "%.10f %.10f %.10f\n", point(0), point(1), point(2)) <
             0) {
-            utility::LogWarning("Write XYZ failed: unable to write file: {}\n",
+            utility::LogWarning("Write XYZ failed: unable to write file: {}",
                                 filename);
             fclose(file);
             return false;  // error happens during writing.

--- a/src/Open3D/IO/FileFormat/FileXYZN.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZN.cpp
@@ -38,7 +38,7 @@ bool ReadPointCloudFromXYZN(const std::string &filename,
                             bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
-        utility::LogWarning("Read XYZN failed: unable to open file: {}\n",
+        utility::LogWarning("Read XYZN failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -70,7 +70,7 @@ bool WritePointCloudToXYZN(const std::string &filename,
 
     FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
-        utility::LogWarning("Write XYZN failed: unable to open file: {}\n",
+        utility::LogWarning("Write XYZN failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -80,7 +80,7 @@ bool WritePointCloudToXYZN(const std::string &filename,
         const Eigen::Vector3d &normal = pointcloud.normals_[i];
         if (fprintf(file, "%.10f %.10f %.10f %.10f %.10f %.10f\n", point(0),
                     point(1), point(2), normal(0), normal(1), normal(2)) < 0) {
-            utility::LogWarning("Write XYZN failed: unable to write file: {}\n",
+            utility::LogWarning("Write XYZN failed: unable to write file: {}",
                                 filename);
             fclose(file);
             return false;  // error happens during writing.

--- a/src/Open3D/IO/FileFormat/FileXYZRGB.cpp
+++ b/src/Open3D/IO/FileFormat/FileXYZRGB.cpp
@@ -38,7 +38,7 @@ bool ReadPointCloudFromXYZRGB(const std::string &filename,
                               bool print_progress) {
     FILE *file = utility::filesystem::FOpen(filename, "r");
     if (file == NULL) {
-        utility::LogWarning("Read XYZRGB failed: unable to open file: {}\n",
+        utility::LogWarning("Read XYZRGB failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -70,7 +70,7 @@ bool WritePointCloudToXYZRGB(const std::string &filename,
 
     FILE *file = utility::filesystem::FOpen(filename, "w");
     if (file == NULL) {
-        utility::LogWarning("Write XYZRGB failed: unable to open file: {}\n",
+        utility::LogWarning("Write XYZRGB failed: unable to open file: {}",
                             filename);
         return false;
     }
@@ -80,9 +80,8 @@ bool WritePointCloudToXYZRGB(const std::string &filename,
         const Eigen::Vector3d &color = pointcloud.colors_[i];
         if (fprintf(file, "%.10f %.10f %.10f %.10f %.10f %.10f\n", point(0),
                     point(1), point(2), color(0), color(1), color(2)) < 0) {
-            utility::LogWarning(
-                    "Write XYZRGB failed: unable to write file: {}\n",
-                    filename);
+            utility::LogWarning("Write XYZRGB failed: unable to write file: {}",
+                                filename);
             fclose(file);
             return false;  // error happens during writing.
         }

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
@@ -66,15 +66,15 @@ bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
                     filename.c_str(), sensor_.device_,
                     sensor_.sensor_config_.ConvertToNativeConfig(),
                     &recording_))) {
-            utility::LogWarning("Unable to create recording file: {}\n",
+            utility::LogWarning("Unable to create recording file: {}",
                                 filename);
             return false;
         }
         if (K4A_FAILED(k4a_plugin::k4a_record_write_header(recording_))) {
-            utility::LogWarning("Unable to write header\n");
+            utility::LogWarning("Unable to write header");
             return false;
         }
-        utility::LogInfo("Writing to header\n");
+        utility::LogInfo("Writing to header");
 
         is_record_created_ = true;
     }
@@ -83,13 +83,13 @@ bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
 
 bool AzureKinectRecorder::CloseRecord() {
     if (is_record_created_) {
-        utility::LogInfo("Saving recording...\n");
+        utility::LogInfo("Saving recording...");
         if (K4A_FAILED(k4a_plugin::k4a_record_flush(recording_))) {
-            utility::LogWarning("Unable to flush record file\n");
+            utility::LogWarning("Unable to flush record file");
             return false;
         }
         k4a_plugin::k4a_record_close(recording_);
-        utility::LogInfo("Done\n");
+        utility::LogInfo("Done");
 
         is_record_created_ = false;
     }
@@ -102,7 +102,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectRecorder::RecordFrame(
     if (capture != nullptr && is_record_created_ && write) {
         if (K4A_FAILED(k4a_plugin::k4a_record_write_capture(recording_,
                                                             capture))) {
-            utility::LogError("Unable to write to capture\n");
+            utility::LogError("Unable to write to capture");
         }
     }
 
@@ -111,7 +111,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectRecorder::RecordFrame(
                              ? sensor_.transform_depth_to_color_
                              : nullptr);
     if (im_rgbd == nullptr) {
-        utility::LogInfo("Invalid capture, skipping this frame\n");
+        utility::LogInfo("Invalid capture, skipping this frame");
         return nullptr;
     }
     k4a_plugin::k4a_capture_release(capture);

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectRecorder.cpp
@@ -66,12 +66,12 @@ bool AzureKinectRecorder::OpenRecord(const std::string& filename) {
                     filename.c_str(), sensor_.device_,
                     sensor_.sensor_config_.ConvertToNativeConfig(),
                     &recording_))) {
-            utility::LogError("Unable to create recording file: {}\n",
-                              filename);
+            utility::LogWarning("Unable to create recording file: {}\n",
+                                filename);
             return false;
         }
         if (K4A_FAILED(k4a_plugin::k4a_record_write_header(recording_))) {
-            utility::LogError("Unable to write header\n");
+            utility::LogWarning("Unable to write header\n");
             return false;
         }
         utility::LogInfo("Writing to header\n");
@@ -85,7 +85,7 @@ bool AzureKinectRecorder::CloseRecord() {
     if (is_record_created_) {
         utility::LogInfo("Saving recording...\n");
         if (K4A_FAILED(k4a_plugin::k4a_record_flush(recording_))) {
-            utility::LogError("Unable to flush record file\n");
+            utility::LogWarning("Unable to flush record file\n");
             return false;
         }
         k4a_plugin::k4a_record_close(recording_);
@@ -103,7 +103,6 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectRecorder::RecordFrame(
         if (K4A_FAILED(k4a_plugin::k4a_record_write_capture(recording_,
                                                             capture))) {
             utility::LogError("Unable to write to capture\n");
-            return nullptr;
         }
     }
 

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.cpp
@@ -47,8 +47,8 @@ AzureKinectSensor::~AzureKinectSensor() {
 }
 
 bool AzureKinectSensor::Connect(size_t sensor_index) {
-    utility::LogInfo("AzureKinectSensor::Connect\n");
-    utility::LogInfo("sensor_index {}\n", sensor_index);
+    utility::LogInfo("AzureKinectSensor::Connect");
+    utility::LogInfo("sensor_index {}", sensor_index);
     auto device_config = sensor_config_.ConvertToNativeConfig();
 
     // check mode
@@ -73,7 +73,7 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
         device_config.depth_mode == K4A_DEPTH_MODE_OFF) {
         utility::LogWarning(
                 "Config error: either the color or depth modes must be "
-                "enabled to record.\n");
+                "enabled to record.");
         return false;
     }
 
@@ -81,14 +81,14 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
     const uint32_t installed_devices =
             k4a_plugin::k4a_device_get_installed_count();
     if (sensor_index >= installed_devices) {
-        utility::LogWarning("Device not found.\n");
+        utility::LogWarning("Device not found.");
         return false;
     }
 
     // open device
     if (K4A_FAILED(k4a_plugin::k4a_device_open(sensor_index, &device_))) {
         utility::LogWarning(
-                "Runtime error: k4a_plugin::k4a_device_open() failed\n");
+                "Runtime error: k4a_plugin::k4a_device_open() failed");
         return false;
     }
 
@@ -99,7 +99,7 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
                                                         &device_config))) {
         utility::LogWarning(
                 "Runtime error: k4a_plugin::k4a_device_set_color_control() "
-                "failed\n");
+                "failed");
         k4a_plugin::k4a_device_close(device_);
         return false;
     }
@@ -110,7 +110,7 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
                 K4A_COLOR_CONTROL_MODE_AUTO, 0))) {
         utility::LogWarning(
                 "Runtime error: k4a_plugin::k4a_device_set_color_control() "
-                "failed\n");
+                "failed");
         k4a_plugin::k4a_device_close(device_);
         return false;
     }
@@ -135,7 +135,7 @@ k4a_capture_t AzureKinectSensor::CaptureRawFrame() const {
     } else if (result != K4A_WAIT_RESULT_SUCCEEDED) {
         utility::LogWarning(
                 "Runtime error: k4a_plugin::k4a_device_get_capture() returned "
-                "{}\n",
+                "{}",
                 result);
         return nullptr;
     }
@@ -197,25 +197,25 @@ bool AzureKinectSensor::PrintFirmware(k4a_device_t device) {
                                              &serial_number_buffer_size)) {
         utility::LogWarning(
                 "Runtime error: k4a_plugin::k4a_device_get_serialnum() "
-                "failed\n");
+                "failed");
         return false;
     }
 
     k4a_hardware_version_t version_info;
     if (K4A_FAILED(k4a_plugin::k4a_device_get_version(device, &version_info))) {
         utility::LogWarning(
-                "Runtime error: k4a_plugin::k4a_device_get_version() failed\n");
+                "Runtime error: k4a_plugin::k4a_device_get_version() failed");
         return false;
     }
 
-    utility::LogInfo("Serial number: {}\n", serial_number_buffer);
-    utility::LogInfo("Firmware build: {}\n",
+    utility::LogInfo("Serial number: {}", serial_number_buffer);
+    utility::LogInfo("Firmware build: {}",
                      (version_info.firmware_build == K4A_FIRMWARE_BUILD_RELEASE
                               ? "Rel"
                               : "Dbg"));
-    utility::LogInfo("> Color: {}.{}.{}\n", version_info.rgb.major,
+    utility::LogInfo("> Color: {}.{}.{}", version_info.rgb.major,
                      version_info.rgb.minor, version_info.rgb.iteration);
-    utility::LogInfo("> Depth: {}.{}.{}[{}.{}]\n", version_info.depth.major,
+    utility::LogInfo("> Depth: {}.{}.{}[{}.{}]", version_info.depth.major,
                      version_info.depth.minor, version_info.depth.iteration,
                      version_info.depth_sensor.major,
                      version_info.depth_sensor.minor);
@@ -226,18 +226,18 @@ bool AzureKinectSensor::ListDevices() {
     uint32_t device_count = k4a_plugin::k4a_device_get_installed_count();
     if (device_count > 0) {
         for (uint8_t i = 0; i < device_count; i++) {
-            utility::LogInfo("Device index {}\n", i);
+            utility::LogInfo("Device index {}", i);
             k4a_device_t device;
             if (K4A_SUCCEEDED(k4a_plugin::k4a_device_open(i, &device))) {
                 AzureKinectSensor::PrintFirmware(device);
                 k4a_plugin::k4a_device_close(device);
             } else {
-                utility::LogWarning("Device Open Failed\n");
+                utility::LogWarning("Device Open Failed");
                 return false;
             }
         }
     } else {
-        utility::LogError("No devices connected.\n");
+        utility::LogError("No devices connected.");
     }
 
     return true;
@@ -258,7 +258,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectSensor::DecompressCapture(
     k4a_image_t k4a_color = k4a_plugin::k4a_capture_get_color_image(capture);
     k4a_image_t k4a_depth = k4a_plugin::k4a_capture_get_depth_image(capture);
     if (k4a_color == nullptr || k4a_depth == nullptr) {
-        utility::LogDebug("Skipping empty captures.\n");
+        utility::LogDebug("Skipping empty captures.");
         return nullptr;
     }
 
@@ -267,7 +267,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectSensor::DecompressCapture(
         k4a_plugin::k4a_image_get_format(k4a_color)) {
         utility::LogWarning(
                 "Unexpected image format. The stream may have "
-                "corrupted.\n");
+                "corrupted.");
         return nullptr;
     }
 
@@ -286,7 +286,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectSensor::DecompressCapture(
                               k4a_plugin::k4a_image_get_size(k4a_color)),
                       color_buffer->data_.data(), width, 0 /* pitch */, height,
                       TJPF_BGRA, TJFLAG_FASTDCT | TJFLAG_FASTUPSAMPLE)) {
-        utility::LogWarning("Failed to decompress color image.\n");
+        utility::LogWarning("Failed to decompress color image.");
         return nullptr;
     }
     tjDestroy(tjHandle);
@@ -305,7 +305,7 @@ std::shared_ptr<geometry::RGBDImage> AzureKinectSensor::DecompressCapture(
             k4a_plugin::k4a_transformation_depth_image_to_color_camera(
                     transformation, k4a_depth, k4a_transformed_depth)) {
             utility::LogWarning(
-                    "Failed to transform depth frame to color frame.\n");
+                    "Failed to transform depth frame to color frame.");
             return nullptr;
         }
     } else {

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensorConfig.cpp
@@ -154,8 +154,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
     for (const auto &it : config) {
         if (standard_config.find(it.first) == standard_config.end()) {
             rc = false;
-            utility::LogWarning("IsValidConfig: Unrecognized key {}\n",
-                                it.first);
+            utility::LogWarning("IsValidConfig: Unrecognized key {}", it.first);
         }
     }
 
@@ -163,7 +162,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
         string_to_k4a_image_format_t.count(config.at("color_format")) == 0) {
         rc = false;
         if (verbose) {
-            utility::LogWarning("IsValidConfig: color_format invalid\n");
+            utility::LogWarning("IsValidConfig: color_format invalid");
         }
     }
 
@@ -172,7 +171,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
                 0) {
         rc = false;
         if (verbose) {
-            utility::LogWarning("IsValidConfig: color_resolution invalid\n");
+            utility::LogWarning("IsValidConfig: color_resolution invalid");
         }
     }
 
@@ -180,7 +179,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
         string_to_k4a_depth_mode_t.count(config.at("depth_mode")) == 0) {
         rc = false;
         if (verbose) {
-            utility::LogWarning("IsValidConfig: depth_mode invalid\n");
+            utility::LogWarning("IsValidConfig: depth_mode invalid");
         }
     }
 
@@ -188,7 +187,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
         string_to_k4a_fps_t.count(config.at("camera_fps")) == 0) {
         rc = false;
         if (verbose) {
-            utility::LogWarning("IsValidConfig: camera_fps invalid\n");
+            utility::LogWarning("IsValidConfig: camera_fps invalid");
         }
     } else {
         if (config.count("camera_fps") != 0 &&
@@ -198,7 +197,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
             rc = false;
             if (verbose) {
                 utility::LogWarning(
-                        "K4A_COLOR_RESOLUTION_3072P does not support 30 FPS\n");
+                        "K4A_COLOR_RESOLUTION_3072P does not support 30 FPS");
             }
         }
     }
@@ -209,7 +208,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
         rc = false;
         if (verbose) {
             utility::LogWarning(
-                    "IsValidConfig: synchronized_images_only invalid\n");
+                    "IsValidConfig: synchronized_images_only invalid");
         }
     }
 
@@ -218,7 +217,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
                 0) {
         rc = false;
         if (verbose) {
-            utility::LogWarning("IsValidConfig: wired_sync_mode invalid\n");
+            utility::LogWarning("IsValidConfig: wired_sync_mode invalid");
         }
     }
 
@@ -228,7 +227,7 @@ bool AzureKinectSensorConfig::IsValidConfig(
         rc = false;
         if (verbose) {
             utility::LogWarning(
-                    "IsValidConfig: disable_streaming_indicator invalid\n");
+                    "IsValidConfig: disable_streaming_indicator invalid");
         }
     }
 
@@ -239,7 +238,7 @@ AzureKinectSensorConfig::AzureKinectSensorConfig(
         const std::unordered_map<std::string, std::string> &config)
     : AzureKinectSensorConfig() {
     if (!IsValidConfig(config)) {
-        utility::LogWarning("Invalid configs, default configs will be used.\n");
+        utility::LogWarning("Invalid configs, default configs will be used.");
         return;
     }
     for (const auto &it : config) {
@@ -294,7 +293,7 @@ void AzureKinectSensorConfig::ConvertFromNativeConfig(
     if (!IsValidConfig(config_)) {
         utility::LogError(
                 "Internal error, invalid configs. Maybe SDK version is "
-                "mismatched.\n");
+                "mismatched.");
     }
 }
 

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -88,7 +88,7 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
             }
         }
         if (handle == NULL) {
-            utility::LogFatal("Cannot load {}\n", lib_name);
+            utility::LogError("Cannot load {}\n", lib_name);
         }
         map_lib_name_to_handle[lib_name] = handle;
     }
@@ -106,7 +106,7 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
             f = (f_type)GetProcAddress(GetDynamicLibHandle(lib_name), \
                                        #f_name);                      \
             if (f == nullptr) {                                       \
-                utility::LogFatal("Cannot load func {}\n", #f_name);  \
+                utility::LogError("Cannot load func {}\n", #f_name);  \
             } else {                                                  \
                 utility::LogDebug("Loaded func {}\n", #f_name);       \
             }                                                         \
@@ -152,7 +152,7 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
             }
         }
         if (!handle) {
-            utility::LogFatal("Cannot load {}\n", dlerror());
+            utility::LogError("Cannot load {}\n", dlerror());
         } else {
             utility::LogDebug("Loaded {}\n", full_path);
             struct link_map* map = nullptr;
@@ -181,7 +181,7 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
         if (!f) {                                                              \
             f = (f_type)dlsym(GetDynamicLibHandle(lib_name), #f_name);         \
             if (!f) {                                                          \
-                utility::LogFatal("Cannot load {}: {}\n", #f_name, dlerror()); \
+                utility::LogError("Cannot load {}: {}\n", #f_name, dlerror()); \
             }                                                                  \
         }                                                                      \
         return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));                       \

--- a/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/K4aPlugin.cpp
@@ -67,7 +67,7 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
         if (temp != nullptr) {
             env_lib_dir = std::string(temp);
         }
-        utility::LogDebug("Environment variable K4A_LIB_DIR: {}\n", env_lib_dir);
+        utility::LogDebug("Environment variable K4A_LIB_DIR: {}", env_lib_dir);
 
         static const std::vector<std::string> k4a_lib_path_hints = {
             env_lib_dir,
@@ -78,17 +78,17 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
 
         HINSTANCE handle = NULL;
         for (const std::string& k4a_lib_path_hint : k4a_lib_path_hints) {
-            utility::LogDebug("Trying k4a_lib_path_hint: {}\n",
+            utility::LogDebug("Trying k4a_lib_path_hint: {}",
                               k4a_lib_path_hint);
             std::string full_path = k4a_lib_path_hint + "\\" + lib_name;
             handle = LoadLibrary(TEXT(full_path.c_str()));
             if (handle != NULL) {
-                utility::LogDebug("Loaded {}\n", full_path);
+                utility::LogDebug("Loaded {}", full_path);
                 break;
             }
         }
         if (handle == NULL) {
-            utility::LogError("Cannot load {}\n", lib_name);
+            utility::LogError("Cannot load {}", lib_name);
         }
         map_lib_name_to_handle[lib_name] = handle;
     }
@@ -106,9 +106,9 @@ static HINSTANCE GetDynamicLibHandle(const std::string& lib_name) {
             f = (f_type)GetProcAddress(GetDynamicLibHandle(lib_name), \
                                        #f_name);                      \
             if (f == nullptr) {                                       \
-                utility::LogError("Cannot load func {}\n", #f_name);  \
+                utility::LogError("Cannot load func {}", #f_name);    \
             } else {                                                  \
-                utility::LogDebug("Loaded func {}\n", #f_name);       \
+                utility::LogDebug("Loaded func {}", #f_name);         \
             }                                                         \
         }                                                             \
         return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));              \
@@ -152,18 +152,18 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
             }
         }
         if (!handle) {
-            utility::LogError("Cannot load {}\n", dlerror());
+            utility::LogError("Cannot load {}", dlerror());
         } else {
-            utility::LogDebug("Loaded {}\n", full_path);
+            utility::LogDebug("Loaded {}", full_path);
             struct link_map* map = nullptr;
             if (!dlinfo(handle, RTLD_DI_LINKMAP, &map)) {
                 if (map != nullptr) {
-                    utility::LogDebug("Library path {}\n", map->l_name);
+                    utility::LogDebug("Library path {}", map->l_name);
                 } else {
-                    utility::LogWarning("Cannot get link_map\n");
+                    utility::LogWarning("Cannot get link_map");
                 }
             } else {
-                utility::LogWarning("Cannot get dlinfo\n");
+                utility::LogWarning("Cannot get dlinfo");
             }
         }
         map_lib_name_to_handle[lib_name] = handle;
@@ -171,20 +171,20 @@ static void* GetDynamicLibHandle(const std::string& lib_name) {
     return map_lib_name_to_handle.at(lib_name);
 }
 
-#define DEFINE_BRIDGED_FUNC_WITH_COUNT(lib_name, return_type, f_name,          \
-                                       num_args, ...)                          \
-    return_type f_name(EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) {          \
-        typedef return_type (*f_type)(                                         \
-                EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));                  \
-        static f_type f = nullptr;                                             \
-                                                                               \
-        if (!f) {                                                              \
-            f = (f_type)dlsym(GetDynamicLibHandle(lib_name), #f_name);         \
-            if (!f) {                                                          \
-                utility::LogError("Cannot load {}: {}\n", #f_name, dlerror()); \
-            }                                                                  \
-        }                                                                      \
-        return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));                       \
+#define DEFINE_BRIDGED_FUNC_WITH_COUNT(lib_name, return_type, f_name,        \
+                                       num_args, ...)                        \
+    return_type f_name(EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__)) {        \
+        typedef return_type (*f_type)(                                       \
+                EXTRACT_TYPES_PARAMS(num_args, __VA_ARGS__));                \
+        static f_type f = nullptr;                                           \
+                                                                             \
+        if (!f) {                                                            \
+            f = (f_type)dlsym(GetDynamicLibHandle(lib_name), #f_name);       \
+            if (!f) {                                                        \
+                utility::LogError("Cannot load {}: {}", #f_name, dlerror()); \
+            }                                                                \
+        }                                                                    \
+        return f(EXTRACT_PARAMS(num_args, __VA_ARGS__));                     \
     }
 
 #endif

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVReader.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVReader.cpp
@@ -52,9 +52,9 @@ std::string MKVReader::GetTagInMetadata(const std::string &tag_name) {
     if (K4A_BUFFER_RESULT_SUCCEEDED == result) {
         return res_buffer;
     } else if (K4A_BUFFER_RESULT_TOO_SMALL == result) {
-        utility::LogError("{} tag's content is too long.\n", tag_name);
+        utility::LogError("{} tag's content is too long.", tag_name);
     } else {
-        utility::LogError("{} tag does not exist.\n", tag_name);
+        utility::LogError("{} tag does not exist.", tag_name);
     }
 }
 
@@ -65,7 +65,7 @@ bool MKVReader::Open(const std::string &filename) {
 
     if (K4A_RESULT_SUCCEEDED !=
         k4a_plugin::k4a_playback_open(filename.c_str(), &handle_)) {
-        utility::LogWarning("Unable to open file {}\n", filename);
+        utility::LogWarning("Unable to open file {}", filename);
         return false;
     }
 
@@ -87,7 +87,7 @@ Json::Value MKVReader::GetMetadataJson() {
                                         {"3072P", std::make_pair(4096, 3072)}});
 
     if (!IsOpened()) {
-        utility::LogError("Null file handler. Please call Open().\n");
+        utility::LogError("Null file handler. Please call Open().");
     }
 
     Json::Value value;
@@ -95,7 +95,7 @@ Json::Value MKVReader::GetMetadataJson() {
     k4a_calibration_t calibration;
     if (K4A_RESULT_SUCCEEDED !=
         k4a_plugin::k4a_playback_get_calibration(handle_, &calibration)) {
-        utility::LogError("Failed to get calibration\n");
+        utility::LogError("Failed to get calibration");
     }
 
     camera::PinholeCameraIntrinsic pinhole_camera;
@@ -115,12 +115,12 @@ Json::Value MKVReader::GetMetadataJson() {
     auto color_mode = value["color_mode"].asString();
     size_t pos = color_mode.find('_');
     if (pos == std::string::npos) {
-        utility::LogError("Unknown color format {}\n", color_mode);
+        utility::LogError("Unknown color format {}", color_mode);
     }
     std::string resolution =
             std::string(color_mode.begin() + pos + 1, color_mode.end());
     if (resolution_to_width_height.count(resolution) == 0) {
-        utility::LogError("Unknown resolution format {}\n", resolution);
+        utility::LogError("Unknown resolution format {}", resolution);
     }
 
     auto width_height = resolution_to_width_height.at(resolution);
@@ -135,20 +135,20 @@ Json::Value MKVReader::GetMetadataJson() {
 
 bool MKVReader::SeekTimestamp(size_t timestamp) {
     if (!IsOpened()) {
-        utility::LogWarning("Null file handler. Please call Open().\n");
+        utility::LogWarning("Null file handler. Please call Open().");
         return false;
     }
 
     if (timestamp >= metadata_.stream_length_usec_) {
-        utility::LogWarning("Timestamp {} exceeds maximum {} (us).\n",
-                            timestamp, metadata_.stream_length_usec_);
+        utility::LogWarning("Timestamp {} exceeds maximum {} (us).", timestamp,
+                            metadata_.stream_length_usec_);
         return false;
     }
 
     if (K4A_RESULT_SUCCEEDED !=
         k4a_plugin::k4a_playback_seek_timestamp(handle_, timestamp,
                                                 K4A_PLAYBACK_SEEK_BEGIN)) {
-        utility::LogWarning("Unable to go to timestamp {}\n", timestamp);
+        utility::LogWarning("Unable to go to timestamp {}", timestamp);
         return false;
     }
     return true;
@@ -156,18 +156,18 @@ bool MKVReader::SeekTimestamp(size_t timestamp) {
 
 std::shared_ptr<geometry::RGBDImage> MKVReader::NextFrame() {
     if (!IsOpened()) {
-        utility::LogError("Null file handler. Please call Open().\n");
+        utility::LogError("Null file handler. Please call Open().");
     }
 
     k4a_capture_t k4a_capture;
     k4a_stream_result_t res =
             k4a_plugin::k4a_playback_get_next_capture(handle_, &k4a_capture);
     if (K4A_STREAM_RESULT_EOF == res) {
-        utility::LogInfo("EOF reached\n");
+        utility::LogInfo("EOF reached");
         is_eof_ = true;
         return nullptr;
     } else if (K4A_STREAM_RESULT_FAILED == res) {
-        utility::LogInfo("Empty frame encountered, skip\n");
+        utility::LogInfo("Empty frame encountered, skip");
         return nullptr;
     }
 

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
@@ -47,7 +47,7 @@ bool MKVWriter::Open(const std::string &filename,
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_create(filename.c_str(),
                                                               device, config,
                                                               &handle_)) {
-        utility::LogWarning("Unable to open file {}\n", filename);
+        utility::LogWarning("Unable to open file {}", filename);
         return false;
     }
 
@@ -60,7 +60,7 @@ bool MKVWriter::SetMetadata(const MKVMetadata &metadata) {
     metadata_ = metadata;
 
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_write_header(handle_)) {
-        utility::LogWarning("Unable to write header\n");
+        utility::LogWarning("Unable to write header");
         return false;
     }
     return true;
@@ -68,20 +68,20 @@ bool MKVWriter::SetMetadata(const MKVMetadata &metadata) {
 
 void MKVWriter::Close() {
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_flush(handle_)) {
-        utility::LogWarning("Unable to flush before writing\n");
+        utility::LogWarning("Unable to flush before writing");
     }
     k4a_plugin::k4a_record_close(handle_);
 }
 
 bool MKVWriter::NextFrame(k4a_capture_t capture) {
     if (!IsOpened()) {
-        utility::LogWarning("Null file handler. Please call Open().\n");
+        utility::LogWarning("Null file handler. Please call Open().");
         return false;
     }
 
     if (K4A_RESULT_SUCCEEDED !=
         k4a_plugin::k4a_record_write_capture(handle_, capture)) {
-        utility::LogWarning("Unable to write frame to mkv.\n");
+        utility::LogWarning("Unable to write frame to mkv.");
         return false;
     }
 

--- a/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/MKVWriter.cpp
@@ -47,7 +47,7 @@ bool MKVWriter::Open(const std::string &filename,
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_create(filename.c_str(),
                                                               device, config,
                                                               &handle_)) {
-        utility::LogError("Unable to open file {}\n", filename);
+        utility::LogWarning("Unable to open file {}\n", filename);
         return false;
     }
 
@@ -60,7 +60,7 @@ bool MKVWriter::SetMetadata(const MKVMetadata &metadata) {
     metadata_ = metadata;
 
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_write_header(handle_)) {
-        utility::LogError("Unable to write header\n");
+        utility::LogWarning("Unable to write header\n");
         return false;
     }
     return true;
@@ -68,20 +68,20 @@ bool MKVWriter::SetMetadata(const MKVMetadata &metadata) {
 
 void MKVWriter::Close() {
     if (K4A_RESULT_SUCCEEDED != k4a_plugin::k4a_record_flush(handle_)) {
-        utility::LogError("Unable to flush before writing\n");
+        utility::LogWarning("Unable to flush before writing\n");
     }
     k4a_plugin::k4a_record_close(handle_);
 }
 
 bool MKVWriter::NextFrame(k4a_capture_t capture) {
     if (!IsOpened()) {
-        utility::LogError("Null file handler. Please call Open().\n");
+        utility::LogWarning("Null file handler. Please call Open().\n");
         return false;
     }
 
     if (K4A_RESULT_SUCCEEDED !=
         k4a_plugin::k4a_record_write_capture(handle_, capture)) {
-        utility::LogError("Unable to write frame to mkv.\n");
+        utility::LogWarning("Unable to write frame to mkv.\n");
         return false;
     }
 

--- a/src/Open3D/Integration/ScalableTSDFVolume.cpp
+++ b/src/Open3D/Integration/ScalableTSDFVolume.cpp
@@ -71,7 +71,7 @@ void ScalableTSDFVolume::Integrate(
         (color_type_ != TSDFVolumeColorType::NoColor &&
          image.color_.height_ != intrinsic.height_)) {
         utility::LogError(
-                "[ScalableTSDFVolume::Integrate] Unsupported image format.\n");
+                "[ScalableTSDFVolume::Integrate] Unsupported image format.");
     }
     auto depth2cameradistance =
             geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(

--- a/src/Open3D/Integration/ScalableTSDFVolume.cpp
+++ b/src/Open3D/Integration/ScalableTSDFVolume.cpp
@@ -70,9 +70,8 @@ void ScalableTSDFVolume::Integrate(
          image.color_.width_ != intrinsic.width_) ||
         (color_type_ != TSDFVolumeColorType::NoColor &&
          image.color_.height_ != intrinsic.height_)) {
-        utility::LogWarning(
+        utility::LogError(
                 "[ScalableTSDFVolume::Integrate] Unsupported image format.\n");
-        return;
     }
     auto depth2cameradistance =
             geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(

--- a/src/Open3D/Integration/UniformTSDFVolume.cpp
+++ b/src/Open3D/Integration/UniformTSDFVolume.cpp
@@ -78,9 +78,8 @@ void UniformTSDFVolume::Integrate(
          image.color_.width_ != intrinsic.width_) ||
         (color_type_ != TSDFVolumeColorType::NoColor &&
          image.color_.height_ != intrinsic.height_)) {
-        utility::LogWarning(
+        utility::LogError(
                 "[UniformTSDFVolume::Integrate] Unsupported image format.\n");
-        return;
     }
     auto depth2cameradistance =
             geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(

--- a/src/Open3D/Integration/UniformTSDFVolume.cpp
+++ b/src/Open3D/Integration/UniformTSDFVolume.cpp
@@ -79,7 +79,7 @@ void UniformTSDFVolume::Integrate(
         (color_type_ != TSDFVolumeColorType::NoColor &&
          image.color_.height_ != intrinsic.height_)) {
         utility::LogError(
-                "[UniformTSDFVolume::Integrate] Unsupported image format.\n");
+                "[UniformTSDFVolume::Integrate] Unsupported image format.");
     }
     auto depth2cameradistance =
             geometry::Image::CreateDepthToCameraDistanceMultiplierFloatImage(

--- a/src/Open3D/Odometry/Odometry.cpp
+++ b/src/Open3D/Odometry/Odometry.cpp
@@ -201,9 +201,8 @@ std::shared_ptr<geometry::Image> ConvertDepthImageToXYZImage(
         const geometry::Image &depth, const Eigen::Matrix3d &intrinsic_matrix) {
     auto image_xyz = std::make_shared<geometry::Image>();
     if (depth.num_of_channels_ != 1 || depth.bytes_per_channel_ != 4) {
-        utility::LogWarning(
+        utility::LogError(
                 "[ConvertDepthImageToXYZImage] Unsupported image format.\n");
-        return image_xyz;
     }
     const double inv_fx = 1.0 / intrinsic_matrix(0, 0);
     const double inv_fy = 1.0 / intrinsic_matrix(1, 1);
@@ -305,10 +304,9 @@ void NormalizeIntensity(geometry::Image &image_s,
                         CorrespondenceSetPixelWise &correspondence) {
     if (image_s.width_ != image_t.width_ ||
         image_s.height_ != image_t.height_) {
-        utility::LogWarning(
+        utility::LogError(
                 "[NormalizeIntensity] Size of two input images should be "
                 "same\n");
-        return;
     }
     double mean_s = 0.0, mean_t = 0.0;
     for (size_t row = 0; row < correspondence.size(); row++) {

--- a/src/Open3D/Odometry/Odometry.cpp
+++ b/src/Open3D/Odometry/Odometry.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<geometry::Image> ConvertDepthImageToXYZImage(
     auto image_xyz = std::make_shared<geometry::Image>();
     if (depth.num_of_channels_ != 1 || depth.bytes_per_channel_ != 4) {
         utility::LogError(
-                "[ConvertDepthImageToXYZImage] Unsupported image format.\n");
+                "[ConvertDepthImageToXYZImage] Unsupported image format.");
     }
     const double inv_fx = 1.0 / intrinsic_matrix(0, 0);
     const double inv_fy = 1.0 / intrinsic_matrix(1, 1);
@@ -306,7 +306,7 @@ void NormalizeIntensity(geometry::Image &image_s,
         image_s.height_ != image_t.height_) {
         utility::LogError(
                 "[NormalizeIntensity] Size of two input images should be "
-                "same\n");
+                "same");
     }
     double mean_s = 0.0, mean_t = 0.0;
     for (size_t row = 0; row < correspondence.size(); row++) {
@@ -434,7 +434,7 @@ std::tuple<bool, Eigen::Matrix4d> DoSingleIteration(
     std::tie(is_success, extrinsic) =
             utility::SolveJacobianSystemAndObtainExtrinsicMatrix(JTJ, JTr);
     if (!is_success) {
-        utility::LogWarning("[ComputeOdometry] no solution!\n");
+        utility::LogWarning("[ComputeOdometry] no solution!");
         return std::make_tuple(false, Eigen::Matrix4d::Identity());
     } else {
         return std::make_tuple(true, extrinsic);
@@ -491,7 +491,7 @@ std::tuple<bool, Eigen::Matrix4d> ComputeMultiscale(
             result_odo = curr_odo * result_odo;
 
             if (!is_success) {
-                utility::LogWarning("[ComputeOdometry] no solution!\n");
+                utility::LogWarning("[ComputeOdometry] no solution!");
                 return std::make_tuple(false, Eigen::Matrix4d::Identity());
             }
         }
@@ -514,7 +514,7 @@ std::tuple<bool, Eigen::Matrix4d, Eigen::Matrix6d> ComputeRGBDOdometry(
         const OdometryOption &option /*= OdometryOption()*/) {
     if (!CheckRGBDImagePair(source, target)) {
         utility::LogWarning(
-                "[RGBDOdometry] Two RGBD pairs should be same in size.\n");
+                "[RGBDOdometry] Two RGBD pairs should be same in size.");
         return std::make_tuple(false, Eigen::Matrix4d::Identity(),
                                Eigen::Matrix6d::Zero());
     }

--- a/src/Open3D/Open3DConfig.cpp
+++ b/src/Open3D/Open3DConfig.cpp
@@ -30,6 +30,6 @@
 
 namespace open3d {
 
-void PrintOpen3DVersion() { utility::LogInfo("Open3D {}\n", OPEN3D_VERSION); }
+void PrintOpen3DVersion() { utility::LogInfo("Open3D {}", OPEN3D_VERSION); }
 
 }  // namespace open3d

--- a/src/Open3D/Registration/ColoredICP.cpp
+++ b/src/Open3D/Registration/ColoredICP.cpp
@@ -78,7 +78,7 @@ private:
 std::shared_ptr<PointCloudForColoredICP> InitializePointCloudForColoredICP(
         const geometry::PointCloud &target,
         const geometry::KDTreeSearchParamHybrid &search_param) {
-    utility::LogDebug("InitializePointCloudForColoredICP\n");
+    utility::LogDebug("InitializePointCloudForColoredICP");
 
     geometry::KDTreeFlann tree;
     tree.SetGeometry(target);

--- a/src/Open3D/Registration/CorrespondenceChecker.cpp
+++ b/src/Open3D/Registration/CorrespondenceChecker.cpp
@@ -82,7 +82,7 @@ bool CorrespondenceCheckerBasedOnNormal::Check(
     if (source.HasNormals() == false || target.HasNormals() == false) {
         utility::LogWarning(
                 "[CorrespondenceCheckerBasedOnNormal::Check] Pointcloud has no "
-                "normals.\n");
+                "normals.");
         return true;
     }
     double cos_normal_angle_threshold = std::cos(normal_angle_threshold_);

--- a/src/Open3D/Registration/FastGlobalRegistration.cpp
+++ b/src/Open3D/Registration/FastGlobalRegistration.cpp
@@ -46,7 +46,7 @@ std::vector<std::pair<int, int>> AdvancedMatching(
         const FastGlobalRegistrationOption& option) {
     // STEP 0) Swap source and target if necessary
     int fi = 0, fj = 1;
-    utility::LogDebug("Advanced matching : [{:d} - {:d}]\n", fi, fj);
+    utility::LogDebug("Advanced matching : [{:d} - {:d}]", fi, fj);
     bool swapped = false;
     if (point_cloud_vec[fj].points_.size() >
         point_cloud_vec[fi].points_.size()) {
@@ -92,7 +92,7 @@ std::vector<std::pair<int, int>> AdvancedMatching(
     for (int j = 0; j < ncorres_ji; ++j)
         corres.push_back(
                 std::pair<int, int>(corres_ji[j].first, corres_ji[j].second));
-    utility::LogDebug("points are remained : {:d}\n", (int)corres.size());
+    utility::LogDebug("points are remained : {:d}", (int)corres.size());
 
     // STEP 2) CROSS CHECK
     utility::LogDebug("\t[cross check] ");
@@ -118,7 +118,7 @@ std::vector<std::pair<int, int>> AdvancedMatching(
             }
         }
     }
-    utility::LogDebug("points are remained : %d\n", (int)corres_cross.size());
+    utility::LogDebug("points are remained : %d", (int)corres_cross.size());
 
     // STEP 3) TUPLE CONSTRAINT
     utility::LogDebug("\t[tuple constraint] ");
@@ -166,7 +166,7 @@ std::vector<std::pair<int, int>> AdvancedMatching(
         }
         if (cnt >= option.maximum_tuple_count_) break;
     }
-    utility::LogDebug("{:d} tuples ({:d} trial, {:d} actual).\n", cnt,
+    utility::LogDebug("{:d} tuples ({:d} trial, {:d} actual).", cnt,
                       number_of_trial, i);
 
     if (swapped) {
@@ -177,7 +177,7 @@ std::vector<std::pair<int, int>> AdvancedMatching(
         corres_tuple.clear();
         corres_tuple = temp;
     }
-    utility::LogDebug("\t[final] matches {:d}.\n", (int)corres_tuple.size());
+    utility::LogDebug("\t[final] matches {:d}.", (int)corres_tuple.size());
     return corres_tuple;
 }
 
@@ -201,7 +201,7 @@ std::tuple<std::vector<Eigen::Vector3d>, double, double> NormalizePointCloud(
         mean = mean / npti;
         pcd_mean_vec.push_back(mean);
 
-        utility::LogDebug("normalize points :: mean = [{:f} {:f} {:f}]\n",
+        utility::LogDebug("normalize points :: mean = [{:f} {:f} {:f}]",
                           mean(0), mean(1), mean(2));
         for (int ii = 0; ii < npti; ++ii)
             point_cloud_vec[i].points_[ii] -= mean;
@@ -221,8 +221,7 @@ std::tuple<std::vector<Eigen::Vector3d>, double, double> NormalizePointCloud(
         scale_global = scale;
         scale_start = 1.0;
     }
-    utility::LogDebug("normalize points :: global scale : {:f}\n",
-                      scale_global);
+    utility::LogDebug("normalize points :: global scale : {:f}", scale_global);
 
     for (int i = 0; i < num; ++i) {
         int npti = static_cast<int>(point_cloud_vec[i].points_.size());
@@ -238,7 +237,7 @@ Eigen::Matrix4d OptimizePairwiseRegistration(
         const std::vector<std::pair<int, int>>& corres,
         double scale_start,
         const FastGlobalRegistrationOption& option) {
-    utility::LogDebug("Pairwise rigid pose optimization\n");
+    utility::LogDebug("Pairwise rigid pose optimization");
     double par = scale_start;
     int numIter = option.iteration_number_;
 

--- a/src/Open3D/Registration/Feature.cpp
+++ b/src/Open3D/Registration/Feature.cpp
@@ -123,7 +123,7 @@ std::shared_ptr<Feature> ComputeFPFHFeature(
     if (input.HasNormals() == false) {
         utility::LogError(
                 "[ComputeFPFHFeature] Failed because input point cloud has no "
-                "normal.\n");
+                "normal.");
     }
     geometry::KDTreeFlann kdtree(input);
     auto spfh = ComputeSPFHFeature(input, kdtree, search_param);

--- a/src/Open3D/Registration/Feature.cpp
+++ b/src/Open3D/Registration/Feature.cpp
@@ -121,10 +121,9 @@ std::shared_ptr<Feature> ComputeFPFHFeature(
     auto feature = std::make_shared<Feature>();
     feature->Resize(33, (int)input.points_.size());
     if (input.HasNormals() == false) {
-        utility::LogWarning(
+        utility::LogError(
                 "[ComputeFPFHFeature] Failed because input point cloud has no "
                 "normal.\n");
-        return feature;
     }
     geometry::KDTreeFlann kdtree(input);
     auto spfh = ComputeSPFHFeature(input, kdtree, search_param);

--- a/src/Open3D/Registration/GlobalOptimization.cpp
+++ b/src/Open3D/Registration/GlobalOptimization.cpp
@@ -275,7 +275,7 @@ std::shared_ptr<PoseGraph> UpdatePoseGraph(const PoseGraph &pose_graph,
 bool CheckRightTerm(const Eigen::VectorXd &right_term,
                     const GlobalOptimizationConvergenceCriteria &criteria) {
     if (right_term.maxCoeff() < criteria.min_right_term_) {
-        utility::LogDebug("Maximum coefficient of right term < {:e}\n",
+        utility::LogDebug("Maximum coefficient of right term < {:e}",
                           criteria.min_right_term_);
         return true;
     }
@@ -288,7 +288,7 @@ bool CheckRelativeIncrement(
         const GlobalOptimizationConvergenceCriteria &criteria) {
     if (delta.norm() < criteria.min_relative_increment_ *
                                (x.norm() + criteria.min_relative_increment_)) {
-        utility::LogDebug("Delta.norm() < {:e} * (x.norm() + {:e})\n",
+        utility::LogDebug("Delta.norm() < {:e} * (x.norm() + {:e})",
                           criteria.min_relative_increment_,
                           criteria.min_relative_increment_);
         return true;
@@ -303,7 +303,7 @@ bool CheckRelativeResidualIncrement(
     if (current_residual - new_residual <
         criteria.min_relative_residual_increment_ * current_residual) {
         utility::LogDebug(
-                "Current_residual - new_residual < {:e} * current_residual\n",
+                "Current_residual - new_residual < {:e} * current_residual",
                 criteria.min_relative_residual_increment_);
         return true;
     }
@@ -313,7 +313,7 @@ bool CheckRelativeResidualIncrement(
 bool CheckResidual(double residual,
                    const GlobalOptimizationConvergenceCriteria &criteria) {
     if (residual < criteria.min_residual_) {
-        utility::LogDebug("Current_residual < {:e}\n", criteria.min_residual_);
+        utility::LogDebug("Current_residual < {:e}", criteria.min_residual_);
         return true;
     }
     return false;
@@ -322,7 +322,7 @@ bool CheckResidual(double residual,
 bool CheckMaxIteration(int iteration,
                        const GlobalOptimizationConvergenceCriteria &criteria) {
     if (iteration >= criteria.max_iteration_) {
-        utility::LogDebug("Reached maximum number of iterations ({:d})\n",
+        utility::LogDebug("Reached maximum number of iterations ({:d})",
                           criteria.max_iteration_);
         return true;
     }
@@ -332,7 +332,7 @@ bool CheckMaxIteration(int iteration,
 bool CheckMaxIterationLM(
         int iteration, const GlobalOptimizationConvergenceCriteria &criteria) {
     if (iteration >= criteria.max_iteration_lm_) {
-        utility::LogDebug("Reached maximum number of iterations ({:d})\n",
+        utility::LogDebug("Reached maximum number of iterations ({:d})",
                           criteria.max_iteration_lm_);
         return true;
     }
@@ -364,7 +364,7 @@ double ComputeLineProcessWeight(const PoseGraph &pose_graph,
 void CompensateReferencePoseGraphNode(PoseGraph &pose_graph_new,
                                       const PoseGraph &pose_graph_orig,
                                       int reference_node) {
-    utility::LogDebug("CompensateReferencePoseGraphNode : reference : {:d}\n",
+    utility::LogDebug("CompensateReferencePoseGraphNode : reference : {:d}",
                       reference_node);
     int n_nodes = (int)pose_graph_new.nodes_.size();
     if (reference_node < 0 || reference_node >= n_nodes) {
@@ -425,13 +425,13 @@ bool ValidatePoseGraph(const PoseGraph &pose_graph) {
     int n_edges = (int)pose_graph.edges_.size();
 
     if (!ValidatePoseGraphConnectivity(pose_graph, false)) {
-        utility::LogWarning("Invalid PoseGraph - graph is not connected.\n");
+        utility::LogWarning("Invalid PoseGraph - graph is not connected.");
         return false;
     }
 
     if (!ValidatePoseGraphConnectivity(pose_graph, true)) {
         utility::LogWarning(
-                "Certain-edge subset of PoseGraph is not connected.\n");
+                "Certain-edge subset of PoseGraph is not connected.");
     }
 
     for (int j = 0; j < n_edges; j++) {
@@ -443,7 +443,7 @@ bool ValidatePoseGraph(const PoseGraph &pose_graph) {
         if (!valid) {
             utility::LogWarning(
                     "Invalid PoseGraph - an edge references an invalide "
-                    "node.\n");
+                    "node.");
             return false;
         }
     }
@@ -452,11 +452,11 @@ bool ValidatePoseGraph(const PoseGraph &pose_graph) {
         if (!t.uncertain_ && t.confidence_ != 1.0) {
             utility::LogWarning(
                     "Invalid PoseGraph - the certain edge does not have 1.0 as "
-                    "a confidence.\n");
+                    "a confidence.");
             return false;
         }
     }
-    utility::LogDebug("Validating PoseGraph - finished.\n");
+    utility::LogDebug("Validating PoseGraph - finished.");
     return true;
 }
 
@@ -497,9 +497,9 @@ void GlobalOptimizationGaussNewton::OptimizePoseGraph(
 
     utility::LogDebug(
             "[GlobalOptimizationGaussNewton] Optimizing PoseGraph having {:d} "
-            "nodes and %d edges. \n",
+            "nodes and %d edges.",
             n_nodes, n_edges);
-    utility::LogDebug("Line process weight : {:f}\n", line_process_weight);
+    utility::LogDebug("Line process weight : {:f}", line_process_weight);
 
     Eigen::VectorXd zeta = ComputeZeta(pose_graph);
     double current_residual, new_residual;
@@ -517,7 +517,7 @@ void GlobalOptimizationGaussNewton::OptimizePoseGraph(
 
     std::tie(H, b) = ComputeLinearSystem(pose_graph, zeta);
 
-    utility::LogDebug("[Initial     ] residual : {:e}\n", current_residual);
+    utility::LogDebug("[Initial     ] residual : {:e}", current_residual);
 
     bool stop = false;
     if (stop || CheckRightTerm(b, criteria)) return;
@@ -567,7 +567,7 @@ void GlobalOptimizationGaussNewton::OptimizePoseGraph(
         utility::LogDebug(
                 "[Iteration {:02d}] residual : {:e}, valid edges : {:d}, time "
                 ": {:.3f} "
-                "sec.\n",
+                "sec.",
                 iter, current_residual, valid_edges_num,
                 timer_iter.GetDuration() / 1000.0);
         stop = stop || CheckResidual(current_residual, criteria) ||
@@ -575,7 +575,7 @@ void GlobalOptimizationGaussNewton::OptimizePoseGraph(
     }  // end for
     timer_overall.Stop();
     utility::LogDebug(
-            "[GlobalOptimizationGaussNewton] total time : {:.3f} sec.\n",
+            "[GlobalOptimizationGaussNewton] total time : {:.3f} sec.",
             timer_overall.GetDuration() / 1000.0);
 }
 
@@ -589,9 +589,9 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
 
     utility::LogDebug(
             "[GlobalOptimizationLM] Optimizing PoseGraph having {:d} nodes and "
-            "{:d} edges. \n",
+            "{:d} edges.",
             n_nodes, n_edges);
-    utility::LogDebug("Line process weight : {:f}\n", line_process_weight);
+    utility::LogDebug("Line process weight : {:f}", line_process_weight);
 
     Eigen::VectorXd zeta = ComputeZeta(pose_graph);
     double current_residual, new_residual;
@@ -615,7 +615,7 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
     double ni = 2.0;
     double rho = 0.0;
 
-    utility::LogDebug("[Initial     ] residual : {:e}, lambda : {:e}\n",
+    utility::LogDebug("[Initial     ] residual : {:e}, lambda : {:e}",
                       current_residual, current_lambda);
 
     bool stop = false;
@@ -684,7 +684,7 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
             utility::LogDebug(
                     "[Iteration {:02d}] residual : {:e}, valid edges : {:d}, "
                     "time : "
-                    "{:.3f} sec.\n",
+                    "{:.3f} sec.",
                     iter, current_residual, valid_edges_num,
                     timer_iter.GetDuration() / 1000.0);
         }
@@ -692,7 +692,7 @@ void GlobalOptimizationLevenbergMarquardt::OptimizePoseGraph(
                CheckMaxIteration(iter, criteria);
     }  // end for
     timer_overall.Stop();
-    utility::LogDebug("[GlobalOptimizationLM] total time : {:.3f} sec.\n",
+    utility::LogDebug("[GlobalOptimizationLM] total time : {:.3f} sec.",
                       timer_overall.GetDuration() / 1000.0);
 }
 

--- a/src/Open3D/Registration/PoseGraph.cpp
+++ b/src/Open3D/Registration/PoseGraph.cpp
@@ -51,14 +51,14 @@ bool PoseGraphNode::ConvertToJsonValue(Json::Value &value) const {
 bool PoseGraphNode::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "PoseGraphNode read JSON failed: unsupported json format.\n");
+                "PoseGraphNode read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "PoseGraphNode" ||
         value.get("version_major", 1).asInt() != 1 ||
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
-                "PoseGraphNode read JSON failed: unsupported json format.\n");
+                "PoseGraphNode read JSON failed: unsupported json format.");
         return false;
     }
 
@@ -97,14 +97,14 @@ bool PoseGraphEdge::ConvertToJsonValue(Json::Value &value) const {
 bool PoseGraphEdge::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "PoseGraphEdge read JSON failed: unsupported json format.\n");
+                "PoseGraphEdge read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "PoseGraphEdge" ||
         value.get("version_major", 1).asInt() != 1 ||
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
-                "PoseGraphEdge read JSON failed: unsupported json format.\n");
+                "PoseGraphEdge read JSON failed: unsupported json format.");
         return false;
     }
 
@@ -158,20 +158,20 @@ bool PoseGraph::ConvertToJsonValue(Json::Value &value) const {
 bool PoseGraph::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "PoseGraph read JSON failed: unsupported json format.\n");
+                "PoseGraph read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "PoseGraph" ||
         value.get("version_major", 1).asInt() != 1 ||
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
-                "PoseGraph read JSON failed: unsupported json format.\n");
+                "PoseGraph read JSON failed: unsupported json format.");
         return false;
     }
 
     const Json::Value &node_array = value["nodes"];
     if (node_array.size() == 0) {
-        utility::LogWarning("PoseGraph read JSON failed: empty nodes.\n");
+        utility::LogWarning("PoseGraph read JSON failed: empty nodes.");
         return false;
     }
     nodes_.clear();
@@ -186,7 +186,7 @@ bool PoseGraph::ConvertFromJsonValue(const Json::Value &value) {
 
     const Json::Value &edge_array = value["edges"];
     if (edge_array.size() == 0) {
-        utility::LogWarning("PoseGraph read JSON failed: empty edges.\n");
+        utility::LogWarning("PoseGraph read JSON failed: empty edges.");
         return false;
     }
     edges_.clear();

--- a/src/Open3D/Registration/Registration.cpp
+++ b/src/Open3D/Registration/Registration.cpp
@@ -155,19 +155,17 @@ RegistrationResult RegistrationICP(
         const ICPConvergenceCriteria
                 &criteria /* = ICPConvergenceCriteria()*/) {
     if (max_correspondence_distance <= 0.0) {
-        utility::LogWarning("Invalid max_correspondence_distance.\n");
-        return RegistrationResult(init);
+        utility::LogError("Invalid max_correspondence_distance.\n");
     }
     if ((estimation.GetTransformationEstimationType() ==
                  TransformationEstimationType::PointToPlane ||
          estimation.GetTransformationEstimationType() ==
                  TransformationEstimationType::ColoredICP) &&
         (!source.HasNormals() || !target.HasNormals())) {
-        utility::LogWarning(
+        utility::LogError(
                 "TransformationEstimationPointToPlane and "
                 "TransformationEstimationColoredICP "
                 "require pre-computed normal vectors.\n");
-        return RegistrationResult(init);
     }
 
     Eigen::Matrix4d transformation = init;

--- a/src/Open3D/Registration/Registration.cpp
+++ b/src/Open3D/Registration/Registration.cpp
@@ -155,7 +155,7 @@ RegistrationResult RegistrationICP(
         const ICPConvergenceCriteria
                 &criteria /* = ICPConvergenceCriteria()*/) {
     if (max_correspondence_distance <= 0.0) {
-        utility::LogError("Invalid max_correspondence_distance.\n");
+        utility::LogError("Invalid max_correspondence_distance.");
     }
     if ((estimation.GetTransformationEstimationType() ==
                  TransformationEstimationType::PointToPlane ||
@@ -165,7 +165,7 @@ RegistrationResult RegistrationICP(
         utility::LogError(
                 "TransformationEstimationPointToPlane and "
                 "TransformationEstimationColoredICP "
-                "require pre-computed normal vectors.\n");
+                "require pre-computed normal vectors.");
     }
 
     Eigen::Matrix4d transformation = init;
@@ -179,8 +179,8 @@ RegistrationResult RegistrationICP(
     result = GetRegistrationResultAndCorrespondences(
             pcd, target, kdtree, max_correspondence_distance, transformation);
     for (int i = 0; i < criteria.max_iteration_; i++) {
-        utility::LogDebug("ICP Iteration #{:d}: Fitness {:.4f}, RMSE {:.4f}\n",
-                          i, result.fitness_, result.inlier_rmse_);
+        utility::LogDebug("ICP Iteration #{:d}: Fitness {:.4f}, RMSE {:.4f}", i,
+                          result.fitness_, result.inlier_rmse_);
         Eigen::Matrix4d update = estimation.ComputeTransformation(
                 pcd, target, result.correspondence_set_);
         transformation = update * transformation;
@@ -236,7 +236,7 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
             result = this_result;
         }
     }
-    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}\n", result.fitness_,
+    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}", result.fitness_,
                       result.inlier_rmse_);
     return result;
 }
@@ -367,8 +367,8 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
 #ifdef _OPENMP
     }
 #endif
-    utility::LogDebug("total_validation : {:d}\n", total_validation);
-    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}\n", result.fitness_,
+    utility::LogDebug("total_validation : {:d}", total_validation);
+    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}", result.fitness_,
                       result.inlier_rmse_);
     return result;
 }

--- a/src/Open3D/Utility/Console.h
+++ b/src/Open3D/Utility/Console.h
@@ -42,9 +42,22 @@ namespace open3d {
 namespace utility {
 
 enum class VerbosityLevel {
+    /// LogError throws now a runtime_error with the given error message. This
+    /// should be used if there is no point in continuing the given algorithm at
+    /// some point and the error is not returned in another way (e.g., via a
+    /// bool/int as return value).
     Error = 0,
+    /// LogWarning is used if an error occured, but the error is also signaled
+    /// via a return value (i.e., there is no need to throw an exception). This
+    /// warning should further be used, if the algorithms encounters a state
+    /// that does not break its continuation, but the output is likely not to be
+    /// what the user expected.
     Warning = 1,
+    /// LogInfo is used to inform the user with expected output, e.g, pressed a
+    /// key in the visualizer prints helping information.
     Info = 2,
+    /// LogDebug is used to print debug/additional information on the state of
+    /// the algorithm.
     Debug = 3,
 };
 
@@ -82,6 +95,7 @@ public:
             ChangeConsoleColor(TextColor::Yellow, 1);
             fmt::print("[Open3D WARNING] ");
             fmt::vprint(format, args);
+            fmt::print("\n");
             ResetConsoleColor();
         }
     }
@@ -90,6 +104,7 @@ public:
         if (verbosity_level_ >= VerbosityLevel::Info) {
             fmt::print("[Open3D INFO] ");
             fmt::vprint(format, args);
+            fmt::print("\n");
         }
     }
 
@@ -97,6 +112,7 @@ public:
         if (verbosity_level_ >= VerbosityLevel::Debug) {
             fmt::print("[Open3D DEBUG] ");
             fmt::vprint(format, args);
+            fmt::print("\n");
         }
     }
 
@@ -137,6 +153,7 @@ public:
             fmt::print("[Open3D WARNING] ");
             fmt::printf(format, args...);
             ResetConsoleColor();
+            fmt::print("\n");
         }
     }
 
@@ -145,6 +162,7 @@ public:
         if (verbosity_level_ >= VerbosityLevel::Info) {
             fmt::print("[Open3D INFO] ");
             fmt::printf(format, args...);
+            fmt::print("\n");
         }
     }
 
@@ -153,6 +171,7 @@ public:
         if (verbosity_level_ >= VerbosityLevel::Debug) {
             fmt::print("[Open3D DEBUG] ");
             fmt::printf(format, args...);
+            fmt::print("\n");
         }
     }
 

--- a/src/Open3D/Utility/Console.h
+++ b/src/Open3D/Utility/Console.h
@@ -42,11 +42,10 @@ namespace open3d {
 namespace utility {
 
 enum class VerbosityLevel {
-    Fatal = 0,
-    Error = 1,
-    Warning = 2,
-    Info = 3,
-    Debug = 4,
+    Error = 0,
+    Warning = 1,
+    Info = 2,
+    Debug = 3,
 };
 
 class Logger {
@@ -71,20 +70,11 @@ public:
         return instance;
     }
 
-    void VFatal[[noreturn]](const char *format, fmt::format_args args) const {
+    void VError[[noreturn]](const char *format, fmt::format_args args) const {
         std::string err_msg = fmt::vformat(format, args);
-        err_msg = fmt::format("[Open3D FATAL] {}", err_msg);
+        err_msg = fmt::format("[Open3D ERROR] {}", err_msg);
         err_msg = ColorString(err_msg, TextColor::Red, 1);
         throw std::runtime_error(err_msg);
-    }
-
-    void VError(const char *format, fmt::format_args args) const {
-        if (verbosity_level_ >= VerbosityLevel::Error) {
-            ChangeConsoleColor(TextColor::Red, 1);
-            fmt::print("[Open3D ERROR] ");
-            fmt::vprint(format, args);
-            ResetConsoleColor();
-        }
     }
 
     void VWarning(const char *format, fmt::format_args args) const {
@@ -111,11 +101,6 @@ public:
     }
 
     template <typename... Args>
-    void Fatal(const char *format, const Args &... args) const {
-        VFatal(format, fmt::make_format_args(args...));
-    }
-
-    template <typename... Args>
     void Error(const char *format, const Args &... args) const {
         VError(format, fmt::make_format_args(args...));
     }
@@ -136,22 +121,12 @@ public:
     }
 
     template <typename... Args>
-    void Fatalf(const char *format, const Args &... args) const {
-        if (verbosity_level_ >= VerbosityLevel::Fatal) {
-            std::string err_msg = fmt::sprintf(format, args...);
-            err_msg = fmt::format("[Open3D FATAL] {}", err_msg);
-            err_msg = ColorString(err_msg, TextColor::Red, 1);
-            throw std::runtime_error(err_msg);
-        }
-    }
-
-    template <typename... Args>
     void Errorf(const char *format, const Args &... args) const {
         if (verbosity_level_ >= VerbosityLevel::Error) {
-            ChangeConsoleColor(TextColor::Red, 1);
-            fmt::print("[Open3D ERROR] ");
-            fmt::printf(format, args...);
-            ResetConsoleColor();
+            std::string err_msg = fmt::sprintf(format, args...);
+            err_msg = fmt::format("[Open3D Error] {}", err_msg);
+            err_msg = ColorString(err_msg, TextColor::Red, 1);
+            throw std::runtime_error(err_msg);
         }
     }
 
@@ -206,11 +181,6 @@ inline VerbosityLevel GetVerbosityLevel() {
 }
 
 template <typename... Args>
-inline void LogFatal[[noreturn]](const char *format, const Args &... args) {
-    Logger::i().VFatal(format, fmt::make_format_args(args...));
-}
-
-template <typename... Args>
 inline void LogError(const char *format, const Args &... args) {
     Logger::i().VError(format, fmt::make_format_args(args...));
 }
@@ -228,11 +198,6 @@ inline void LogInfo(const char *format, const Args &... args) {
 template <typename... Args>
 inline void LogDebug(const char *format, const Args &... args) {
     Logger::i().VDebug(format, fmt::make_format_args(args...));
-}
-
-template <typename... Args>
-inline void LogFatalf(const char *format, const Args &... args) {
-    Logger::i().Fatalf(format, args...);
 }
 
 template <typename... Args>

--- a/src/Open3D/Utility/Eigen.cpp
+++ b/src/Open3D/Utility/Eigen.cpp
@@ -45,14 +45,14 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
     // PSD implies symmetric
     check_symmetric = check_symmetric || check_psd;
     if (check_symmetric && !A.isApprox(A.transpose())) {
-        LogWarning("check_symmetric failed, empty vector will be returned\n");
+        LogWarning("check_symmetric failed, empty vector will be returned");
         return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
     }
 
     if (check_det) {
         double det = A.determinant();
         if (fabs(det) < 1e-6 || std::isnan(det) || std::isinf(det)) {
-            LogWarning("check_det failed, empty vector will be returned\n");
+            LogWarning("check_det failed, empty vector will be returned");
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }
@@ -61,7 +61,7 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
     if (check_psd) {
         Eigen::LLT<Eigen::MatrixXd> A_llt(A);
         if (A_llt.info() == Eigen::NumericalIssue) {
-            LogWarning("check_psd failed, empty vector will be returned\n");
+            LogWarning("check_psd failed, empty vector will be returned");
             return std::make_tuple(false, Eigen::VectorXd::Zero(b.rows()));
         }
     }
@@ -79,10 +79,10 @@ std::tuple<bool, Eigen::VectorXd> SolveLinearSystemPSD(
                 // Both decompose and solve are successful
                 return std::make_tuple(true, std::move(x));
             } else {
-                LogWarning("Cholesky solve failed, switched to dense solver\n");
+                LogWarning("Cholesky solve failed, switched to dense solver");
             }
         } else {
-            LogWarning("Cholesky decompose failed, switched to dense solver\n");
+            LogWarning("Cholesky decompose failed, switched to dense solver");
         }
     }
 
@@ -144,7 +144,7 @@ SolveJacobianSystemAndObtainExtrinsicMatrixArray(const Eigen::MatrixXd &JTJ,
     if (JTJ.rows() != JTr.rows() || JTJ.cols() % 6 != 0) {
         LogWarning(
                 "[SolveJacobianSystemAndObtainExtrinsicMatrixArray] "
-                "Unsupported matrix format.\n");
+                "Unsupported matrix format.");
         return std::make_tuple(false, std::move(output_matrix_array));
     }
 
@@ -207,7 +207,7 @@ std::tuple<MatType, VecType, double> ComputeJTJandJTr(
     }
 #endif
     if (verbose) {
-        LogDebug("Residual : {:.2e} (# of elements : {:d})\n",
+        LogDebug("Residual : {:.2e} (# of elements : {:d})",
                  r2_sum / (double)iteration_num, iteration_num);
     }
     return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);
@@ -260,7 +260,7 @@ std::tuple<MatType, VecType, double> ComputeJTJandJTr(
     }
 #endif
     if (verbose) {
-        LogDebug("Residual : {:.2e} (# of elements : {:d})\n",
+        LogDebug("Residual : {:.2e} (# of elements : {:d})",
                  r2_sum / (double)iteration_num, iteration_num);
     }
     return std::make_tuple(std::move(JTJ), std::move(JTr), r2_sum);

--- a/src/Open3D/Utility/Timer.cpp
+++ b/src/Open3D/Utility/Timer.cpp
@@ -57,7 +57,7 @@ double Timer::GetDuration() const {
 }
 
 void Timer::Print(const std::string &timer_info) const {
-    LogInfo("{} {:.2f} ms.\n", timer_info,
+    LogInfo("{} {:.2f} ms.", timer_info,
             end_time_in_milliseconds_ - start_time_in_milliseconds_);
 }
 
@@ -92,10 +92,10 @@ void FPSTimer::Signal() {
         event_fragment_count_ >= events_to_print_) {
         // print and reset
         if (expectation_ == -1) {
-            LogInfo("{} at {:.2f} fps.\n", fps_timer_info_,
+            LogInfo("{} at {:.2f} fps.", fps_timer_info_,
                     double(event_fragment_count_ + 1) / GetDuration() * 1000.0);
         } else {
-            LogInfo("{} at {:.2f} fps (progress {:.2f}%).\n",
+            LogInfo("{} at {:.2f} fps (progress {:.2f}%).",
                     fps_timer_info_.c_str(),
                     double(event_fragment_count_ + 1) / GetDuration() * 1000.0,
                     (double)event_total_count_ * 100.0 / (double)expectation_);

--- a/src/Open3D/Visualization/Shader/ShaderWrapper.cpp
+++ b/src/Open3D/Visualization/Shader/ShaderWrapper.cpp
@@ -57,7 +57,7 @@ void ShaderWrapper::InvalidateGeometry() {
 }
 
 void ShaderWrapper::PrintShaderWarning(const std::string &message) const {
-    utility::LogWarning("[{}] {}\n", GetShaderName(), message);
+    utility::LogWarning("[{}] {}", GetShaderName(), message);
 }
 
 bool ShaderWrapper::CompileShaders(const char *const vertex_shader_code,
@@ -145,7 +145,7 @@ bool ShaderWrapper::ValidateShader(GLuint shader_index) {
             std::vector<char> error_message(info_log_length + 1);
             glGetShaderInfoLog(shader_index, info_log_length, NULL,
                                &error_message[0]);
-            utility::LogWarning("Shader error: {}\n", &error_message[0]);
+            utility::LogWarning("Shader error: {}", &error_message[0]);
         }
         return false;
     }
@@ -162,7 +162,7 @@ bool ShaderWrapper::ValidateProgram(GLuint program_index) {
             std::vector<char> error_message(info_log_length + 1);
             glGetShaderInfoLog(program_index, info_log_length, NULL,
                                &error_message[0]);
-            utility::LogWarning("Shader error: {}\n", &error_message[0]);
+            utility::LogWarning("Shader error: {}", &error_message[0]);
         }
         return false;
     }

--- a/src/Open3D/Visualization/Shader/ShaderWrapper.cpp
+++ b/src/Open3D/Visualization/Shader/ShaderWrapper.cpp
@@ -145,7 +145,7 @@ bool ShaderWrapper::ValidateShader(GLuint shader_index) {
             std::vector<char> error_message(info_log_length + 1);
             glGetShaderInfoLog(shader_index, info_log_length, NULL,
                                &error_message[0]);
-            utility::LogError("Shader error: {}\n", &error_message[0]);
+            utility::LogWarning("Shader error: {}\n", &error_message[0]);
         }
         return false;
     }
@@ -162,7 +162,7 @@ bool ShaderWrapper::ValidateProgram(GLuint program_index) {
             std::vector<char> error_message(info_log_length + 1);
             glGetShaderInfoLog(program_index, info_log_length, NULL,
                                &error_message[0]);
-            utility::LogError("Shader error: {}\n", &error_message[0]);
+            utility::LogWarning("Shader error: {}\n", &error_message[0]);
         }
         return false;
     }

--- a/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
+++ b/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
@@ -293,7 +293,7 @@ bool TexturePhongShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogError("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!\n");
             return false;
         }
     }
@@ -313,7 +313,7 @@ bool TexturePhongShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogError("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!\n");
             return false;
         }
     }

--- a/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
+++ b/src/Open3D/Visualization/Shader/TexturePhongShader.cpp
@@ -293,7 +293,7 @@ bool TexturePhongShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogWarning("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!");
             return false;
         }
     }
@@ -313,7 +313,7 @@ bool TexturePhongShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogWarning("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!");
             return false;
         }
     }

--- a/src/Open3D/Visualization/Shader/TextureSimpleShader.cpp
+++ b/src/Open3D/Visualization/Shader/TextureSimpleShader.cpp
@@ -199,7 +199,7 @@ bool TextureSimpleShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogWarning("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!");
             return false;
         }
     }
@@ -219,7 +219,7 @@ bool TextureSimpleShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogWarning("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!");
             return false;
         }
     }

--- a/src/Open3D/Visualization/Shader/TextureSimpleShader.cpp
+++ b/src/Open3D/Visualization/Shader/TextureSimpleShader.cpp
@@ -199,7 +199,7 @@ bool TextureSimpleShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogError("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!\n");
             return false;
         }
     }
@@ -219,7 +219,7 @@ bool TextureSimpleShaderForTriangleMesh::PrepareBinding(
             break;
         }
         default: {
-            utility::LogError("Unknown format, abort!\n");
+            utility::LogWarning("Unknown format, abort!\n");
             return false;
         }
     }

--- a/src/Open3D/Visualization/Utility/ColorMap.cpp
+++ b/src/Open3D/Visualization/Utility/ColorMap.cpp
@@ -36,7 +36,7 @@ using namespace visualization;
 class GlobalColorMapSingleton {
 private:
     GlobalColorMapSingleton() : color_map_(new ColorMapJet) {
-        utility::LogDebug("Global colormap init.\n");
+        utility::LogDebug("Global colormap init.");
     }
     GlobalColorMapSingleton(const GlobalColorMapSingleton &) = delete;
     GlobalColorMapSingleton &operator=(const GlobalColorMapSingleton &) =
@@ -44,7 +44,7 @@ private:
 
 public:
     ~GlobalColorMapSingleton() {
-        utility::LogDebug("Global colormap destruct.\n");
+        utility::LogDebug("Global colormap destruct.");
     }
 
 public:

--- a/src/Open3D/Visualization/Utility/DrawGeometry.cpp
+++ b/src/Open3D/Visualization/Utility/DrawGeometry.cpp
@@ -46,16 +46,15 @@ bool DrawGeometries(const std::vector<std::shared_ptr<const geometry::Geometry>>
     Visualizer visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogWarning(
-                "[DrawGeometries] Failed creating OpenGL window.\n");
+        utility::LogWarning("[DrawGeometries] Failed creating OpenGL window.");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
         if (visualizer.AddGeometry(geometry_ptr) == false) {
-            utility::LogWarning("[DrawGeometries] Failed adding geometry.\n");
+            utility::LogWarning("[DrawGeometries] Failed adding geometry.");
             utility::LogWarning(
                     "[DrawGeometries] Possibly due to bad geometry or wrong "
-                    "geometry type.\n");
+                    "geometry type.");
             return false;
         }
     }
@@ -78,17 +77,17 @@ bool DrawGeometriesWithCustomAnimation(
                                           top) == false) {
         utility::LogWarning(
                 "[DrawGeometriesWithCustomAnimation] Failed creating OpenGL "
-                "window.\n");
+                "window.");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
         if (visualizer.AddGeometry(geometry_ptr) == false) {
             utility::LogWarning(
                     "[DrawGeometriesWithCustomAnimation] Failed adding "
-                    "geometry.\n");
+                    "geometry.");
             utility::LogWarning(
                     "[DrawGeometriesWithCustomAnimation] Possibly due to bad "
-                    "geometry or wrong geometry type.\n");
+                    "geometry or wrong geometry type.");
             return false;
         }
     }
@@ -98,10 +97,10 @@ bool DrawGeometriesWithCustomAnimation(
         if (view_control.LoadTrajectoryFromJsonFile(json_filename) == false) {
             utility::LogWarning(
                     "[DrawGeometriesWithCustomAnimation] Failed loading json "
-                    "file.\n");
+                    "file.");
             utility::LogWarning(
                     "[DrawGeometriesWithCustomAnimation] Possibly due to bad "
-                    "file or file does not contain trajectory.\n");
+                    "file or file does not contain trajectory.");
             return false;
         }
         visualizer.UpdateWindowTitle();
@@ -125,17 +124,17 @@ bool DrawGeometriesWithAnimationCallback(
                                           top) == false) {
         utility::LogWarning(
                 "[DrawGeometriesWithAnimationCallback] Failed creating OpenGL "
-                "window.\n");
+                "window.");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
         if (visualizer.AddGeometry(geometry_ptr) == false) {
             utility::LogWarning(
                     "[DrawGeometriesWithAnimationCallback] Failed adding "
-                    "geometry.\n");
+                    "geometry.");
             utility::LogWarning(
                     "[DrawGeometriesWithAnimationCallback] Possibly due to bad "
-                    "geometry or wrong geometry type.\n");
+                    "geometry or wrong geometry type.");
             return false;
         }
     }
@@ -159,17 +158,17 @@ bool DrawGeometriesWithKeyCallbacks(
                                           top) == false) {
         utility::LogWarning(
                 "[DrawGeometriesWithKeyCallbacks] Failed creating OpenGL "
-                "window.\n");
+                "window.");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
         if (visualizer.AddGeometry(geometry_ptr) == false) {
             utility::LogWarning(
                     "[DrawGeometriesWithKeyCallbacks] Failed adding "
-                    "geometry.\n");
+                    "geometry.");
             utility::LogWarning(
                     "[DrawGeometriesWithKeyCallbacks] Possibly due to bad "
-                    "geometry or wrong geometry type.\n");
+                    "geometry or wrong geometry type.");
             return false;
         }
     }
@@ -194,16 +193,16 @@ bool DrawGeometriesWithEditing(
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
         utility::LogWarning(
-                "[DrawGeometriesWithEditing] Failed creating OpenGL window.\n");
+                "[DrawGeometriesWithEditing] Failed creating OpenGL window.");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
         if (visualizer.AddGeometry(geometry_ptr) == false) {
             utility::LogWarning(
-                    "[DrawGeometriesWithEditing] Failed adding geometry.\n");
+                    "[DrawGeometriesWithEditing] Failed adding geometry.");
             utility::LogWarning(
                     "[DrawGeometriesWithEditing] Possibly due to bad geometry "
-                    "or wrong geometry type.\n");
+                    "or wrong geometry type.");
             return false;
         }
     }

--- a/src/Open3D/Visualization/Utility/DrawGeometry.cpp
+++ b/src/Open3D/Visualization/Utility/DrawGeometry.cpp
@@ -46,7 +46,8 @@ bool DrawGeometries(const std::vector<std::shared_ptr<const geometry::Geometry>>
     Visualizer visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogError("[DrawGeometries] Failed creating OpenGL window.\n");
+        utility::LogWarning(
+                "[DrawGeometries] Failed creating OpenGL window.\n");
         return false;
     }
     for (const auto &geometry_ptr : geometry_ptrs) {
@@ -75,7 +76,7 @@ bool DrawGeometriesWithCustomAnimation(
     VisualizerWithCustomAnimation visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogError(
+        utility::LogWarning(
                 "[DrawGeometriesWithCustomAnimation] Failed creating OpenGL "
                 "window.\n");
         return false;
@@ -122,7 +123,7 @@ bool DrawGeometriesWithAnimationCallback(
     Visualizer visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogError(
+        utility::LogWarning(
                 "[DrawGeometriesWithAnimationCallback] Failed creating OpenGL "
                 "window.\n");
         return false;
@@ -156,7 +157,7 @@ bool DrawGeometriesWithKeyCallbacks(
     VisualizerWithKeyCallback visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogError(
+        utility::LogWarning(
                 "[DrawGeometriesWithKeyCallbacks] Failed creating OpenGL "
                 "window.\n");
         return false;
@@ -192,7 +193,7 @@ bool DrawGeometriesWithEditing(
     VisualizerWithEditing visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogError(
+        utility::LogWarning(
                 "[DrawGeometriesWithEditing] Failed creating OpenGL window.\n");
         return false;
     }

--- a/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
+++ b/src/Open3D/Visualization/Utility/SelectionPolygon.cpp
@@ -148,7 +148,7 @@ std::shared_ptr<geometry::TriangleMesh> SelectionPolygon::CropTriangleMesh(
         utility::LogWarning(
                 "geometry::TriangleMesh contains vertices, but no triangles; "
                 "cropping will always yield an empty "
-                "geometry::TriangleMesh.\n");
+                "geometry::TriangleMesh.");
         return std::make_shared<geometry::TriangleMesh>();
     }
     switch (polygon_type_) {

--- a/src/Open3D/Visualization/Utility/SelectionPolygonVolume.cpp
+++ b/src/Open3D/Visualization/Utility/SelectionPolygonVolume.cpp
@@ -58,7 +58,7 @@ bool SelectionPolygonVolume::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "SelectionPolygonVolume read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "SelectionPolygonVolume" ||
@@ -66,7 +66,7 @@ bool SelectionPolygonVolume::ConvertFromJsonValue(const Json::Value &value) {
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
                 "SelectionPolygonVolume read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     orthogonal_axis_ = value.get("orthogonal_axis", "").asString();
@@ -75,7 +75,7 @@ bool SelectionPolygonVolume::ConvertFromJsonValue(const Json::Value &value) {
     const Json::Value &polygon_array = value["bounding_polygon"];
     if (polygon_array.size() == 0) {
         utility::LogWarning(
-                "SelectionPolygonVolume read JSON failed: empty trajectory.\n");
+                "SelectionPolygonVolume read JSON failed: empty trajectory.");
         return false;
     }
     bounding_polygon_.resize(polygon_array.size());
@@ -111,7 +111,7 @@ SelectionPolygonVolume::CropTriangleMesh(
         utility::LogWarning(
                 "geometry::TriangleMesh contains vertices, but no triangles; "
                 "cropping will always yield an empty "
-                "geometry::TriangleMesh.\n");
+                "geometry::TriangleMesh.");
         return std::make_shared<geometry::TriangleMesh>();
     }
     return CropTriangleMeshInPolygon(input);

--- a/src/Open3D/Visualization/Visualizer/RenderOption.cpp
+++ b/src/Open3D/Visualization/Visualizer/RenderOption.cpp
@@ -119,14 +119,14 @@ bool RenderOption::ConvertToJsonValue(Json::Value &value) const {
 bool RenderOption::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "ViewTrajectory read JSON failed: unsupported json format.\n");
+                "ViewTrajectory read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "RenderOption" ||
         value.get("version_major", 1).asInt() != 1 ||
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
-                "ViewTrajectory read JSON failed: unsupported json format.\n");
+                "ViewTrajectory read JSON failed: unsupported json format.");
         return false;
     }
 

--- a/src/Open3D/Visualization/Visualizer/ViewControl.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewControl.cpp
@@ -128,14 +128,14 @@ bool ViewControl::ConvertToPinholeCameraParameters(
     if (window_height_ <= 0 || window_width_ <= 0) {
         utility::LogWarning(
                 "[ViewControl] ConvertToPinholeCameraParameters() failed "
-                "because window height and width are not set.\n");
+                "because window height and width are not set.");
         return false;
     }
     if (GetProjectionType() == ProjectionType::Orthogonal) {
         utility::LogWarning(
                 "[ViewControl] ConvertToPinholeCameraParameters() failed "
                 "because orthogonal view cannot be translated to a pinhole "
-                "camera.\n");
+                "camera.");
         return false;
     }
     SetProjectionParameters();
@@ -179,7 +179,7 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
                 (double)window_height_ / 2.0 - 0.5) {
         utility::LogWarning(
                 "[ViewControl] ConvertFromPinholeCameraParameters() failed "
-                "because window height and width do not match.\n");
+                "because window height and width do not match.");
         return false;
     }
     double tan_half_fov =
@@ -193,7 +193,7 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
         field_of_view_ = old_fov;
         utility::LogWarning(
                 "[ViewControl] ConvertFromPinholeCameraParameters() failed "
-                "because field of view is impossible.\n");
+                "because field of view is impossible.");
         return false;
     }
     right_ = extrinsic.block<1, 3>(0, 0).transpose();

--- a/src/Open3D/Visualization/Visualizer/ViewControlWithCustomAnimation.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewControlWithCustomAnimation.cpp
@@ -240,7 +240,7 @@ bool ViewControlWithCustomAnimation::CaptureTrajectory(
         json_filename =
                 "ViewTrajectory_" + utility::GetCurrentTimeStamp() + ".json";
     }
-    utility::LogDebug("[Visualizer] Trejactory capture to {}\n",
+    utility::LogDebug("[Visualizer] Trejactory capture to {}",
                       json_filename.c_str());
     return io::WriteIJsonConvertible(json_filename, view_trajectory_);
 }

--- a/src/Open3D/Visualization/Visualizer/ViewParameters.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewParameters.cpp
@@ -82,31 +82,31 @@ bool ViewParameters::ConvertToJsonValue(Json::Value &value) const {
 bool ViewParameters::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "ViewParameters read JSON failed: unsupported json format.\n");
+                "ViewParameters read JSON failed: unsupported json format.");
         return false;
     }
     field_of_view_ = value.get("field_of_view", 60.0).asDouble();
     zoom_ = value.get("zoom", 0.7).asDouble();
     if (EigenVector3dFromJsonArray(lookat_, value["lookat"]) == false) {
-        utility::LogWarning("ViewParameters read JSON failed: wrong format.\n");
+        utility::LogWarning("ViewParameters read JSON failed: wrong format.");
         return false;
     }
     if (EigenVector3dFromJsonArray(up_, value["up"]) == false) {
-        utility::LogWarning("ViewParameters read JSON failed: wrong format.\n");
+        utility::LogWarning("ViewParameters read JSON failed: wrong format.");
         return false;
     }
     if (EigenVector3dFromJsonArray(front_, value["front"]) == false) {
-        utility::LogWarning("ViewParameters read JSON failed: wrong format.\n");
+        utility::LogWarning("ViewParameters read JSON failed: wrong format.");
         return false;
     }
     if (EigenVector3dFromJsonArray(boundingbox_min_,
                                    value["boundingbox_min"]) == false) {
-        utility::LogWarning("ViewParameters read JSON failed: wrong format.\n");
+        utility::LogWarning("ViewParameters read JSON failed: wrong format.");
         return false;
     }
     if (EigenVector3dFromJsonArray(boundingbox_max_,
                                    value["boundingbox_max"]) == false) {
-        utility::LogWarning("ViewParameters read JSON failed: wrong format.\n");
+        utility::LogWarning("ViewParameters read JSON failed: wrong format.");
         return false;
     }
     return true;

--- a/src/Open3D/Visualization/Visualizer/ViewTrajectory.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewTrajectory.cpp
@@ -165,14 +165,14 @@ bool ViewTrajectory::ConvertToJsonValue(Json::Value &value) const {
 bool ViewTrajectory::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
-                "ViewTrajectory read JSON failed: unsupported json format.\n");
+                "ViewTrajectory read JSON failed: unsupported json format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "ViewTrajectory" ||
         value.get("version_major", 1).asInt() != 1 ||
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
-                "ViewTrajectory read JSON failed: unsupported json format.\n");
+                "ViewTrajectory read JSON failed: unsupported json format.");
         return false;
     }
     is_loop_ = value.get("is_loop", false).asBool();
@@ -180,7 +180,7 @@ bool ViewTrajectory::ConvertFromJsonValue(const Json::Value &value) {
     const Json::Value &trajectory_array = value["trajectory"];
     if (trajectory_array.size() == 0) {
         utility::LogWarning(
-                "ViewTrajectory read JSON failed: empty trajectory.\n");
+                "ViewTrajectory read JSON failed: empty trajectory.");
         return false;
     }
     view_status_.resize(trajectory_array.size());

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -96,7 +96,7 @@ bool Visualizer::CreateVisualizerWindow(
 
     glfwSetErrorCallback(GLFWEnvironmentSingleton::GLFWErrorCallback);
     if (!GLFWEnvironmentSingleton::InitGLFW()) {
-        utility::LogError("Failed to initialize GLFW\n");
+        utility::LogWarning("Failed to initialize GLFW\n");
         return false;
     }
 
@@ -109,7 +109,7 @@ bool Visualizer::CreateVisualizerWindow(
 
     window_ = glfwCreateWindow(width, height, window_name_.c_str(), NULL, NULL);
     if (!window_) {
-        utility::LogError("Failed to create window\n");
+        utility::LogWarning("Failed to create window\n");
         return false;
     }
     glfwSetWindowPos(window_, left, top);

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -34,7 +34,7 @@ namespace {
 
 class GLFWEnvironmentSingleton {
 private:
-    GLFWEnvironmentSingleton() { utility::LogDebug("GLFW init.\n"); }
+    GLFWEnvironmentSingleton() { utility::LogDebug("GLFW init."); }
     GLFWEnvironmentSingleton(const GLFWEnvironmentSingleton &) = delete;
     GLFWEnvironmentSingleton &operator=(const GLFWEnvironmentSingleton &) =
             delete;
@@ -42,7 +42,7 @@ private:
 public:
     ~GLFWEnvironmentSingleton() {
         glfwTerminate();
-        utility::LogDebug("GLFW destruct.\n");
+        utility::LogDebug("GLFW destruct.");
     }
 
 public:
@@ -57,7 +57,7 @@ public:
     }
 
     static void GLFWErrorCallback(int error, const char *description) {
-        utility::LogError("GLFW Error: {}\n", description);
+        utility::LogError("GLFW Error: {}", description);
     }
 };
 
@@ -96,7 +96,7 @@ bool Visualizer::CreateVisualizerWindow(
 
     glfwSetErrorCallback(GLFWEnvironmentSingleton::GLFWErrorCallback);
     if (!GLFWEnvironmentSingleton::InitGLFW()) {
-        utility::LogWarning("Failed to initialize GLFW\n");
+        utility::LogWarning("Failed to initialize GLFW");
         return false;
     }
 
@@ -109,7 +109,7 @@ bool Visualizer::CreateVisualizerWindow(
 
     window_ = glfwCreateWindow(width, height, window_name_.c_str(), NULL, NULL);
     if (!window_) {
-        utility::LogWarning("Failed to create window\n");
+        utility::LogWarning("Failed to create window");
         return false;
     }
     glfwSetWindowPos(window_, left, top);
@@ -264,7 +264,7 @@ void Visualizer::Run() {
 
 void Visualizer::Close() {
     glfwSetWindowShouldClose(window_, GL_TRUE);
-    utility::LogDebug("[Visualizer] Window closing.\n");
+    utility::LogDebug("[Visualizer] Window closing.");
 }
 
 bool Visualizer::WaitEvents() {
@@ -373,7 +373,7 @@ bool Visualizer::AddGeometry(
     view_control_ptr_->FitInGeometry(*geometry_ptr);
     ResetViewPoint();
     utility::LogDebug(
-            "Add geometry and update bounding box to {}\n",
+            "Add geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
     return UpdateGeometry();
 }
@@ -394,7 +394,7 @@ bool Visualizer::RemoveGeometry(
     geometry_ptrs_.erase(geometry_ptr);
     ResetViewPoint(true);
     utility::LogDebug(
-            "Remove geometry and update bounding box to {}\n",
+            "Remove geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
     return UpdateGeometry();
 }
@@ -415,60 +415,60 @@ bool Visualizer::HasGeometry() const { return !geometry_ptrs_.empty(); }
 
 void Visualizer::PrintVisualizerHelp() {
     // clang-format off
-    utility::LogInfo("  -- Mouse view control --\n");
-    utility::LogInfo("    Left button + drag         : Rotate.\n");
-    utility::LogInfo("    Ctrl + left button + drag  : Translate.\n");
-    utility::LogInfo("    Wheel button + drag        : Translate.\n");
-    utility::LogInfo("    Shift + left button + drag : Roll.\n");
-    utility::LogInfo("    Wheel                      : Zoom in/out.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("  -- Keyboard view control --\n");
-    utility::LogInfo("    [/]          : Increase/decrease field of view.\n");
-    utility::LogInfo("    R            : Reset view point.\n");
-    utility::LogInfo("    Ctrl/Cmd + C : Copy current view status into the clipboard.\n");
-    utility::LogInfo("    Ctrl/Cmd + V : Paste view status from clipboard.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("  -- General control --\n");
-    utility::LogInfo("    Q, Esc       : Exit window.\n");
-    utility::LogInfo("    H            : Print help message.\n");
-    utility::LogInfo("    P, PrtScn    : Take a screen capture.\n");
-    utility::LogInfo("    D            : Take a depth capture.\n");
-    utility::LogInfo("    O            : Take a capture of current rendering settings.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("  -- Render mode control --\n");
-    utility::LogInfo("    L            : Turn on/off lighting.\n");
-    utility::LogInfo("    +/-          : Increase/decrease point size.\n");
-    utility::LogInfo("    Ctrl + +/-   : Increase/decrease width of geometry::LineSet.\n");
-    utility::LogInfo("    N            : Turn on/off point cloud normal rendering.\n");
-    utility::LogInfo("    S            : Toggle between mesh flat shading and smooth shading.\n");
-    utility::LogInfo("    W            : Turn on/off mesh wireframe.\n");
-    utility::LogInfo("    B            : Turn on/off back face rendering.\n");
-    utility::LogInfo("    I            : Turn on/off image zoom in interpolation.\n");
-    utility::LogInfo("    T            : Toggle among image render:\n");
-    utility::LogInfo("                   no stretch / keep ratio / freely stretch.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("  -- Color control --\n");
-    utility::LogInfo("    0..4,9       : Set point cloud color option.\n");
-    utility::LogInfo("                   0 - Default behavior, render point color.\n");
-    utility::LogInfo("                   1 - Render point color.\n");
-    utility::LogInfo("                   2 - x coordinate as color.\n");
-    utility::LogInfo("                   3 - y coordinate as color.\n");
-    utility::LogInfo("                   4 - z coordinate as color.\n");
-    utility::LogInfo("                   9 - normal as color.\n");
-    utility::LogInfo("    Ctrl + 0..4,9: Set mesh color option.\n");
-    utility::LogInfo("                   0 - Default behavior, render uniform gray color.\n");
-    utility::LogInfo("                   1 - Render point color.\n");
-    utility::LogInfo("                   2 - x coordinate as color.\n");
-    utility::LogInfo("                   3 - y coordinate as color.\n");
-    utility::LogInfo("                   4 - z coordinate as color.\n");
-    utility::LogInfo("                   9 - normal as color.\n");
-    utility::LogInfo("    Shift + 0..4 : Color map options.\n");
-    utility::LogInfo("                   0 - Gray scale color.\n");
-    utility::LogInfo("                   1 - JET color map.\n");
-    utility::LogInfo("                   2 - SUMMER color map.\n");
-    utility::LogInfo("                   3 - WINTER color map.\n");
-    utility::LogInfo("                   4 - HOT color map.\n");
-    utility::LogInfo("\n");
+    utility::LogInfo("  -- Mouse view control --");
+    utility::LogInfo("    Left button + drag         : Rotate.");
+    utility::LogInfo("    Ctrl + left button + drag  : Translate.");
+    utility::LogInfo("    Wheel button + drag        : Translate.");
+    utility::LogInfo("    Shift + left button + drag : Roll.");
+    utility::LogInfo("    Wheel                      : Zoom in/out.");
+    utility::LogInfo("");
+    utility::LogInfo("  -- Keyboard view control --");
+    utility::LogInfo("    [/]          : Increase/decrease field of view.");
+    utility::LogInfo("    R            : Reset view point.");
+    utility::LogInfo("    Ctrl/Cmd + C : Copy current view status into the clipboard.");
+    utility::LogInfo("    Ctrl/Cmd + V : Paste view status from clipboard.");
+    utility::LogInfo("");
+    utility::LogInfo("  -- General control --");
+    utility::LogInfo("    Q, Esc       : Exit window.");
+    utility::LogInfo("    H            : Print help message.");
+    utility::LogInfo("    P, PrtScn    : Take a screen capture.");
+    utility::LogInfo("    D            : Take a depth capture.");
+    utility::LogInfo("    O            : Take a capture of current rendering settings.");
+    utility::LogInfo("");
+    utility::LogInfo("  -- Render mode control --");
+    utility::LogInfo("    L            : Turn on/off lighting.");
+    utility::LogInfo("    +/-          : Increase/decrease point size.");
+    utility::LogInfo("    Ctrl + +/-   : Increase/decrease width of geometry::LineSet.");
+    utility::LogInfo("    N            : Turn on/off point cloud normal rendering.");
+    utility::LogInfo("    S            : Toggle between mesh flat shading and smooth shading.");
+    utility::LogInfo("    W            : Turn on/off mesh wireframe.");
+    utility::LogInfo("    B            : Turn on/off back face rendering.");
+    utility::LogInfo("    I            : Turn on/off image zoom in interpolation.");
+    utility::LogInfo("    T            : Toggle among image render:");
+    utility::LogInfo("                   no stretch / keep ratio / freely stretch.");
+    utility::LogInfo("");
+    utility::LogInfo("  -- Color control --");
+    utility::LogInfo("    0..4,9       : Set point cloud color option.");
+    utility::LogInfo("                   0 - Default behavior, render point color.");
+    utility::LogInfo("                   1 - Render point color.");
+    utility::LogInfo("                   2 - x coordinate as color.");
+    utility::LogInfo("                   3 - y coordinate as color.");
+    utility::LogInfo("                   4 - z coordinate as color.");
+    utility::LogInfo("                   9 - normal as color.");
+    utility::LogInfo("    Ctrl + 0..4,9: Set mesh color option.");
+    utility::LogInfo("                   0 - Default behavior, render uniform gray color.");
+    utility::LogInfo("                   1 - Render point color.");
+    utility::LogInfo("                   2 - x coordinate as color.");
+    utility::LogInfo("                   3 - y coordinate as color.");
+    utility::LogInfo("                   4 - z coordinate as color.");
+    utility::LogInfo("                   9 - normal as color.");
+    utility::LogInfo("    Shift + 0..4 : Color map options.");
+    utility::LogInfo("                   0 - Gray scale color.");
+    utility::LogInfo("                   1 - JET color map.");
+    utility::LogInfo("                   2 - SUMMER color map.");
+    utility::LogInfo("                   3 - WINTER color map.");
+    utility::LogInfo("                   4 - HOT color map.");
+    utility::LogInfo("");
     // clang-format on
 }
 }  // namespace visualization

--- a/src/Open3D/Visualization/Visualizer/VisualizerCallback.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerCallback.cpp
@@ -119,17 +119,17 @@ void Visualizer::KeyPressCallback(
     switch (key) {
         case GLFW_KEY_LEFT_BRACKET:
             view_control_ptr_->ChangeFieldOfView(-1.0);
-            utility::LogDebug("[Visualizer] Field of view set to {:.2f}.\n",
+            utility::LogDebug("[Visualizer] Field of view set to {:.2f}.",
                               view_control_ptr_->GetFieldOfView());
             break;
         case GLFW_KEY_RIGHT_BRACKET:
             view_control_ptr_->ChangeFieldOfView(1.0);
-            utility::LogDebug("[Visualizer] Field of view set to {:.2f}.\n",
+            utility::LogDebug("[Visualizer] Field of view set to {:.2f}.",
                               view_control_ptr_->GetFieldOfView());
             break;
         case GLFW_KEY_R:
             ResetViewPoint();
-            utility::LogDebug("[Visualizer] Reset view point.\n");
+            utility::LogDebug("[Visualizer] Reset view point.");
             break;
         case GLFW_KEY_C:
             if (mods & GLFW_MOD_CONTROL || mods & GLFW_MOD_SUPER) {
@@ -160,34 +160,34 @@ void Visualizer::KeyPressCallback(
             break;
         case GLFW_KEY_L:
             render_option_ptr_->ToggleLightOn();
-            utility::LogDebug("[Visualizer] Lighting {}.\n",
+            utility::LogDebug("[Visualizer] Lighting {}.",
                               render_option_ptr_->light_on_ ? "ON" : "OFF");
             break;
         case GLFW_KEY_EQUAL:
             if (mods & GLFW_MOD_SHIFT) {
                 render_option_ptr_->ChangeLineWidth(1.0);
-                utility::LogDebug("[Visualizer] Line width set to {:.2f}.\n",
+                utility::LogDebug("[Visualizer] Line width set to {:.2f}.",
                                   render_option_ptr_->line_width_);
             } else {
                 render_option_ptr_->ChangePointSize(1.0);
                 if (render_option_ptr_->point_show_normal_) {
                     UpdateGeometry();
                 }
-                utility::LogDebug("[Visualizer] Point size set to {:.2f}.\n",
+                utility::LogDebug("[Visualizer] Point size set to {:.2f}.",
                                   render_option_ptr_->point_size_);
             }
             break;
         case GLFW_KEY_MINUS:
             if (mods & GLFW_MOD_SHIFT) {
                 render_option_ptr_->ChangeLineWidth(-1.0);
-                utility::LogDebug("[Visualizer] Line width set to {:.2f}.\n",
+                utility::LogDebug("[Visualizer] Line width set to {:.2f}.",
                                   render_option_ptr_->line_width_);
             } else {
                 render_option_ptr_->ChangePointSize(-1.0);
                 if (render_option_ptr_->point_show_normal_) {
                     UpdateGeometry();
                 }
-                utility::LogDebug("[Visualizer] Point size set to {:.2f}.\n",
+                utility::LogDebug("[Visualizer] Point size set to {:.2f}.",
                                   render_option_ptr_->point_size_);
             }
             break;
@@ -197,14 +197,14 @@ void Visualizer::KeyPressCallback(
                 UpdateGeometry();
             }
             utility::LogDebug(
-                    "[Visualizer] Point normal rendering {}.\n",
+                    "[Visualizer] Point normal rendering {}.",
                     render_option_ptr_->point_show_normal_ ? "ON" : "OFF");
             break;
         case GLFW_KEY_S:
             render_option_ptr_->ToggleShadingOption();
             UpdateGeometry();
             utility::LogDebug(
-                    "[Visualizer] Mesh shading mode is {}.\n",
+                    "[Visualizer] Mesh shading mode is {}.",
                     render_option_ptr_->mesh_shade_option_ ==
                                     RenderOption::MeshShadeOption::FlatShade
                             ? "FLAT"
@@ -213,20 +213,20 @@ void Visualizer::KeyPressCallback(
         case GLFW_KEY_W:
             render_option_ptr_->ToggleMeshShowWireframe();
             utility::LogDebug(
-                    "[Visualizer] Mesh wireframe rendering {}.\n",
+                    "[Visualizer] Mesh wireframe rendering {}.",
                     render_option_ptr_->mesh_show_wireframe_ ? "ON" : "OFF");
             break;
         case GLFW_KEY_B:
             render_option_ptr_->ToggleMeshShowBackFace();
             utility::LogDebug(
-                    "[Visualizer] Mesh back face rendering {}.\n",
+                    "[Visualizer] Mesh back face rendering {}.",
                     render_option_ptr_->mesh_show_back_face_ ? "ON" : "OFF");
             break;
         case GLFW_KEY_I:
             render_option_ptr_->ToggleInterpolationOption();
             UpdateGeometry();
             utility::LogDebug(
-                    "[Visualizer] geometry::Image interpolation mode is {}.\n",
+                    "[Visualizer] geometry::Image interpolation mode is {}.",
                     render_option_ptr_->interpolation_option_ ==
                                     RenderOption::TextureInterpolationOption::
                                             Nearest
@@ -236,7 +236,7 @@ void Visualizer::KeyPressCallback(
         case GLFW_KEY_T:
             render_option_ptr_->ToggleImageStretchOption();
             utility::LogDebug(
-                    "[Visualizer] geometry::Image stretch mode is #{}.\n",
+                    "[Visualizer] geometry::Image stretch mode is #{}.",
                     int(render_option_ptr_->image_stretch_option_));
             break;
         case GLFW_KEY_0:
@@ -244,16 +244,16 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::Default;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to DEFAULT.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to DEFAULT.");
             } else if (mods & GLFW_MOD_SHIFT) {
                 SetGlobalColorMap(ColorMap::ColorMapOption::Gray);
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Color map set to GRAY.\n");
+                utility::LogDebug("[Visualizer] Color map set to GRAY.");
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::Default;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to DEFAULT.\n");
+                utility::LogDebug("[Visualizer] Point color set to DEFAULT.");
             }
             break;
         case GLFW_KEY_1:
@@ -261,16 +261,16 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::Color;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to COLOR.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to COLOR.");
             } else if (mods & GLFW_MOD_SHIFT) {
                 SetGlobalColorMap(ColorMap::ColorMapOption::Jet);
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Color map set to JET.\n");
+                utility::LogDebug("[Visualizer] Color map set to JET.");
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::Color;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to COLOR.\n");
+                utility::LogDebug("[Visualizer] Point color set to COLOR.");
             }
             break;
         case GLFW_KEY_2:
@@ -278,16 +278,16 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::XCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to X.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to X.");
             } else if (mods & GLFW_MOD_SHIFT) {
                 SetGlobalColorMap(ColorMap::ColorMapOption::Summer);
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Color map set to SUMMER.\n");
+                utility::LogDebug("[Visualizer] Color map set to SUMMER.");
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::XCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to X.\n");
+                utility::LogDebug("[Visualizer] Point color set to X.");
             }
             break;
         case GLFW_KEY_3:
@@ -295,16 +295,16 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::YCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to Y.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to Y.");
             } else if (mods & GLFW_MOD_SHIFT) {
                 SetGlobalColorMap(ColorMap::ColorMapOption::Winter);
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Color map set to WINTER.\n");
+                utility::LogDebug("[Visualizer] Color map set to WINTER.");
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::YCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to Y.\n");
+                utility::LogDebug("[Visualizer] Point color set to Y.");
             }
             break;
         case GLFW_KEY_4:
@@ -312,16 +312,16 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::ZCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to Z.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to Z.");
             } else if (mods & GLFW_MOD_SHIFT) {
                 SetGlobalColorMap(ColorMap::ColorMapOption::Hot);
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Color map set to HOT.\n");
+                utility::LogDebug("[Visualizer] Color map set to HOT.");
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::ZCoordinate;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to Z.\n");
+                utility::LogDebug("[Visualizer] Point color set to Z.");
             }
             break;
         case GLFW_KEY_9:
@@ -329,13 +329,13 @@ void Visualizer::KeyPressCallback(
                 render_option_ptr_->mesh_color_option_ =
                         RenderOption::MeshColorOption::Normal;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Mesh color set to NORMAL.\n");
+                utility::LogDebug("[Visualizer] Mesh color set to NORMAL.");
             } else if (mods & GLFW_MOD_SHIFT) {
             } else {
                 render_option_ptr_->point_color_option_ =
                         RenderOption::PointColorOption::Normal;
                 UpdateGeometry();
-                utility::LogDebug("[Visualizer] Point color set to NORMAL.\n");
+                utility::LogDebug("[Visualizer] Point color set to NORMAL.");
             }
             break;
         default:

--- a/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
@@ -40,7 +40,7 @@ namespace visualization {
 bool Visualizer::InitOpenGL() {
     glewExperimental = true;
     if (glewInit() != GLEW_OK) {
-        utility::LogError("Failed to initialize GLEW.\n");
+        utility::LogWarning("Failed to initialize GLEW.\n");
         return false;
     }
 
@@ -109,16 +109,14 @@ void Visualizer::ResetViewPoint(bool reset_bounding_box /* = false*/) {
 void Visualizer::CopyViewStatusToClipboard() {
     ViewParameters current_status;
     if (view_control_ptr_->ConvertToViewParameters(current_status) == false) {
-        utility::LogWarning("Something is wrong copying view status.\n");
-        return;
+        utility::LogError("Something is wrong copying view status.\n");
     }
     ViewTrajectory trajectory;
     trajectory.view_status_.push_back(current_status);
     std::string clipboard_string;
     if (io::WriteIJsonConvertibleToJSONString(clipboard_string, trajectory) ==
         false) {
-        utility::LogWarning("Something is wrong copying view status.\n");
-        return;
+        utility::LogError("Something is wrong copying view status.\n");
     }
     glfwSetClipboardString(window_, clipboard_string.c_str());
 }
@@ -130,12 +128,10 @@ void Visualizer::CopyViewStatusFromClipboard() {
         ViewTrajectory trajectory;
         if (io::ReadIJsonConvertibleFromJSONString(clipboard_string,
                                                    trajectory) == false) {
-            utility::LogWarning("Something is wrong copying view status.\n");
-            return;
+            utility::LogError("Something is wrong copying view status.\n");
         }
         if (trajectory.view_status_.size() != 1) {
-            utility::LogWarning("Something is wrong copying view status.\n");
-            return;
+            utility::LogError("Something is wrong copying view status.\n");
         }
         view_control_ptr_->ConvertFromViewParameters(
                 trajectory.view_status_[0]);

--- a/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerRender.cpp
@@ -40,7 +40,7 @@ namespace visualization {
 bool Visualizer::InitOpenGL() {
     glewExperimental = true;
     if (glewInit() != GLEW_OK) {
-        utility::LogWarning("Failed to initialize GLEW.\n");
+        utility::LogWarning("Failed to initialize GLEW.");
         return false;
     }
 
@@ -109,14 +109,14 @@ void Visualizer::ResetViewPoint(bool reset_bounding_box /* = false*/) {
 void Visualizer::CopyViewStatusToClipboard() {
     ViewParameters current_status;
     if (view_control_ptr_->ConvertToViewParameters(current_status) == false) {
-        utility::LogError("Something is wrong copying view status.\n");
+        utility::LogError("Something is wrong copying view status.");
     }
     ViewTrajectory trajectory;
     trajectory.view_status_.push_back(current_status);
     std::string clipboard_string;
     if (io::WriteIJsonConvertibleToJSONString(clipboard_string, trajectory) ==
         false) {
-        utility::LogError("Something is wrong copying view status.\n");
+        utility::LogError("Something is wrong copying view status.");
     }
     glfwSetClipboardString(window_, clipboard_string.c_str());
 }
@@ -128,10 +128,10 @@ void Visualizer::CopyViewStatusFromClipboard() {
         ViewTrajectory trajectory;
         if (io::ReadIJsonConvertibleFromJSONString(clipboard_string,
                                                    trajectory) == false) {
-            utility::LogError("Something is wrong copying view status.\n");
+            utility::LogError("Something is wrong copying view status.");
         }
         if (trajectory.view_status_.size() != 1) {
-            utility::LogError("Something is wrong copying view status.\n");
+            utility::LogError("Something is wrong copying view status.");
         }
         view_control_ptr_->ConvertFromViewParameters(
                 trajectory.view_status_[0]);
@@ -201,11 +201,11 @@ void Visualizer::CaptureScreenImage(const std::string &filename /* = ""*/,
                bytes_per_line);
     }
 
-    utility::LogDebug("[Visualizer] Screen capture to {}\n",
+    utility::LogDebug("[Visualizer] Screen capture to {}",
                       png_filename.c_str());
     io::WriteImage(png_filename, png_image);
     if (!camera_filename.empty()) {
-        utility::LogDebug("[Visualizer] Screen camera capture to {}\n",
+        utility::LogDebug("[Visualizer] Screen camera capture to {}",
                           camera_filename.c_str());
         camera::PinholeCameraParameters parameter;
         view_control_ptr_->ConvertToPinholeCameraParameters(parameter);
@@ -349,11 +349,10 @@ void Visualizer::CaptureDepthImage(const std::string &filename /* = ""*/,
         }
     }
 
-    utility::LogDebug("[Visualizer] Depth capture to {}\n",
-                      png_filename.c_str());
+    utility::LogDebug("[Visualizer] Depth capture to {}", png_filename.c_str());
     io::WriteImage(png_filename, png_image);
     if (!camera_filename.empty()) {
-        utility::LogDebug("[Visualizer] Depth camera capture to {}\n",
+        utility::LogDebug("[Visualizer] Depth camera capture to {}",
                           camera_filename.c_str());
         camera::PinholeCameraParameters parameter;
         view_control_ptr_->ConvertToPinholeCameraParameters(parameter);
@@ -431,11 +430,11 @@ void Visualizer::CaptureDepthPointCloud(
         }
     }
 
-    utility::LogDebug("[Visualizer] Depth point cloud capture to {}\n",
+    utility::LogDebug("[Visualizer] Depth point cloud capture to {}",
                       ply_filename.c_str());
     io::WritePointCloud(ply_filename, depth_pointcloud);
     if (!camera_filename.empty()) {
-        utility::LogDebug("[Visualizer] Depth camera capture to {}\n",
+        utility::LogDebug("[Visualizer] Depth camera capture to {}",
                           camera_filename.c_str());
         camera::PinholeCameraParameters parameter;
         view_control_ptr_->ConvertToPinholeCameraParameters(parameter);
@@ -449,7 +448,7 @@ void Visualizer::CaptureRenderOption(const std::string &filename /* = ""*/) {
         std::string timestamp = utility::GetCurrentTimeStamp();
         json_filename = "RenderOption_" + timestamp + ".json";
     }
-    utility::LogDebug("[Visualizer] Render option capture to {}\n",
+    utility::LogDebug("[Visualizer] Render option capture to {}",
                       json_filename.c_str());
     io::WriteIJsonConvertible(json_filename, *render_option_ptr_);
 }

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithCustomAnimation.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithCustomAnimation.cpp
@@ -44,31 +44,31 @@ VisualizerWithCustomAnimation::~VisualizerWithCustomAnimation() {}
 void VisualizerWithCustomAnimation::PrintVisualizerHelp() {
     Visualizer::PrintVisualizerHelp();
     // clang-format off
-    utility::LogInfo("  -- Animation control --\n");
-    utility::LogInfo("    Ctrl + F     : Enter freeview (editing) mode.\n");
-    utility::LogInfo("    Ctrl + W     : Enter preview mode.\n");
-    utility::LogInfo("    Ctrl + P     : Enter animation mode and play animation from beginning.\n");
-    utility::LogInfo("    Ctrl + R     : Enter animation mode, play animation, and record screen.\n");
-    utility::LogInfo("    Ctrl + G     : Enter animation mode, play animation, and record depth.\n");
-    utility::LogInfo("    Ctrl + S     : Save the camera path into a json file.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("    -- In free view mode --\n");
-    utility::LogInfo("    Ctrl + <-/-> : Go backward/forward a keyframe.\n");
-    utility::LogInfo("    Ctrl + Wheel : Same as Ctrl + <-/->.\n");
-    utility::LogInfo("    Ctrl + [/]   : Go to the first/last keyframe.\n");
-    utility::LogInfo("    Ctrl + +/-   : Increase/decrease interval between keyframes.\n");
-    utility::LogInfo("    Ctrl + L     : Turn on/off camera path as a loop.\n");
-    utility::LogInfo("    Ctrl + A     : Add a keyframe right after the current keyframe.\n");
-    utility::LogInfo("    Ctrl + U     : Update the current keyframe.\n");
-    utility::LogInfo("    Ctrl + D     : Delete the current keyframe.\n");
-    utility::LogInfo("    Ctrl + N     : Add 360 spin right after the current keyframe.\n");
-    utility::LogInfo("    Ctrl + E     : Erase the entire camera path.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("    -- In preview mode --\n");
-    utility::LogInfo("    Ctrl + <-/-> : Go backward/forward a frame.\n");
-    utility::LogInfo("    Ctrl + Wheel : Same as Ctrl + <-/->.\n");
-    utility::LogInfo("    Ctrl + [/]   : Go to beginning/end of the camera path.\n");
-    utility::LogInfo("\n");
+    utility::LogInfo("  -- Animation control --");
+    utility::LogInfo("    Ctrl + F     : Enter freeview (editing) mode.");
+    utility::LogInfo("    Ctrl + W     : Enter preview mode.");
+    utility::LogInfo("    Ctrl + P     : Enter animation mode and play animation from beginning.");
+    utility::LogInfo("    Ctrl + R     : Enter animation mode, play animation, and record screen.");
+    utility::LogInfo("    Ctrl + G     : Enter animation mode, play animation, and record depth.");
+    utility::LogInfo("    Ctrl + S     : Save the camera path into a json file.");
+    utility::LogInfo("");
+    utility::LogInfo("    -- In free view mode --");
+    utility::LogInfo("    Ctrl + <-/-> : Go backward/forward a keyframe.");
+    utility::LogInfo("    Ctrl + Wheel : Same as Ctrl + <-/->.");
+    utility::LogInfo("    Ctrl + [/]   : Go to the first/last keyframe.");
+    utility::LogInfo("    Ctrl + +/-   : Increase/decrease interval between keyframes.");
+    utility::LogInfo("    Ctrl + L     : Turn on/off camera path as a loop.");
+    utility::LogInfo("    Ctrl + A     : Add a keyframe right after the current keyframe.");
+    utility::LogInfo("    Ctrl + U     : Update the current keyframe.");
+    utility::LogInfo("    Ctrl + D     : Delete the current keyframe.");
+    utility::LogInfo("    Ctrl + N     : Add 360 spin right after the current keyframe.");
+    utility::LogInfo("    Ctrl + E     : Erase the entire camera path.");
+    utility::LogInfo("");
+    utility::LogInfo("    -- In preview mode --");
+    utility::LogInfo("    Ctrl + <-/-> : Go backward/forward a frame.");
+    utility::LogInfo("    Ctrl + Wheel : Same as Ctrl + <-/->.");
+    utility::LogInfo("    Ctrl + [/]   : Go to beginning/end of the camera path.");
+    utility::LogInfo("");
     // clang-format on
 }
 
@@ -88,7 +88,7 @@ void VisualizerWithCustomAnimation::Play(
         bool close_window_when_animation_ends /* = false*/) {
     auto &view_control = (ViewControlWithCustomAnimation &)(*view_control_ptr_);
     if (view_control.NumOfFrames() == 0) {
-        utility::LogWarning("Abort playing due to empty trajectory.\n");
+        utility::LogWarning("Abort playing due to empty trajectory.");
         return;
     }
     view_control.SetAnimationMode(
@@ -183,13 +183,13 @@ void VisualizerWithCustomAnimation::KeyPressCallback(
                 view_control.SetAnimationMode(ViewControlWithCustomAnimation::
                                                       AnimationMode::FreeMode);
                 utility::LogDebug(
-                        "[Visualizer] Enter freeview (editing) mode.\n");
+                        "[Visualizer] Enter freeview (editing) mode.");
                 break;
             case GLFW_KEY_W:
                 view_control.SetAnimationMode(
                         ViewControlWithCustomAnimation::AnimationMode::
                                 PreviewMode);
-                utility::LogDebug("[Visualizer] Enter preview mode.\n");
+                utility::LogDebug("[Visualizer] Enter preview mode.");
                 break;
             case GLFW_KEY_P:
                 Play(false);
@@ -217,15 +217,13 @@ void VisualizerWithCustomAnimation::KeyPressCallback(
                 break;
             case GLFW_KEY_EQUAL:
                 view_control.ChangeTrajectoryInterval(1);
-                utility::LogDebug(
-                        "[Visualizer] Trajectory interval set to {}.\n",
-                        view_control.GetTrajectoryInterval());
+                utility::LogDebug("[Visualizer] Trajectory interval set to {}.",
+                                  view_control.GetTrajectoryInterval());
                 break;
             case GLFW_KEY_MINUS:
                 view_control.ChangeTrajectoryInterval(-1);
-                utility::LogDebug(
-                        "[Visualizer] Trajectory interval set to {}.\n",
-                        view_control.GetTrajectoryInterval());
+                utility::LogDebug("[Visualizer] Trajectory interval set to {}.",
+                                  view_control.GetTrajectoryInterval());
                 break;
             case GLFW_KEY_L:
                 view_control.ToggleTrajectoryLoop();
@@ -233,31 +231,31 @@ void VisualizerWithCustomAnimation::KeyPressCallback(
             case GLFW_KEY_A:
                 view_control.AddKeyFrame();
                 utility::LogDebug(
-                        "[Visualizer] Insert key frame; {} remaining.\n",
+                        "[Visualizer] Insert key frame; {} remaining.",
                         view_control.NumOfKeyFrames());
                 break;
             case GLFW_KEY_U:
                 view_control.UpdateKeyFrame();
                 utility::LogDebug(
-                        "[Visualizer] Update key frame; {} remaining.\n",
+                        "[Visualizer] Update key frame; {} remaining.",
                         view_control.NumOfKeyFrames());
                 break;
             case GLFW_KEY_D:
                 view_control.DeleteKeyFrame();
                 utility::LogDebug(
-                        "[Visualizer] Delete last key frame; {} remaining.\n",
+                        "[Visualizer] Delete last key frame; {} remaining.",
                         view_control.NumOfKeyFrames());
                 break;
             case GLFW_KEY_N:
                 view_control.AddSpinKeyFrames();
                 utility::LogDebug(
-                        "[Visualizer] Insert spin key frames; {} remaining.\n",
+                        "[Visualizer] Insert spin key frames; {} remaining.",
                         view_control.NumOfKeyFrames());
                 break;
             case GLFW_KEY_E:
                 view_control.ClearAllKeyFrames();
                 utility::LogDebug(
-                        "[Visualizer] Clear key frames; {} remaining.\n",
+                        "[Visualizer] Clear key frames; {} remaining.",
                         view_control.NumOfKeyFrames());
                 break;
             default:

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -208,10 +208,9 @@ int VisualizerWithEditing::PickPoint(double x, double y) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     if (!GLEW_ARB_framebuffer_object) {
         // OpenGL 2.1 doesn't require this, 3.1+ does
-        utility::LogError(
+        utility::LogWarning(
                 "[PickPoint] Your GPU does not provide framebuffer objects. "
-                "Use "
-                "a texture instead.\n");
+                "Use a texture instead.\n");
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glEnable(GL_MULTISAMPLE);
         return -1;
@@ -228,7 +227,7 @@ int VisualizerWithEditing::PickPoint(double x, double y) {
     GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
     glDrawBuffers(1, DrawBuffers);  // "1" is the size of DrawBuffers
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        utility::LogError("[PickPoint] Something is wrong with FBO.\n");
+        utility::LogWarning("[PickPoint] Something is wrong with FBO.\n");
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glEnable(GL_MULTISAMPLE);
         return -1;
@@ -344,7 +343,7 @@ void VisualizerWithEditing::KeyPressCallback(
                             buff.c_str());
                     if (str == NULL) {
                         utility::LogWarning(
-                                "Illegal input, use default voxel size.\n");
+                                "Illegal input, using default voxel size.\n");
                     } else {
                         char *end;
                         errno = 0;
@@ -352,7 +351,8 @@ void VisualizerWithEditing::KeyPressCallback(
                         if (errno == ERANGE &&
                             (l == HUGE_VAL || l == -HUGE_VAL)) {
                             utility::LogWarning(
-                                    "Illegal input, use default voxel size.\n");
+                                    "Illegal input, using default voxel "
+                                    "size.\n");
                         } else {
                             voxel_size_ = l;
                         }

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -109,7 +109,7 @@ bool VisualizerWithEditing::AddGeometry(
     geometry_renderer_ptrs_.insert(editing_geometry_renderer_ptr_);
     ResetViewPoint(true);
     utility::LogDebug(
-            "Add geometry and update bounding box to {}\n",
+            "Add geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
     return UpdateGeometry();
 }
@@ -117,26 +117,26 @@ bool VisualizerWithEditing::AddGeometry(
 void VisualizerWithEditing::PrintVisualizerHelp() {
     Visualizer::PrintVisualizerHelp();
     // clang-format off
-    utility::LogInfo("  -- Editing control --\n");
-    utility::LogInfo("    F            : Enter freeview mode.\n");
-    utility::LogInfo("    X            : Enter orthogonal view along X axis, press again to flip.\n");
-    utility::LogInfo("    Y            : Enter orthogonal view along Y axis, press again to flip.\n");
-    utility::LogInfo("    Z            : Enter orthogonal view along Z axis, press again to flip.\n");
-    utility::LogInfo("    K            : Lock / unlock camera.\n");
-    utility::LogInfo("    Ctrl + D     : Downsample point cloud with a voxel grid.\n");
-    utility::LogInfo("    Ctrl + R     : Reset geometry to its initial state.\n");
-    utility::LogInfo("    Shift + +/-  : Increase/decrease picked point size..\n");
-    utility::LogInfo("    Shift + mouse left button   : Pick a point and add in queue.\n");
-    utility::LogInfo("    Shift + mouse right button  : Remove last picked point from queue.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("    -- When camera is locked --\n");
-    utility::LogInfo("    Mouse left button + drag    : Create a selection rectangle.\n");
-    utility::LogInfo("    Ctrl + mouse buttons + drag : Hold Ctrl key to draw a selection polygon.\n");
-    utility::LogInfo("                                  Left mouse button to add point. Right mouse\n");
-    utility::LogInfo("                                  button to remove point. Release Ctrl key to\n");
-    utility::LogInfo("                                  close the polygon.\n");
-    utility::LogInfo("    C                           : Crop the geometry with selection region.\n");
-    utility::LogInfo("\n");
+    utility::LogInfo("  -- Editing control --");
+    utility::LogInfo("    F            : Enter freeview mode.");
+    utility::LogInfo("    X            : Enter orthogonal view along X axis, press again to flip.");
+    utility::LogInfo("    Y            : Enter orthogonal view along Y axis, press again to flip.");
+    utility::LogInfo("    Z            : Enter orthogonal view along Z axis, press again to flip.");
+    utility::LogInfo("    K            : Lock / unlock camera.");
+    utility::LogInfo("    Ctrl + D     : Downsample point cloud with a voxel grid.");
+    utility::LogInfo("    Ctrl + R     : Reset geometry to its initial state.");
+    utility::LogInfo("    Shift + +/-  : Increase/decrease picked point size..");
+    utility::LogInfo("    Shift + mouse left button   : Pick a point and add in queue.");
+    utility::LogInfo("    Shift + mouse right button  : Remove last picked point from queue.");
+    utility::LogInfo("");
+    utility::LogInfo("    -- When camera is locked --");
+    utility::LogInfo("    Mouse left button + drag    : Create a selection rectangle.");
+    utility::LogInfo("    Ctrl + mouse buttons + drag : Hold Ctrl key to draw a selection polygon.");
+    utility::LogInfo("                                  Left mouse button to add point. Right mouse");
+    utility::LogInfo("                                  button to remove point. Release Ctrl key to");
+    utility::LogInfo("                                  close the polygon.");
+    utility::LogInfo("    C                           : Crop the geometry with selection region.");
+    utility::LogInfo("");
     // clang-format on
 }
 
@@ -210,7 +210,7 @@ int VisualizerWithEditing::PickPoint(double x, double y) {
         // OpenGL 2.1 doesn't require this, 3.1+ does
         utility::LogWarning(
                 "[PickPoint] Your GPU does not provide framebuffer objects. "
-                "Use a texture instead.\n");
+                "Use a texture instead.");
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glEnable(GL_MULTISAMPLE);
         return -1;
@@ -227,7 +227,7 @@ int VisualizerWithEditing::PickPoint(double x, double y) {
     GLenum DrawBuffers[1] = {GL_COLOR_ATTACHMENT0};
     glDrawBuffers(1, DrawBuffers);  // "1" is the size of DrawBuffers
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        utility::LogWarning("[PickPoint] Something is wrong with FBO.\n");
+        utility::LogWarning("[PickPoint] Something is wrong with FBO.");
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glEnable(GL_MULTISAMPLE);
         return -1;
@@ -299,27 +299,24 @@ void VisualizerWithEditing::KeyPressCallback(
         case GLFW_KEY_F:
             view_control.SetEditingMode(
                     ViewControlWithEditing::EditingMode::FreeMode);
-            utility::LogDebug("[Visualizer] Enter freeview mode.\n");
+            utility::LogDebug("[Visualizer] Enter freeview mode.");
             break;
         case GLFW_KEY_X:
             view_control.ToggleEditingX();
-            utility::LogDebug(
-                    "[Visualizer] Enter orthogonal X editing mode.\n");
+            utility::LogDebug("[Visualizer] Enter orthogonal X editing mode.");
             break;
         case GLFW_KEY_Y:
             view_control.ToggleEditingY();
-            utility::LogDebug(
-                    "[Visualizer] Enter orthogonal Y editing mode.\n");
+            utility::LogDebug("[Visualizer] Enter orthogonal Y editing mode.");
             break;
         case GLFW_KEY_Z:
             view_control.ToggleEditingZ();
-            utility::LogDebug(
-                    "[Visualizer] Enter orthogonal Z editing mode.\n");
+            utility::LogDebug("[Visualizer] Enter orthogonal Z editing mode.");
             break;
         case GLFW_KEY_K:
             view_control.ToggleLocking();
             InvalidateSelectionPolygon();
-            utility::LogDebug("[Visualizer] Camera %s.\n",
+            utility::LogDebug("[Visualizer] Camera %s.",
                               view_control.IsLocked() ? "Lock" : "Unlock");
             break;
         case GLFW_KEY_R:
@@ -343,7 +340,7 @@ void VisualizerWithEditing::KeyPressCallback(
                             buff.c_str());
                     if (str == NULL) {
                         utility::LogWarning(
-                                "Illegal input, using default voxel size.\n");
+                                "Illegal input, using default voxel size.");
                     } else {
                         char *end;
                         errno = 0;
@@ -352,7 +349,7 @@ void VisualizerWithEditing::KeyPressCallback(
                             (l == HUGE_VAL || l == -HUGE_VAL)) {
                             utility::LogWarning(
                                     "Illegal input, using default voxel "
-                                    "size.\n");
+                                    "size.");
                         } else {
                             voxel_size_ = l;
                         }
@@ -361,9 +358,8 @@ void VisualizerWithEditing::KeyPressCallback(
                 if (voxel_size_ > 0.0 && editing_geometry_ptr_ &&
                     editing_geometry_ptr_->GetGeometryType() ==
                             geometry::Geometry::GeometryType::PointCloud) {
-                    utility::LogInfo(
-                            "Voxel downsample with voxel size {:.4f}.\n",
-                            voxel_size_);
+                    utility::LogInfo("Voxel downsample with voxel size {:.4f}.",
+                                     voxel_size_);
                     geometry::PointCloud &pcd =
                             (geometry::PointCloud &)*editing_geometry_ptr_;
                     pcd = *pcd.VoxelDownSample(voxel_size_);
@@ -371,7 +367,7 @@ void VisualizerWithEditing::KeyPressCallback(
                 } else {
                     utility::LogWarning(
                             "No voxel downsample performed due to illegal "
-                            "voxel size.\n");
+                            "voxel size.");
                 }
             } else {
                 Visualizer::KeyPressCallback(window, key, scancode, action,
@@ -404,7 +400,7 @@ void VisualizerWithEditing::KeyPressCallback(
                     }
                     if (filename == NULL) {
                         utility::LogWarning(
-                                "No filename is given. Abort saving.\n");
+                                "No filename is given. Abort saving.");
                     } else {
                         SaveCroppingResult(filename);
                         crop_action_count_++;
@@ -436,7 +432,7 @@ void VisualizerWithEditing::KeyPressCallback(
                     }
                     if (filename == NULL) {
                         utility::LogWarning(
-                                "No filename is given. Abort saving.\n");
+                                "No filename is given. Abort saving.");
                     } else {
                         SaveCroppingResult(filename);
                         crop_action_count_++;
@@ -608,14 +604,14 @@ void VisualizerWithEditing::MouseButtonCallback(GLFWwindow *window,
 #endif
             int index = PickPoint(x, y);
             if (index == -1) {
-                utility::LogInfo("No point has been picked.\n");
+                utility::LogInfo("No point has been picked.");
             } else {
                 const auto &point =
                         ((const geometry::PointCloud &)(*editing_geometry_ptr_))
                                 .points_[index];
                 utility::LogInfo(
                         "Picked point #{:d} ({:.2}, {:.2}, {:.2}) to add in "
-                        "queue.\n",
+                        "queue.",
                         index, point(0), point(1), point(2));
                 pointcloud_picker_ptr_->picked_indices_.push_back(
                         (size_t)index);
@@ -625,7 +621,7 @@ void VisualizerWithEditing::MouseButtonCallback(GLFWwindow *window,
                    action == GLFW_RELEASE && (mods & GLFW_MOD_SHIFT)) {
             if (pointcloud_picker_ptr_->picked_indices_.empty() == false) {
                 utility::LogInfo(
-                        "Remove picked point #{} from pick queue.\n",
+                        "Remove picked point #{} from pick queue.",
                         pointcloud_picker_ptr_->picked_indices_.back());
                 pointcloud_picker_ptr_->picked_indices_.pop_back();
                 is_redraw_required_ = true;

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithKeyCallback.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithKeyCallback.cpp
@@ -36,15 +36,15 @@ VisualizerWithKeyCallback::~VisualizerWithKeyCallback() {}
 
 void VisualizerWithKeyCallback::PrintVisualizerHelp() {
     Visualizer::PrintVisualizerHelp();
-    utility::LogInfo("  -- Keys registered for callback functions --\n");
+    utility::LogInfo("  -- Keys registered for callback functions --");
     utility::LogInfo("    ");
     for (auto &key_callback_pair : key_to_callback_) {
         utility::LogInfo("[{}] ", PrintKeyToString(key_callback_pair.first));
     }
-    utility::LogInfo("\n");
+    utility::LogInfo("");
     utility::LogInfo(
-            "    The default functions of these keys will be overridden.\n");
-    utility::LogInfo("\n");
+            "    The default functions of these keys will be overridden.");
+    utility::LogInfo("");
 }
 
 void VisualizerWithKeyCallback::RegisterKeyCallback(

--- a/src/Python/docstring.cpp
+++ b/src/Python/docstring.cpp
@@ -52,13 +52,13 @@ void ClassMethodDocInject(py::module& pybind_module,
     PyObject* module = pybind_module.ptr();
     PyObject* class_obj = PyObject_GetAttrString(module, class_name.c_str());
     if (class_obj == nullptr) {
-        utility::LogWarning("{} docstring failed to inject.\n", class_name);
+        utility::LogWarning("{} docstring failed to inject.", class_name);
         return;
     }
     PyObject* class_method_obj =
             PyObject_GetAttrString(class_obj, function_name.c_str());
     if (class_method_obj == nullptr) {
-        utility::LogWarning("{}::{} docstring failed to inject.\n", class_name,
+        utility::LogWarning("{}::{} docstring failed to inject.", class_name,
                             function_name);
         return;
     }
@@ -112,7 +112,7 @@ void FunctionDocInject(py::module& pybind_module,
     PyObject* module = pybind_module.ptr();
     PyObject* f_obj = PyObject_GetAttrString(module, function_name.c_str());
     if (f_obj == nullptr) {
-        utility::LogWarning("{} docstring failed to inject.\n", function_name);
+        utility::LogWarning("{} docstring failed to inject.", function_name);
         return;
     }
     if (Py_TYPE(f_obj) != &PyCFunction_Type) {

--- a/src/Python/io/class_io.cpp
+++ b/src/Python/io/class_io.cpp
@@ -325,21 +325,22 @@ void pybind_class_io(py::module &m_io) {
                                  map_shared_argument_docstrings);
 
 #ifdef BUILD_AZURE_KINECT
-    m_io.def("read_azure_kinect_sensor_config",
-             [](const std::string &filename) {
-                 io::AzureKinectSensorConfig config;
-                 bool success =
-                         io::ReadIJsonConvertibleFromJSON(filename, config);
-                 if (!success) {
-                     utility::LogWarning(
-                             "Invalid sensor config {}, use default instead\n",
-                             filename);
-                     return io::AzureKinectSensorConfig();
-                 }
-                 return config;
-             },
-             "Function to read Azure Kinect sensor config from file",
-             "filename"_a);
+    m_io.def(
+            "read_azure_kinect_sensor_config",
+            [](const std::string &filename) {
+                io::AzureKinectSensorConfig config;
+                bool success =
+                        io::ReadIJsonConvertibleFromJSON(filename, config);
+                if (!success) {
+                    utility::LogWarning(
+                            "Invalid sensor config {}, using default instead\n",
+                            filename);
+                    return io::AzureKinectSensorConfig();
+                }
+                return config;
+            },
+            "Function to read Azure Kinect sensor config from file",
+            "filename"_a);
     docstring::FunctionDocInject(m_io, "read_azure_kinect_sensor_config",
                                  map_shared_argument_docstrings);
 
@@ -360,7 +361,7 @@ void pybind_class_io(py::module &m_io) {
                          io::ReadIJsonConvertibleFromJSON(filename, metadata);
                  if (!success) {
                      utility::LogWarning(
-                             "Invalid mkv metadata {}, use default instead\n",
+                             "Invalid mkv metadata {}, using default instead\n",
                              filename);
                      return io::MKVMetadata();
                  }

--- a/src/Python/io/class_io.cpp
+++ b/src/Python/io/class_io.cpp
@@ -325,22 +325,21 @@ void pybind_class_io(py::module &m_io) {
                                  map_shared_argument_docstrings);
 
 #ifdef BUILD_AZURE_KINECT
-    m_io.def(
-            "read_azure_kinect_sensor_config",
-            [](const std::string &filename) {
-                io::AzureKinectSensorConfig config;
-                bool success =
-                        io::ReadIJsonConvertibleFromJSON(filename, config);
-                if (!success) {
-                    utility::LogWarning(
-                            "Invalid sensor config {}, using default instead\n",
-                            filename);
-                    return io::AzureKinectSensorConfig();
-                }
-                return config;
-            },
-            "Function to read Azure Kinect sensor config from file",
-            "filename"_a);
+    m_io.def("read_azure_kinect_sensor_config",
+             [](const std::string &filename) {
+                 io::AzureKinectSensorConfig config;
+                 bool success =
+                         io::ReadIJsonConvertibleFromJSON(filename, config);
+                 if (!success) {
+                     utility::LogWarning(
+                             "Invalid sensor config {}, using default instead",
+                             filename);
+                     return io::AzureKinectSensorConfig();
+                 }
+                 return config;
+             },
+             "Function to read Azure Kinect sensor config from file",
+             "filename"_a);
     docstring::FunctionDocInject(m_io, "read_azure_kinect_sensor_config",
                                  map_shared_argument_docstrings);
 
@@ -361,7 +360,7 @@ void pybind_class_io(py::module &m_io) {
                          io::ReadIJsonConvertibleFromJSON(filename, metadata);
                  if (!success) {
                      utility::LogWarning(
-                             "Invalid mkv metadata {}, using default instead\n",
+                             "Invalid mkv metadata {}, using default instead",
                              filename);
                      return io::MKVMetadata();
                  }

--- a/src/Python/utility/console.cpp
+++ b/src/Python/utility/console.cpp
@@ -33,8 +33,7 @@ using namespace open3d;
 void pybind_console(py::module &m) {
     py::enum_<utility::VerbosityLevel> vl(m, "VerbosityLevel", py::arithmetic(),
                                           "VerbosityLevel");
-    vl.value("Fatal", utility::VerbosityLevel::Fatal)
-            .value("Error", utility::VerbosityLevel::Error)
+    vl.value("Error", utility::VerbosityLevel::Error)
             .value("Warning", utility::VerbosityLevel::Warning)
             .value("Info", utility::VerbosityLevel::Info)
             .value("Debug", utility::VerbosityLevel::Debug)

--- a/src/Tools/ConvertPointCloud.cpp
+++ b/src/Tools/ConvertPointCloud.cpp
@@ -214,7 +214,8 @@ int main(int argc, char **argv) {
         }
     } else {
         utility::LogWarning("File or directory does not exist.\n");
+        return 1;
     }
 
-    return 1;
+    return 0;
 }

--- a/src/Tools/ConvertPointCloud.cpp
+++ b/src/Tools/ConvertPointCloud.cpp
@@ -32,36 +32,36 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ConvertPointCloud source_file target_file [options]\n");
-    utility::LogInfo("    > ConvertPointCloud source_directory target_directory [options]\n");
-    utility::LogInfo("      Read point cloud from source file and convert it to target file.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Options (listed in the order of execution priority):\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::LogInfo("    --clip_x_min x0           : Clip points with x coordinate < x0.\n");
-    utility::LogInfo("    --clip_x_max x1           : Clip points with x coordinate > x1.\n");
-    utility::LogInfo("    --clip_y_min y0           : Clip points with y coordinate < y0.\n");
-    utility::LogInfo("    --clip_y_max y1           : Clip points with y coordinate > y1.\n");
-    utility::LogInfo("    --clip_z_min z0           : Clip points with z coordinate < z0.\n");
-    utility::LogInfo("    --clip_z_max z1           : Clip points with z coordinate > z1.\n");
-    utility::LogInfo("    --filter_mahalanobis d    : Filter out points with Mahalanobis distance > d.\n");
-    utility::LogInfo("    --uniform_sample_every K  : Downsample the point cloud uniformly. Keep only\n");
-    utility::LogInfo("                              : one point for every K points.\n");
-    utility::LogInfo("    --voxel_sample voxel_size : Downsample the point cloud with a voxel.\n");
-    utility::LogInfo("    --estimate_normals radius : Estimate normals using a search neighborhood of\n");
-    utility::LogInfo("                                radius. The normals are oriented w.r.t. the\n");
-    utility::LogInfo("                                original normals of the pointcloud if they\n");
-    utility::LogInfo("                                exist. Otherwise, they are oriented towards -Z\n");
-    utility::LogInfo("                                direction.\n");
-    utility::LogInfo("    --estimate_normals_knn k  : Estimate normals using a search with k nearest\n");
-    utility::LogInfo("                                neighbors. The normals are oriented w.r.t. the\n");
-    utility::LogInfo("                                original normals of the pointcloud if they\n");
-    utility::LogInfo("                                exist. Otherwise, they are oriented towards -Z\n");
-    utility::LogInfo("                                direction.\n");
-    utility::LogInfo("    --orient_normals [x,y,z]  : Orient the normals w.r.t the direction [x,y,z].\n");
-    utility::LogInfo("    --camera_location [x,y,z] : Orient the normals w.r.t camera location [x,y,z].\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ConvertPointCloud source_file target_file [options]");
+    utility::LogInfo("    > ConvertPointCloud source_directory target_directory [options]");
+    utility::LogInfo("      Read point cloud from source file and convert it to target file.");
+    utility::LogInfo("");
+    utility::LogInfo("Options (listed in the order of execution priority):");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4).");
+    utility::LogInfo("    --clip_x_min x0           : Clip points with x coordinate < x0.");
+    utility::LogInfo("    --clip_x_max x1           : Clip points with x coordinate > x1.");
+    utility::LogInfo("    --clip_y_min y0           : Clip points with y coordinate < y0.");
+    utility::LogInfo("    --clip_y_max y1           : Clip points with y coordinate > y1.");
+    utility::LogInfo("    --clip_z_min z0           : Clip points with z coordinate < z0.");
+    utility::LogInfo("    --clip_z_max z1           : Clip points with z coordinate > z1.");
+    utility::LogInfo("    --filter_mahalanobis d    : Filter out points with Mahalanobis distance > d.");
+    utility::LogInfo("    --uniform_sample_every K  : Downsample the point cloud uniformly. Keep only");
+    utility::LogInfo("                              : one point for every K points.");
+    utility::LogInfo("    --voxel_sample voxel_size : Downsample the point cloud with a voxel.");
+    utility::LogInfo("    --estimate_normals radius : Estimate normals using a search neighborhood of");
+    utility::LogInfo("                                radius. The normals are oriented w.r.t. the");
+    utility::LogInfo("                                original normals of the pointcloud if they");
+    utility::LogInfo("                                exist. Otherwise, they are oriented towards -Z");
+    utility::LogInfo("                                direction.");
+    utility::LogInfo("    --estimate_normals_knn k  : Estimate normals using a search with k nearest");
+    utility::LogInfo("                                neighbors. The normals are oriented w.r.t. the");
+    utility::LogInfo("                                original normals of the pointcloud if they");
+    utility::LogInfo("                                exist. Otherwise, they are oriented towards -Z");
+    utility::LogInfo("                                direction.");
+    utility::LogInfo("    --orient_normals [x,y,z]  : Orient the normals w.r.t the direction [x,y,z].");
+    utility::LogInfo("    --camera_location [x,y,z] : Orient the normals w.r.t camera location [x,y,z].");
     // clang-format on
 }
 
@@ -114,7 +114,7 @@ void convert(int argc,
         }
         auto pcd = pointcloud_ptr->SelectDownSample(indices);
         utility::LogDebug(
-                "Based on Mahalanobis distance, {:d} points were filtered.\n",
+                "Based on Mahalanobis distance, {:d} points were filtered.",
                 (int)(pointcloud_ptr->points_.size() - pcd->points_.size()));
         pointcloud_ptr = pcd;
     }
@@ -123,9 +123,8 @@ void convert(int argc,
     int every_k = utility::GetProgramOptionAsInt(argc, argv,
                                                  "--uniform_sample_every", 0);
     if (every_k > 1) {
-        utility::LogDebug(
-                "Downsample point cloud uniformly every {:d} points.\n",
-                every_k);
+        utility::LogDebug("Downsample point cloud uniformly every {:d} points.",
+                          every_k);
         pointcloud_ptr = pointcloud_ptr->UniformDownSample(every_k);
         processed = true;
     }
@@ -134,7 +133,7 @@ void convert(int argc,
     double voxel_size = utility::GetProgramOptionAsDouble(
             argc, argv, "--voxel_sample", 0.0);
     if (voxel_size > 0.0) {
-        utility::LogDebug("Downsample point cloud with voxel size {:.4f}.\n",
+        utility::LogDebug("Downsample point cloud with voxel size {:.4f}.",
                           voxel_size);
         pointcloud_ptr = pointcloud_ptr->VoxelDownSample(voxel_size);
         processed = true;
@@ -144,7 +143,7 @@ void convert(int argc,
     double radius = utility::GetProgramOptionAsDouble(
             argc, argv, "--estimate_normals", 0.0);
     if (radius > 0.0) {
-        utility::LogDebug("Estimate normals with search radius {:.4f}.\n",
+        utility::LogDebug("Estimate normals with search radius {:.4f}.",
                           radius);
         pointcloud_ptr->EstimateNormals(
                 geometry::KDTreeSearchParamRadius(radius));
@@ -154,7 +153,7 @@ void convert(int argc,
     int k = utility::GetProgramOptionAsInt(argc, argv, "--estimate_normals_knn",
                                            0);
     if (k > 0) {
-        utility::LogDebug("Estimate normals with search knn {:d}.\n", k);
+        utility::LogDebug("Estimate normals with search knn {:d}.", k);
         pointcloud_ptr->EstimateNormals(geometry::KDTreeSearchParamKNN(k));
         processed = true;
     }
@@ -163,8 +162,8 @@ void convert(int argc,
     Eigen::VectorXd direction = utility::GetProgramOptionAsEigenVectorXd(
             argc, argv, "--orient_normals");
     if (direction.size() == 3 && pointcloud_ptr->HasNormals()) {
-        utility::LogDebug("Orient normals to [%.2f, %.2f, %.2f].\n",
-                          direction(0), direction(1), direction(2));
+        utility::LogDebug("Orient normals to [%.2f, %.2f, %.2f].", direction(0),
+                          direction(1), direction(2));
         Eigen::Vector3d dir(direction);
         pointcloud_ptr->OrientNormalsToAlignWithDirection(dir);
         processed = true;
@@ -172,7 +171,7 @@ void convert(int argc,
     Eigen::VectorXd camera_loc = utility::GetProgramOptionAsEigenVectorXd(
             argc, argv, "--camera_location");
     if (camera_loc.size() == 3 && pointcloud_ptr->HasNormals()) {
-        utility::LogDebug("Orient normals towards [%.2f, %.2f, %.2f].\n",
+        utility::LogDebug("Orient normals towards [%.2f, %.2f, %.2f].",
                           camera_loc(0), camera_loc(1), camera_loc(2));
         Eigen::Vector3d loc(camera_loc);
         pointcloud_ptr->OrientNormalsTowardsCameraLocation(loc);
@@ -182,7 +181,7 @@ void convert(int argc,
     size_t point_num_out = pointcloud_ptr->points_.size();
     if (processed) {
         utility::LogInfo(
-                "Processed point cloud from {:d} points to {:d} points.\n",
+                "Processed point cloud from {:d} points to {:d} points.",
                 (int)point_num_in, (int)point_num_out);
     }
     io::WritePointCloud(file_out.c_str(), *pointcloud_ptr, false, true);
@@ -213,7 +212,7 @@ int main(int argc, char **argv) {
                             GetFileNameWithoutDirectory(fn));
         }
     } else {
-        utility::LogWarning("File or directory does not exist.\n");
+        utility::LogWarning("File or directory does not exist.");
         return 1;
     }
 

--- a/src/Tools/ManuallyAlignPointCloud/AlignmentSession.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/AlignmentSession.cpp
@@ -58,7 +58,7 @@ bool AlignmentSession::ConvertFromJsonValue(const Json::Value &value) {
     if (value.isObject() == false) {
         utility::LogWarning(
                 "AlignmentSession read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     if (value.get("class_name", "").asString() != "AlignmentSession" ||
@@ -66,7 +66,7 @@ bool AlignmentSession::ConvertFromJsonValue(const Json::Value &value) {
         value.get("version_minor", 0).asInt() != 0) {
         utility::LogWarning(
                 "AlignmentSession read JSON failed: unsupported json "
-                "format.\n");
+                "format.");
         return false;
     }
     const auto &source_array = value["source_indices"];

--- a/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     auto target_ptr = io::CreatePointCloudFromFile(argv[2]);
     if (source_ptr->IsEmpty() || target_ptr->IsEmpty()) {
         utility::LogWarning("Failed to read one of the point clouds.\n");
-        return 0;
+        return 1;
     }
 
     if (!alignment_filename.empty()) {
@@ -228,5 +228,5 @@ int main(int argc, char **argv) {
     vis_source.DestroyVisualizerWindow();
     vis_target.DestroyVisualizerWindow();
     vis_main.DestroyVisualizerWindow();
-    return 1;
+    return 0;
 }

--- a/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/ManuallyAlignPointCloud.cpp
@@ -31,17 +31,17 @@
 
 void PrintTransformation(const Eigen::Matrix4d &transformation) {
     using namespace open3d;
-    utility::LogInfo("Current transformation is:\n");
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation(0, 0),
+    utility::LogInfo("Current transformation is:");
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation(0, 0),
                      transformation(0, 1), transformation(0, 2),
                      transformation(0, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation(1, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation(1, 0),
                      transformation(1, 1), transformation(1, 2),
                      transformation(1, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation(2, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation(2, 0),
                      transformation(2, 1), transformation(2, 2),
                      transformation(2, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation(3, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation(3, 0),
                      transformation(3, 1), transformation(3, 2),
                      transformation(3, 3));
 }
@@ -50,25 +50,25 @@ void PrintHelp() {
     using namespace open3d;
     // PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ManuallyAlignPointCloud source_file target_file [options]\n");
-    utility::LogInfo("      Manually align point clouds in source_file and target_file.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::LogInfo("    --voxel_size d            : Set downsample voxel size.\n");
-    utility::LogInfo("    --max_corres_distance d   : Set max correspondence distance.\n");
-    utility::LogInfo("    --without_scaling         : Disable scaling in transformations.\n");
-    utility::LogInfo("    --without_dialog          : Disable dialogs. Default files will be used.\n");
-    utility::LogInfo("    --without_gui_icp file    : The program runs as a console command. No window\n");
-    utility::LogInfo("                                will be created. The program reads an alignment\n");
-    utility::LogInfo("                                from file. It does cropping, downsample, ICP,\n");
-    utility::LogInfo("                                then saves the alignment session into file.\n");
-    utility::LogInfo("    --without_gui_eval file   : The program runs as a console command. No window\n");
-    utility::LogInfo("                                will be created. The program reads an alignment\n");
-    utility::LogInfo("                                from file. It does cropping, downsample,\n");
-    utility::LogInfo("                                evaluation, then saves everything.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ManuallyAlignPointCloud source_file target_file [options]");
+    utility::LogInfo("      Manually align point clouds in source_file and target_file.");
+    utility::LogInfo("");
+    utility::LogInfo("Options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4).");
+    utility::LogInfo("    --voxel_size d            : Set downsample voxel size.");
+    utility::LogInfo("    --max_corres_distance d   : Set max correspondence distance.");
+    utility::LogInfo("    --without_scaling         : Disable scaling in transformations.");
+    utility::LogInfo("    --without_dialog          : Disable dialogs. Default files will be used.");
+    utility::LogInfo("    --without_gui_icp file    : The program runs as a console command. No window");
+    utility::LogInfo("                                will be created. The program reads an alignment");
+    utility::LogInfo("                                from file. It does cropping, downsample, ICP,");
+    utility::LogInfo("                                then saves the alignment session into file.");
+    utility::LogInfo("    --without_gui_eval file   : The program runs as a console command. No window");
+    utility::LogInfo("                                will be created. The program reads an alignment");
+    utility::LogInfo("                                from file. It does cropping, downsample,");
+    utility::LogInfo("                                evaluation, then saves everything.");
     // clang-format on
 }
 
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
     auto source_ptr = io::CreatePointCloudFromFile(argv[1]);
     auto target_ptr = io::CreatePointCloudFromFile(argv[2]);
     if (source_ptr->IsEmpty() || target_ptr->IsEmpty()) {
-        utility::LogWarning("Failed to read one of the point clouds.\n");
+        utility::LogWarning("Failed to read one of the point clouds.");
         return 1;
     }
 
@@ -119,16 +119,16 @@ int main(int argc, char **argv) {
                 std::make_shared<visualization::SelectionPolygonVolume>();
         if (io::ReadIJsonConvertible(default_polygon_filename,
                                      *polygon_volume)) {
-            utility::LogInfo("Crop point cloud.\n");
+            utility::LogInfo("Crop point cloud.");
             source_ptr = polygon_volume->CropPointCloud(*source_ptr);
         }
         if (voxel_size > 0.0) {
-            utility::LogInfo("Downsample point cloud with voxel size {:.4f}.\n",
+            utility::LogInfo("Downsample point cloud with voxel size {:.4f}.",
                              voxel_size);
             source_ptr = source_ptr->VoxelDownSample(voxel_size);
         }
         if (max_corres_distance > 0.0) {
-            utility::LogInfo("ICP with max correspondence distance {:.4f}.\n",
+            utility::LogInfo("ICP with max correspondence distance {:.4f}.",
                              max_corres_distance);
             auto result = registration::RegistrationICP(
                     *source_ptr, *target_ptr, max_corres_distance,
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
                     registration::ICPConvergenceCriteria(1e-6, 1e-6, 30));
             utility::LogInfo(
                     "Registration finished with fitness {:.4f} and RMSE "
-                    "{:.4f}.\n",
+                    "{:.4f}.",
                     result.fitness_, result.inlier_rmse_);
             if (result.fitness_ > 0.0) {
                 session.transformation_ =
@@ -160,11 +160,11 @@ int main(int argc, char **argv) {
                 std::make_shared<visualization::SelectionPolygonVolume>();
         if (io::ReadIJsonConvertible(default_polygon_filename,
                                      *polygon_volume)) {
-            utility::LogInfo("Crop point cloud.\n");
+            utility::LogInfo("Crop point cloud.");
             source_ptr = polygon_volume->CropPointCloud(*source_ptr);
         }
         if (voxel_size > 0.0) {
-            utility::LogInfo("Downsample point cloud with voxel size {:.4f}.\n",
+            utility::LogInfo("Downsample point cloud with voxel size {:.4f}.",
                              voxel_size);
             source_ptr = source_ptr->VoxelDownSample(voxel_size);
         }

--- a/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
+++ b/src/Tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
@@ -33,15 +33,15 @@ namespace open3d {
 void VisualizerForAlignment::PrintVisualizerHelp() {
     visualization::Visualizer::PrintVisualizerHelp();
     // clang-format off
-    utility::LogInfo("  -- Alignment control --\n");
-    utility::LogInfo("    Ctrl + R     : Reset source and target to initial state.\n");
-    utility::LogInfo("    Ctrl + S     : Save current alignment session into a JSON file.\n");
-    utility::LogInfo("    Ctrl + O     : Load current alignment session from a JSON file.\n");
-    utility::LogInfo("    Ctrl + A     : Align point clouds based on manually annotations.\n");
-    utility::LogInfo("    Ctrl + I     : Run ICP refinement.\n");
-    utility::LogInfo("    Ctrl + D     : Run voxel downsample for both source and target.\n");
-    utility::LogInfo("    Ctrl + K     : Load a polygon from a JSON file and crop source.\n");
-    utility::LogInfo("    Ctrl + E     : Evaluate error and save to files.\n");
+    utility::LogInfo("  -- Alignment control --");
+    utility::LogInfo("    Ctrl + R     : Reset source and target to initial state.");
+    utility::LogInfo("    Ctrl + S     : Save current alignment session into a JSON file.");
+    utility::LogInfo("    Ctrl + O     : Load current alignment session from a JSON file.");
+    utility::LogInfo("    Ctrl + A     : Align point clouds based on manually annotations.");
+    utility::LogInfo("    Ctrl + I     : Run ICP refinement.");
+    utility::LogInfo("    Ctrl + D     : Run voxel downsample for both source and target.");
+    utility::LogInfo("    Ctrl + K     : Load a polygon from a JSON file and crop source.");
+    utility::LogInfo("    Ctrl + E     : Evaluate error and save to files.");
     // clang-format on
 }
 
@@ -118,7 +118,7 @@ void VisualizerForAlignment::KeyPressCallback(
                             "if it is non-positive)",
                             buffer.c_str());
                     if (str == NULL) {
-                        utility::LogWarning("Dialog closed.\n");
+                        utility::LogWarning("Dialog closed.");
                         return;
                     } else {
                         char *end;
@@ -128,7 +128,7 @@ void VisualizerForAlignment::KeyPressCallback(
                             (l == HUGE_VAL || l == -HUGE_VAL)) {
                             utility::LogWarning(
                                     "Illegal input, use default max "
-                                    "correspondence distance.\n");
+                                    "correspondence distance.");
                         } else {
                             max_correspondence_distance_ = l;
                         }
@@ -136,7 +136,7 @@ void VisualizerForAlignment::KeyPressCallback(
                 }
                 if (max_correspondence_distance_ > 0.0) {
                     utility::LogInfo(
-                            "ICP with max correspondence distance {:.4f}.\n",
+                            "ICP with max correspondence distance {:.4f}.",
                             max_correspondence_distance_);
                     auto result = registration::RegistrationICP(
                             *source_copy_ptr_, *target_copy_ptr_,
@@ -148,8 +148,7 @@ void VisualizerForAlignment::KeyPressCallback(
                                                                  30));
                     utility::LogInfo(
                             "Registration finished with fitness {:.4f} and "
-                            "RMSE "
-                            "{:.4f}.\n",
+                            "RMSE {:.4f}.",
                             result.fitness_, result.inlier_rmse_);
                     if (result.fitness_ > 0.0) {
                         transformation_ =
@@ -161,7 +160,7 @@ void VisualizerForAlignment::KeyPressCallback(
                 } else {
                     utility::LogWarning(
                             "No ICP performed due to illegal max "
-                            "correspondence distance.\n");
+                            "correspondence distance.");
                 }
                 return;
             }
@@ -173,7 +172,7 @@ void VisualizerForAlignment::KeyPressCallback(
                             "Set voxel size (ignored if it is non-positive)",
                             buffer.c_str());
                     if (str == NULL) {
-                        utility::LogWarning("Dialog closed.\n");
+                        utility::LogWarning("Dialog closed.");
                         return;
                     } else {
                         char *end;
@@ -182,23 +181,22 @@ void VisualizerForAlignment::KeyPressCallback(
                         if (errno == ERANGE &&
                             (l == HUGE_VAL || l == -HUGE_VAL)) {
                             utility::LogWarning(
-                                    "Illegal input, use default voxel size.\n");
+                                    "Illegal input, use default voxel size.");
                         } else {
                             voxel_size_ = l;
                         }
                     }
                 }
                 if (voxel_size_ > 0.0) {
-                    utility::LogInfo(
-                            "Voxel downsample with voxel size {:.4f}.\n",
-                            voxel_size_);
+                    utility::LogInfo("Voxel downsample with voxel size {:.4f}.",
+                                     voxel_size_);
                     *source_copy_ptr_ =
                             *source_copy_ptr_->VoxelDownSample(voxel_size_);
                     UpdateGeometry();
                 } else {
                     utility::LogWarning(
                             "No voxel downsample performed due to illegal "
-                            "voxel size.\n");
+                            "voxel size.");
                 }
                 return;
             }
@@ -282,7 +280,7 @@ bool VisualizerForAlignment::AlignWithManualAnnotation() {
         source_idx.size() != target_idx.size()) {
         utility::LogWarning(
                 "# of picked points mismatch: {:d} in source, {:d} in "
-                "target.\n",
+                "target.",
                 (int)source_idx.size(), (int)target_idx.size());
         return false;
     }
@@ -291,7 +289,7 @@ bool VisualizerForAlignment::AlignWithManualAnnotation() {
     for (size_t i = 0; i < source_idx.size(); i++) {
         corres.push_back(Eigen::Vector2i(source_idx[i], target_idx[i]));
     }
-    utility::LogInfo("Error is {:.4f} before alignment.\n",
+    utility::LogInfo("Error is {:.4f} before alignment.",
                      p2p.ComputeRMSE(*alignment_session_.source_ptr_,
                                      *alignment_session_.target_ptr_, corres));
     transformation_ =
@@ -300,24 +298,24 @@ bool VisualizerForAlignment::AlignWithManualAnnotation() {
     PrintTransformation();
     *source_copy_ptr_ = *alignment_session_.source_ptr_;
     source_copy_ptr_->Transform(transformation_);
-    utility::LogInfo("Error is {:.4f} before alignment.\n",
+    utility::LogInfo("Error is {:.4f} before alignment.",
                      p2p.ComputeRMSE(*source_copy_ptr_,
                                      *alignment_session_.target_ptr_, corres));
     return true;
 }
 
 void VisualizerForAlignment::PrintTransformation() {
-    utility::LogInfo("Current transformation is:\n");
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation_(0, 0),
+    utility::LogInfo("Current transformation is:");
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation_(0, 0),
                      transformation_(0, 1), transformation_(0, 2),
                      transformation_(0, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation_(1, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation_(1, 0),
                      transformation_(1, 1), transformation_(1, 2),
                      transformation_(1, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation_(2, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation_(2, 0),
                      transformation_(2, 1), transformation_(2, 2),
                      transformation_(2, 3));
-    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}\n", transformation_(3, 0),
+    utility::LogInfo("\t{:.6f} {:.6f} {:.6f} {:.6f}", transformation_(3, 0),
                      transformation_(3, 1), transformation_(3, 2),
                      transformation_(3, 3));
 }

--- a/src/Tools/ManuallyCropGeometry.cpp
+++ b/src/Tools/ManuallyCropGeometry.cpp
@@ -30,17 +30,17 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ManuallyCropGeometry [--pointcloud/mesh] geometry_file [options]\n");
-    utility::LogInfo("      Manually crop geometry in speficied file.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Options:\n");
-    utility::LogInfo("    --pointcloud,             : Read geometry as point cloud.\n");
-    utility::LogInfo("    --mesh,                   : Read geometry as mesh.\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::LogInfo("    --voxel_size d            : Set downsample voxel size.\n");
-    utility::LogInfo("    --without_dialog          : Disable dialogs. Default files will be used.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ManuallyCropGeometry [--pointcloud/mesh] geometry_file [options]");
+    utility::LogInfo("      Manually crop geometry in speficied file.");
+    utility::LogInfo("");
+    utility::LogInfo("Options:");
+    utility::LogInfo("    --pointcloud,             : Read geometry as point cloud.");
+    utility::LogInfo("    --mesh,                   : Read geometry as mesh.");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4).");
+    utility::LogInfo("    --voxel_size d            : Set downsample voxel size.");
+    utility::LogInfo("    --without_dialog          : Disable dialogs. Default files will be used.");
     // clang-format on
 }
 
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
     if (utility::ProgramOptionExists(argc, argv, "--pointcloud")) {
         auto pcd_ptr = io::CreatePointCloudFromFile(argv[2]);
         if (pcd_ptr->IsEmpty()) {
-            utility::LogWarning("Failed to read the point cloud.\n");
+            utility::LogWarning("Failed to read the point cloud.");
             return 1;
         }
         vis.AddGeometry(pcd_ptr);
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     } else if (utility::ProgramOptionExists(argc, argv, "--mesh")) {
         auto mesh_ptr = io::CreateMeshFromFile(argv[2]);
         if (mesh_ptr->IsEmpty()) {
-            utility::LogWarning("Failed to read the mesh.\n");
+            utility::LogWarning("Failed to read the mesh.");
             return 1;
         }
         vis.AddGeometry(mesh_ptr);

--- a/src/Tools/ManuallyCropGeometry.cpp
+++ b/src/Tools/ManuallyCropGeometry.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
         auto pcd_ptr = io::CreatePointCloudFromFile(argv[2]);
         if (pcd_ptr->IsEmpty()) {
             utility::LogWarning("Failed to read the point cloud.\n");
-            return 0;
+            return 1;
         }
         vis.AddGeometry(pcd_ptr);
         if (pcd_ptr->points_.size() > 5000000) {
@@ -78,11 +78,11 @@ int main(int argc, char **argv) {
         auto mesh_ptr = io::CreateMeshFromFile(argv[2]);
         if (mesh_ptr->IsEmpty()) {
             utility::LogWarning("Failed to read the mesh.\n");
-            return 0;
+            return 1;
         }
         vis.AddGeometry(mesh_ptr);
     }
     vis.Run();
     vis.DestroyVisualizerWindow();
-    return 1;
+    return 0;
 }

--- a/src/Tools/MergeMesh.cpp
+++ b/src/Tools/MergeMesh.cpp
@@ -30,15 +30,15 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > MergeMesh source_directory target_file [option]\n");
-    utility::LogInfo("      Merge mesh files under <source_directory>.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Options (listed in the order of execution priority):\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::LogInfo("    --purge                   : Clear duplicated and unreferenced vertices and\n");
-    utility::LogInfo("                                triangles.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > MergeMesh source_directory target_file [option]");
+    utility::LogInfo("      Merge mesh files under <source_directory>.");
+    utility::LogInfo("");
+    utility::LogInfo("Options (listed in the order of execution priority):");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4).");
+    utility::LogInfo("    --purge                   : Clear duplicated and unreferenced vertices and");
+    utility::LogInfo("                                triangles.");
     // clang-format on
 }
 

--- a/src/Tools/ViewGeometry.cpp
+++ b/src/Tools/ViewGeometry.cpp
@@ -30,37 +30,37 @@ void PrintHelp() {
     using namespace open3d;
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage:\n");
-    utility::LogInfo("    > ViewGeometry [options]\n");
-    utility::LogInfo("      Open a window to view geometry.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Basic options:\n");
-    utility::LogInfo("    --help, -h                : Print help information.\n");
-    utility::LogInfo("    --mesh file               : Add a triangle mesh from file.\n");
-    utility::LogInfo("    --pointcloud file         : Add a point cloud from file.\n");
-    utility::LogInfo("    --lineset file            : Add a line set from file.\n");
-    utility::LogInfo("    --voxelgrid file          : Add a voxel grid from file.\n");
-    utility::LogInfo("    --image file              : Add an image from file.\n");
-    utility::LogInfo("    --depth file              : Add a point cloud converted from a depth image.\n");
-    utility::LogInfo("    --depth_camera file       : Use with --depth, read a json file that stores\n");
-    utility::LogInfo("                                the camera parameters.\n");
-    utility::LogInfo("    --show_frame              : Add a coordinate frame.\n");
-    utility::LogInfo("    --verbose n               : Set verbose level (0-4).\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Animation options:\n");
-    utility::LogInfo("    --render_option file      : Read a json file of rendering settings.\n");
-    utility::LogInfo("    --view_trajectory file    : Read a json file of view trajectory.\n");
-    utility::LogInfo("    --camera_trajectory file  : Read a json file of camera trajectory.\n");
-    utility::LogInfo("    --auto_recording [i|d]    : Automatically plays the animation, record\n");
-    utility::LogInfo("                                images (i) or depth images (d). Exits when\n");
-    utility::LogInfo("                                animation ends.\n");
-    utility::LogInfo("\n");
-    utility::LogInfo("Window options:\n");
-    utility::LogInfo("    --window_name name        : Set window name.\n");
-    utility::LogInfo("    --height n                : Set window height.\n");
-    utility::LogInfo("    --width n                 : Set window width.\n");
-    utility::LogInfo("    --top n                   : Set window top edge.\n");
-    utility::LogInfo("    --left n                  : Set window left edge.\n");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ViewGeometry [options]");
+    utility::LogInfo("      Open a window to view geometry.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --mesh file               : Add a triangle mesh from file.");
+    utility::LogInfo("    --pointcloud file         : Add a point cloud from file.");
+    utility::LogInfo("    --lineset file            : Add a line set from file.");
+    utility::LogInfo("    --voxelgrid file          : Add a voxel grid from file.");
+    utility::LogInfo("    --image file              : Add an image from file.");
+    utility::LogInfo("    --depth file              : Add a point cloud converted from a depth image.");
+    utility::LogInfo("    --depth_camera file       : Use with --depth, read a json file that stores");
+    utility::LogInfo("                                the camera parameters.");
+    utility::LogInfo("    --show_frame              : Add a coordinate frame.");
+    utility::LogInfo("    --verbose n               : Set verbose level (0-4).");
+    utility::LogInfo("");
+    utility::LogInfo("Animation options:");
+    utility::LogInfo("    --render_option file      : Read a json file of rendering settings.");
+    utility::LogInfo("    --view_trajectory file    : Read a json file of view trajectory.");
+    utility::LogInfo("    --camera_trajectory file  : Read a json file of camera trajectory.");
+    utility::LogInfo("    --auto_recording [i|d]    : Automatically plays the animation, record");
+    utility::LogInfo("                                images (i) or depth images (d). Exits when");
+    utility::LogInfo("                                animation ends.");
+    utility::LogInfo("");
+    utility::LogInfo("Window options:");
+    utility::LogInfo("    --window_name name        : Set window name.");
+    utility::LogInfo("    --height n                : Set window height.");
+    utility::LogInfo("    --width n                 : Set window width.");
+    utility::LogInfo("    --top n                   : Set window top edge.");
+    utility::LogInfo("    --left n                  : Set window left edge.");
     // clang-format on
 }
 
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
     visualization::VisualizerWithCustomAnimation visualizer;
     if (visualizer.CreateVisualizerWindow(window_name, width, height, left,
                                           top) == false) {
-        utility::LogWarning("Failed creating OpenGL window.\n");
+        utility::LogWarning("Failed creating OpenGL window.");
         return 0;
     }
 
@@ -117,14 +117,14 @@ int main(int argc, char **argv) {
         auto mesh_ptr = io::CreateMeshFromFile(mesh_filename);
         mesh_ptr->ComputeVertexNormals();
         if (visualizer.AddGeometry(mesh_ptr) == false) {
-            utility::LogWarning("Failed adding triangle mesh.\n");
+            utility::LogWarning("Failed adding triangle mesh.");
             return 1;
         }
     }
     if (!pcd_filename.empty()) {
         auto pointcloud_ptr = io::CreatePointCloudFromFile(pcd_filename);
         if (visualizer.AddGeometry(pointcloud_ptr) == false) {
-            utility::LogWarning("Failed adding point cloud.\n");
+            utility::LogWarning("Failed adding point cloud.");
             return 1;
         }
         if (pointcloud_ptr->points_.size() > 5000000) {
@@ -134,21 +134,21 @@ int main(int argc, char **argv) {
     if (!lineset_filename.empty()) {
         auto lineset_ptr = io::CreateLineSetFromFile(lineset_filename);
         if (visualizer.AddGeometry(lineset_ptr) == false) {
-            utility::LogWarning("Failed adding line set.\n");
+            utility::LogWarning("Failed adding line set.");
             return 1;
         }
     }
     if (!voxelgrid_filename.empty()) {
         auto voxelgrid_ptr = io::CreateVoxelGridFromFile(voxelgrid_filename);
         if (visualizer.AddGeometry(voxelgrid_ptr) == false) {
-            utility::LogWarning("Failed adding voxel grid.\n");
+            utility::LogWarning("Failed adding voxel grid.");
             return 1;
         }
     }
     if (!image_filename.empty()) {
         auto image_ptr = io::CreateImageFromFile(image_filename);
         if (visualizer.AddGeometry(image_ptr) == false) {
-            utility::LogWarning("Failed adding image.\n");
+            utility::LogWarning("Failed adding image.");
             return 1;
         }
     }
@@ -157,8 +157,8 @@ int main(int argc, char **argv) {
         if (depth_parameter_filename.empty() ||
             !io::ReadIJsonConvertible(depth_parameter_filename, parameters)) {
             utility::LogWarning(
-                    "Failed to read intrinsic parameters for depth image.\n");
-            utility::LogWarning("Using default value for Primesense camera.\n");
+                    "Failed to read intrinsic parameters for depth image.");
+            utility::LogWarning("Using default value for Primesense camera.");
             parameters.intrinsic_.SetIntrinsics(640, 480, 525.0, 525.0, 319.5,
                                                 239.5);
         }
@@ -166,13 +166,13 @@ int main(int argc, char **argv) {
         auto pointcloud_ptr = geometry::PointCloud::CreateFromDepthImage(
                 *image_ptr, parameters.intrinsic_, parameters.extrinsic_);
         if (visualizer.AddGeometry(pointcloud_ptr) == false) {
-            utility::LogWarning("Failed adding depth image.\n");
+            utility::LogWarning("Failed adding depth image.");
             return 1;
         }
     }
 
     if (visualizer.HasGeometry() == false) {
-        utility::LogWarning("No geometry to render!\n");
+        utility::LogWarning("No geometry to render!");
         visualizer.DestroyVisualizerWindow();
         return 1;
     }
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
     if (!render_filename.empty()) {
         if (io::ReadIJsonConvertible(render_filename,
                                      visualizer.GetRenderOption()) == false) {
-            utility::LogWarning("Failed loading rendering settings.\n");
+            utility::LogWarning("Failed loading rendering settings.");
             return 1;
         }
     }
@@ -189,14 +189,14 @@ int main(int argc, char **argv) {
         auto &view_control = (visualization::ViewControlWithCustomAnimation &)
                                      visualizer.GetViewControl();
         if (view_control.LoadTrajectoryFromJsonFile(view_filename) == false) {
-            utility::LogWarning("Failed loading view trajectory.\n");
+            utility::LogWarning("Failed loading view trajectory.");
             return 1;
         }
     } else if (!camera_filename.empty()) {
         camera::PinholeCameraTrajectory camera_trajectory;
         if (io::ReadIJsonConvertible(camera_filename, camera_trajectory) ==
             false) {
-            utility::LogWarning("Failed loading camera trajectory.\n");
+            utility::LogWarning("Failed loading camera trajectory.");
             return 1;
         } else {
             auto &view_control =
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
                         camera_trajectory) == false) {
                 utility::LogWarning(
                         "Failed converting camera trajectory to view "
-                        "trajectory.\n");
+                        "trajectory.");
                 return 1;
             }
         }

--- a/src/Tools/ViewGeometry.cpp
+++ b/src/Tools/ViewGeometry.cpp
@@ -118,12 +118,14 @@ int main(int argc, char **argv) {
         mesh_ptr->ComputeVertexNormals();
         if (visualizer.AddGeometry(mesh_ptr) == false) {
             utility::LogWarning("Failed adding triangle mesh.\n");
+            return 1;
         }
     }
     if (!pcd_filename.empty()) {
         auto pointcloud_ptr = io::CreatePointCloudFromFile(pcd_filename);
         if (visualizer.AddGeometry(pointcloud_ptr) == false) {
             utility::LogWarning("Failed adding point cloud.\n");
+            return 1;
         }
         if (pointcloud_ptr->points_.size() > 5000000) {
             visualizer.GetRenderOption().point_size_ = 1.0;
@@ -133,18 +135,21 @@ int main(int argc, char **argv) {
         auto lineset_ptr = io::CreateLineSetFromFile(lineset_filename);
         if (visualizer.AddGeometry(lineset_ptr) == false) {
             utility::LogWarning("Failed adding line set.\n");
+            return 1;
         }
     }
     if (!voxelgrid_filename.empty()) {
         auto voxelgrid_ptr = io::CreateVoxelGridFromFile(voxelgrid_filename);
         if (visualizer.AddGeometry(voxelgrid_ptr) == false) {
             utility::LogWarning("Failed adding voxel grid.\n");
+            return 1;
         }
     }
     if (!image_filename.empty()) {
         auto image_ptr = io::CreateImageFromFile(image_filename);
         if (visualizer.AddGeometry(image_ptr) == false) {
             utility::LogWarning("Failed adding image.\n");
+            return 1;
         }
     }
     if (!depth_filename.empty()) {
@@ -153,7 +158,7 @@ int main(int argc, char **argv) {
             !io::ReadIJsonConvertible(depth_parameter_filename, parameters)) {
             utility::LogWarning(
                     "Failed to read intrinsic parameters for depth image.\n");
-            utility::LogWarning("Use default value for Primesense camera.\n");
+            utility::LogWarning("Using default value for Primesense camera.\n");
             parameters.intrinsic_.SetIntrinsics(640, 480, 525.0, 525.0, 319.5,
                                                 239.5);
         }
@@ -162,19 +167,21 @@ int main(int argc, char **argv) {
                 *image_ptr, parameters.intrinsic_, parameters.extrinsic_);
         if (visualizer.AddGeometry(pointcloud_ptr) == false) {
             utility::LogWarning("Failed adding depth image.\n");
+            return 1;
         }
     }
 
     if (visualizer.HasGeometry() == false) {
         utility::LogWarning("No geometry to render!\n");
         visualizer.DestroyVisualizerWindow();
-        return 0;
+        return 1;
     }
 
     if (!render_filename.empty()) {
         if (io::ReadIJsonConvertible(render_filename,
                                      visualizer.GetRenderOption()) == false) {
             utility::LogWarning("Failed loading rendering settings.\n");
+            return 1;
         }
     }
 
@@ -183,12 +190,14 @@ int main(int argc, char **argv) {
                                      visualizer.GetViewControl();
         if (view_control.LoadTrajectoryFromJsonFile(view_filename) == false) {
             utility::LogWarning("Failed loading view trajectory.\n");
+            return 1;
         }
     } else if (!camera_filename.empty()) {
         camera::PinholeCameraTrajectory camera_trajectory;
         if (io::ReadIJsonConvertible(camera_filename, camera_trajectory) ==
             false) {
             utility::LogWarning("Failed loading camera trajectory.\n");
+            return 1;
         } else {
             auto &view_control =
                     (visualization::ViewControlWithCustomAnimation &)
@@ -198,6 +207,7 @@ int main(int argc, char **argv) {
                 utility::LogWarning(
                         "Failed converting camera trajectory to view "
                         "trajectory.\n");
+                return 1;
             }
         }
     }
@@ -220,5 +230,5 @@ int main(int argc, char **argv) {
     }
     visualizer.DestroyVisualizerWindow();
 
-    return 1;
+    return 0;
 }

--- a/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
+++ b/src/UnitTest/Geometry/HalfEdgeTriangleMesh.cpp
@@ -368,8 +368,8 @@ TEST(HalfEdgeTriangleMesh, BoundaryHalfEdgesFromVertex_Hexagon) {
                           {{1, 0}, {0, 2}, {2, 5}, {5, 6}, {6, 4}, {4, 1}});
     assert_ordreded_edges(het_mesh, het_mesh->BoundaryHalfEdgesFromVertex(2),
                           {{2, 5}, {5, 6}, {6, 4}, {4, 1}, {1, 0}, {0, 2}});
-    assert_ordreded_edges(het_mesh, het_mesh->BoundaryHalfEdgesFromVertex(3),
-                          {});  // Vertex 3 is not a boundary, thus empty
+    EXPECT_THROW(het_mesh->BoundaryHalfEdgesFromVertex(3),
+                 std::runtime_error);  // Vertex 3 is not a boundary, thus empty
     assert_ordreded_edges(het_mesh, het_mesh->BoundaryHalfEdgesFromVertex(4),
                           {{4, 1}, {1, 0}, {0, 2}, {2, 5}, {5, 6}, {6, 4}});
     assert_ordreded_edges(het_mesh, het_mesh->BoundaryHalfEdgesFromVertex(5),
@@ -421,7 +421,7 @@ TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_TwoTriangles) {
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(3), {3, 1, 0, 2});
 }
 
-TEST(HalfEdgeTriangleMesh, BoundarVerticesFromVertex_Hexagon) {
+TEST(HalfEdgeTriangleMesh, BoundaryVerticesFromVertex_Hexagon) {
     auto mesh = get_mesh_hexagon();
     auto het_mesh =
             geometry::HalfEdgeTriangleMesh::CreateFromTriangleMesh(mesh);
@@ -431,8 +431,8 @@ TEST(HalfEdgeTriangleMesh, BoundarVerticesFromVertex_Hexagon) {
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(0), {0, 2, 5, 6, 4, 1});
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(1), {1, 0, 2, 5, 6, 4});
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(2), {2, 5, 6, 4, 1, 0});
-    ExpectEQ(het_mesh->BoundaryVerticesFromVertex(3),
-             {});  // Vertex 3 is not a boundary, thus empty
+    EXPECT_THROW(het_mesh->BoundaryVerticesFromVertex(3),
+                 std::runtime_error);  // Vertex 3 is not a boundary, thus empty
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(4), {4, 1, 0, 2, 5, 6});
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(5), {5, 6, 4, 1, 0, 2});
     ExpectEQ(het_mesh->BoundaryVerticesFromVertex(6), {6, 4, 1, 0, 2, 5});

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -694,10 +694,7 @@ TEST(TriangleMesh, MergeCloseVertices) {
 
 TEST(TriangleMesh, SamplePointsUniformly) {
     auto mesh_empty = geometry::TriangleMesh();
-    auto pcd_empty = mesh_empty.SamplePointsUniformly(100);
-    EXPECT_TRUE(pcd_empty->points_.size() == 0);
-    EXPECT_TRUE(pcd_empty->colors_.size() == 0);
-    EXPECT_TRUE(pcd_empty->normals_.size() == 0);
+    EXPECT_THROW(mesh_empty.SamplePointsUniformly(100), std::runtime_error);
 
     vector<Vector3d> vertices = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
     vector<Vector3i> triangles = {{0, 1, 2}};

--- a/src/UnitTest/Integration/UniformTSDFVolume.cpp
+++ b/src/UnitTest/Integration/UniformTSDFVolume.cpp
@@ -41,7 +41,7 @@ bool ReadPoses(const std::string& trajectory_path,
                std::vector<Eigen::Matrix4d>& poses) {
     FILE* f = utility::filesystem::FOpen(trajectory_path, "r");
     if (f == NULL) {
-        utility::LogWarning("Read poses failed: unable to open file: {}\n",
+        utility::LogWarning("Read poses failed: unable to open file: {}",
                             trajectory_path);
         return false;
     }

--- a/src/UnitTest/Utility/Console.cpp
+++ b/src/UnitTest/Utility/Console.cpp
@@ -29,16 +29,14 @@
 
 using namespace open3d;
 
-TEST(Logger, LogFatal) {
-    EXPECT_THROW(utility::LogFatal("Example exeption message\n"),
+TEST(Logger, LogError) {
+    EXPECT_THROW(utility::LogError("Example exeption message\n"),
                  std::runtime_error);
 }
 
 TEST(Console, DISABLED_SetVerbosityLevel) { unit_test::NotImplemented(); }
 
 TEST(Console, DISABLED_GetVerbosityLevel) { unit_test::NotImplemented(); }
-
-TEST(Console, DISABLED_PrintError) { unit_test::NotImplemented(); }
 
 TEST(Console, DISABLED_PrintWarning) { unit_test::NotImplemented(); }
 

--- a/src/UnitTest/Utility/Console.cpp
+++ b/src/UnitTest/Utility/Console.cpp
@@ -30,7 +30,7 @@
 using namespace open3d;
 
 TEST(Logger, LogError) {
-    EXPECT_THROW(utility::LogError("Example exeption message\n"),
+    EXPECT_THROW(utility::LogError("Example exeption message"),
                  std::runtime_error);
 }
 


### PR DESCRIPTION
Based on the comment in #863, I did have a look at the `LogWarning`, `LogError` and `LogFatal` usage in the current Open3D code base and did a clean up. I applied the following rules that might be useful for future PRs:
- `LogFatal` has been removed
- `LogError` throws now a `runtime_error` with the given error message. This should be used if there is no point in continuing the given algorithm at some point *and* the error is not returned in another way (e.g., a `bool`/`int` as return value).
- `LogWarning` is used if an error occured, but this is signaled via a return value for example. This warning should further be used if the algorithms encounters a state that does not break its continuation, but the output is likely to be not what the user expected.
- `LogInfo` no changes in this PR. Is used to inform the user with expected output, e.g, pressed a key in the visualizer and help is printed.
- `LogDebug` no changes in this PR. Is used to print debug/additional information on the state of the algorithm for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1237)
<!-- Reviewable:end -->
