### PR TITLE
Avoid cstdlib random generators in ransac for global registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated travis.yml to support Ubuntu 18.04, gcc-7, and clang-7.0
 * Contributors guidelines updated
+* Avoid cstdlib random generators in ransac registration, use C++11 random instead.
 
 ## 0.9.0
 

--- a/src/Open3D/Registration/FastGlobalRegistration.cpp
+++ b/src/Open3D/Registration/FastGlobalRegistration.cpp
@@ -26,14 +26,12 @@
 
 #include "Open3D/Registration/FastGlobalRegistration.h"
 
-#include <random>
-
 #include "Open3D/Geometry/KDTreeFlann.h"
 #include "Open3D/Geometry/PointCloud.h"
 #include "Open3D/Registration/Feature.h"
 #include "Open3D/Registration/Registration.h"
 #include "Open3D/Utility/Console.h"
-#include "Open3D/Utility/Eigen.h"
+#include "Open3D/Utility/Helper.h"
 
 namespace open3d {
 
@@ -128,14 +126,11 @@ std::vector<std::pair<int, int>> AdvancedMatching(
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
 
-    std::mt19937 rgen(std::random_device{}());
-    std::uniform_int_distribution<int> uniform_dist(0, ncorr - 1);
-
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
-        rand0 = uniform_dist(rgen);
-        rand1 = uniform_dist(rgen);
-        rand2 = uniform_dist(rgen);
+        rand0 = utility::UniformRandInt(0, ncorr - 1);
+        rand1 = utility::UniformRandInt(0, ncorr - 1);
+        rand2 = utility::UniformRandInt(0, ncorr - 1);
         idi0 = corres_cross[rand0].first;
         idj0 = corres_cross[rand0].second;
         idi1 = corres_cross[rand1].first;

--- a/src/Open3D/Registration/FastGlobalRegistration.cpp
+++ b/src/Open3D/Registration/FastGlobalRegistration.cpp
@@ -26,7 +26,7 @@
 
 #include "Open3D/Registration/FastGlobalRegistration.h"
 
-#include <ctime>
+#include <random>
 
 #include "Open3D/Geometry/KDTreeFlann.h"
 #include "Open3D/Geometry/PointCloud.h"
@@ -122,17 +122,20 @@ std::vector<std::pair<int, int>> AdvancedMatching(
 
     // STEP 3) TUPLE CONSTRAINT
     utility::LogDebug("\t[tuple constraint] ");
-    std::srand((unsigned int)std::time(0));
     int rand0, rand1, rand2, i, cnt = 0;
     int idi0, idi1, idi2, idj0, idj1, idj2;
     double scale = option.tuple_scale_;
     int ncorr = static_cast<int>(corres_cross.size());
     int number_of_trial = ncorr * 100;
+
+    std::mt19937 rgen(std::random_device{}());
+    std::uniform_int_distribution<int> uniform_dist(0, ncorr - 1);
+
     std::vector<std::pair<int, int>> corres_tuple;
     for (i = 0; i < number_of_trial; i++) {
-        rand0 = rand() % ncorr;
-        rand1 = rand() % ncorr;
-        rand2 = rand() % ncorr;
+        rand0 = uniform_dist(rgen);
+        rand1 = uniform_dist(rgen);
+        rand2 = uniform_dist(rgen);
         idi0 = corres_cross[rand0].first;
         idj0 = corres_cross[rand0].second;
         idi1 = corres_cross[rand1].first;

--- a/src/Open3D/Utility/Helper.cpp
+++ b/src/Open3D/Utility/Helper.cpp
@@ -27,6 +27,7 @@
 #include "Open3D/Utility/Helper.h"
 
 #include <cctype>
+#include <random>
 #include <unordered_set>
 
 #ifdef _WIN32
@@ -95,6 +96,12 @@ void Sleep(int milliseconds) {
 #else
     usleep(milliseconds * 1000);
 #endif  // _WIN32
+}
+
+int UniformRandInt(const int min, const int max) {
+    static thread_local std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<int> distribution(min, max);
+    return distribution(generator);
 }
 
 }  // namespace utility

--- a/src/Open3D/Utility/Helper.h
+++ b/src/Open3D/Utility/Helper.h
@@ -128,5 +128,10 @@ std::string& StripString(std::string& str,
 
 void Sleep(int milliseconds);
 
+/// Thread-safe function returning a pseudo-random integer.
+/// The integer is drawn from a uniform distribution bounded by min and max
+/// (inclusive)
+int UniformRandInt(const int min, const int max);
+
 }  // namespace utility
 }  // namespace open3d


### PR DESCRIPTION
This PR follows up on https://github.com/intel-isl/Open3D/issues/359 and mostly cherry picks from https://github.com/syncle/open3d/tree/uniform_real_distribution

**What's done here**
Rely on C++11 random generators instead of `std::srand` and `std::rand` in global registration.

**Context**
cstdlib random generators can have severe limitations in some implementations, and are awkward to use in multithreaded code. I have not observed changes in ransac stability related to this change, as suggested instead in the thread mentioned above, but this may well depend on the specific platform I am on.

~On the other hand, I observed an important performance gain by switching to the C++11 random generator, and this is the main reason for opening this PR. The performance gain is probably related to the removal of `#pragma omp critical`, allowed by defining the random generator as `thread_local`.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1486)
<!-- Reviewable:end -->
