### PR TITLE
changes to compile flags for Unix because of nvcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,7 @@ elseif (UNIX)
     add_definitions(-DUNIX)
     # enable c++11
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -Wno-deprecated-declarations -Wno-unused-result")
-    add_definitions(-O3)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -Wno-deprecated-declarations")
     # disable BUILD_LIBREALSENSE since it is not fully supported on Linux
     message(STATUS "Compiling on Unix")
     message(STATUS "Disable RealSense since it is not fully supported on Linux.")

--- a/examples/Cpp/CMakeLists.txt
+++ b/examples/Cpp/CMakeLists.txt
@@ -1,6 +1,9 @@
 macro(EXAMPLE_CPP EXAMPLE_CPP_NAME)
     add_executable(${EXAMPLE_CPP_NAME} "${EXAMPLE_CPP_NAME}.cpp")
     ShowAndAbortOnWarning(${EXAMPLE_CPP_NAME})
+    if (UNIX)
+        set_target_properties(${EXAMPLE_CPP_NAME} PROPERTIES COMPILE_FLAGS -Wno-unused-result )
+    endif ()
 
     set(DEPENDENCIES "${ARGN}")
     foreach(DEPENDENCY IN LISTS DEPENDENCIES)

--- a/src/Open3D/IO/CMakeLists.txt
+++ b/src/Open3D/IO/CMakeLists.txt
@@ -18,5 +18,9 @@ add_library(IO OBJECT
             ${LIBLZF_SOURCE_FILES})
 ShowAndAbortOnWarning(IO)
 
+if (UNIX)
+    set_source_files_properties( "FileFormat/FileSTL.cpp" PROPERTIES COMPILE_FLAGS -Wno-unused-result )
+endif ()
+
 # Enforce 3rd party dependencies
 add_dependencies(IO build_all_3rd_party_libs)

--- a/src/Open3D/Utility/CMakeLists.txt
+++ b/src/Open3D/Utility/CMakeLists.txt
@@ -5,5 +5,9 @@ file(GLOB_RECURSE ALL_SOURCE_FILES "*.cpp")
 add_library(Utility OBJECT ${ALL_SOURCE_FILES})
 ShowAndAbortOnWarning(Utility)
 
+if (UNIX)
+    set_source_files_properties( "FileSystem.cpp" PROPERTIES COMPILE_FLAGS -Wno-unused-result )
+endif ()
+
 # Enforce 3rd party dependencies
 add_dependencies(Utility build_all_3rd_party_libs)

--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -52,9 +52,17 @@ ADD_SOURCE_GROUP(Core)
 ADD_SOURCE_GROUP(IO)
 ADD_SOURCE_GROUP(Tutorial)
 ADD_SOURCE_GROUP(Visualization)
-pybind11_add_module(${PACKAGE_NAME}
-    ${PY_ALL_HEADER_FILES} ${PY_ALL_SOURCE_FILES}
-)
+
+# NO_EXTRAS disables LTO which causes problems during link with nvcc 9.x
+if ( CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.0.0" )
+    pybind11_add_module(${PACKAGE_NAME} NO_EXTRAS
+        ${PY_ALL_HEADER_FILES} ${PY_ALL_SOURCE_FILES}
+    )
+else ()
+    pybind11_add_module(${PACKAGE_NAME}
+        ${PY_ALL_HEADER_FILES} ${PY_ALL_SOURCE_FILES}
+    )
+endif ()
 
 # Suppress Pybind11 warnings
 target_include_directories(${PACKAGE_NAME} SYSTEM PRIVATE


### PR DESCRIPTION
This PR addresses some problems with nvcc 10.0 and earlier for Unix builds.

- removed duplicate optimize flag
- removed global "-Wno-unused-result". Flag is now set for the specific files that need it and the examples only.
- Disabled LTO when using nvcc < 10.0 for python module

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1255)
<!-- Reviewable:end -->
