### PR TITLE
Only update single geometry in Visualizer::AddGeometry and Visualizer::RemoveGeometry

### DIFF
--- a/src/Open3D/Visualization/Shader/GeometryRenderer.h
+++ b/src/Open3D/Visualization/Shader/GeometryRenderer.h
@@ -70,6 +70,11 @@ public:
         return geometry_ptr_;
     }
 
+    bool HasGeometry(
+            std::shared_ptr<const geometry::Geometry> geometry_ptr) const {
+        return geometry_ptr_ == geometry_ptr;
+    }
+
     bool IsVisible() const { return is_visible_; }
     void SetVisible(bool visible) { is_visible_ = visible; };
 

--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -417,11 +417,15 @@ bool Visualizer::ClearGeometries() {
     return UpdateGeometry();
 }
 
-bool Visualizer::UpdateGeometry() {
+bool Visualizer::UpdateGeometry(
+        std::shared_ptr<const geometry::Geometry> geometry_ptr) {
     glfwMakeContextCurrent(window_);
     bool success = true;
     for (const auto &renderer_ptr : geometry_renderer_ptrs_) {
-        success = (success && renderer_ptr->UpdateGeometry());
+        if (geometry_ptr == nullptr ||
+            renderer_ptr->HasGeometry(geometry_ptr)) {
+            success = (success && renderer_ptr->UpdateGeometry());
+        }
     }
     UpdateRender();
     return success;

--- a/src/Open3D/Visualization/Visualizer/Visualizer.h
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.h
@@ -141,7 +141,10 @@ public:
     /// Function to update geometry
     /// This function must be called when geometry has been changed. Otherwise
     /// the behavior of Visualizer is undefined.
-    virtual bool UpdateGeometry();
+    /// If called without an argument, updates all geometries, otherwise only
+    /// updates the geometry specified.
+    virtual bool UpdateGeometry(
+            std::shared_ptr<const geometry::Geometry> geometry_ptr = nullptr);
     virtual bool HasGeometry() const;
 
     /// Function to set the redraw flag as dirty

--- a/src/Python/open3d_pybind/visualization/visualization_trampoline.h
+++ b/src/Python/open3d_pybind/visualization/visualization_trampoline.h
@@ -41,7 +41,8 @@ public:
                      bool reset_bounding_box = true) override {
         PYBIND11_OVERLOAD(bool, VisualizerBase, AddGeometry, geometry_ptr);
     }
-    bool UpdateGeometry() override {
+    bool UpdateGeometry(std::shared_ptr<const geometry::Geometry> geometry_ptr =
+                                nullptr) override {
         PYBIND11_OVERLOAD(bool, VisualizerBase, UpdateGeometry, );
     }
     bool HasGeometry() const override {


### PR DESCRIPTION
This resurrects and improves an old PR #804 

Significant speedups when `AddGeometry` or `RemoveGeometry` is called when there are many other geometries in the scene.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1392)
<!-- Reviewable:end -->
