### PR TITLE
Add point cloud plane segmentation

### DIFF
--- a/examples/Python/Basic/pointcloud_plane_segmentation.py
+++ b/examples/Python/Basic/pointcloud_plane_segmentation.py
@@ -13,7 +13,9 @@ if __name__ == "__main__":
     print(
         "Find the plane model and the inliers of the largest planar segment in the point cloud."
     )
-    plane_model, inliers = pcd.segment_plane(0.01, 3, 250)
+    plane_model, inliers = pcd.segment_plane(
+        distance_threshold=0.01, ransac_n=3, num_iterations=250
+    )
 
     [a, b, c, d] = plane_model
     print(f"Plane model: {a:.2f}x + {b:.2f}y + {c:.2f}z + {d:.2f} = 0")

--- a/examples/Python/Basic/pointcloud_plane_segmentation.py
+++ b/examples/Python/Basic/pointcloud_plane_segmentation.py
@@ -13,9 +13,9 @@ if __name__ == "__main__":
     print(
         "Find the plane model and the inliers of the largest planar segment in the point cloud."
     )
-    plane_model, inliers = pcd.segment_plane(
-        distance_threshold=0.01, ransac_n=3, num_iterations=250
-    )
+    plane_model, inliers = pcd.segment_plane(distance_threshold=0.01,
+                                             ransac_n=3,
+                                             num_iterations=250)
 
     [a, b, c, d] = plane_model
     print(f"Plane model: {a:.2f}x + {b:.2f}y + {c:.2f}z + {d:.2f} = 0")

--- a/examples/Python/Basic/pointcloud_plane_segmentation.py
+++ b/examples/Python/Basic/pointcloud_plane_segmentation.py
@@ -1,0 +1,26 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Basic/pointcloud_plane_segmentation.py
+
+import numpy as np
+import open3d as o3d
+
+if __name__ == "__main__":
+    pcd = o3d.io.read_point_cloud("../../TestData/fragment.pcd")
+
+    print(
+        "Find the plane model and the inliers of the largest planar segment in the point cloud."
+    )
+    plane_model, inliers = pcd.segment_plane(0.01, 3, 250)
+
+    [a, b, c, d] = plane_model
+    print(f"Plane model: {a:.2f}x + {b:.2f}y + {c:.2f}z + {d:.2f} = 0")
+
+    inlier_cloud = pcd.select_down_sample(inliers)
+    inlier_cloud.paint_uniform_color([1.0, 0, 0])
+
+    outlier_cloud = pcd.select_down_sample(inliers, invert=True)
+
+    o3d.visualization.draw_geometries([inlier_cloud, outlier_cloud])

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -33,6 +33,7 @@
 
 #include "Open3D/Geometry/Geometry3D.h"
 #include "Open3D/Geometry/KDTreeSearchParam.h"
