### PR TITLE
[PointCloudFactory/CreatePointCloud] Add project_valid_depth_only option

### DIFF
--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -239,7 +239,7 @@ public:
             double depth_scale = 1000.0,
             double depth_trunc = 1000.0,
             int stride = 1,
-            bool keep_organized = false);
+            bool project_valid_depth_only = true);
 
     /// Factory function to create a pointcloud from an RGB-D image and a camera
     /// model (PointCloudFactory.cpp)
@@ -248,7 +248,7 @@ public:
             const RGBDImage &image,
             const camera::PinholeCameraIntrinsic &intrinsic,
             const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
-            bool keep_organized = false);
+            bool project_valid_depth_only = true);
 
     /// Function to create a PointCloud from a VoxelGrid.
     /// It transforms the voxel centers to 3D points using the original point

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -238,7 +238,8 @@ public:
             const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
             double depth_scale = 1000.0,
             double depth_trunc = 1000.0,
-            int stride = 1);
+            int stride = 1,
+            bool keep_organized = false);
 
     /// Factory function to create a pointcloud from an RGB-D image and a camera
     /// model (PointCloudFactory.cpp)
@@ -246,7 +247,8 @@ public:
     static std::shared_ptr<PointCloud> CreateFromRGBDImage(
             const RGBDImage &image,
             const camera::PinholeCameraIntrinsic &intrinsic,
-            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity());
+            const Eigen::Matrix4d &extrinsic = Eigen::Matrix4d::Identity(),
+            bool keep_organized = false);
 
     /// Function to create a PointCloud from a VoxelGrid.
     /// It transforms the voxel centers to 3D points using the original point

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -232,6 +232,10 @@ public:
     /// truncated at depth_trunc distance. The depth image is also sampled with
     /// stride, in order to support (fast) coarse point cloud extraction. Return
     /// an empty pointcloud if the conversion fails.
