### PR TITLE
Fix brew link problem for python/tbb on OSX for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ matrix:
       osx_image: xcode10.1
       before_install:
         - brew update
-        - brew install python || true
+        - brew upgrade python || true
         - ./util/scripts/install-deps-osx.sh
       script: travis_wait 30 ./util/scripts/run-travis.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,8 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       before_install:
+        - brew update
+        - brew install python || true
         - ./util/scripts/install-deps-osx.sh
       script: travis_wait 30 ./util/scripts/run-travis.sh
 


### PR DESCRIPTION
The brew formula for tbb changed and now depends on python which in turn cannot be installed on the travis osx without error.
Install python beforehand as a workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1440)
<!-- Reviewable:end -->