+#include "Open3D/Registration/Registration.h"
 
 namespace open3d {
 
@@ -210,6 +211,20 @@ public:
     std::vector<int> ClusterDBSCAN(double eps,
                                    size_t min_points,
                                    bool print_progress = false) const;
+
+    /// \brief Segment PointCloud plane using the RANSAC algorithm.
+    ///
+    /// \param distance_threshold Max distance a point can be from the plane
+    /// model, and still be considered an inlier.
+    /// \param ransac_n Number of initial points to be considered inliers in
+    /// each iteration.
+    /// \param criteria The maximum number of iterations. See \ref
+    /// RANSACConvergenceCriteria.
+    std::tuple<Eigen::Vector4d, std::vector<int>> SegmentPlane(
+            double distance_threshold = 0.01,
+            int ransac_n = 3,
+            const registration::RANSACConvergenceCriteria &criteria =
+                    registration::RANSACConvergenceCriteria()) const;
 
     /// Factory function to create a pointcloud from a depth image and a camera
     /// model (PointCloudFactory.cpp)

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -220,7 +220,7 @@ public:
     /// \param num_iterations Number of iterations.
     /// \return Returns the plane model ax + by + cz + d = 0 and the indices of
     /// the plane inliers.
-    std::tuple<Eigen::Vector4d, std::vector<int>> SegmentPlane(
+    std::tuple<Eigen::Vector4d, std::vector<size_t>> SegmentPlane(
             const double distance_threshold = 0.01,
             const int ransac_n = 3,
             const int num_iterations = 100) const;

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -33,7 +33,6 @@
 
 #include "Open3D/Geometry/Geometry3D.h"
 #include "Open3D/Geometry/KDTreeSearchParam.h"
-#include "Open3D/Registration/Registration.h"
 
 namespace open3d {
 
@@ -218,13 +217,13 @@ public:
     /// model, and still be considered an inlier.
     /// \param ransac_n Number of initial points to be considered inliers in
     /// each iteration.
-    /// \param criteria The maximum number of iterations. See \ref
-    /// RANSACConvergenceCriteria.
+    /// \param num_iterations Number of iterations.
+    /// \return Returns the plane model ax + by + cz + d = 0 and the indices of
+    /// the plane inliers.
     std::tuple<Eigen::Vector4d, std::vector<int>> SegmentPlane(
-            double distance_threshold = 0.01,
-            int ransac_n = 3,
-            const registration::RANSACConvergenceCriteria &criteria =
-                    registration::RANSACConvergenceCriteria()) const;
+            const double distance_threshold = 0.01,
+            const int ransac_n = 3,
+            const int num_iterations = 100) const;
 
     /// Factory function to create a pointcloud from a depth image and a camera
     /// model (PointCloudFactory.cpp)

--- a/src/Open3D/Geometry/PointCloudSegmentation.cpp
+++ b/src/Open3D/Geometry/PointCloudSegmentation.cpp
@@ -29,6 +29,7 @@
 #include <Eigen/Dense>
 #include <algorithm>
 #include <iterator>
+#include <numeric>
 #include <random>
 #include <unordered_set>
 
@@ -38,7 +39,9 @@
 namespace open3d {
 namespace geometry {
 
-// Stores the current best result in the RANSAC algorithm.
+/// \class RANSACResult
+///
+/// \brief Stores the current best result in the RANSAC algorithm.
 class RANSACResult {
 public:
     RANSACResult() : fitness_(0), inlier_rmse_(0) {}

--- a/src/Open3D/Geometry/PointCloudSegmentation.cpp
+++ b/src/Open3D/Geometry/PointCloudSegmentation.cpp
@@ -1,0 +1,168 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Geometry/PointCloud.h"
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <iterator>
+#include <random>
+#include <unordered_set>
+
+#include "Open3D/Geometry/TriangleMesh.h"
+#include "Open3D/Utility/Console.h"
+
+namespace open3d {
+namespace geometry {
+
+// std::exchange introduced in C++14
+template <class T, class U = T>
+T exchange(T &obj, U &&new_value) {
+    T old_value = std::move(obj);
+    obj = std::forward<U>(new_value);
+    return old_value;
+}
+
+class RANSACResult {
+public:
+    RANSACResult() : inlier_rmse_(0), fitness_(0) {}
+    ~RANSACResult() {}
+
+public:
+    double inlier_rmse_;
+    double fitness_;
+};
+
+RANSACResult EvaluateRANSACBasedOnDistance(
+        const std::vector<int> &inliers,
+        const std::vector<Eigen::Vector3d> &points,
+        const double error) {
+    RANSACResult result;
+    int inlier_num = inliers.size();
+
+    if (inlier_num == 0) {
+        result.fitness_ = 0;
+        result.inlier_rmse_ = 0;
+    } else {
+        result.fitness_ = (double)inlier_num / (double)points.size();
+        result.inlier_rmse_ = error / std::sqrt((double)inlier_num);
+    }
+    return result;
+}
+
+std::tuple<Eigen::Vector4d, std::vector<int>> PointCloud::SegmentPlane(
+        double distance_threshold /* = 0.01 */,
+        int ransac_n /* = 3 */,
+        const registration::RANSACConvergenceCriteria &criteria
+        /* = RANSACConvergenceCriteria() */) const {
+    RANSACResult result;
+    double error = 0;
+
+    // Initialize the plane model ax + by + cz + d = 0.
+    Eigen::Vector4d plane_model = Eigen::Vector4d(0, 0, 0, 0);
+    // Initialize the best plane model.
+    Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
+    const int num_model_parameters = 3;
+
+    // Initialize consensus set.
+    std::vector<int> inliers;
+    int prev_inliers_num = 0;
+
+    int num_points = points_.size();
+    std::vector<int> indices(num_points);
+    std::iota(std::begin(indices), std::end(indices), 0);
+
+    std::random_device rd;
+    std::mt19937 rng(rd());
+
+    for (int itr = 0;
+         itr < criteria.max_iteration_ && itr < criteria.max_validation_;
+         itr++) {
+        if (prev_inliers_num == inliers.size()) {
+            for (int i = 0; i < ransac_n; ++i) {
+                indices[i] = exchange(indices[rng() % num_points], indices[i]);
+            }
+
+            inliers.clear();
+            for (size_t idx = 0; idx < ransac_n; ++idx) {
+                inliers.emplace_back(indices[idx]);
+            }
+        }
+        prev_inliers_num = inliers.size();
+
+        // Fit model to num_model_parameters randomly selected points among the
+        // inliers.
+        for (int i = 0; i < num_model_parameters; ++i) {
+            inliers[i] = exchange(inliers[rng() % inliers.size()], indices[i]);
+        }
+        plane_model = TriangleMesh::ComputeTrianglePlane(
+                points_[inliers[0]], points_[inliers[1]], points_[inliers[2]]);
+        if (plane_model.isZero(0)) {
+            continue;
+        }
+
+        inliers.clear();
+        error = 0;
+        for (int idx = 0; idx < points_.size(); ++idx) {
+            Eigen::Vector4d point(points_[idx](0), points_[idx](1),
+                                  points_[idx](2), 1);
+            double distance = std::abs(plane_model.dot(point));
+
+            if (distance < distance_threshold) {
+                error += distance;
+                inliers.emplace_back(idx);
+            }
+        }
+
+        auto this_result =
+                EvaluateRANSACBasedOnDistance(inliers, points_, error);
+        if (this_result.fitness_ > result.fitness_ ||
+            (this_result.fitness_ == result.fitness_ &&
+             this_result.inlier_rmse_ < result.inlier_rmse_)) {
+            result = this_result;
+            best_plane_model = plane_model;
+        }
+    }
+
+    // Find the final inliers using best_plane_model.
+    inliers.clear();
+    for (size_t idx = 0; idx < points_.size(); ++idx) {
+        Eigen::Vector4d point(points_[idx](0), points_[idx](1), points_[idx](2),
+                              1);
+        double distance = std::abs(best_plane_model.dot(point));
+
+        if (distance < distance_threshold) {
+            inliers.emplace_back(idx);
+        }
+    }
+
+    utility::LogDebug("RANSAC | Inliers: {:d}, Fitness: {:.4f}, RMSE: {:.4f}",
+                      inliers.size(), result.fitness_, result.inlier_rmse_);
+    return std::make_tuple(best_plane_model, inliers);
+}
+
+}  // namespace geometry
+}  // namespace open3d

--- a/src/Open3D/Geometry/PointCloudSegmentation.cpp
+++ b/src/Open3D/Geometry/PointCloudSegmentation.cpp
@@ -55,12 +55,12 @@ public:
 RANSACResult EvaluateRANSACBasedOnDistance(
         const std::vector<Eigen::Vector3d> &points,
         const Eigen::Vector4d plane_model,
-        std::vector<int> &inliers,
+        std::vector<size_t> &inliers,
         double distance_threshold,
         double error) {
     RANSACResult result;
 
-    for (int idx = 0; idx < points.size(); ++idx) {
+    for (size_t idx = 0; idx < points.size(); ++idx) {
         Eigen::Vector4d point(points[idx](0), points[idx](1), points[idx](2),
                               1);
         double distance = std::abs(plane_model.dot(point));
@@ -71,7 +71,7 @@ RANSACResult EvaluateRANSACBasedOnDistance(
         }
     }
 
-    int inlier_num = inliers.size();
+    size_t inlier_num = inliers.size();
     if (inlier_num == 0) {
         result.fitness_ = 0;
         result.inlier_rmse_ = 0;
@@ -88,7 +88,7 @@ RANSACResult EvaluateRANSACBasedOnDistance(
 // Reference:
 // https://www.ilikebigbits.com/2015_03_04_plane_from_points.html
 Eigen::Vector4d GetPlaneFromPoints(const std::vector<Eigen::Vector3d> &points,
-                                   const std::vector<int> &inliers) {
+                                   const std::vector<size_t> &inliers) {
     Eigen::Vector3d centroid(0, 0, 0);
     for (size_t idx : inliers) {
         centroid += points[idx];
@@ -130,7 +130,7 @@ Eigen::Vector4d GetPlaneFromPoints(const std::vector<Eigen::Vector3d> &points,
     return Eigen::Vector4d(abc(0), abc(1), abc(2), d);
 }
 
-std::tuple<Eigen::Vector4d, std::vector<int>> PointCloud::SegmentPlane(
+std::tuple<Eigen::Vector4d, std::vector<size_t>> PointCloud::SegmentPlane(
         const double distance_threshold /* = 0.01 */,
         const int ransac_n /* = 3 */,
         const int num_iterations /* = 100 */) const {
@@ -143,10 +143,10 @@ std::tuple<Eigen::Vector4d, std::vector<int>> PointCloud::SegmentPlane(
     Eigen::Vector4d best_plane_model = Eigen::Vector4d(0, 0, 0, 0);
 
     // Initialize consensus set.
-    std::vector<int> inliers;
+    std::vector<size_t> inliers;
 
-    int num_points = points_.size();
-    std::vector<int> indices(num_points);
+    size_t num_points = points_.size();
+    std::vector<size_t> indices(num_points);
     std::iota(std::begin(indices), std::end(indices), 0);
 
     std::random_device rd;
@@ -164,7 +164,7 @@ std::tuple<Eigen::Vector4d, std::vector<int>> PointCloud::SegmentPlane(
             std::swap(indices[i], indices[rng() % num_points]);
         }
         inliers.clear();
-        for (size_t idx = 0; idx < ransac_n; ++idx) {
+        for (int idx = 0; idx < ransac_n; ++idx) {
             inliers.emplace_back(indices[idx]);
         }
 

--- a/src/Open3D/Registration/Registration.cpp
+++ b/src/Open3D/Registration/Registration.cpp
@@ -236,7 +236,7 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
             result = this_result;
         }
     }
-    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}", result.fitness_,
+    utility::LogDebug("RANSAC: Fitness {:e}, RMSE {:e}", result.fitness_,
                       result.inlier_rmse_);
     return result;
 }
@@ -368,7 +368,7 @@ RegistrationResult RegistrationRANSACBasedOnFeatureMatching(
     }
 #endif
     utility::LogDebug("total_validation : {:d}", total_validation);
-    utility::LogDebug("RANSAC: Fitness {:.4f}, RMSE {:.4f}", result.fitness_,
+    utility::LogDebug("RANSAC: Fitness {:e}, RMSE {:e}", result.fitness_,
                       result.inlier_rmse_);
     return result;
 }

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -174,7 +174,8 @@ void pybind_pointcloud(py::module &m) {
                  "eps"_a, "min_points"_a, "print_progress"_a = false)
             .def("segment_plane", &geometry::PointCloud::SegmentPlane,
                  "Segments a plane in the point cloud using the RANSAC "
-                 "algorithm.")
+                 "algorithm.",
+                 "distance_threshold"_a, "ransac_n"_a, "num_iterations"_a)
             .def_static(
                     "create_from_depth_image",
                     &geometry::PointCloud::CreateFromDepthImage,
@@ -297,7 +298,15 @@ void pybind_pointcloud(py::module &m) {
              {"min_points", "Minimum number of points to form a cluster."},
              {"print_progress",
               "If true the progress is visualized in the console."}});
-    docstring::ClassMethodDocInject(m, "PointCloud", "segment_plane");
+    docstring::ClassMethodDocInject(
+            m, "PointCloud", "segment_plane",
+            {{"distance_threshold",
+              "Max distance a point can be from the plane model, and still be "
+              "considered an inlier."},
+             {"ransac_n",
+              "Number of initial points to be considered inliers in each "
+              "iteration."},
+             {"num_iterations", "Number of iterations."}});
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_depth_image");
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_rgbd_image");
 }

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -172,6 +172,9 @@ void pybind_pointcloud(py::module &m) {
                  "Spatial Databases with Noise', 1996. Returns a list of point "
                  "labels, -1 indicates noise according to the algorithm.",
                  "eps"_a, "min_points"_a, "print_progress"_a = false)
+            .def("segment_plane", &geometry::PointCloud::SegmentPlane,
+                 "Segments a plane in the point cloud using the RANSAC "
+                 "algorithm.")
             .def_static(
                     "create_from_depth_image",
                     &geometry::PointCloud::CreateFromDepthImage,
@@ -294,6 +297,7 @@ void pybind_pointcloud(py::module &m) {
              {"min_points", "Minimum number of points to form a cluster."},
              {"print_progress",
               "If true the progress is visualized in the console."}});
+    docstring::ClassMethodDocInject(m, "PointCloud", "segment_plane");
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_depth_image");
     docstring::ClassMethodDocInject(m, "PointCloud", "create_from_rgbd_image");
 }

--- a/src/Python/open3d_pybind/registration/registration.cpp
+++ b/src/Python/open3d_pybind/registration/registration.cpp
@@ -77,7 +77,7 @@ public:
 };
 
 void pybind_registration_classes(py::module &m) {
-    // ope3dn.registration.ICPConvergenceCriteria
+    // open3d.registration.ICPConvergenceCriteria
     py::class_<registration::ICPConvergenceCriteria> convergence_criteria(
             m, "ICPConvergenceCriteria",
             "Class that defines the convergence criteria of ICP. ICP algorithm "
@@ -119,7 +119,7 @@ void pybind_registration_classes(py::module &m) {
                                    std::to_string(c.max_iteration_));
             });
 
-    // ope3dn.registration.RANSACConvergenceCriteria
+    // open3d.registration.RANSACConvergenceCriteria
     py::class_<registration::RANSACConvergenceCriteria> ransac_criteria(
             m, "RANSACConvergenceCriteria",
             "Class that defines the convergence criteria of RANSAC. RANSAC "
@@ -157,7 +157,7 @@ void pybind_registration_classes(py::module &m) {
                                         std::to_string(c.max_validation_));
                  });
 
-    // ope3dn.registration.TransformationEstimation
+    // open3d.registration.TransformationEstimation
     py::class_<
             registration::TransformationEstimation,
             PyTransformationEstimation<registration::TransformationEstimation>>
@@ -187,7 +187,7 @@ void pybind_registration_classes(py::module &m) {
              {"corres",
               "Correspondence set between source and target point cloud."}});
 
-    // ope3dn.registration.TransformationEstimationPointToPoint:
+    // open3d.registration.TransformationEstimationPointToPoint:
     // TransformationEstimation
     py::class_<registration::TransformationEstimationPointToPoint,
                PyTransformationEstimation<
@@ -227,7 +227,7 @@ The homogeneous transformation is given by
 Sets :math:`c = 1` if ``with_scaling`` is ``False``.
 )");
 
-    // ope3dn.registration.TransformationEstimationPointToPlane:
+    // open3d.registration.TransformationEstimationPointToPlane:
     // TransformationEstimation
     py::class_<registration::TransformationEstimationPointToPlane,
                PyTransformationEstimation<
@@ -246,7 +246,7 @@ Sets :math:`c = 1` if ``with_scaling`` is ``False``.
                 return std::string("TransformationEstimationPointToPlane");
             });
 
-    // ope3dn.registration.CorrespondenceChecker
+    // open3d.registration.CorrespondenceChecker
     py::class_<registration::CorrespondenceChecker,
                PyCorrespondenceChecker<registration::CorrespondenceChecker>>
             cc(m, "CorrespondenceChecker",
@@ -267,7 +267,7 @@ Sets :math:`c = 1` if ``with_scaling`` is ``False``.
               "Correspondence set between source and target point cloud."},
              {"transformation", "The estimated transformation (inplace)."}});
 