+    /// If \param project_valid_depth_only is true, return point cloud, which
+    /// doesn't
+    /// have nan point. If the value is false, return point cloud, which has
+    /// whole points.
     static std::shared_ptr<PointCloud> CreateFromDepthImage(
             const Image &depth,
             const camera::PinholeCameraIntrinsic &intrinsic,
@@ -244,6 +248,10 @@ public:
     /// Factory function to create a pointcloud from an RGB-D image and a camera
     /// model (PointCloudFactory.cpp)
     /// Return an empty pointcloud if the conversion fails.
+    /// If \param project_valid_depth_only is true, return point cloud, which
+    /// doesn't
+    /// have nan point. If the value is false, return point cloud, which has
+    /// whole points.
     static std::shared_ptr<PointCloud> CreateFromRGBDImage(
             const RGBDImage &image,
             const camera::PinholeCameraIntrinsic &intrinsic,

--- a/src/Open3D/Geometry/PointCloud.h
+++ b/src/Open3D/Geometry/PointCloud.h
@@ -235,7 +235,7 @@ public:
     /// If \param project_valid_depth_only is true, return point cloud, which
     /// doesn't
     /// have nan point. If the value is false, return point cloud, which has
-    /// whole points.
+    /// a point for each pixel, whereas invalid depth results in NaN points.
     static std::shared_ptr<PointCloud> CreateFromDepthImage(
             const Image &depth,
             const camera::PinholeCameraIntrinsic &intrinsic,
@@ -251,7 +251,7 @@ public:
     /// If \param project_valid_depth_only is true, return point cloud, which
     /// doesn't
     /// have nan point. If the value is false, return point cloud, which has
-    /// whole points.
+    /// a point for each pixel, whereas invalid depth results in NaN points.
     static std::shared_ptr<PointCloud> CreateFromRGBDImage(
             const RGBDImage &image,
             const camera::PinholeCameraIntrinsic &intrinsic,

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -55,13 +55,13 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic,
         int stride,
-        bool keep_organized) {
+        bool project_valid_depth_only) {
     auto pointcloud = std::make_shared<PointCloud>();
     Eigen::Matrix4d camera_pose = extrinsic.inverse();
     auto focal_length = intrinsic.GetFocalLength();
     auto principal_point = intrinsic.GetPrincipalPoint();
     int num_valid_pixels;
-    if (keep_organized) {
+    if (!project_valid_depth_only) {
         num_valid_pixels =
                 int(depth.height_ / stride) * int(depth.width_ / stride);
     } else {
@@ -80,12 +80,11 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
                 Eigen::Vector4d point =
                         camera_pose * Eigen::Vector4d(x, y, z, 1.0);
                 pointcloud->points_[cnt++] = point.block<3, 1>(0, 0);
-            } else {
+            } else if (!project_valid_depth_only) {
                 double z = std::numeric_limits<float>::quiet_NaN();
                 double x = std::numeric_limits<float>::quiet_NaN();
                 double y = std::numeric_limits<float>::quiet_NaN();
-                Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
-                pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
+                pointcloud->points_[cnt++] = Eigen::Vector3d(x, y, z);
             }
         }
     }
@@ -97,14 +96,14 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
         const RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic,
-        bool keep_organized = false) {
+        bool project_valid_depth_only) {
     auto pointcloud = std::make_shared<PointCloud>();
     Eigen::Matrix4d camera_pose = extrinsic.inverse();
     auto focal_length = intrinsic.GetFocalLength();
     auto principal_point = intrinsic.GetPrincipalPoint();
     double scale = (sizeof(TC) == 1) ? 255.0 : 1.0;
     int num_valid_pixels;
-    if (keep_organized) {
+    if (!project_valid_depth_only) {
         num_valid_pixels = image.depth_.height_ * image.depth_.width_;
     } else {
         num_valid_pixels = CountValidDepthPixels(image.depth_, 1);
@@ -129,12 +128,11 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
                 pointcloud->colors_[cnt++] =
                         Eigen::Vector3d(pc[0], pc[(NC - 1) / 2], pc[NC - 1]) /
                         scale;
-            } else {
+            } else if (!project_valid_depth_only) {
                 double z = std::numeric_limits<float>::quiet_NaN();
                 double x = std::numeric_limits<float>::quiet_NaN();
                 double y = std::numeric_limits<float>::quiet_NaN();
-                Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
-                pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
+                pointcloud->points_[cnt] = Eigen::Vector3d(x, y, z);
                 pointcloud->colors_[cnt++] =
                         Eigen::Vector3d(std::numeric_limits<TC>::quiet_NaN(),
                                         std::numeric_limits<TC>::quiet_NaN(),
@@ -155,16 +153,18 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
         double depth_scale /* = 1000.0*/,
         double depth_trunc /* = 1000.0*/,
         int stride /* = 1*/,
-        bool keep_organized) {
+        bool project_valid_depth_only) {
     if (depth.num_of_channels_ == 1) {
         if (depth.bytes_per_channel_ == 2) {
             auto float_depth =
                     depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
             return CreatePointCloudFromFloatDepthImage(
-                    *float_depth, intrinsic, extrinsic, stride, keep_organized);
+                    *float_depth, intrinsic, extrinsic, stride,
+                    project_valid_depth_only);
         } else if (depth.bytes_per_channel_ == 4) {
             return CreatePointCloudFromFloatDepthImage(
-                    depth, intrinsic, extrinsic, stride, keep_organized);
+                    depth, intrinsic, extrinsic, stride,
+                    project_valid_depth_only);
         }
     }
     utility::LogError(
@@ -176,17 +176,17 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
         const RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic /* = Eigen::Matrix4d::Identity()*/,
-        bool keep_organized) {
+        bool project_valid_depth_only) {
     if (image.depth_.num_of_channels_ == 1 &&
         image.depth_.bytes_per_channel_ == 4) {
         if (image.color_.bytes_per_channel_ == 1 &&
             image.color_.num_of_channels_ == 3) {
             return CreatePointCloudFromRGBDImageT<uint8_t, 3>(
-                    image, intrinsic, extrinsic, keep_organized);
+                    image, intrinsic, extrinsic, project_valid_depth_only);
         } else if (image.color_.bytes_per_channel_ == 4 &&
                    image.color_.num_of_channels_ == 1) {
             return CreatePointCloudFromRGBDImageT<float, 1>(
-                    image, intrinsic, extrinsic, keep_organized);
+                    image, intrinsic, extrinsic, project_valid_depth_only);
         }
     }
     utility::LogError(

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include <Eigen/Dense>
+#include <limits>
 
 #include "Open3D/Camera/PinholeCameraIntrinsic.h"
 #include "Open3D/Geometry/Image.h"
@@ -78,6 +79,12 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
                 Eigen::Vector4d point =
                         camera_pose * Eigen::Vector4d(x, y, z, 1.0);
                 pointcloud->points_[cnt++] = point.block<3, 1>(0, 0);
+            } else {
+              double z = std::numeric_limits<float>::quiet_NaN();
+              double x = std::numeric_limits<float>::quiet_NaN();
+              double y = std::numeric_limits<float>::quiet_NaN();
+              Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
+              pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
             }
         }
     }
@@ -121,6 +128,16 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
                 pointcloud->colors_[cnt++] =
                         Eigen::Vector3d(pc[0], pc[(NC - 1) / 2], pc[NC - 1]) /
                         scale;
+            } else {
+              double z = std::numeric_limits<float>::quiet_NaN();
+              double x = std::numeric_limits<float>::quiet_NaN();
+              double y = std::numeric_limits<float>::quiet_NaN();
+              Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
+              pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
+              pointcloud->colors_[cnt++] =
+                Eigen::Vector3d(std::numeric_limits<TC>::quiet_NaN(),
+                                std::numeric_limits<TC>::quiet_NaN(),
+                                std::numeric_limits<TC>::quiet_NaN());
             }
         }
     }

