### PR TITLE
Refactor Image::Prepare() in RealSense.cpp

### DIFF
--- a/3rdparty/librealsense/src/verify.c
+++ b/3rdparty/librealsense/src/verify.c
@@ -2,4 +2,4 @@
    Copyright(c) 2015 Intel Corporation. All Rights Reserved. */
 
 /* This file simply verifies that rs.h can be correctly included by a C compiler */
-#include <C:\Users\JJT\Documents\MTSI\librealsenseMaster\include\librealsense2/rs.h> //C:\Users\JJT\Documents\MTSI\librealsenseMaster\include\librealsense2
+#include <librealsense/rs.h> 

--- a/3rdparty/librealsense/src/verify.c
+++ b/3rdparty/librealsense/src/verify.c
@@ -2,4 +2,4 @@
    Copyright(c) 2015 Intel Corporation. All Rights Reserved. */
 
 /* This file simply verifies that rs.h can be correctly included by a C compiler */
-#include <librealsense/rs.h>
+#include <C:\Users\JJT\Documents\MTSI\librealsenseMaster\include\librealsense2/rs.h> //C:\Users\JJT\Documents\MTSI\librealsenseMaster\include\librealsense2

--- a/3rdparty/librealsense/src/verify.c
+++ b/3rdparty/librealsense/src/verify.c
@@ -2,4 +2,4 @@
    Copyright(c) 2015 Intel Corporation. All Rights Reserved. */
 
 /* This file simply verifies that rs.h can be correctly included by a C compiler */
-#include <librealsense/rs.h> 
+#include <librealsense/rs.h>

--- a/examples/Cpp/RealSense.cpp
+++ b/examples/Cpp/RealSense.cpp
@@ -57,9 +57,9 @@ int main(int argc, char **args) {
     dev->set_option(rs::option::color_white_balance, 2100.0);
 
     auto depth_image_ptr = std::make_shared<geometry::Image>();
-    depth_image_ptr->PrepareImage(640, 480, 1, 2);
+    depth_image_ptr->Prepare(640, 480, 1, 2);
     auto color_image_ptr = std::make_shared<geometry::Image>();
-    color_image_ptr->PrepareImage(1920, 1080, 3, 1);
+    color_image_ptr->Prepare(1920, 1080, 3, 1);
     utility::FPSTimer timer("Realsense stream");
 
     rs::extrinsics extrinsics =


### PR DESCRIPTION
RealSense.cpp was not updated when Image PrepareImage() was refactored. See #1276

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1277)
<!-- Reviewable:end -->