-    // ope3dn.registration.CorrespondenceCheckerBasedOnEdgeLength:
+    // open3d.registration.CorrespondenceCheckerBasedOnEdgeLength:
     // CorrespondenceChecker
     py::class_<registration::CorrespondenceCheckerBasedOnEdgeLength,
                PyCorrespondenceChecker<
@@ -311,7 +311,7 @@ check to be true,
 
 must hold true for all edges.)");
 
-    // ope3dn.registration.CorrespondenceCheckerBasedOnDistance:
+    // open3d.registration.CorrespondenceCheckerBasedOnDistance:
     // CorrespondenceChecker
     py::class_<registration::CorrespondenceCheckerBasedOnDistance,
                PyCorrespondenceChecker<
@@ -341,7 +341,7 @@ must hold true for all edges.)");
                                    distance_threshold_,
                            "Distance threashold for the check.");
 
-    // ope3dn.registration.CorrespondenceCheckerBasedOnNormal:
+    // open3d.registration.CorrespondenceCheckerBasedOnNormal:
     // CorrespondenceChecker
     py::class_<registration::CorrespondenceCheckerBasedOnNormal,
                PyCorrespondenceChecker<
@@ -372,7 +372,7 @@ must hold true for all edges.)");
                                    normal_angle_threshold_,
                            "Radian value for angle threshold.");
 
