### PR TITLE
Add geometry without resetting bounding box

### DIFF
--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -296,7 +296,6 @@ bool Visualizer::PollEvents() {
 bool Visualizer::AddGeometry(
         std::shared_ptr<const geometry::Geometry> geometry_ptr,
         bool reset_bounding_box) {
-
     if (is_initialized_ == false) {
         return false;
     }
@@ -385,7 +384,6 @@ bool Visualizer::AddGeometry(
 bool Visualizer::RemoveGeometry(
         std::shared_ptr<const geometry::Geometry> geometry_ptr,
         bool reset_bounding_box) {
-
     if (is_initialized_ == false) {
         return false;
     }

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -293,94 +293,10 @@ bool Visualizer::PollEvents() {
     return !glfwWindowShouldClose(window_);
 }
 
-bool Visualizer::AddGeometryNoFit(
-        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
-    if (is_initialized_ == false) {
-        return false;
-    }
-    glfwMakeContextCurrent(window_);
-    std::shared_ptr<glsl::GeometryRenderer> renderer_ptr;
-    if (geometry_ptr->GetGeometryType() ==
-        geometry::Geometry::GeometryType::Unspecified) {
-        return false;
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::PointCloud) {
-        renderer_ptr = std::make_shared<glsl::PointCloudRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::VoxelGrid) {
-        renderer_ptr = std::make_shared<glsl::VoxelGridRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::Octree) {
-        renderer_ptr = std::make_shared<glsl::OctreeRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::LineSet) {
-        renderer_ptr = std::make_shared<glsl::LineSetRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-                       geometry::Geometry::GeometryType::TriangleMesh ||
-               geometry_ptr->GetGeometryType() ==
-                       geometry::Geometry::GeometryType::HalfEdgeTriangleMesh) {
-        renderer_ptr = std::make_shared<glsl::TriangleMeshRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::Image) {
-        renderer_ptr = std::make_shared<glsl::ImageRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::RGBDImage) {
-        renderer_ptr = std::make_shared<glsl::RGBDImageRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::TetraMesh) {
-        renderer_ptr = std::make_shared<glsl::TetraMeshRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::OrientedBoundingBox) {
-        renderer_ptr = std::make_shared<glsl::OrientedBoundingBoxRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else if (geometry_ptr->GetGeometryType() ==
-               geometry::Geometry::GeometryType::AxisAlignedBoundingBox) {
-        renderer_ptr = std::make_shared<glsl::AxisAlignedBoundingBoxRenderer>();
-        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
-            return false;
-        }
-    } else {
-        return false;
-    }
-    geometry_renderer_ptrs_.insert(renderer_ptr);
-    geometry_ptrs_.insert(geometry_ptr);
-    //view_control_ptr_->FitInGeometry(*geometry_ptr);
-    //ResetViewPoint();
-    //utility::LogDebug(
-    //        "Add geometry and update bounding box to {}",
-    //        view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
-    return UpdateGeometry();
-}
-
-
 bool Visualizer::AddGeometry(
-        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
+        std::shared_ptr<const geometry::Geometry> geometry_ptr,
+        bool reset_bounding_box) {
+
     if (is_initialized_ == false) {
         return false;
     }
@@ -456,8 +372,10 @@ bool Visualizer::AddGeometry(
     }
     geometry_renderer_ptrs_.insert(renderer_ptr);
     geometry_ptrs_.insert(geometry_ptr);
-    view_control_ptr_->FitInGeometry(*geometry_ptr);
-    ResetViewPoint();
+    if (reset_bounding_box) {
+        view_control_ptr_->FitInGeometry(*geometry_ptr);
+        ResetViewPoint();
+    }
     utility::LogDebug(
             "Add geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
@@ -465,7 +383,9 @@ bool Visualizer::AddGeometry(
 }
 
 bool Visualizer::RemoveGeometry(
-        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
+        std::shared_ptr<const geometry::Geometry> geometry_ptr,
+        bool reset_bounding_box) {
+
     if (is_initialized_ == false) {
         return false;
     }
@@ -478,10 +398,12 @@ bool Visualizer::RemoveGeometry(
     if (geometry_renderer_delete == NULL) return false;
     geometry_renderer_ptrs_.erase(geometry_renderer_delete);
     geometry_ptrs_.erase(geometry_ptr);
-    //ResetViewPoint(true);
-    //utility::LogDebug(
-    //        "Remove geometry and update bounding box to {}",
-    //        view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
+    if (reset_bounding_box) {
+        ResetViewPoint(true);
+    }
+    utility::LogDebug(
+            "Remove geometry and update bounding box to {}",
+            view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
     return UpdateGeometry();
 }
 

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -293,6 +293,92 @@ bool Visualizer::PollEvents() {
     return !glfwWindowShouldClose(window_);
 }
 
+bool Visualizer::AddGeometryNoFit(
+        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
+    if (is_initialized_ == false) {
+        return false;
+    }
+    glfwMakeContextCurrent(window_);
+    std::shared_ptr<glsl::GeometryRenderer> renderer_ptr;
+    if (geometry_ptr->GetGeometryType() ==
+        geometry::Geometry::GeometryType::Unspecified) {
+        return false;
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::PointCloud) {
+        renderer_ptr = std::make_shared<glsl::PointCloudRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::VoxelGrid) {
+        renderer_ptr = std::make_shared<glsl::VoxelGridRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::Octree) {
+        renderer_ptr = std::make_shared<glsl::OctreeRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::LineSet) {
+        renderer_ptr = std::make_shared<glsl::LineSetRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+                       geometry::Geometry::GeometryType::TriangleMesh ||
+               geometry_ptr->GetGeometryType() ==
+                       geometry::Geometry::GeometryType::HalfEdgeTriangleMesh) {
+        renderer_ptr = std::make_shared<glsl::TriangleMeshRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::Image) {
+        renderer_ptr = std::make_shared<glsl::ImageRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::RGBDImage) {
+        renderer_ptr = std::make_shared<glsl::RGBDImageRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::TetraMesh) {
+        renderer_ptr = std::make_shared<glsl::TetraMeshRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::OrientedBoundingBox) {
+        renderer_ptr = std::make_shared<glsl::OrientedBoundingBoxRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else if (geometry_ptr->GetGeometryType() ==
+               geometry::Geometry::GeometryType::AxisAlignedBoundingBox) {
+        renderer_ptr = std::make_shared<glsl::AxisAlignedBoundingBoxRenderer>();
+        if (renderer_ptr->AddGeometry(geometry_ptr) == false) {
+            return false;
+        }
+    } else {
+        return false;
+    }
+    geometry_renderer_ptrs_.insert(renderer_ptr);
+    geometry_ptrs_.insert(geometry_ptr);
+    //view_control_ptr_->FitInGeometry(*geometry_ptr);
+    //ResetViewPoint();
+    //utility::LogDebug(
+    //        "Add geometry and update bounding box to {}",
+    //        view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
+    return UpdateGeometry();
+}
+
+
 bool Visualizer::AddGeometry(
         std::shared_ptr<const geometry::Geometry> geometry_ptr) {
     if (is_initialized_ == false) {
@@ -392,10 +478,10 @@ bool Visualizer::RemoveGeometry(
     if (geometry_renderer_delete == NULL) return false;
     geometry_renderer_ptrs_.erase(geometry_renderer_delete);
     geometry_ptrs_.erase(geometry_ptr);
-    ResetViewPoint(true);
-    utility::LogDebug(
-            "Remove geometry and update bounding box to {}",
-            view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
+    //ResetViewPoint(true);
+    //utility::LogDebug(
+    //        "Remove geometry and update bounding box to {}",
+    //        view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
     return UpdateGeometry();
 }
 

--- a/src/Open3D/Visualization/Visualizer/Visualizer.h
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.h
@@ -119,6 +119,8 @@ public:
     /// undefined. Programmers are responsible for calling UpdateGeometry() to
     /// notify the Visualizer that the geometry has been changed and the
     /// Visualizer should be updated accordingly.
+    virtual bool AddGeometryNoFit(
+            std::shared_ptr<const geometry::Geometry> geometry_ptr);
     virtual bool AddGeometry(
             std::shared_ptr<const geometry::Geometry> geometry_ptr);
 

--- a/src/Open3D/Visualization/Visualizer/Visualizer.h
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.h
@@ -119,10 +119,9 @@ public:
     /// undefined. Programmers are responsible for calling UpdateGeometry() to
     /// notify the Visualizer that the geometry has been changed and the
     /// Visualizer should be updated accordingly.
-    virtual bool AddGeometryNoFit(
-            std::shared_ptr<const geometry::Geometry> geometry_ptr);
     virtual bool AddGeometry(
-            std::shared_ptr<const geometry::Geometry> geometry_ptr);
+            std::shared_ptr<const geometry::Geometry> geometry_ptr,
+            bool reset_bounding_box = true);
 
     /// Function to remove geometry from the scene
     /// 1. After calling this function, the Visualizer releases the pointer of
@@ -131,7 +130,8 @@ public:
     /// 3. This function returns FALSE if the geometry to be removed is not
     /// added by AddGeometry
     virtual bool RemoveGeometry(
-            std::shared_ptr<const geometry::Geometry> geometry_ptr);
+            std::shared_ptr<const geometry::Geometry> geometry_ptr,
+            bool reset_bounding_box = true);
 
     /// Function to update geometry
     /// This function must be called when geometry has been changed. Otherwise

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -108,7 +108,9 @@ bool VisualizerWithEditing::AddGeometry(
     }
     geometry_ptrs_.insert(editing_geometry_ptr_);
     geometry_renderer_ptrs_.insert(editing_geometry_renderer_ptr_);
-    ResetViewPoint(true);
+    if (reset_bounding_box) {
+        ResetViewPoint(true);
+    }
     utility::LogDebug(
             "Add geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -49,7 +49,6 @@ namespace visualization {
 bool VisualizerWithEditing::AddGeometry(
         std::shared_ptr<const geometry::Geometry> geometry_ptr,
         bool reset_bounding_box) {
-
     if (is_initialized_ == false || geometry_ptrs_.empty() == false) {
         return false;
     }

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.cpp
@@ -47,7 +47,9 @@ namespace open3d {
 namespace visualization {
 
 bool VisualizerWithEditing::AddGeometry(
-        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
+        std::shared_ptr<const geometry::Geometry> geometry_ptr,
+        bool reset_bounding_box) {
+
     if (is_initialized_ == false || geometry_ptrs_.empty() == false) {
         return false;
     }

--- a/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.h
+++ b/src/Open3D/Visualization/Visualizer/VisualizerWithEditing.h
@@ -54,8 +54,8 @@ public:
     VisualizerWithEditing &operator=(const VisualizerWithEditing &) = delete;
 
 public:
-    bool AddGeometry(
-            std::shared_ptr<const geometry::Geometry> geometry_ptr) override;
+    bool AddGeometry(std::shared_ptr<const geometry::Geometry> geometry_ptr,
+                     bool reset_bounding_box = true) override;
     void PrintVisualizerHelp() override;
     void UpdateWindowTitle() override;
     void BuildUtilities() override;

--- a/src/Python/open3d_pybind/visualization/visualization_trampoline.h
+++ b/src/Python/open3d_pybind/visualization/visualization_trampoline.h
@@ -37,8 +37,8 @@ template <class VisualizerBase = visualization::Visualizer>
 class PyVisualizer : public VisualizerBase {
 public:
     using VisualizerBase::VisualizerBase;
-    bool AddGeometry(
-            std::shared_ptr<const geometry::Geometry> geometry_ptr) override {
+    bool AddGeometry(std::shared_ptr<const geometry::Geometry> geometry_ptr,
+                     bool reset_bounding_box = true) override {
         PYBIND11_OVERLOAD(bool, VisualizerBase, AddGeometry, geometry_ptr);
     }
     bool UpdateGeometry() override {

--- a/src/Python/open3d_pybind/visualization/visualizer.cpp
+++ b/src/Python/open3d_pybind/visualization/visualizer.cpp
@@ -51,7 +51,9 @@ static const std::unordered_map<std::string, std::string>
                 {"width", "Width of the window."},
                 {"window_name", "Window title name."},
                 {"convert_to_world_coordinate",
-                 "Set to ``True`` to convert to world coordinates"}};
+                 "Set to ``True`` to convert to world coordinates"},
+                {"reset_bounding_box",
+                 "Set to ``False`` to keep current viewpoint"}};
 
 void pybind_visualizer(py::module &m) {
     py::class_<visualization::Visualizer, PyVisualizer<>,

--- a/src/Python/open3d_pybind/visualization/visualizer.cpp
+++ b/src/Python/open3d_pybind/visualization/visualizer.cpp
@@ -89,6 +89,10 @@ void pybind_visualizer(py::module &m) {
                  "Function to inform render needed to be updated")
             .def("poll_events", &visualization::Visualizer::PollEvents,
                  "Function to poll events")
+            .def("add_geometry_no_fit", &visualization::Visualizer::AddGeometryNoFit,
+                 "Function to add geometry to the scene and create "
+                 "corresponding shaders",
+                 "geometry"_a)
             .def("add_geometry", &visualization::Visualizer::AddGeometry,
                  "Function to add geometry to the scene and create "
                  "corresponding shaders",

--- a/src/Python/open3d_pybind/visualization/visualizer.cpp
+++ b/src/Python/open3d_pybind/visualization/visualizer.cpp
@@ -89,16 +89,13 @@ void pybind_visualizer(py::module &m) {
                  "Function to inform render needed to be updated")
             .def("poll_events", &visualization::Visualizer::PollEvents,
                  "Function to poll events")
-            .def("add_geometry_no_fit", &visualization::Visualizer::AddGeometryNoFit,
-                 "Function to add geometry to the scene and create "
-                 "corresponding shaders",
-                 "geometry"_a)
             .def("add_geometry", &visualization::Visualizer::AddGeometry,
                  "Function to add geometry to the scene and create "
                  "corresponding shaders",
-                 "geometry"_a)
+                 "geometry"_a, "reset_bounding_box"_a = true)
             .def("remove_geometry", &visualization::Visualizer::RemoveGeometry,
-                 "Function to remove geometry", "geometry"_a)
+                 "Function to remove geometry", "geometry"_a,
+                 "reset_bounding_box"_a = true)
             .def("get_view_control", &visualization::Visualizer::GetViewControl,
                  "Function to retrieve the associated ``ViewControl``",
                  py::return_value_policy::reference_internal)


### PR DESCRIPTION
Currently, when `open3d.visualization.Visualizer.add_geometry()` and `open3d.visualization.Visualizer.remove_geometry()` is called, the viewpoint is reset based on the new bounding box.

In some situations, it is necessary to keep the viewpoint between adding/removing geometries.

This pull request adds optional `reset_bounding_box` parameter to those methods.

Usage example:

```python
vis.add_geometry(mypcd, reset_bounding_box=False)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1315)
<!-- Reviewable:end -->
