### PR TITLE
TensorList initial pybind

### DIFF
--- a/src/Open3D/Core/Kernel/BinaryEWCUDA.cu
+++ b/src/Open3D/Core/Kernel/BinaryEWCUDA.cu
@@ -113,7 +113,6 @@ void BinaryEWCUDA(const Tensor& lhs,
             default:
                 break;
         }
-
     });
 }
 

--- a/src/Open3D/Core/TensorList.cpp
+++ b/src/Open3D/Core/TensorList.cpp
@@ -179,7 +179,7 @@ TensorList TensorList::Concatenate(const TensorList& a, const TensorList& b) {
     return a + b;
 }
 
-void TensorList::operator+=(const TensorList& other) {
+TensorList& TensorList::operator+=(const TensorList& other) {
     /// Check consistency
     if (shape_ != other.GetShape()) {
         utility::LogError("TensorList shapes {} and {} are inconsistent.",
@@ -199,7 +199,7 @@ void TensorList::operator+=(const TensorList& other) {
 
     /// Ignore empty TensorList
     if (other.GetSize() == 0) {
-        return;
+        return *this;
     }
 
     int64_t new_reserved_size = ReserveSize(size_ + other.GetSize());
@@ -209,6 +209,8 @@ void TensorList::operator+=(const TensorList& other) {
     internal_tensor_.Slice(0 /* dim */, size_, size_ + other.GetSize()) =
             other.AsTensor();
     size_ = size_ + other.GetSize();
+
+    return *this;
 }
 
 void TensorList::Extend(const TensorList& b) { *this += b; }
@@ -305,4 +307,11 @@ void TensorList::CheckIndex(int64_t index) const {
     }
 }
 
+std::string TensorList::ToString() const {
+    std::ostringstream rc;
+    rc << fmt::format("\nTensorList[size={}, shape={}, {}, {}]", size_,
+                      shape_.ToString(), DtypeUtil::ToString(dtype_),
+                      GetDevice().ToString());
+    return rc.str();
+}
 }  // namespace open3d

--- a/src/Open3D/Core/TensorList.h
+++ b/src/Open3D/Core/TensorList.h
@@ -92,12 +92,12 @@ public:
 
     /// Constructor from a raw internal tensor.
     /// The inverse of AsTensor().
-    /// \param copy:
+    /// \param inplace:
     /// - if false, use the raw internal tensor (could be non-contiguous),
     /// typically only used for Slice() assignment
     /// - if true, create a new contiguous internal tensor with precomputed
     /// reserved size.
-    TensorList(const Tensor& internal_tensor, bool copy = true);
+    TensorList(const Tensor& internal_tensor, bool inplace = true);
 
     /// Copy constructor from a tensor list.
     /// Create a new tensor list with copy of data.
@@ -143,7 +143,7 @@ public:
     /// Concatenate two tensor lists and append the copy of the other tensor
     /// list to the end of *this.
     /// Two TensorLists must have the same shape, dtype, and device.
-    void operator+=(const TensorList& other);
+    TensorList& operator+=(const TensorList& other);
     void Extend(const TensorList& b);
 
     /// Return the reference of one tensor with shared memory.
@@ -160,6 +160,8 @@ public:
 
     /// Clear the tensor list by discarding all data and creating a empty one.
     void Clear();
+
+    std::string ToString() const;
 
     const SizeVector& GetShape() const { return shape_; }
     const Device& GetDevice() const { return device_; }

--- a/src/Open3D/ML/Misc/Detail/ReduceSubarraysSumCPU.h
+++ b/src/Open3D/ML/Misc/Detail/ReduceSubarraysSumCPU.h
@@ -50,7 +50,6 @@ void ReduceSubarraysSumCPU(const T* const values,
                            T* out_sums) {
     tbb::parallel_for(tbb::blocked_range<size_t>(0, prefix_sum_size),
                       [&](const tbb::blocked_range<size_t>& r) {
-
                           for (size_t i = r.begin(); i != r.end(); ++i) {
                               size_t begin_idx = prefix_sum[i];
                               // use values_size as end_idx for the last

--- a/src/Python/open3d/__init__.py
+++ b/src/Python/open3d/__init__.py
@@ -59,6 +59,7 @@ from open3d.open3d_pybind import DtypeUtil
 from open3d.open3d_pybind import cuda
 from open3d.core import SizeVector
 from open3d.core import Tensor
+from open3d.core import TensorList
 
 __version__ = '@PROJECT_VERSION@'
 

--- a/src/Python/open3d/core.py
+++ b/src/Python/open3d/core.py
@@ -42,7 +42,7 @@ class Tensor(open3d_pybind.Tensor):
         if isinstance(data, tuple) or isinstance(data, list):
             data = np.array(data)
         if not isinstance(data, np.ndarray):
-            raise ValueError("data must be a list, tuple or Numpy array.")
+            raise ValueError("data must be a list, tuple, or Numpy array.")
         if dtype is None:
             dtype = _numpy_dtype_to_dtype(data.dtype)
         if device is None:
@@ -99,3 +99,62 @@ class Tensor(open3d_pybind.Tensor):
         Returns a tensor converted from DLPack PyCapsule.
         """
         return super(Tensor, Tensor).from_dlpack(dlpack)
+
+class TensorList(open3d_pybind.TensorList):
+    """
+    Open3D TensorList class. A TensorList is an extendable tensor at the 0-th dimension.
+    It is similar to python list, but uses Open3D's tensor memory management system.
+    """
+
+    def __init__(self, shape, dtype=None, device=None, size=None):
+        if isinstance(shape, list) or isinstance(shape, tuple):
+            shape = o3d.SizeVector(shape)
+        elif isinstance(shape, o3d.SizeVector):
+            pass
+        else:
+            raise ValueError('shape must be a list, tuple, or o3d.SizeVector')
+
+        if dtype is None:
+            dtype = _numpy_dtype_to_dtype(data.dtype)
+        if device is None:
+            device = o3d.Device("CPU:0")
+        if size is None:
+            size = 0
+
+        super(TensorList, self).__init__(shape, dtype, device, size)
+
+    @staticmethod
+    def from_tensor(tensor, inplace=False):
+        """
+        Returns a TensorList from an existing tensor.
+        Args:
+            tensor: The internal o3d.Tensor to construct from, whose 0-th dimension
+                    corresponds to the size of the tensorlist.
+            inplace: Reuse tensor memory in place if True, else make a copy.
+        """
+
+        if not isinstance(tensor, o3d.Tensor):
+            raise ValueError('tensor must be a o3d.Tensor')
+
+        return super(TensorList, TensorList).from_tensor(tensor, inplace)
+
+    @staticmethod
+    def from_tensors(tensors, device=None):
+        """
+        Returns a TensorList from a list of existing tensors.
+        Args:
+            tensors: The list of o3d.Tensor to construct from.
+                     The tensors' shapes should be compatible.
+            device: The device where the tensorlist is targeted.
+        """
+
+        if not isinstance(tensors, list) and not isinstance(tensors, tuple):
+            raise ValueError('tensors must be a list or tuple')
+
+        for tensor in tensors:
+            if not isinstance(tensor, o3d.Tensor):
+                raise ValueError('every element of the input list must be a valid tensor')
+        if device is None:
+            device = o3d.Device("CPU:0")
+
+        return super(TensorList, TensorList).from_tensors(tensors, device)

--- a/src/Python/open3d/core.py
+++ b/src/Python/open3d/core.py
@@ -182,7 +182,7 @@ class Tensor(open3d_pybind.Tensor):
         # True div and floor div are the same for Tensor.
         return self.div_(value)
 
-    
+
 class TensorList(open3d_pybind.TensorList):
     """
     Open3D TensorList class. A TensorList is an extendable tensor at the 0-th dimension.
@@ -236,7 +236,8 @@ class TensorList(open3d_pybind.TensorList):
 
         for tensor in tensors:
             if not isinstance(tensor, o3d.Tensor):
-                raise ValueError('every element of the input list must be a valid tensor')
+                raise ValueError(
+                    'every element of the input list must be a valid tensor')
         if device is None:
             device = o3d.Device("CPU:0")
 

--- a/src/Python/open3d_pybind/core/container.cpp
+++ b/src/Python/open3d_pybind/core/container.cpp
@@ -33,4 +33,5 @@ void pybind_core(py::module &m) {
     pybind_core_device(m);
     pybind_core_size_vector(m);
     pybind_core_tensor(m);
+    pybind_core_tensorlist(m);
 }

--- a/src/Python/open3d_pybind/core/container.h
+++ b/src/Python/open3d_pybind/core/container.h
@@ -35,3 +35,4 @@ void pybind_core_dtype(py::module& m);
 void pybind_core_device(py::module& m);
 void pybind_core_size_vector(py::module& m);
 void pybind_core_tensor(py::module& m);
+void pybind_core_tensorlist(py::module& m);

--- a/src/Python/open3d_pybind/core/tensorlist.cpp
+++ b/src/Python/open3d_pybind/core/tensorlist.cpp
@@ -1,0 +1,81 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/Core/TensorList.h"
+
+#include <vector>
+
+#include "Open3D/Core/Blob.h"
+#include "Open3D/Core/CUDAUtils.h"
+#include "Open3D/Core/Device.h"
+#include "Open3D/Core/Dispatch.h"
+#include "Open3D/Core/Dtype.h"
+#include "Open3D/Core/SizeVector.h"
+#include "Open3D/Core/Tensor.h"
+#include "open3d_pybind/core/container.h"
+#include "open3d_pybind/docstring.h"
+#include "open3d_pybind/open3d_pybind.h"
+#include "open3d_pybind/pybind_utils.h"
+using namespace open3d;
+
+void pybind_core_tensorlist(py::module& m) {
+    py::class_<TensorList> tensorlist(
+            m, "TensorList",
+            "A TensorList is an extendable tensor at the 0-th dimension.");
+
+    tensorlist
+            .def(py::init([](const SizeVector& shape, const Dtype& dtype,
+                             const Device& device, const int64_t& size = 0) {
+                TensorList tl = TensorList(shape, dtype, device, size);
+                return tl;
+            }))
+            .def(py::init([](const std::vector<Tensor>& tensors,
+                             const Device& device) {
+                TensorList tl = TensorList(tensors, device);
+                return tl;
+            }))
+            .def(py::init([](const Tensor& internal_tensor, bool copy = true) {
+                TensorList tl = TensorList(internal_tensor, copy);
+                return tl;
+            }))
+            .def("tensor", [](const TensorList& tl) { return tl.AsTensor(); })
+            .def("push_back",
+                 [](TensorList& tl, const Tensor& tensor) {
+                     return tl.PushBack(tensor);
+                 })
+            .def("resize",
+                 [](TensorList& tl, int64_t n) { return tl.Resize(n); })
+            .def("extend",
+                 [](TensorList& tl_a, const TensorList& tl_b) {
+                     return tl_a.Extend(tl_b);
+                 })
+            .def(py::self + py::self)
+            .def(py::self += py::self)
+            .def_static("concat",
+                        [](const TensorList& tl_a, const TensorList& tl_b) {
+                            return TensorList::Concatenate(tl_a, tl_b);
+                        });
+}

--- a/src/Python/open3d_pybind/core/tensorlist.cpp
+++ b/src/Python/open3d_pybind/core/tensorlist.cpp
@@ -77,6 +77,7 @@ void pybind_core_tensorlist(py::module& m) {
                  [](TensorList& tl_a, const TensorList& tl_b) {
                      return tl_a.Extend(tl_b);
                  })
+            .def("size", [](const TensorList& tl) { return tl.GetSize(); })
             .def(py::self + py::self)
             .def(py::self += py::self)
             .def("__repr__", [](const TensorList& tl) { return tl.ToString(); })

--- a/src/UnitTest/Python/test_core.py
+++ b/src/UnitTest/Python/test_core.py
@@ -45,7 +45,9 @@ def list_devices():
                 f"o3d.cuda.device_count() != torch.cuda.device_count(), "
                 f"{o3d.cuda.device_count()} != {torch.cuda.device_count()}")
     else:
-        print('Warning: torch is not imported, cannot guarantee the correctness of device_count()')
+        print(
+            'Warning: torch is not imported, cannot guarantee the correctness of device_count()'
+        )
 
     for i in range(o3d.cuda.device_count()):
         devices.append(o3d.Device("CUDA:" + str(i)))
@@ -296,14 +298,17 @@ def test_binary_ew_ops():
     a //= b
     np.testing.assert_equal(a.numpy(), np.array([2, 2, 2, 2, 2, 2]))
 
+
 def test_tensorlist_operations():
     a = o3d.TensorList([3, 4], o3d.Dtype.Float32, o3d.Device(), size=1)
     assert a.size() == 1
 
-    b = o3d.TensorList.from_tensor(o3d.Tensor(np.ones((2, 3, 4), dtype=np.float32)))
+    b = o3d.TensorList.from_tensor(
+        o3d.Tensor(np.ones((2, 3, 4), dtype=np.float32)))
     assert b.size() == 2
 
-    c = o3d.TensorList.from_tensors([o3d.Tensor(np.zeros((3, 4), dtype=np.float32))])
+    c = o3d.TensorList.from_tensors(
+        [o3d.Tensor(np.zeros((3, 4), dtype=np.float32))])
     assert c.size() == 1
 
     d = a + b

--- a/src/UnitTest/Python/test_core.py
+++ b/src/UnitTest/Python/test_core.py
@@ -26,17 +26,27 @@
 
 import open3d as o3d
 import numpy as np
-import torch
-import torch.utils.dlpack
 import pytest
+
+try:
+    import torch
+    import torch.utils.dlpack
+except ImportError:
+    _torch_imported = False
+else:
+    _torch_imported = True
 
 
 def list_devices():
     devices = [o3d.Device("CPU:" + str(0))]
-    if (o3d.cuda.device_count() != torch.cuda.device_count()):
-        raise RuntimeError(
-            f"o3d.cuda.device_count() != torch.cuda.device_count(), "
-            f"{o3d.cuda.device_count()} != {torch.cuda.device_count()}")
+    if _torch_imported:
+        if (o3d.cuda.device_count() != torch.cuda.device_count()):
+            raise RuntimeError(
+                f"o3d.cuda.device_count() != torch.cuda.device_count(), "
+                f"{o3d.cuda.device_count()} != {torch.cuda.device_count()}")
+    else:
+        print('Warning: torch is not imported, cannot guarantee the correctness of device_count()')
+
     for i in range(o3d.cuda.device_count()):
         devices.append(o3d.Device("CUDA:" + str(i)))
     return devices
@@ -122,7 +132,7 @@ def test_tensor_constructor():
 
     # 2D list
     li_t = [[0, 1, 2], [3, 4, 5]]
-    o3_t = o3d.Tensor(li_t, dtype, device)
+    no3_t = o3d.Tensor(li_t, dtype, device)
     np.testing.assert_equal(li_t, o3_t.numpy())
 
     # 2D list, inconsistent length
@@ -195,6 +205,9 @@ def test_tensor_to_numpy_scope():
 
 @pytest.mark.parametrize("device", list_devices())
 def test_tensor_to_pytorch_scope(device):
+    if not _torch_imported:
+        return
+
     src_t = np.array([[10, 11, 12.], [13., 14., 15.]])
 
     def get_dst_t():
@@ -208,6 +221,9 @@ def test_tensor_to_pytorch_scope(device):
 
 @pytest.mark.parametrize("device", list_devices())
 def test_tensor_from_to_pytorch(device):
+    if not _torch_imported:
+        return
+
     device_id = device.get_id()
     device_type = device.get_type()
 
@@ -240,6 +256,9 @@ def test_tensor_from_to_pytorch(device):
 
 
 def test_tensor_numpy_to_open3d_to_pytorch():
+    if not _torch_imported:
+        return
+
     # Numpy -> Open3D -> PyTorch all share the same memory
     a = np.ones((2, 2))
     b = o3d.Tensor.from_numpy(a)
@@ -251,3 +270,28 @@ def test_tensor_numpy_to_open3d_to_pytorch():
     np.testing.assert_equal(r, a)
     np.testing.assert_equal(r, b.cpu().numpy())
     np.testing.assert_equal(r, c.cpu().numpy())
+
+def test_tensorlist_operations():
+    a = o3d.TensorList([3, 4], o3d.Dtype.Float32, o3d.Device(), size=1)
+    assert a.size() == 1
+
+    b = o3d.TensorList.from_tensor(o3d.Tensor(np.ones((2, 3, 4), dtype=np.float32)))
+    assert b.size() == 2
+
+    c = o3d.TensorList.from_tensors([o3d.Tensor(np.zeros((3, 4), dtype=np.float32))])
+    assert c.size() == 1
+
+    d = a + b
+    assert d.size() == 3
+
+    e = o3d.TensorList.concat(c, d)
+    assert e.size() == 4
+
+    e.push_back(o3d.Tensor(np.zeros((3, 4), dtype=np.float32)))
+    assert e.size() == 5
+
+    e.extend(d)
+    assert e.size() == 8
+
+    e += a
+    assert e.size() == 9


### PR DESCRIPTION
Initial Python binding for the TensorList class
- Supports construct from (shape, dtype, device, size); from tensors; from an internal tensor.
- Initial tests with various interfaces for concat and push back. 
- TBD: finish indexing when Tensor's indexing is done (for consistency).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1505)
<!-- Reviewable:end -->