-    // ope3dn.registration.FastGlobalRegistrationOption:
+    // open3d.registration.FastGlobalRegistrationOption:
     py::class_<registration::FastGlobalRegistrationOption> fgr_option(
             m, "FastGlobalRegistrationOption",
             "Options for FastGlobalRegistration.");
@@ -450,7 +450,7 @@ must hold true for all edges.)");
                             std::to_string(c.maximum_tuple_count_);
                  });
 
-    // ope3dn.registration.RegistrationResult
+    // open3d.registration.RegistrationResult
     py::class_<registration::RegistrationResult> registration_result(
             m, "RegistrationResult",
             "Class that contains the registration results.");

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -1067,7 +1067,7 @@ TEST(PointCloud, SegmentPlane) {
 
     geometry::PointCloud pc;
 
-    for (int i = 0; i < ref.size(); i++) {
+    for (size_t i = 0; i < ref.size(); i++) {
         pc.points_.emplace_back(ref[i]);
     }
 

--- a/src/UnitTest/Geometry/PointCloud.cpp
+++ b/src/UnitTest/Geometry/PointCloud.cpp
@@ -1056,3 +1056,25 @@ TEST(PointCloud, CreatePointCloudFromRGBDImage_1_4) {
                                        color_bytes_per_channel, ref_points,
                                        ref_colors);
 }
+
+TEST(PointCloud, SegmentPlane) {
+    // Points sampled from the plane x + y + z + 1 = 0
+    vector<Vector3d> ref = {{1.0, 1.0, -3.0},
+                            {2.0, 2.0, -5.0},
+                            {-1.0, -1.0, 1.0},
+                            {-2.0, -2.0, 3.0},
+                            {10.0, 10.0, -21.0}};
+
+    geometry::PointCloud pc;
+
+    for (int i = 0; i < ref.size(); i++) {
+        pc.points_.emplace_back(ref[i]);
+    }
+
+    Eigen::Vector4d plane_model;
+    std::vector<size_t> inliers;
+    std::tie(plane_model, inliers) = pc.SegmentPlane(0.01, 3, 10);
+    auto output_pc = pc.SelectDownSample(inliers);
+
+    ExpectEQ(ref, output_pc->points_);
+}


### PR DESCRIPTION
Implementation of plane segmentation for `PointCloud` using the RANSAC algorithm.
It will find the plane with the greatest number of points in the cloud. Therefore, if the cloud has several planes, the model can be rerun multiple times until all planes are found by removing the inliers each time.

Adresses issue #591.

Example segmentation for `fragment.pcd` with 50 iterations is given below:
<img width="1680" alt="plane_segmentation" src="https://user-images.githubusercontent.com/13556755/67897337-7d591b00-fb5e-11e9-9b84-e7edec8c0045.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1287)
<!-- Reviewable:end -->
