### PR TITLE
Quick fix to colored icp

### DIFF
--- a/src/Open3D/Registration/ColoredICP.cpp
+++ b/src/Open3D/Registration/ColoredICP.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<PointCloudForColoredICP> InitializePointCloudForColoredICP(
         std::vector<double> point_squared_distance;
 
         if (tree.SearchHybrid(vt, search_param.radius_, search_param.max_nn_,
-                              point_idx, point_squared_distance) >= 3) {
+                              point_idx, point_squared_distance) >= 4) {
             // approximate image gradient of vt's tangential plane
             size_t nn = point_idx.size();
             Eigen::MatrixXd A(nn, 3);


### PR DESCRIPTION
This simple patch will fix #1264 #1281 #1286.

Colored ICP will fail due to incorrect color gradients. 

The incorrect color gradients are from outlier points with only 2 neighbors (3-nn including itself). In this rare case, ill-posed linear systems will be built that generate singular gradients. 
Singular gradients look like
```
-24266.6 -69947.5   415081
```
whereas regular gradients have norms < 1.

These singular gradients will be the dominant factor in the global linear system to solve for pose that cancels the existance of other valid points.

The randomness of the problem in the reconstruction system may come from RANSAC: RANSAC may cause minor changes of initial poses for the initialization of colored ICP. During nn search, a minor shift of pose might lead to change of nns.

Simply changing 3-nn to 4-nn (3 neighbors) will address the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1292)
<!-- Reviewable:end -->
