### PR TITLE
change of prefix sum format to row splits

### DIFF
--- a/src/Open3D/ML/Misc/Detail/ReduceSubarraysSum.h
+++ b/src/Open3D/ML/Misc/Detail/ReduceSubarraysSum.h
@@ -37,27 +37,25 @@ namespace detail {
 ///
 /// \param values          The linear array with all values
 /// \param values_size     Number of elements of \p values
-/// \param prefix_sum      The exclusive prefix sum of the number of elements
-///                        for each array
-/// \param prefix_sum_size The number of subarrays
+/// \param row_splits      Defines the start and end of each subarray. This is
+///                        an exclusive prefix sum with 0 as the first element
+///                        and the length of \p values as last element.
+///                        The size is \p num_arrays + 1
+/// \param num_arrays      The number of subarrays
 /// \param out_sums        The preallocated output array with size
-///                        \p prefix_sum_size
+///                        \p num_arrays
 template <class T>
 void ReduceSubarraysSumCPU(const T* const values,
                            const size_t values_size,
-                           const int64_t* const prefix_sum,
-                           const size_t prefix_sum_size,
+                           const int64_t* const row_splits,
+                           const size_t num_arrays,
                            T* out_sums) {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, prefix_sum_size),
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, num_arrays),
                       [&](const tbb::blocked_range<size_t>& r) {
 
                           for (size_t i = r.begin(); i != r.end(); ++i) {
-                              size_t begin_idx = prefix_sum[i];
-                              // use values_size as end_idx for the last
-                              // subarray
-                              size_t end_idx = (i + 1 < prefix_sum_size
-                                                        ? prefix_sum[i + 1]
-                                                        : values_size);
+                              size_t begin_idx = row_splits[i];
+                              size_t end_idx = row_splits[i + 1];
 
                               T sum = T(0);
                               for (size_t j = begin_idx; j < end_idx; ++j) {

--- a/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.cpp
@@ -43,11 +43,11 @@ public:
                 const tensorflow::Tensor& queries,
                 const tensorflow::Tensor& radius,
                 const size_t hash_table_size,
-                tensorflow::Tensor& query_neighbors_prefix_sum) {
+                tensorflow::Tensor& query_neighbors_row_splits) {
         OutputAllocator<T> output_allocator(context);
 
         FixedRadiusSearchCPU(
-                (int64_t*)query_neighbors_prefix_sum.flat<int64>().data(),
+                (int64_t*)query_neighbors_row_splits.flat<int64>().data(),
                 points.shape().dim_size(0), points.flat<T>().data(),
                 queries.shape().dim_size(0), queries.flat<T>().data(),
                 radius.scalar<T>()(), hash_table_size, metric,

--- a/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.cu
+++ b/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.cu
@@ -48,7 +48,7 @@ public:
                 const tensorflow::Tensor& queries,
                 const tensorflow::Tensor& radius,
                 const size_t hash_table_size,
-                tensorflow::Tensor& query_neighbors_prefix_sum) {
+                tensorflow::Tensor& query_neighbors_row_splits) {
         auto device = context->eigen_gpu_device();
 
         OutputAllocator<T> output_allocator(context);
@@ -59,7 +59,7 @@ public:
         // determine temp_size
         FixedRadiusSearchCUDA(
                 device.stream(), temp_ptr, temp_size, texture_alignment,
-                (int64_t*)query_neighbors_prefix_sum.flat<int64>().data(),
+                (int64_t*)query_neighbors_row_splits.flat<int64>().data(),
                 points.shape().dim_size(0), points.flat<T>().data(),
                 queries.shape().dim_size(0), queries.flat<T>().data(),
                 radius.scalar<T>()(), hash_table_size, metric,
@@ -75,7 +75,7 @@ public:
         // actually run the search
         FixedRadiusSearchCUDA(
                 device.stream(), temp_ptr, temp_size, texture_alignment,
-                (int64_t*)query_neighbors_prefix_sum.flat<int64>().data(),
+                (int64_t*)query_neighbors_row_splits.flat<int64>().data(),
                 points.shape().dim_size(0), points.flat<T>().data(),
                 queries.shape().dim_size(0), queries.flat<T>().data(),
                 radius.scalar<T>()(), hash_table_size, metric,

--- a/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.h
+++ b/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOpKernel.h
@@ -123,12 +123,12 @@ public:
                         hash_table_size_factor * points.shape().dim_size(0), 1),
                 max_hash_table_size);
 
-        Tensor* query_neighbors_prefix_sum = 0;
-        TensorShape query_neighbors_prefix_sum_shape(
-                {queries.shape().dim_size(0)});
+        Tensor* query_neighbors_row_splits = 0;
+        TensorShape query_neighbors_row_splits_shape(
+                {queries.shape().dim_size(0) + 1});
         OP_REQUIRES_OK(context, context->allocate_output(
-                                        1, query_neighbors_prefix_sum_shape,
-                                        &query_neighbors_prefix_sum));
+                                        1, query_neighbors_row_splits_shape,
+                                        &query_neighbors_row_splits));
 
         Tensor hash_table;
         TensorShape hash_table_shape({ssize_t(hash_table_size)});
@@ -137,7 +137,7 @@ public:
                                               hash_table_shape, &hash_table));
 
         Kernel(context, points, queries, radius, hash_table_size,
-               *query_neighbors_prefix_sum);
+               *query_neighbors_row_splits);
     }
 
     virtual void Kernel(tensorflow::OpKernelContext* context,
@@ -145,7 +145,7 @@ public:
                         const tensorflow::Tensor& queries,
                         const tensorflow::Tensor& radius,
                         const size_t hash_table_size,
-                        tensorflow::Tensor& query_neighbors_prefix_sum) = 0;
+                        tensorflow::Tensor& query_neighbors_row_splits) = 0;
 
 protected:
     open3d::ml::detail::Metric metric;

