### PR TITLE
Some cameras are flipped (in the z-axis) in ViewControl::ConvertFromPinholeCameraParameters

### DIFF
--- a/src/Open3D/Visualization/Visualizer/ViewControl.cpp
+++ b/src/Open3D/Visualization/Visualizer/ViewControl.cpp
@@ -201,7 +201,9 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
     front_ = -extrinsic.block<1, 3>(2, 0).transpose();
     eye_ = extrinsic.block<3, 3>(0, 0).inverse() *
            (extrinsic.block<3, 1>(0, 3) * -1.0);
-    double ideal_distance = (eye_ - bounding_box_.GetCenter()).dot(front_);
+
+    auto bb_center = bounding_box_.GetCenter();
+    double ideal_distance = std::abs((eye_ - bb_center).dot(front_));
     double ideal_zoom = ideal_distance *
                         std::tan(field_of_view_ * 0.5 / 180.0 * M_PI) /
                         bounding_box_.GetMaxExtent();


### PR DESCRIPTION
Some cameras are flipped (in the z-axis) when the bounding_box center of the scene is not visible (i.e. center is behind the camera). This situation could happen when you are in an indoor scene, for instance, and looking at the walls instead of towards the center of the room.

The fix is simple, basically adding a absolute value to the result of the dot product (projection to the 'front_' vector).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1447)
<!-- Reviewable:end -->
