### PR TITLE
Assignment operator

### DIFF
--- a/src/Open3D/Container/Kernel/CPULauncher.h
+++ b/src/Open3D/Container/Kernel/CPULauncher.h
@@ -35,7 +35,7 @@ namespace kernel {
 class CPULauncher {
 public:
     /// Recover src tensor element offsets given dst tensor element offsets
-    /// src and dst tensors have the same size but different strides
+    /// src and dst tensors have the same size but may have different strides
     class OffsetCalculator {
     public:
         OffsetCalculator(const std::vector<size_t>& src_strides,
@@ -67,16 +67,21 @@ public:
         const char* src_data_ptr = static_cast<const char*>(src.GetDataPtr());
         char* dst_data_ptr = static_cast<char*>(dst.GetDataPtr());
         size_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
-        OffsetCalculator offset_calculator(src.GetStrides(), dst.GetStrides());
+        SizeVector default_strides = Tensor::DefaultStrides(src.GetShape());
+        OffsetCalculator src_offset_calculator(src.GetStrides(),
+                                               default_strides);
+        OffsetCalculator dst_offset_calculator(dst.GetStrides(),
+                                               default_strides);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
-        for (int64_t dst_idx = 0;
-             dst_idx < static_cast<int64_t>(src.GetShape().NumElements());
-             dst_idx++) {
-            size_t src_idx = offset_calculator.GetOffset(dst_idx);
+        for (int64_t dst_raw_idx = 0;
+             dst_raw_idx < static_cast<int64_t>(src.GetShape().NumElements());
+             dst_raw_idx++) {
+            size_t src_idx = src_offset_calculator.GetOffset(dst_raw_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
+            size_t dst_idx = dst_offset_calculator.GetOffset(dst_raw_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;
             element_kernel(src_ptr, dst_ptr);
         }

--- a/src/Open3D/Container/Kernel/CUDALauncher.cuh
+++ b/src/Open3D/Container/Kernel/CUDALauncher.cuh
@@ -62,7 +62,7 @@ __global__ void ElementWiseKernel(int N, func_t f) {
 class CUDALauncher {
 public:
     /// Recover src tensor element offsets given dst tensor element offsets
-    /// src and dst tensors have the same size but different strides
+    /// src and dst tensors have the same size but may have different strides
     class OffsetCalculator {
     public:
         OffsetCalculator(size_t num_dims,
@@ -105,13 +105,19 @@ public:
         const char* src_data_ptr = static_cast<const char*>(src.GetDataPtr());
         char* dst_data_ptr = static_cast<char*>(dst.GetDataPtr());
         int element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
-        OffsetCalculator offset_calculator(src.GetShape().size(),
-                                           src.GetStrides().data(),
-                                           dst.GetStrides().data());
 
-        auto f = [=] OPEN3D_HOST_DEVICE(int dst_idx) {
-            int src_idx = offset_calculator.GetOffset(dst_idx);
+        SizeVector default_strides = Tensor::DefaultStrides(src.GetShape());
+        OffsetCalculator src_offset_calculator(src.GetShape().size(),
+                                               src.GetStrides().data(),
+                                               default_strides.data());
+        OffsetCalculator dst_offset_calculator(dst.GetShape().size(),
+                                               dst.GetStrides().data(),
+                                               default_strides.data());
+
+        auto f = [=] OPEN3D_HOST_DEVICE(int dst_raw_idx) {
+            int src_idx = src_offset_calculator.GetOffset(dst_raw_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
+            int dst_idx = dst_offset_calculator.GetOffset(dst_raw_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;
             element_kernel(src_ptr, dst_ptr);
         };

--- a/src/Open3D/Container/Kernel/UnaryEW.cpp
+++ b/src/Open3D/Container/Kernel/UnaryEW.cpp
@@ -40,12 +40,6 @@ void Copy(const Tensor& src, Tensor& dst) {
                           src.GetShape().ToString(), dst.GetShape().ToString());
     }
 
-    // Check strides
-    // TODO: currently we require dst to be contiguous
-    if (!dst.IsContiguous()) {
-        utility::LogError("Unimplemented: dst must be contiguous");
-    }
-
     // Check dtype
     // TODO: in the future, we may want to allow automatic casting
     if (src.GetDtype() != dst.GetDtype()) {

--- a/src/Open3D/Container/Kernel/UnaryEWCPU.cpp
+++ b/src/Open3D/Container/Kernel/UnaryEWCPU.cpp
@@ -43,11 +43,10 @@ static void CPUCopyElementKernel(const void* src, void* dst) {
 }
 
 void CopyCPU(const Tensor& src, Tensor& dst) {
-    // src and dst have been checked to have the same shape, dtype, device, and
-    // dst must be contiguous
+    // src and dst have been checked to have the same shape, dtype, device
     SizeVector shape = src.GetShape();
     Dtype dtype = src.GetDtype();
-    if (src.IsContiguous()) {
+    if (src.IsContiguous() && dst.IsContiguous()) {
         MemoryManager::Memcpy(dst.GetDataPtr(), dst.GetDevice(),
                               src.GetDataPtr(), src.GetDevice(),
                               DtypeUtil::ByteSize(dtype) * shape.NumElements());

--- a/src/Open3D/Container/Kernel/UnaryEWCUDA.cu
+++ b/src/Open3D/Container/Kernel/UnaryEWCUDA.cu
@@ -42,12 +42,11 @@ static OPEN3D_HOST_DEVICE void CUDACopyElementKernel(const void* src,
 
 void CopyCUDA(const Tensor& src, Tensor& dst) {
     // It has been checked that
-    // - src and dst have the same shape, dtype, and dst
-    // - dst must be contiguous
+    // - src and dst have the same shape, dtype
     // - at least one of src or dst is CUDA device
     SizeVector shape = src.GetShape();
     Dtype dtype = src.GetDtype();
-    if (src.IsContiguous()) {
+    if (src.IsContiguous() && dst.IsContiguous()) {
         MemoryManager::Memcpy(dst.GetDataPtr(), dst.GetDevice(),
                               src.GetDataPtr(), src.GetDevice(),
                               DtypeUtil::ByteSize(dtype) * shape.NumElements());

--- a/src/Open3D/Container/Tensor.cpp
+++ b/src/Open3D/Container/Tensor.cpp
@@ -38,6 +38,42 @@
 
 namespace open3d {
 
+/// Copy constructor with lvalue input, e.g. `Tensor dst(src)`
+Tensor::Tensor(const Tensor& other)
+    : Tensor(other.GetShape(), other.GetDtype(), other.GetDevice()) {
+    kernel::Copy(other, *this);
+}
+
+/// Copy constructor with rvalue input, e.g. `Tensor dst(src[0])`
+Tensor::Tensor(Tensor&& other)
+    : Tensor(other.GetShape(), other.GetDtype(), other.GetDevice()) {
+    kernel::Copy(other, *this);
+}
+
+/// Tensor assignment lvalue = lvalue, e.g. `tensor_a = tensor_b`
+Tensor& Tensor::operator=(const Tensor& other) & {
+    kernel::Copy(other, *this);
+    return *this;
+}
+
+/// Tensor assignment lvalue = rvalue, e.g. `tensor_a = tensor_b[0]`
+Tensor& Tensor::operator=(Tensor&& other) & {
+    kernel::Copy(other, *this);
+    return *this;
+}
+
+/// Tensor assignment rvalue = lvalue, e.g. `tensor_a[0] = tensor_b`
+Tensor& Tensor::operator=(const Tensor& other) && {
+    kernel::Copy(other, *this);
+    return *this;
+};
+
+/// Tensor assignment rvalue = rvalue, e.g. `tensor_a[0] = tensor_b[0]`
+Tensor& Tensor::operator=(Tensor&& other) && {
+    kernel::Copy(other, *this);
+    return *this;
+};
+
 Tensor Tensor::Copy(const Device& device) const {
     Tensor dst_tensor(shape_, dtype_, device);
     kernel::Copy(*this, dst_tensor);

--- a/src/UnitTest/Container/Blob.cpp
+++ b/src/UnitTest/Container/Blob.cpp
@@ -50,7 +50,7 @@ TEST_P(BlobPermuteDevices, IsPtrInBlob) {
 
     Blob b(10, Device(device));
 
-    const char* head = static_cast<const char*>(b.v_);
+    const char *head = static_cast<const char *>(b.v_);
     EXPECT_TRUE(b.IsPtrInBlob(head));
     EXPECT_TRUE(b.IsPtrInBlob(head + 9));
     EXPECT_FALSE(b.IsPtrInBlob(head + 10));


### PR DESCRIPTION
Supports copy constructor and assignment of the following syntax:
```cpp
Tensor tensor_a(tensor_b);
Tensor tensor_a(tensor_b[0]);
tensor_a = tensor_b;
tensor_a = tensor_b[0];
tensor_a[0] = tensor_b;
tensor_a[0] = tensor_b[0];
tensor_a[0] = 100;  // with automatic casting
```

Notably, we now can assign to a non-contiguous tensor, e.g (in python equivalent).
```python
a = np.ones((10,))
b = np.ones((20,))
a[0:10:2] = b[0:20:4]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1293)
<!-- Reviewable:end -->