--- a/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOps.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/FixedRadiusSearchOps.cpp
@@ -42,13 +42,13 @@ REGISTER_OP("Open3DFixedRadiusSearch")
         .Input("radius: T")
         .Input("hash_table_size_factor: double")
         .Output("neighbors_index: int32")
-        .Output("neighbors_prefix_sum: int64")
+        .Output("neighbors_row_splits: int64")
         .Output("neighbors_distance: T")
         .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
             using namespace ::tensorflow::shape_inference;
             ShapeHandle points_shape, queries_shape, radius_shape,
                     hash_table_size_factor_shape, indices_shape,
-                    neighbors_prefix_sum_shape, neighbors_distance_shape;
+                    neighbors_row_splits_shape, neighbors_distance_shape;
 
             TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &points_shape));
             TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 2, &queries_shape));
@@ -76,8 +76,12 @@ REGISTER_OP("Open3DFixedRadiusSearch")
             indices_shape = c->MakeShape({c->UnknownDim()});
             c->set_output(0, indices_shape);
 
-            neighbors_prefix_sum_shape = c->MakeShape({num_query_points});
-            c->set_output(1, neighbors_prefix_sum_shape);
+            DimensionHandle neighbors_row_splits_size;
+            TF_RETURN_IF_ERROR(
+                    c->Add(num_query_points, 1, &neighbors_row_splits_size));
+            neighbors_row_splits_shape =
+                    c->MakeShape({neighbors_row_splits_size});
+            c->set_output(1, neighbors_row_splits_shape);
 
             bool return_distances;
             TF_RETURN_IF_ERROR(
@@ -126,10 +130,12 @@ hash_table_size_factor:
 
 neighbors_index:
   The compact list of indices of the neighbors. The corresponding query point 
-  can be inferred from the 'neighbor_count_prefix_sum' vector.
+  can be inferred from the 'neighbor_count_row_splits' vector.
 
-neighbors_prefix_sum:
-  The exclusive prefix sum of the neighbor count for the query points.
+neighbors_row_splits:
+  The exclusive prefix sum of the neighbor count for the query points including
+  the total neighbor count as the last element. The size of this array is the 
+  number of queries + 1.
 
 neighbors_distance:
   Stores the distance to each neighbor if 'return_distances' is True.

--- a/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.cpp
@@ -39,25 +39,25 @@ public:
 
     void Kernel(tensorflow::OpKernelContext* context,
                 const tensorflow::Tensor& inp_neighbors_index,
-                const tensorflow::Tensor& inp_neighbors_prefix_sum,
+                const tensorflow::Tensor& inp_neighbors_row_splits,
                 const tensorflow::Tensor& inp_neighbors_attributes,
                 const int num_attributes,
                 tensorflow::Tensor& neighbors_index,
-                tensorflow::Tensor& neighbors_prefix_sum,
+                tensorflow::Tensor& neighbors_row_splits,
                 tensorflow::Tensor& neighbors_attributes) {
         InvertNeighborsListCPU(
                 inp_neighbors_index.flat<TIndex>().data(),
                 num_attributes ? inp_neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 num_attributes,
-                (int64_t*)inp_neighbors_prefix_sum.flat<int64>().data(),
-                inp_neighbors_prefix_sum.shape().dim_size(0),
+                (int64_t*)inp_neighbors_row_splits.flat<int64>().data(),
+                inp_neighbors_row_splits.shape().dim_size(0) - 1,
                 neighbors_index.flat<TIndex>().data(),
                 num_attributes ? neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 neighbors_index.shape().dim_size(0),
-                (int64_t*)neighbors_prefix_sum.flat<int64>().data(),
-                neighbors_prefix_sum.shape().dim_size(0));
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                neighbors_row_splits.shape().dim_size(0) - 1);
     }
 };
 

