### PR TITLE
Expose RenderOption.mesh_show_wireframe to Python API

### DIFF
--- a/src/Python/open3d_pybind/visualization/renderoption.cpp
+++ b/src/Python/open3d_pybind/visualization/renderoption.cpp
@@ -84,6 +84,9 @@ void pybind_renderoption(py::module &m) {
                     "mesh_show_back_face",
                     &visualization::RenderOption::mesh_show_back_face_,
                     "bool: Whether to show back faces for ``TriangleMesh``.")
+            .def_readwrite("mesh_show_wireframe",
+                           &visualization::RenderOption::mesh_show_wireframe_,
+                           "bool: Whether to show wireframe for ``TriangleMesh``.")
             .def_readwrite("point_color_option",
                            &visualization::RenderOption::point_color_option_,
                            "``PointColorOption``: Point color option for "

--- a/src/Python/open3d_pybind/visualization/renderoption.cpp
+++ b/src/Python/open3d_pybind/visualization/renderoption.cpp
@@ -84,9 +84,10 @@ void pybind_renderoption(py::module &m) {
                     "mesh_show_back_face",
                     &visualization::RenderOption::mesh_show_back_face_,
                     "bool: Whether to show back faces for ``TriangleMesh``.")
-            .def_readwrite("mesh_show_wireframe",
-                           &visualization::RenderOption::mesh_show_wireframe_,
-                           "bool: Whether to show wireframe for ``TriangleMesh``.")
+            .def_readwrite(
+                    "mesh_show_wireframe",
+                    &visualization::RenderOption::mesh_show_wireframe_,
+                    "bool: Whether to show wireframe for ``TriangleMesh``.")
             .def_readwrite("point_color_option",
                            &visualization::RenderOption::point_color_option_,
                            "``PointColorOption``: Point color option for "


### PR DESCRIPTION
Currently `visualization.RenderOption` exposes `mesh_show_back_face` but does not expose `mesh_show_wireframe`.

This PR simply adds `mesh_show_wireframe` to the Python API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1388)
<!-- Reviewable:end -->
