### PR TITLE
Use int64_t for all Tensor indexing code

### DIFF
--- a/src/Open3D/Container/Blob.h
+++ b/src/Open3D/Container/Blob.h
@@ -37,7 +37,7 @@ namespace open3d {
 
 class Blob : public std::enable_shared_from_this<Blob> {
 public:
-    Blob(size_t byte_size, const Device& device)
+    Blob(int64_t byte_size, const Device& device)
         : byte_size_(byte_size), device_(device) {
         v_ = MemoryManager::Malloc(byte_size_, device_);
     }
@@ -54,7 +54,7 @@ public:
     void* v_ = nullptr;
 
     /// Size of Blob in bytes
-    size_t byte_size_ = 0;
+    int64_t byte_size_ = 0;
 
     /// Device context for the blob
     Device device_;

--- a/src/Open3D/Container/Broadcast.cpp
+++ b/src/Open3D/Container/Broadcast.cpp
@@ -33,8 +33,8 @@ namespace open3d {
 
 bool IsCompatibleBroadcastShape(const SizeVector& left_shape,
                                 const SizeVector& right_shape) {
-    size_t left_ndim = left_shape.size();
-    size_t right_ndim = right_shape.size();
+    int64_t left_ndim = left_shape.size();
+    int64_t right_ndim = right_shape.size();
 
     if (left_ndim == 0 || right_ndim == 0) {
         return true;
@@ -44,10 +44,10 @@ bool IsCompatibleBroadcastShape(const SizeVector& left_shape,
     // E.g. LHS: [100, 200, 2, 3, 4]
     //      RHS:           [2, 1, 4] <- only last 3 dims need to be checked
     // Checked from right to left
-    size_t shorter_ndim = std::min(left_ndim, right_ndim);
-    for (size_t ind = 0; ind < shorter_ndim; ++ind) {
-        size_t left_dim = left_shape[left_ndim - 1 - ind];
-        size_t right_dim = right_shape[right_ndim - 1 - ind];
+    int64_t shorter_ndim = std::min(left_ndim, right_ndim);
+    for (int64_t ind = 0; ind < shorter_ndim; ++ind) {
+        int64_t left_dim = left_shape[left_ndim - 1 - ind];
+        int64_t right_dim = right_shape[right_ndim - 1 - ind];
         if (!(left_dim == right_dim || left_dim == 1 || right_dim == 1)) {
             return false;
         }

--- a/src/Open3D/Container/Broadcast.cpp
+++ b/src/Open3D/Container/Broadcast.cpp
@@ -62,10 +62,10 @@ SizeVector BroadcastedShape(const SizeVector& left_shape,
                           left_shape, right_shape);
     }
 
-    int left_ndim = left_shape.size();
-    int right_ndim = right_shape.size();
-    int shorter_ndim = std::min(left_ndim, right_ndim);
-    int longer_ndim = std::max(left_ndim, right_ndim);
+    int64_t left_ndim = left_shape.size();
+    int64_t right_ndim = right_shape.size();
+    int64_t shorter_ndim = std::min(left_ndim, right_ndim);
+    int64_t longer_ndim = std::max(left_ndim, right_ndim);
 
     if (left_ndim == 0) {
         return right_shape;
@@ -76,11 +76,11 @@ SizeVector BroadcastedShape(const SizeVector& left_shape,
 
     SizeVector broadcasted_shape(longer_ndim, 0);
     // Checked from right to left
-    for (int ind = 0; ind < longer_ndim; ind++) {
-        int left_ind = left_ndim - longer_ndim + ind;
-        int right_ind = right_ndim - longer_ndim + ind;
-        int left_dim = left_ind >= 0 ? left_shape[left_ind] : 0;
-        int right_dim = right_ind >= 0 ? right_shape[right_ind] : 0;
+    for (int64_t ind = 0; ind < longer_ndim; ind++) {
+        int64_t left_ind = left_ndim - longer_ndim + ind;
+        int64_t right_ind = right_ndim - longer_ndim + ind;
+        int64_t left_dim = left_ind >= 0 ? left_shape[left_ind] : 0;
+        int64_t right_dim = right_ind >= 0 ? right_shape[right_ind] : 0;
         broadcasted_shape[ind] = std::max(left_dim, right_dim);
     }
     return broadcasted_shape;

--- a/src/Open3D/Container/Dtype.h
+++ b/src/Open3D/Container/Dtype.h
@@ -55,8 +55,8 @@ enum class Dtype {
 
 class DtypeUtil {
 public:
-    static size_t ByteSize(const Dtype &dtype) {
-        size_t byte_size = 0;
+    static int64_t ByteSize(const Dtype &dtype) {
+        int64_t byte_size = 0;
         switch (dtype) {
             case Dtype::Float32:
                 byte_size = 4;

--- a/src/Open3D/Container/Indexing.cpp
+++ b/src/Open3D/Container/Indexing.cpp
@@ -38,15 +38,15 @@ std::tuple<std::vector<Tensor>, SizeVector> PreprocessIndexTensors(
     Tensor empty_index_tensor =
             Tensor(SizeVector(), Dtype::Int32, tensor.GetDevice());
     std::vector<Tensor> full_index_tensors = index_tensors;
-    for (size_t i = 0; i < tensor.NumDims() - index_tensors.size(); ++i) {
+    for (int64_t i = 0; i < tensor.NumDims() - index_tensors.size(); ++i) {
         full_index_tensors.push_back(empty_index_tensor);
     }
 
     // Find all trivial and non-trivial index_tensors
-    std::vector<size_t> trivial_dims;
-    std::vector<size_t> non_trivial_dims;
+    std::vector<int64_t> trivial_dims;
+    std::vector<int64_t> non_trivial_dims;
     std::vector<SizeVector> non_trivial_shapes;
-    for (size_t dim = 0; dim < full_index_tensors.size(); ++dim) {
+    for (int64_t dim = 0; dim < full_index_tensors.size(); ++dim) {
         if (full_index_tensors[dim].NumDims() == 0) {
             trivial_dims.push_back(dim);
         } else {
@@ -75,14 +75,14 @@ std::tuple<std::vector<Tensor>, SizeVector> PreprocessIndexTensors(
     }
 
     // Now, broadcast non-trivial index tensors
-    for (size_t i = 0; i < full_index_tensors.size(); ++i) {
+    for (int64_t i = 0; i < full_index_tensors.size(); ++i) {
         if (full_index_tensors[i].NumDims() != 0) {
             full_index_tensors[i].Assign(full_index_tensors[i].Broadcast(
                     broadcasted_non_trivial_shape));
         }
     }
 
-    for (size_t i = 1; i < non_trivial_dims.size(); ++i) {
+    for (int64_t i = 1; i < non_trivial_dims.size(); ++i) {
         if (non_trivial_dims[i - 1] + 1 != non_trivial_dims[i]) {
             utility::LogError(
                     "Only supporting the case where advanced indices are all"
@@ -96,7 +96,7 @@ std::tuple<std::vector<Tensor>, SizeVector> PreprocessIndexTensors(
     std::vector<int> slice_map;
     bool filled_non_trivial_dims = false;
     const auto& tensor_shape = tensor.GetShape();
-    for (size_t dim = 0; dim < tensor_shape.size(); ++dim) {
+    for (int64_t dim = 0; dim < tensor_shape.size(); ++dim) {
         if (full_index_tensors[dim].NumDims() == 0) {
             output_shape.emplace_back(tensor_shape[dim]);
             slice_map.emplace_back(dim);

--- a/src/Open3D/Container/Indexing.cpp
+++ b/src/Open3D/Container/Indexing.cpp
@@ -34,6 +34,15 @@ namespace open3d {
 
 std::tuple<std::vector<Tensor>, SizeVector> PreprocessIndexTensors(
         const Tensor& tensor, const std::vector<Tensor>& index_tensors) {
+    // Index tensors must be using int64_t
+    for (const Tensor& index_tensor : index_tensors) {
+        if (index_tensor.GetDtype() != Dtype::Int64) {
+            utility::LogError(
+                    "Indexing Tensor must have Int64 dtype, but {} was used.",
+                    DtypeUtil::ToString(index_tensor.GetDtype()));
+        }
+    }
+
     // Fill implied 0-d indexing tensors at the tail dimensions.
     Tensor empty_index_tensor =
             Tensor(SizeVector(), Dtype::Int32, tensor.GetDevice());
@@ -93,7 +102,7 @@ std::tuple<std::vector<Tensor>, SizeVector> PreprocessIndexTensors(
     }
 
     SizeVector output_shape;
-    std::vector<int> slice_map;
+    std::vector<int64_t> slice_map;
     bool filled_non_trivial_dims = false;
     const auto& tensor_shape = tensor.GetShape();
     for (int64_t dim = 0; dim < tensor_shape.size(); ++dim) {

--- a/src/Open3D/Container/Kernel/CPULauncher.h
+++ b/src/Open3D/Container/Kernel/CPULauncher.h
@@ -40,7 +40,7 @@ public:
                                     func_t element_kernel) {
         const char* src_data_ptr = static_cast<const char*>(src.GetDataPtr());
         char* dst_data_ptr = static_cast<char*>(dst.GetDataPtr());
-        size_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
+        int64_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
 
         // src - (broadcast) -> mid -> dst
         SizeVector mid_shape = dst.GetShape();
@@ -56,9 +56,9 @@ public:
         for (int64_t thread_idx = 0;
              thread_idx < static_cast<int64_t>(dst.NumElements());
              thread_idx++) {
-            size_t src_idx = src_offset_calculator.GetOffset(thread_idx);
+            int64_t src_idx = src_offset_calculator.GetOffset(thread_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
-            size_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
+            int64_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;
             element_kernel(src_ptr, dst_ptr);
         }
@@ -101,17 +101,17 @@ public:
         int64_t num_elems = static_cast<int64_t>(dst.GetShape().NumElements());
         const char* src_data_ptr = static_cast<const char*>(src.GetDataPtr());
         char* dst_data_ptr = static_cast<char*>(dst.GetDataPtr());
-        size_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
+        int64_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
         for (int64_t thread_idx = 0; thread_idx < num_elems; thread_idx++) {
             // [thread_idx] --un-broadcast--> [mid_idx] --un-fancy--> [src_idx]
-            size_t mid_idx = broadcast_offset_calculator.GetOffset(thread_idx);
-            size_t src_idx = fancy_offset_calculator.GetOffset(mid_idx);
+            int64_t mid_idx = broadcast_offset_calculator.GetOffset(thread_idx);
+            int64_t src_idx = fancy_offset_calculator.GetOffset(mid_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
-            size_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
+            int64_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;
             element_kernel(src_ptr, dst_ptr);
         }
@@ -148,15 +148,15 @@ public:
         int64_t num_elems = static_cast<int64_t>(mid_shape.NumElements());
         const char* src_data_ptr = static_cast<const char*>(src.GetDataPtr());
         char* dst_data_ptr = static_cast<char*>(dst.GetDataPtr());
-        size_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
+        int64_t element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
         for (int64_t thread_idx = 0; thread_idx < num_elems; thread_idx++) {
-            size_t src_idx = src_offset_calculator.GetOffset(thread_idx);
+            int64_t src_idx = src_offset_calculator.GetOffset(thread_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
-            size_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
+            int64_t dst_idx = dst_offset_calculator.GetOffset(thread_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;
             element_kernel(src_ptr, dst_ptr);
         }

--- a/src/Open3D/Container/Kernel/CPULauncher.h
+++ b/src/Open3D/Container/Kernel/CPULauncher.h
@@ -72,9 +72,10 @@ public:
             const std::vector<Tensor>& index_tensors,
             const SizeVector& indexed_out_shape,
             func_t element_kernel) {
-        std::vector<const int*> index_tensor_data_ptrs;
+        std::vector<const int64_t*> index_tensor_data_ptrs;
         for (auto& index : index_tensors) {
-            auto index_tensor_ptr = static_cast<const int*>(index.GetDataPtr());
+            auto index_tensor_ptr =
+                    static_cast<const int64_t*>(index.GetDataPtr());
             index_tensor_data_ptrs.push_back(index_tensor_ptr);
         }
 
@@ -125,9 +126,10 @@ public:
             const std::vector<Tensor>& index_tensors,
             const SizeVector& indexed_out_shape,
             func_t element_kernel) {
-        std::vector<const int*> index_tensor_data_ptrs;
+        std::vector<const int64_t*> index_tensor_data_ptrs;
         for (auto& index : index_tensors) {
-            auto index_tensor_ptr = static_cast<const int*>(index.GetDataPtr());
+            auto index_tensor_ptr =
+                    static_cast<const int64_t*>(index.GetDataPtr());
             index_tensor_data_ptrs.push_back(index_tensor_ptr);
         }
 

--- a/src/Open3D/Container/Kernel/CUDALauncher.cuh
+++ b/src/Open3D/Container/Kernel/CUDALauncher.cuh
@@ -135,9 +135,9 @@ public:
         int element_byte_size = DtypeUtil::ByteSize(src.GetDtype());
 
         auto f = [=] OPEN3D_HOST_DEVICE(int thread_idx) {
-            size_t fancied_idx =
+            int64_t fancied_idx =
                     broadcast_offset_calculator.GetOffset(thread_idx);
-            size_t src_idx = fancy_offset_calculator.GetOffset(fancied_idx);
+            int64_t src_idx = fancy_offset_calculator.GetOffset(fancied_idx);
             const void* src_ptr = src_data_ptr + src_idx * element_byte_size;
             int dst_idx = dst_offset_calculator.GetOffset(thread_idx);
             void* dst_ptr = dst_data_ptr + dst_idx * element_byte_size;

--- a/src/Open3D/Container/Kernel/Scheduler.h
+++ b/src/Open3D/Container/Kernel/Scheduler.h
@@ -34,7 +34,7 @@
 namespace open3d {
 namespace kernel {
 
-static constexpr int MAX_DIMS = 10;
+static constexpr int64_t MAX_DIMS = 10;
 
 /// \brief Compute offset of the target Tensor \p tar_tensor, given the offset
 /// of the reference Tensor \p ref_tensor.
@@ -69,8 +69,8 @@ public:
                               tar_shape, ref_shape);
         }
 
-        int tar_ndims = static_cast<int>(tar_strides.size());
-        int ref_ndims = static_cast<int>(ref_strides.size());
+        int64_t tar_ndims = static_cast<int64_t>(tar_strides.size());
+        int64_t ref_ndims = static_cast<int64_t>(ref_strides.size());
         ndims_ = ref_ndims;
 
         // Fill tar_shape_ and tar_strides_.
@@ -86,11 +86,11 @@ public:
         // tar_strides: [ 0,  3,  0,  1] <- if shape is "1", stride set to "0"
         // ref_shape:   [ 2,  2,  2,  3]
         // ref_strides: [12,  6,  3,  1]
-        for (int i = 0; i < ndims_ - tar_ndims; ++i) {
+        for (int64_t i = 0; i < ndims_ - tar_ndims; ++i) {
             tar_shape_[i] = 1;
             tar_strides_[i] = 0;
         }
-        for (int i = 0; i < tar_ndims; ++i) {
+        for (int64_t i = 0; i < tar_ndims; ++i) {
             tar_shape_[ndims_ - tar_ndims + i] = tar_shape[i];
             if (tar_shape[i] == 1) {
                 tar_strides_[ndims_ - tar_ndims + i] = 0;
@@ -100,36 +100,36 @@ public:
         }
 
         // Fill ref_shape_ and ref_strides_
-        for (int i = 0; i < ndims_; ++i) {
+        for (int64_t i = 0; i < ndims_; ++i) {
             ref_shape_[i] = ref_shape[i];
             ref_strides_[i] = ref_strides[i];
         }
     }
 
-    OPEN3D_HOST_DEVICE int GetOffset(int ref_offset) const {
-        int tar_offset = 0;
+    OPEN3D_HOST_DEVICE int64_t GetOffset(int64_t ref_offset) const {
+        int64_t tar_offset = 0;
 #pragma unroll
-        for (int dim = 0; dim < ndims_; dim++) {
+        for (int64_t dim = 0; dim < ndims_; dim++) {
             tar_offset += ref_offset / ref_strides_[dim] * tar_strides_[dim];
             ref_offset = ref_offset % ref_strides_[dim];
         }
         return tar_offset;
     }
 
-    static void PrintArray(const int* array, int size) {
+    static void PrintArray(const int64_t* array, int64_t size) {
         std::string s;
-        for (int i = 0; i < size; ++i) {
+        for (int64_t i = 0; i < size; ++i) {
             s += std::to_string(array[i]) + ", ";
         }
         utility::LogInfo("{}", s);
     }
 
 protected:
-    int ndims_;
-    int tar_shape_[MAX_DIMS];
-    int tar_strides_[MAX_DIMS];
-    int ref_shape_[MAX_DIMS];
-    int ref_strides_[MAX_DIMS];
+    int64_t ndims_;
+    int64_t tar_shape_[MAX_DIMS];
+    int64_t tar_strides_[MAX_DIMS];
+    int64_t ref_shape_[MAX_DIMS];
+    int64_t ref_strides_[MAX_DIMS];
 };
 
 // Broadcast tar_shape to ref_shape.
@@ -142,15 +142,15 @@ public:
             const SizeVector& ref_shape,
             const SizeVector& ref_strides,
             const std::vector<bool>& is_trivial_dims,
-            const std::vector<const int*>& indexing_tensor_data_ptrs) {
+            const std::vector<const int64_t*>& indexing_tensor_data_ptrs) {
         tar_ndims_ = tar_strides.size();
         ref_ndims_ = ref_strides.size();
 
         bool fancy_index_visited = false;
-        int size_map_next_idx = 0;
-        for (int i = 0; i < tar_ndims_; i++) {
-            tar_strides_[i] = static_cast<int>(tar_strides[i]);
-            tar_shape_[i] = static_cast<int>(tar_shape[i]);
+        int64_t size_map_next_idx = 0;
+        for (int64_t i = 0; i < tar_ndims_; i++) {
+            tar_strides_[i] = static_cast<int64_t>(tar_strides[i]);
+            tar_shape_[i] = static_cast<int64_t>(tar_shape[i]);
             is_trivial_dims_[i] = is_trivial_dims[i];
             indexing_tensor_data_ptrs_[i] = indexing_tensor_data_ptrs[i];
 
@@ -163,12 +163,12 @@ public:
             }
         }
 
-        for (int i = 0; i < ref_ndims_; i++) {
-            ref_strides_[i] = static_cast<int>(ref_strides[i]);
+        for (int64_t i = 0; i < ref_ndims_; i++) {
+            ref_strides_[i] = static_cast<int64_t>(ref_strides[i]);
         }
     }
 
-    OPEN3D_HOST_DEVICE int GetOffset(int64_t ref_offset) const {
+    OPEN3D_HOST_DEVICE int64_t GetOffset(int64_t ref_offset) const {
         int64_t tar_offset = 0;
 #pragma unroll
         for (int64_t dim = 0; dim < ref_ndims_; dim++) {
@@ -193,17 +193,17 @@ public:
     }
 
 protected:
-    int tar_ndims_;
-    int ref_ndims_;
+    int64_t tar_ndims_;
+    int64_t ref_ndims_;
 
-    int tar_shape_[MAX_DIMS];
-    int tar_strides_[MAX_DIMS];
-    int ref_shape_[MAX_DIMS];
-    int ref_strides_[MAX_DIMS];
+    int64_t tar_shape_[MAX_DIMS];
+    int64_t tar_strides_[MAX_DIMS];
+    int64_t ref_shape_[MAX_DIMS];
+    int64_t ref_strides_[MAX_DIMS];
 
     bool is_trivial_dims_[MAX_DIMS];
-    int slice_map_[MAX_DIMS];  // -1 for if that dim is fancy indexed
-    const int* indexing_tensor_data_ptrs_[MAX_DIMS];
+    int64_t slice_map_[MAX_DIMS];  // -1 for if that dim is fancy indexed
+    const int64_t* indexing_tensor_data_ptrs_[MAX_DIMS];
 };
 
 /// # result.ndim == M
@@ -236,15 +236,15 @@ public:
             const SizeVector& tar_strides,
             const SizeVector& ref_strides,
             const std::vector<bool>& is_trivial_dims,
-            const std::vector<const int*>& indexing_tensor_data_ptrs) {
+            const std::vector<const int64_t*>& indexing_tensor_data_ptrs) {
         tar_ndims_ = tar_strides.size();
         ref_ndims_ = ref_strides.size();
 
         bool fancy_index_visited = false;
-        int size_map_next_idx = 0;
-        for (int i = 0; i < tar_ndims_; i++) {
-            tar_strides_[i] = static_cast<int>(tar_strides[i]);
-            tar_shape_[i] = static_cast<int>(tar_shape[i]);
+        int64_t size_map_next_idx = 0;
+        for (int64_t i = 0; i < tar_ndims_; i++) {
+            tar_strides_[i] = static_cast<int64_t>(tar_strides[i]);
+            tar_shape_[i] = static_cast<int64_t>(tar_shape[i]);
             is_trivial_dims_[i] = is_trivial_dims[i];
             indexing_tensor_data_ptrs_[i] = indexing_tensor_data_ptrs[i];
 
@@ -257,12 +257,12 @@ public:
             }
         }
 
-        for (int i = 0; i < ref_ndims_; i++) {
-            ref_strides_[i] = static_cast<int>(ref_strides[i]);
+        for (int64_t i = 0; i < ref_ndims_; i++) {
+            ref_strides_[i] = static_cast<int64_t>(ref_strides[i]);
         }
     }
 
-    OPEN3D_HOST_DEVICE int GetOffset(int64_t ref_offset) const {
+    OPEN3D_HOST_DEVICE int64_t GetOffset(int64_t ref_offset) const {
         int64_t tar_offset = 0;
 #pragma unroll
         for (int64_t dim = 0; dim < ref_ndims_; dim++) {
@@ -293,17 +293,17 @@ public:
     }
 
 protected:
-    int tar_ndims_;
-    int ref_ndims_;
+    int64_t tar_ndims_;
+    int64_t ref_ndims_;
 
-    int tar_shape_[MAX_DIMS];
-    int tar_strides_[MAX_DIMS];
-    int ref_shape_[MAX_DIMS];
-    int ref_strides_[MAX_DIMS];
+    int64_t tar_shape_[MAX_DIMS];
+    int64_t tar_strides_[MAX_DIMS];
+    int64_t ref_shape_[MAX_DIMS];
+    int64_t ref_strides_[MAX_DIMS];
 
     bool is_trivial_dims_[MAX_DIMS];
-    int slice_map_[MAX_DIMS];  // -1 for if that dim is fancy indexed
-    const int* indexing_tensor_data_ptrs_[MAX_DIMS];
+    int64_t slice_map_[MAX_DIMS];  // -1 for if that dim is fancy indexed
+    const int64_t* indexing_tensor_data_ptrs_[MAX_DIMS];
 };
 
 }  // namespace kernel

--- a/src/Open3D/Container/Kernel/Scheduler.h
+++ b/src/Open3D/Container/Kernel/Scheduler.h
@@ -168,10 +168,10 @@ public:
         }
     }
 
-    OPEN3D_HOST_DEVICE int GetOffset(size_t ref_offset) const {
-        size_t tar_offset = 0;
+    OPEN3D_HOST_DEVICE int GetOffset(int64_t ref_offset) const {
+        int64_t tar_offset = 0;
 #pragma unroll
-        for (size_t dim = 0; dim < ref_ndims_; dim++) {
+        for (int64_t dim = 0; dim < ref_ndims_; dim++) {
             int64_t dim_idx = ref_offset / ref_strides_[dim];
 
             if (slice_map_[dim] != -1) {
@@ -179,7 +179,7 @@ public:
                 tar_offset += dim_idx * tar_strides_[slice_map_[dim]];
             } else {
                 // This dim is mapped to one or more fancy indexed input dim(s)
-                for (size_t tar_dim = 0; tar_dim < tar_ndims_; tar_dim++) {
+                for (int64_t tar_dim = 0; tar_dim < tar_ndims_; tar_dim++) {
                     if (!is_trivial_dims_[tar_dim]) {
                         tar_offset +=
                                 indexing_tensor_data_ptrs_[tar_dim][dim_idx] *
@@ -262,10 +262,10 @@ public:
         }
     }
 
-    OPEN3D_HOST_DEVICE int GetOffset(size_t ref_offset) const {
-        size_t tar_offset = 0;
+    OPEN3D_HOST_DEVICE int GetOffset(int64_t ref_offset) const {
+        int64_t tar_offset = 0;
 #pragma unroll
-        for (size_t dim = 0; dim < ref_ndims_; dim++) {
+        for (int64_t dim = 0; dim < ref_ndims_; dim++) {
             int64_t dim_idx = ref_offset / ref_strides_[dim];
 
             if (slice_map_[dim] != -1) {
@@ -273,7 +273,7 @@ public:
                 tar_offset += dim_idx * tar_strides_[slice_map_[dim]];
             } else {
                 // This dim is mapped to one or more fancy indexed input dim(s)
-                for (size_t tar_dim = 0; tar_dim < tar_ndims_; tar_dim++) {
+                for (int64_t tar_dim = 0; tar_dim < tar_ndims_; tar_dim++) {
                     if (!is_trivial_dims_[tar_dim]) {
                         int64_t tar_dim_idx =
                                 indexing_tensor_data_ptrs_[tar_dim][dim_idx];

--- a/src/Open3D/Container/SizeVector.h
+++ b/src/Open3D/Container/SizeVector.h
@@ -35,44 +35,43 @@
 
 namespace open3d {
 
-/// SizeVector is a vector of size_t, typically used in Tensor shape and strides
-/// Similar design from
-/// https://github.com/NervanaSystems/ngraph/blob/master/src/ngraph/shape.hpp
-class SizeVector : public std::vector<size_t> {
+/// SizeVector is a vector of int64_t, typically used in Tensor shape and
+/// strides. A signed int type is chosen to allow negative strides.
+class SizeVector : public std::vector<int64_t> {
 public:
-    SizeVector(const std::initializer_list<size_t>& dim_sizes)
-        : std::vector<size_t>(dim_sizes) {}
+    SizeVector(const std::initializer_list<int64_t>& dim_sizes)
+        : std::vector<int64_t>(dim_sizes) {}
 
-    SizeVector(const std::vector<size_t>& dim_sizes)
-        : std::vector<size_t>(dim_sizes) {}
+    SizeVector(const std::vector<int64_t>& dim_sizes)
+        : std::vector<int64_t>(dim_sizes) {}
 
-    SizeVector(const SizeVector& other) : std::vector<size_t>(other) {}
+    SizeVector(const SizeVector& other) : std::vector<int64_t>(other) {}
 
-    explicit SizeVector(size_t n, size_t initial_value = 0)
-        : std::vector<size_t>(n, initial_value) {}
+    explicit SizeVector(int64_t n, int64_t initial_value = 0)
+        : std::vector<int64_t>(n, initial_value) {}
 
     template <class InputIterator>
     SizeVector(InputIterator first, InputIterator last)
-        : std::vector<size_t>(first, last) {}
+        : std::vector<int64_t>(first, last) {}
 
     SizeVector() {}
 
     SizeVector& operator=(const SizeVector& v) {
-        static_cast<std::vector<size_t>*>(this)->operator=(v);
+        static_cast<std::vector<int64_t>*>(this)->operator=(v);
         return *this;
     }
 
     SizeVector& operator=(SizeVector&& v) {
-        static_cast<std::vector<size_t>*>(this)->operator=(v);
+        static_cast<std::vector<int64_t>*>(this)->operator=(v);
         return *this;
     }
 
-    size_t NumElements() const {
+    int64_t NumElements() const {
         if (this->size() == 0) {
             return 1;
         }
         return std::accumulate(this->begin(), this->end(), 1,
-                               std::multiplies<size_t>());
+                               std::multiplies<int64_t>());
     }
 
     std::string ToString() const { return fmt::format("{}", *this); }

--- a/src/Open3D/Container/SizeVector.h
+++ b/src/Open3D/Container/SizeVector.h
@@ -36,7 +36,7 @@
 namespace open3d {
 
 /// SizeVector is a vector of int64_t, typically used in Tensor shape and
-/// strides. A signed int type is chosen to allow negative strides.
+/// strides. A signed int64_t type is chosen to allow negative strides.
 class SizeVector : public std::vector<int64_t> {
 public:
     SizeVector(const std::initializer_list<int64_t>& dim_sizes)

--- a/src/Open3D/Container/Tensor.cpp
+++ b/src/Open3D/Container/Tensor.cpp
@@ -185,7 +185,7 @@ std::string Tensor::ScalarPtrToString(const void* ptr) const {
     return str;
 }
 
-Tensor Tensor::operator[](int i) const {
+Tensor Tensor::operator[](int64_t i) const {
     if (shape_.size() == 0) {
         utility::LogError("Tensor has shape (), cannot be indexed.");
     }
@@ -210,7 +210,10 @@ Tensor Tensor::operator[](int i) const {
     return Tensor(new_shape, new_stride, new_data_ptr, dtype_, device_, blob_);
 }
 
-Tensor Tensor::Slice(int64_t dim, int start, int stop, int step) const {
+Tensor Tensor::Slice(int64_t dim,
+                     int64_t start,
+                     int64_t stop,
+                     int64_t step) const {
     if (shape_.size() == 0) {
         utility::LogError("Slice cannot be applied to 0-dim Tensor");
     }

--- a/src/Open3D/Container/Tensor.cpp
+++ b/src/Open3D/Container/Tensor.cpp
@@ -106,7 +106,7 @@ void Tensor::CopyFrom(const Tensor& other) { kernel::Copy(other, *this); }
 Tensor Tensor::Clone(const Device& device) const {
     auto new_blob = std::make_shared<Blob>(blob_->byte_size_, device);
     MemoryManager::MemcpyBlob(new_blob, blob_);
-    size_t data_offset =
+    int64_t data_offset =
             static_cast<char*>(data_ptr_) - static_cast<char*>(blob_->v_);
     void* new_data_ptr = static_cast<char*>(new_blob->v_) + data_offset;
     return Tensor(shape_, strides_, new_data_ptr, dtype_, device, new_blob);
@@ -124,11 +124,11 @@ Tensor Tensor::Contiguous() const {
 
 SizeVector Tensor::DefaultStrides(const SizeVector& shape) {
     SizeVector strides(shape.size());
-    size_t stride_size = 1;
-    for (size_t i = shape.size(); i > 0; --i) {
+    int64_t stride_size = 1;
+    for (int64_t i = shape.size(); i > 0; --i) {
         strides[i - 1] = stride_size;
         // Handles 0-sized dimensions
-        stride_size *= std::max<size_t>(shape[i - 1], 1);
+        stride_size *= std::max<int64_t>(shape[i - 1], 1);
     }
     return strides;
 }
@@ -148,8 +148,8 @@ std::string Tensor::ToString(bool with_suffix,
             const char* ptr = static_cast<const char*>(data_ptr_);
             rc << "[";
             std::string delim = "";
-            size_t element_byte_size = DtypeUtil::ByteSize(dtype_);
-            for (size_t i = 0; i < shape_.NumElements(); ++i) {
+            int64_t element_byte_size = DtypeUtil::ByteSize(dtype_);
+            for (int64_t i = 0; i < shape_.NumElements(); ++i) {
                 rc << delim << ScalarPtrToString(ptr);
                 delim = " ";
                 ptr += element_byte_size;
@@ -159,7 +159,7 @@ std::string Tensor::ToString(bool with_suffix,
             rc << "[";
             std::string delim = "";
             std::string child_indent = "";
-            for (size_t i = 0; i < shape_[0]; ++i) {
+            for (int64_t i = 0; i < shape_[0]; ++i) {
                 rc << delim << child_indent
                    << this->operator[](i).ToString(false, indent + " ");
                 delim = ",\n";
@@ -210,7 +210,7 @@ Tensor Tensor::operator[](int i) const {
     return Tensor(new_shape, new_stride, new_data_ptr, dtype_, device_, blob_);
 }
 
-Tensor Tensor::Slice(size_t dim, int start, int stop, int step) const {
+Tensor Tensor::Slice(int64_t dim, int start, int stop, int step) const {
     if (shape_.size() == 0) {
         utility::LogError("Slice cannot be applied to 0-dim Tensor");
     }

--- a/src/Open3D/Container/Tensor.h
+++ b/src/Open3D/Container/Tensor.h
@@ -169,10 +169,13 @@ public:
                          const std::string& indent = "") const;
 
     /// Extract the i-th Tensor along the first axis, creating a new view
-    Tensor operator[](int i) const;
+    Tensor operator[](int64_t i) const;
 
     /// Slice Tensor
-    Tensor Slice(int64_t dim, int start, int stop, int step = 1) const;
+    Tensor Slice(int64_t dim,
+                 int64_t start,
+                 int64_t stop,
+                 int64_t step = 1) const;
 
     /// \brief Advanced indexing getter
     ///

--- a/src/Open3D/Container/Tensor.h
+++ b/src/Open3D/Container/Tensor.h
@@ -62,7 +62,7 @@ public:
            const Device& device = Device("CPU:0"))
         : Tensor(shape, dtype, device) {
         // Check number of elements
-        if (init_vals.size() != shape_.NumElements()) {
+        if (static_cast<int64_t>(init_vals.size()) != shape_.NumElements()) {
             utility::LogError(
                     "Tensor initialization values' size {} does not match the "
                     "shape {}",

--- a/src/Open3D/Container/Tensor.h
+++ b/src/Open3D/Container/Tensor.h
@@ -172,7 +172,7 @@ public:
     Tensor operator[](int i) const;
 
     /// Slice Tensor
-    Tensor Slice(size_t dim, int start, int stop, int step = 1) const;
+    Tensor Slice(int64_t dim, int start, int stop, int step = 1) const;
 
     /// \brief Advanced indexing getter
     ///
@@ -248,9 +248,9 @@ public:
 
     std::shared_ptr<Blob> GetBlob() const { return blob_; }
 
-    size_t NumElements() const { return shape_.NumElements(); }
+    int64_t NumElements() const { return shape_.NumElements(); }
 
-    size_t NumDims() const { return shape_.size(); }
+    int64_t NumDims() const { return shape_.size(); }
 
     template <typename T>
     void AssertTemplateDtype() const {

--- a/src/UnitTest/Container/Tensor.cpp
+++ b/src/UnitTest/Container/Tensor.cpp
@@ -117,9 +117,9 @@ TEST_P(TensorPermuteDevices, FillFancy) {
 
     // t[:, [1, 2], [1, 2]]
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device)};
 
     t.IndexSet(indices, v);  // We cannot use T.Fill() here
     EXPECT_EQ(t.ToFlatVector<float>(),
@@ -475,9 +475,9 @@ TEST_P(TensorPermuteDevices, IndexGet) {
 
     // t[:, [1, 2], [1, 2]]
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device)};
 
     Tensor t_1 = t.IndexGet(indices);
     EXPECT_TRUE(t_1.IsContiguous());
@@ -494,9 +494,9 @@ TEST_P(TensorPermuteDevices, IndexGetNegative) {
 
     // t[:, [1, -1], [1, -2]]
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1, -1}), {2}, Dtype::Int32, device),
-            Tensor(std::vector<int>({1, -2}), {2}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, -1}), {2}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, -2}), {2}, Dtype::Int64, device)};
 
     Tensor t_1 = t.IndexGet(indices);
     EXPECT_TRUE(t_1.IsContiguous());
@@ -513,9 +513,9 @@ TEST_P(TensorPermuteDevices, IndexGetBroadcast) {
 
     // t[:, [1, 2], [1, 2]] to shape {2, 2}
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device)};
 
     // Broadcast to shape {3, 2, 2}
     SizeVector dst_shape{3, 2, 2};
@@ -538,9 +538,9 @@ TEST_P(TensorPermuteDevices, IndexGetActualBroadcast) {
 
     // t[:, [1, 2], [1, 2]] to shape {2, 2}
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device),
-            Tensor(std::vector<int>({1, 2}), {2}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1, 2}), {2}, Dtype::Int64, device)};
 
     // Broadcast to shape {3, 2, 2}
     SizeVector dst_shape{3, 2, 2};
@@ -569,9 +569,9 @@ TEST_P(TensorPermuteDevices, DISABLED_IndexGetSeparateBySlice) {
 
     // t[[0, 1], :, [0, 1]]
     std::vector<Tensor> indices = {
-            Tensor(std::vector<int>{0, 1}, {2}, Dtype::Int32, device),
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>{0, 1}, {2}, Dtype::Int32, device)};
+            Tensor(std::vector<int64_t>{0, 1}, {2}, Dtype::Int64, device),
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>{0, 1}, {2}, Dtype::Int64, device)};
 
     Tensor t_fancy = t.IndexGet(indices);
     EXPECT_EQ(t_fancy.GetShape(), SizeVector({2, 3}));
@@ -590,9 +590,9 @@ TEST_P(TensorPermuteDevices, IndexSet) {
 
     // t[:, [1], [0, 2, 1]]
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1}), {1}, Dtype::Int32, device),
-            Tensor(std::vector<int>({0, 2, 1}), {3}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1}), {1}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({0, 2, 1}), {3}, Dtype::Int64, device)};
 
     t.IndexSet(indices, rhs);
     EXPECT_EQ(t.ToFlatVector<float>(),
@@ -611,9 +611,9 @@ TEST_P(TensorPermuteDevices, IndexSetBroadcast) {
 
     // t[:, [1], [0, 2, 1]] -> slice {2, 3, 4} to {2, 3}
     std::vector<Tensor> indices = {
-            Tensor(SizeVector(), Dtype::Int32, device),
-            Tensor(std::vector<int>({1}), {1}, Dtype::Int32, device),
-            Tensor(std::vector<int>({0, 2, 1}), {3}, Dtype::Int32, device)};
+            Tensor(SizeVector(), Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({1}), {1}, Dtype::Int64, device),
+            Tensor(std::vector<int64_t>({0, 2, 1}), {3}, Dtype::Int64, device)};
 
     dst_t.IndexSet(indices, src_t);
     EXPECT_EQ(dst_t.ToFlatVector<float>(),


### PR DESCRIPTION
- To support negative stride size and avoid confusion of converting `int`, `size_t`, `int64_t` when doing indexing.
- Unchanged:
    - `MemoryManager`'s `malloc` and etc. still uses `size_t`
    - `device_id`  still uses `int`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1335)
<!-- Reviewable:end -->