--- a/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.cu
+++ b/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.cu
@@ -44,11 +44,11 @@ public:
 
     void Kernel(tensorflow::OpKernelContext* context,
                 const tensorflow::Tensor& inp_neighbors_index,
-                const tensorflow::Tensor& inp_neighbors_prefix_sum,
+                const tensorflow::Tensor& inp_neighbors_row_splits,
                 const tensorflow::Tensor& inp_neighbors_attributes,
                 const int num_attributes,
                 tensorflow::Tensor& neighbors_index,
-                tensorflow::Tensor& neighbors_prefix_sum,
+                tensorflow::Tensor& neighbors_row_splits,
                 tensorflow::Tensor& neighbors_attributes) {
         auto device = context->eigen_gpu_device();
 
@@ -62,14 +62,14 @@ public:
                 num_attributes ? inp_neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 num_attributes,
-                (int64_t*)inp_neighbors_prefix_sum.flat<int64>().data(),
-                inp_neighbors_prefix_sum.shape().dim_size(0),
+                (int64_t*)inp_neighbors_row_splits.flat<int64>().data(),
+                inp_neighbors_row_splits.shape().dim_size(0) - 1,
                 neighbors_index.flat<TIndex>().data(),
                 num_attributes ? neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 neighbors_index.shape().dim_size(0),
-                (int64_t*)neighbors_prefix_sum.flat<int64>().data(),
-                neighbors_prefix_sum.shape().dim_size(0));
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                neighbors_row_splits.shape().dim_size(0) - 1);
 
         Tensor temp_tensor;
         TensorShape temp_shape({ssize_t(temp_size)});
@@ -85,14 +85,14 @@ public:
                 num_attributes ? inp_neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 num_attributes,
-                (int64_t*)inp_neighbors_prefix_sum.flat<int64>().data(),
-                inp_neighbors_prefix_sum.shape().dim_size(0),
+                (int64_t*)inp_neighbors_row_splits.flat<int64>().data(),
+                inp_neighbors_row_splits.shape().dim_size(0) - 1,
                 neighbors_index.flat<TIndex>().data(),
                 num_attributes ? neighbors_attributes.flat<TAttr>().data()
                                : nullptr,
                 neighbors_index.shape().dim_size(0),
