### PR TITLE
upgrade versions.js for 0.9

### DIFF
--- a/docs/versions.js
+++ b/docs/versions.js
@@ -18,8 +18,12 @@ document.write('\
             <td><a href="http://www.open3d.org/docs/latest/cpp_api">latest C++</a></td>\
         </tr>\
         <tr>\
-            <td><a href="http://www.open3d.org/docs/release">0.8.0</a></td>\
-            <td><a href="http://www.open3d.org/docs/release/cpp_api">0.8.0 C++</a></td>\
+            <td><a href="http://www.open3d.org/docs/release">0.9.0</a></td>\
+            <td><a href="http://www.open3d.org/docs/release/cpp_api">0.9.0 C++</a></td>\
+        </tr>\
+        <tr>\
+            <td><a href="http://www.open3d.org/docs/0.8.0">0.8.0</a></td>\
+            <td><a href="http://www.open3d.org/docs/0.8.0/cpp_api">0.8.0 C++</a></td>\
         </tr>\
         <tr>\
             <td><a href="http://www.open3d.org/docs/0.7.0">0.7.0</a></td>\


### PR DESCRIPTION
Also the 0.9.0 docs has been pushed manually to the server.
Now http://open3d.org/docs/release/ shall point to 0.9.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1446)
<!-- Reviewable:end -->