--- a/src/Open3D/Geometry/PointCloudFactory.cpp
+++ b/src/Open3D/Geometry/PointCloudFactory.cpp
@@ -62,9 +62,10 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
     auto principal_point = intrinsic.GetPrincipalPoint();
     int num_valid_pixels;
     if (keep_organized) {
-      num_valid_pixels = int(depth.height_ / stride) * int(depth.width_ / stride);
+        num_valid_pixels =
+                int(depth.height_ / stride) * int(depth.width_ / stride);
     } else {
-      num_valid_pixels = CountValidDepthPixels(depth, stride);
+        num_valid_pixels = CountValidDepthPixels(depth, stride);
     }
     pointcloud->points_.resize(num_valid_pixels);
     int cnt = 0;
@@ -80,11 +81,11 @@ std::shared_ptr<PointCloud> CreatePointCloudFromFloatDepthImage(
                         camera_pose * Eigen::Vector4d(x, y, z, 1.0);
                 pointcloud->points_[cnt++] = point.block<3, 1>(0, 0);
             } else {
-              double z = std::numeric_limits<float>::quiet_NaN();
-              double x = std::numeric_limits<float>::quiet_NaN();
-              double y = std::numeric_limits<float>::quiet_NaN();
-              Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
-              pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
+                double z = std::numeric_limits<float>::quiet_NaN();
+                double x = std::numeric_limits<float>::quiet_NaN();
+                double y = std::numeric_limits<float>::quiet_NaN();
+                Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
+                pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
             }
         }
     }
@@ -96,7 +97,7 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
         const RGBDImage &image,
         const camera::PinholeCameraIntrinsic &intrinsic,
         const Eigen::Matrix4d &extrinsic,