-                (int64_t*)neighbors_prefix_sum.flat<int64>().data(),
-                neighbors_prefix_sum.shape().dim_size(0));
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                neighbors_row_splits.shape().dim_size(0) - 1);
     }
 
 private:

--- a/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.h
+++ b/src/Open3D/ML/TensorFlow/Misc/InvertNeighborsListOpKernel.h
@@ -54,11 +54,11 @@ public:
                     errors::InvalidArgument(
                             "inp_neighbors_index must be a rank 1 tensor"));
 
-        const Tensor& inp_neighbors_prefix_sum = context->input(2);
+        const Tensor& inp_neighbors_row_splits = context->input(2);
         OP_REQUIRES(
-                context, inp_neighbors_prefix_sum.shape().dims() == 1,
+                context, inp_neighbors_row_splits.shape().dims() == 1,
                 errors::InvalidArgument(
-                        "inp_neighbors_prefix_sum must be a rank 1 tensor"));
+                        "inp_neighbors_row_splits must be a rank 1 tensor"));
 
         const Tensor& inp_neighbors_attributes = context->input(3);
         OP_REQUIRES(context, inp_neighbors_attributes.shape().dims() >= 1,
@@ -88,11 +88,11 @@ public:
                        context->allocate_output(0, neighbors_index_shape,
                                                 &neighbors_index));
 
-        Tensor* neighbors_prefix_sum = 0;
-        TensorShape neighbors_prefix_sum_shape({num_points});
+        Tensor* neighbors_row_splits = 0;
+        TensorShape neighbors_row_splits_shape({num_points + 1});
         OP_REQUIRES_OK(context,
-                       context->allocate_output(1, neighbors_prefix_sum_shape,
-                                                &neighbors_prefix_sum));
+                       context->allocate_output(1, neighbors_row_splits_shape,
+                                                &neighbors_row_splits));
         Tensor* neighbors_attributes = 0;
         TensorShape neighbors_attributes_shape(
                 inp_neighbors_attributes.shape());
@@ -100,19 +100,19 @@ public:
                        context->allocate_output(2, neighbors_attributes_shape,
                                                 &neighbors_attributes));
 
-        Kernel(context, inp_neighbors_index, inp_neighbors_prefix_sum,
+        Kernel(context, inp_neighbors_index, inp_neighbors_row_splits,
                inp_neighbors_attributes, num_attributes, *neighbors_index,
-               *neighbors_prefix_sum, *neighbors_attributes);
+               *neighbors_row_splits, *neighbors_attributes);
     }
 
     // Function with the device specific code
     virtual void Kernel(tensorflow::OpKernelContext* context,
                         const tensorflow::Tensor& inp_neighbors_index,
-                        const tensorflow::Tensor& inp_neighbors_prefix_sum,
+                        const tensorflow::Tensor& inp_neighbors_row_splits,
                         const tensorflow::Tensor& inp_neighbors_attributes,
                         const int num_attributes,
                         tensorflow::Tensor& neighbors_index,
-                        tensorflow::Tensor& neighbors_prefix_sum,
+                        tensorflow::Tensor& neighbors_row_splits,
                         tensorflow::Tensor& neighbors_attributes) = 0;
 
 private:

--- a/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.cpp
@@ -24,8 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "RadiusSearchOpKernel.h"
 #include "Open3D/ML/Misc/Detail/RadiusSearch.h"
+#include "RadiusSearchOpKernel.h"
 
 using namespace open3d::ml::detail;
 using namespace radius_search_opkernel;
@@ -41,11 +41,11 @@ public:
                 const tensorflow::Tensor& points,
                 const tensorflow::Tensor& queries,
                 const tensorflow::Tensor& radius,
