### PR TITLE
Fix BPA memory leak

### DIFF
--- a/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
+++ b/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
@@ -42,7 +42,7 @@ class BallPivotingVertex;
 class BallPivotingEdge;
 class BallPivotingTriangle;
 
-typedef std::shared_ptr<BallPivotingVertex> BallPivotingVertexPtr;
+typedef BallPivotingVertex* BallPivotingVertexPtr;
 typedef std::shared_ptr<BallPivotingEdge> BallPivotingEdgePtr;
 typedef std::shared_ptr<BallPivotingTriangle> BallPivotingTrianglePtr;
 
@@ -166,8 +166,14 @@ public:
         mesh_->vertex_normals_ = pcd.normals_;
         mesh_->vertex_colors_ = pcd.colors_;
         for (size_t vidx = 0; vidx < pcd.points_.size(); ++vidx) {
-            vertices.emplace_back(std::make_shared<BallPivotingVertex>(
+            vertices.emplace_back(new BallPivotingVertex(
                     vidx, pcd.points_[vidx], pcd.normals_[vidx]));
+        }
+    }
+
+    virtual ~BallPivoting() {
+        for (auto vert : vertices) {
+            delete vert;
         }
     }
 

--- a/src/UnitTest/Utility/Eigen.cpp
+++ b/src/UnitTest/Utility/Eigen.cpp
@@ -184,7 +184,9 @@ TEST(Eigen, ComputeJTJandJTr) {
     ref_JTr << 0.477778, -0.262092, -0.162745, -0.545752, -0.643791, -0.883007;
 
     auto testFunction = [&](int i, Vector6d &J_r, double &r) {
+#ifdef _OPENMP
 #pragma omp critical
+#endif
         {
             vector<double> v(6);
             Rand(v, -1.0, 1.0, i);
@@ -223,7 +225,9 @@ TEST(Eigen, ComputeJTJandJTr_vector) {
     auto testFunction = [&](int i,
                             vector<Vector6d, utility::Vector6d_allocator> &J_r,
                             vector<double> &r) {
+#ifdef _OPENMP
 #pragma omp critical
+#endif
         {
             size_t size = 10;
 


### PR DESCRIPTION
This PR fixes a memory leak in the BPA surface reconstruction caused by cyclic references in shared pointers.
Addesses #1360.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1363)
<!-- Reviewable:end -->
