### PR TITLE
Expose get_rotation_matrix_from_* directly in open3d.geometry

### DIFF
--- a/src/Python/open3d_pybind/geometry/geometry.cpp
+++ b/src/Python/open3d_pybind/geometry/geometry.cpp
@@ -33,6 +33,24 @@
 using namespace open3d;
 
 void pybind_geometry_classes(py::module &m) {
+    // open3d.geometry functions
+    m.def("get_rotation_matrix_from_xyz",
+          &geometry::Geometry3D::GetRotationMatrixFromXYZ, "rotation"_a);
+    m.def("get_rotation_matrix_from_yzx",
+          &geometry::Geometry3D::GetRotationMatrixFromYZX, "rotation"_a);
+    m.def("get_rotation_matrix_from_zxy",
+          &geometry::Geometry3D::GetRotationMatrixFromZXY, "rotation"_a);
+    m.def("get_rotation_matrix_from_xzy",
+          &geometry::Geometry3D::GetRotationMatrixFromXZY, "rotation"_a);
+    m.def("get_rotation_matrix_from_zyx",
+          &geometry::Geometry3D::GetRotationMatrixFromZYX, "rotation"_a);
+    m.def("get_rotation_matrix_from_yxz",
+          &geometry::Geometry3D::GetRotationMatrixFromYXZ, "rotation"_a);
+    m.def("get_rotation_matrix_from_axis_angle",
+          &geometry::Geometry3D::GetRotationMatrixFromAxisAngle, "rotation"_a);
+    m.def("get_rotation_matrix_from_quaternion",
+          &geometry::Geometry3D::GetRotationMatrixFromQuaternion, "rotation"_a);
+
     // open3d.geometry.Geometry
     py::class_<geometry::Geometry, PyGeometry<geometry::Geometry>,
                std::shared_ptr<geometry::Geometry>>


### PR DESCRIPTION
Currently, rotation matrices can be computed via instances of `open3d.geometry.Geometry3D`, or via `open3d.geometry.Geometry3D.get_rotation_matrix_from_*`. This PR exposes these functions directly via the module `open3d.geometry`.

Brought up in #1351.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1355)
<!-- Reviewable:end -->