-                tensorflow::Tensor& query_neighbors_prefix_sum) {
+                tensorflow::Tensor& query_neighbors_row_splits) {
         OutputAllocator<T> output_allocator(context);
 
         RadiusSearchCPU(
-                (int64_t*)query_neighbors_prefix_sum.flat<int64>().data(),
+                (int64_t*)query_neighbors_row_splits.flat<int64>().data(),
                 points.shape().dim_size(0), points.flat<T>().data(),
                 queries.shape().dim_size(0), queries.flat<T>().data(),
                 radius.flat<T>().data(), metric, ignore_query_point,

--- a/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.cpp
@@ -24,8 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "Open3D/ML/Misc/Detail/RadiusSearch.h"
 #include "RadiusSearchOpKernel.h"
+#include "Open3D/ML/Misc/Detail/RadiusSearch.h"
 
 using namespace open3d::ml::detail;
 using namespace radius_search_opkernel;

--- a/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.h
+++ b/src/Open3D/ML/TensorFlow/Misc/RadiusSearchOpKernel.h
@@ -109,21 +109,21 @@ public:
                     errors::InvalidArgument("number of output points and the "
                                             "length of radii do not match"));
 
-        Tensor* query_neighbors_prefix_sum = 0;
-        TensorShape query_neighbors_prefix_sum_shape(
-                {queries.shape().dim_size(0)});
+        Tensor* query_neighbors_row_splits = 0;
+        TensorShape query_neighbors_row_splits_shape(
+                {queries.shape().dim_size(0) + 1});
         OP_REQUIRES_OK(context, context->allocate_output(
-                                        1, query_neighbors_prefix_sum_shape,
-                                        &query_neighbors_prefix_sum));
+                                        1, query_neighbors_row_splits_shape,
+                                        &query_neighbors_row_splits));
 
-        Kernel(context, points, queries, radii, *query_neighbors_prefix_sum);
+        Kernel(context, points, queries, radii, *query_neighbors_row_splits);
     }
 
     virtual void Kernel(tensorflow::OpKernelContext* context,
                         const tensorflow::Tensor& points,
                         const tensorflow::Tensor& queries,
                         const tensorflow::Tensor& radius,
-                        tensorflow::Tensor& query_neighbors_prefix_sum) = 0;
+                        tensorflow::Tensor& query_neighbors_row_splits) = 0;
 
 protected:
     open3d::ml::detail::Metric metric;

--- a/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cpp
@@ -24,8 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "Open3D/ML/Misc/Detail/ReduceSubarraysSum.h"
 #include "ReduceSubarraysSumOpKernel.h"
+#include "Open3D/ML/Misc/Detail/ReduceSubarraysSum.h"
 
 using namespace open3d::ml::detail;
 using namespace reduce_subarrays_sum_opkernel;

--- a/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cpp
@@ -24,8 +24,8 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "ReduceSubarraysSumOpKernel.h"
 #include "Open3D/ML/Misc/Detail/ReduceSubarraysSum.h"
+#include "ReduceSubarraysSumOpKernel.h"
 
 using namespace open3d::ml::detail;
 using namespace reduce_subarrays_sum_opkernel;
@@ -39,12 +39,12 @@ public:
 
     void Kernel(OpKernelContext* context,
                 const tensorflow::Tensor& values,
-                const tensorflow::Tensor& prefix_sum,
+                const tensorflow::Tensor& row_splits,
                 tensorflow::Tensor& sums) {
         ReduceSubarraysSumCPU(
                 values.flat<T>().data(), values.shape().dim_size(0),
-                (int64_t*)prefix_sum.flat<int64>().data(),
-                prefix_sum.shape().dim_size(0), sums.flat<T>().data());
+                (int64_t*)row_splits.flat<int64>().data(),
+                row_splits.shape().dim_size(0) - 1, sums.flat<T>().data());
     }
 };
 