-        bool keep_organized=false) {
+        bool keep_organized = false) {
     auto pointcloud = std::make_shared<PointCloud>();
     Eigen::Matrix4d camera_pose = extrinsic.inverse();
     auto focal_length = intrinsic.GetFocalLength();
@@ -104,9 +105,9 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
     double scale = (sizeof(TC) == 1) ? 255.0 : 1.0;
     int num_valid_pixels;
     if (keep_organized) {
-      num_valid_pixels = image.depth_.height_ * image.depth_.width_;
+        num_valid_pixels = image.depth_.height_ * image.depth_.width_;
     } else {
-      num_valid_pixels = CountValidDepthPixels(image.depth_, 1);
+        num_valid_pixels = CountValidDepthPixels(image.depth_, 1);
     }
     pointcloud->points_.resize(num_valid_pixels);
     pointcloud->colors_.resize(num_valid_pixels);
@@ -129,15 +130,15 @@ std::shared_ptr<PointCloud> CreatePointCloudFromRGBDImageT(
                         Eigen::Vector3d(pc[0], pc[(NC - 1) / 2], pc[NC - 1]) /
                         scale;
             } else {
-              double z = std::numeric_limits<float>::quiet_NaN();
-              double x = std::numeric_limits<float>::quiet_NaN();
-              double y = std::numeric_limits<float>::quiet_NaN();
-              Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
-              pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
-              pointcloud->colors_[cnt++] =
-                Eigen::Vector3d(std::numeric_limits<TC>::quiet_NaN(),
-                                std::numeric_limits<TC>::quiet_NaN(),
-                                std::numeric_limits<TC>::quiet_NaN());
+                double z = std::numeric_limits<float>::quiet_NaN();
+                double x = std::numeric_limits<float>::quiet_NaN();
+                double y = std::numeric_limits<float>::quiet_NaN();
+                Eigen::Vector4d point = Eigen::Vector4d(x, y, z, 1.0);
+                pointcloud->points_[cnt] = point.block<3, 1>(0, 0);
+                pointcloud->colors_[cnt++] =
+                        Eigen::Vector3d(std::numeric_limits<TC>::quiet_NaN(),
+                                        std::numeric_limits<TC>::quiet_NaN(),
+                                        std::numeric_limits<TC>::quiet_NaN());
             }
         }
     }
@@ -159,13 +160,11 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromDepthImage(
         if (depth.bytes_per_channel_ == 2) {
             auto float_depth =
                     depth.ConvertDepthToFloatImage(depth_scale, depth_trunc);
-            return CreatePointCloudFromFloatDepthImage(*float_depth, intrinsic,
-                                                       extrinsic, stride,
-                                                       keep_organized);
+            return CreatePointCloudFromFloatDepthImage(
+                    *float_depth, intrinsic, extrinsic, stride, keep_organized);
         } else if (depth.bytes_per_channel_ == 4) {
-            return CreatePointCloudFromFloatDepthImage(depth, intrinsic,
-                                                       extrinsic, stride,
-                                                       keep_organized);
+            return CreatePointCloudFromFloatDepthImage(
+                    depth, intrinsic, extrinsic, stride, keep_organized);
         }
     }
     utility::LogError(
@@ -182,14 +181,12 @@ std::shared_ptr<PointCloud> PointCloud::CreateFromRGBDImage(
         image.depth_.bytes_per_channel_ == 4) {
         if (image.color_.bytes_per_channel_ == 1 &&
             image.color_.num_of_channels_ == 3) {
-            return CreatePointCloudFromRGBDImageT<uint8_t, 3>(image, intrinsic,
-                                                              extrinsic,
-                                                              keep_organized);
+            return CreatePointCloudFromRGBDImageT<uint8_t, 3>(
+                    image, intrinsic, extrinsic, keep_organized);
         } else if (image.color_.bytes_per_channel_ == 4 &&
                    image.color_.num_of_channels_ == 1) {
-            return CreatePointCloudFromRGBDImageT<float, 1>(image, intrinsic,
-                                                            extrinsic,
-                                                            keep_organized);
+            return CreatePointCloudFromRGBDImageT<float, 1>(
+                    image, intrinsic, extrinsic, keep_organized);
         }
     }
     utility::LogError(

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -190,8 +190,7 @@ void pybind_pointcloud(py::module &m) {
                     "depth"_a, "intrinsic"_a,
                     "extrinsic"_a = Eigen::Matrix4d::Identity(),
                     "depth_scale"_a = 1000.0, "depth_trunc"_a = 1000.0,
-                    "stride"_a = 1,
-                    "keep_organized"_a = false)
+                    "stride"_a = 1, "keep_organized"_a = false)
             .def_static(
                     "create_from_rgbd_image",
                     &geometry::PointCloud::CreateFromRGBDImage,

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -308,8 +308,22 @@ void pybind_pointcloud(py::module &m) {
               "Number of initial points to be considered inliers in each "
               "iteration."},
              {"num_iterations", "Number of iterations."}});