--- a/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cu
+++ b/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.cu
@@ -40,14 +40,14 @@ public:
 
     void Kernel(OpKernelContext* context,
                 const tensorflow::Tensor& values,
-                const tensorflow::Tensor& prefix_sum,
+                const tensorflow::Tensor& row_splits,
                 tensorflow::Tensor& sums) {
         auto device = context->eigen_gpu_device();
 
         ReduceSubarraysSumCUDA(device.stream(), values.flat<T>().data(),
                                values.shape().dim_size(0),
-                               (int64_t*)prefix_sum.flat<int64>().data(),
-                               prefix_sum.shape().dim_size(0),
+                               (int64_t*)row_splits.flat<int64>().data(),
+                               row_splits.shape().dim_size(0) - 1,
                                sums.flat<T>().data());
     }
 };

--- a/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.h
+++ b/src/Open3D/ML/TensorFlow/Misc/ReduceSubarraysSumOpKernel.h
@@ -45,10 +45,10 @@ public:
         OP_REQUIRES(context, values.shape().dims() == 1,
                     errors::InvalidArgument("values must be a rank 1 tensor"));
 
-        const Tensor& prefix_sum = context->input(1);
+        const Tensor& row_splits = context->input(1);
         OP_REQUIRES(
-                context, prefix_sum.shape().dims() == 1,
-                errors::InvalidArgument("prefix_sum must be a rank 1 tensor"));
+                context, row_splits.shape().dims() == 1,
+                errors::InvalidArgument("row_splits must be a rank 1 tensor"));
 
         // special treatment for empty values vector
         if (values.shape().dim_size(0) == 0) {
@@ -59,17 +59,17 @@ public:
         }
 
         Tensor* sums_tensor = 0;
-        TensorShape sums_shape(prefix_sum.shape());
+        TensorShape sums_shape({row_splits.shape().dim_size(0) - 1});
         OP_REQUIRES_OK(context,
                        context->allocate_output(0, sums_shape, &sums_tensor));
 
-        Kernel(context, values, prefix_sum, *sums_tensor);
+        Kernel(context, values, row_splits, *sums_tensor);
     }
 
     // Function with the device specific code
     virtual void Kernel(tensorflow::OpKernelContext* context,
                         const tensorflow::Tensor& values,
-                        const tensorflow::Tensor& prefix_sum,
+                        const tensorflow::Tensor& row_splits,
                         tensorflow::Tensor& sums) = 0;
 
 private:

--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -103,7 +103,7 @@ if ( BUILD_TENSORFLOW_OPS )
     list( APPEND COMPILED_MODULE_PATH_LIST $<TARGET_FILE:open3d_tf_ops> )
     add_custom_command( OUTPUT "${CMAKE_BINARY_DIR}/lib/ml/tf/python/ops/ops.py"
                         COMMAND ${PYTHON_EXECUTABLE} generate_tf_ops_wrapper.py --input open3d/ml/tf/python/ops/ops.py.in --output "${CMAKE_BINARY_DIR}/lib/ml/tf/python/ops/ops.py" --lib $<TARGET_FILE:open3d_tf_ops> 
-                        COMMAND 
+                        DEPENDS open3d_tf_ops
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         COMMENT "Generating python ops.py" )
                 

--- a/src/UnitTest/Python/test_tf_op_library.py
+++ b/src/UnitTest/Python/test_tf_op_library.py
@@ -49,9 +49,9 @@ def test_execute_tf_op():
     import open3d.ml.tf as ml3d
 
     values = np.arange(0, 10)
-    prefix_sum = np.array([0, 3, 4, 4])
+    row_splits = np.array([0, 3, 4, 4, 10])
 
     with tf.device('CPU:0'):
-        ans = ml3d.ops.reduce_subarrays_sum(values, prefix_sum)
+        ans = ml3d.ops.reduce_subarrays_sum(values, row_splits)
     # test was a success if we reach this line but check correctness anyway
     assert np.all(ans.numpy() == [3, 3, 0, 39])