-    docstring::ClassMethodDocInject(m, "PointCloud", "create_from_depth_image");
-    docstring::ClassMethodDocInject(m, "PointCloud", "create_from_rgbd_image");
+    docstring::ClassMethodDocInject(
+            m, "PointCloud", "create_from_depth_image",
+            {
+                    {"project_valid_depth_only",
+                     "If this value is True, return point cloud, which doesn't "
+                     "have nan point. If this value is False, return point "
+                     "cloud, which has whole points"},
+            });
+    docstring::ClassMethodDocInject(
+            m, "PointCloud", "create_from_rgbd_image",
+            {
+                    {"project_valid_depth_only",
+                     "If this value is True, return point cloud, which doesn't "
+                     "have nan point. If this value is False, return point "
+                     "cloud, which has whole points"},
+            });
 }
 
 void pybind_pointcloud_methods(py::module &m) {}

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -190,7 +190,8 @@ void pybind_pointcloud(py::module &m) {
                     "depth"_a, "intrinsic"_a,
                     "extrinsic"_a = Eigen::Matrix4d::Identity(),
                     "depth_scale"_a = 1000.0, "depth_trunc"_a = 1000.0,
-                    "stride"_a = 1)
+                    "stride"_a = 1,
+                    "keep_organized"_a = false)
             .def_static(
                     "create_from_rgbd_image",
                     &geometry::PointCloud::CreateFromRGBDImage,
@@ -203,7 +204,8 @@ void pybind_pointcloud(py::module &m) {
               - y = (v - cy) * z / fy
         )",
                     "image"_a, "intrinsic"_a,
-                    "extrinsic"_a = Eigen::Matrix4d::Identity())
+                    "extrinsic"_a = Eigen::Matrix4d::Identity(),
+                    "keep_organized"_a = false)
             .def_readwrite("points", &geometry::PointCloud::points_,
                            "``float64`` array of shape ``(num_points, 3)``, "
                            "use ``numpy.asarray()`` to access data: Points "

--- a/src/Python/open3d_pybind/geometry/pointcloud.cpp
+++ b/src/Python/open3d_pybind/geometry/pointcloud.cpp
@@ -190,7 +190,7 @@ void pybind_pointcloud(py::module &m) {
                     "depth"_a, "intrinsic"_a,
                     "extrinsic"_a = Eigen::Matrix4d::Identity(),
                     "depth_scale"_a = 1000.0, "depth_trunc"_a = 1000.0,
-                    "stride"_a = 1, "keep_organized"_a = false)
+                    "stride"_a = 1, "project_valid_depth_only"_a = true)
             .def_static(
                     "create_from_rgbd_image",
                     &geometry::PointCloud::CreateFromRGBDImage,
@@ -204,7 +204,7 @@ void pybind_pointcloud(py::module &m) {
         )",
                     "image"_a, "intrinsic"_a,
                     "extrinsic"_a = Eigen::Matrix4d::Identity(),
-                    "keep_organized"_a = false)
+                    "project_valid_depth_only"_a = true)
             .def_readwrite("points", &geometry::PointCloud::points_,
                            "``float64`` array of shape ``(num_points, 3)``, "
                            "use ``numpy.asarray()`` to access data: Points "


### PR DESCRIPTION
Related to the following issue https://github.com/intel-isl/Open3D/issues/647
This PR enables an option `keep_organized` to maintain whole point cloud's points.

```
import open3d as o3d
import matplotlib.pyplot as plt
import numpy as np

color_raw = o3d.io.read_image(
    "../../TestData/RGBD/other_formats/SUN_color.jpg")
depth_raw = o3d.io.read_image(
    "../../TestData/RGBD/other_formats/SUN_depth.png")
rgbd_image = o3d.geometry.RGBDImage.create_from_sun_format(
    color_raw, depth_raw)
pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
    rgbd_image,
    o3d.camera.PinholeCameraIntrinsic(
        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault),
    keep_organized=False)
print(len(pcd.points))
# => 236957
pcd = o3d.geometry.PointCloud.create_from_rgbd_image(
    rgbd_image,
    o3d.camera.PinholeCameraIntrinsic(
        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault),
    keep_organized=True)
print(len(pcd.points))
# => 307200
np_img = np.array(color_raw)
print(np_img.shape[0] * np_img.shape[1])
# => 307200
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1402)
<!-- Reviewable:end -->