--- a/src/UnitTest/Python/tf_ops/test_fixed_radius_search.py
+++ b/src/UnitTest/Python/tf_ops/test_fixed_radius_search.py
@@ -88,16 +88,14 @@ def test_fixed_radius_search(dtype, device_name, num_points_queries, radius,
 
     # convert to numpy for convenience
     ans_neighbors_index = ans.neighbors_index.numpy()
-    ans_neighbors_prefix_sum = ans.neighbors_prefix_sum.numpy()
+    ans_neighbors_row_splits = ans.neighbors_row_splits.numpy()
     if return_distances:
         ans_neighbors_distance = ans.neighbors_distance.numpy()
 
     for i, q in enumerate(queries):
         # check neighbors
-        start = ans_neighbors_prefix_sum[i]
-        end = ans_neighbors_prefix_sum[
-            i + 1] if i + 1 < ans_neighbors_prefix_sum.shape[
-                0] else ans_neighbors_index.shape[0]
+        start = ans_neighbors_row_splits[i]
+        end = ans_neighbors_row_splits[i + 1]
         q_neighbors_index = ans_neighbors_index[start:end]
 
         gt_set = set(gt_neighbors_index[i])
@@ -139,7 +137,7 @@ def test_fixed_radius_search_empty_point_sets(device_name):
         assert device_name in ans.neighbors_index.device
 
     assert ans.neighbors_index.shape.as_list() == [0]
-    assert ans.neighbors_prefix_sum.shape.as_list() == [0]
+    assert ans.neighbors_row_splits.shape.as_list() == [1]
     assert ans.neighbors_distance.shape.as_list() == [0]
 
     # no input points
@@ -155,7 +153,7 @@ def test_fixed_radius_search_empty_point_sets(device_name):
         assert device_name in ans.neighbors_index.device
 
     assert ans.neighbors_index.shape.as_list() == [0]
-    assert ans.neighbors_prefix_sum.shape.as_list() == [100]
-    np.testing.assert_array_equal(np.zeros_like(ans.neighbors_prefix_sum),
-                                  ans.neighbors_prefix_sum)
+    assert ans.neighbors_row_splits.shape.as_list() == [101]
+    np.testing.assert_array_equal(np.zeros_like(ans.neighbors_row_splits),
+                                  ans.neighbors_row_splits)
     assert ans.neighbors_distance.shape.as_list() == [0]

--- a/src/UnitTest/Python/tf_ops/test_reduce_subarray_sum.py
+++ b/src/UnitTest/Python/tf_ops/test_reduce_subarray_sum.py
@@ -50,21 +50,22 @@ def test_reduce_subarray_sum_random(seed, dtype, device_name):
     values_shape = [rng.randint(100, 200)]
     values = rng.uniform(0, 10, size=values_shape).astype(dtype)
 
-    prefix_sum = [0]
+    row_splits = [0]
     for _ in range(rng.randint(1, 10)):
-        prefix_sum.append(
-            rng.randint(0, values_shape[0] - prefix_sum[-1]) + prefix_sum[-1])
+        row_splits.append(
+            rng.randint(0, values_shape[0] - row_splits[-1]) + row_splits[-1])
+    row_splits.extend(values_shape)
 
     expected_result = []
-    for start, stop in zip(prefix_sum, prefix_sum[1:] + values_shape):
+    for start, stop in zip(row_splits, row_splits[1:]):
         # np.sum correctly handles zero length arrays and returns 0
         expected_result.append(np.sum(values[start:stop]))
     np.array(expected_result, dtype=dtype)
 
-    prefix_sum = np.array(prefix_sum, dtype=np.int64)
+    row_splits = np.array(row_splits, dtype=np.int64)
 
     with tf.device(device_name):
-        result = ml3d.ops.reduce_subarrays_sum(values, prefix_sum)
+        result = ml3d.ops.reduce_subarrays_sum(values, row_splits)
         assert device_name in result.device
     result = result.numpy()
 


### PR DESCRIPTION
This PR changes the prefix sum format to row split format to simplify interop with tf.ragged
- var name changes x_prefix_sum -> x_row_splits
- updated unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1488)
<!-- Reviewable:end -->
