### PR TITLE
Fixes and consistency in documentation with filenames

### DIFF
--- a/examples/Python/Advanced/color_map_optimization.py
+++ b/examples/Python/Advanced/color_map_optimization.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advanced/o3d.color_map.color_map_optimization.py
+# examples/Python/Advanced/color_map_optimization.py
 
 import open3d as o3d
 from trajectory_io import *

--- a/examples/Python/Advanced/customized_visualization_key_action.py
+++ b/examples/Python/Advanced/customized_visualization_key_action.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advanced/customized_visualization2.py
+# examples/Python/Advanced/customized_visualization_key_action.py
 
 import open3d as o3d
 

--- a/examples/Python/Advanced/downsampling_and_trace.py
+++ b/examples/Python/Advanced/downsampling_and_trace.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Advanced/downsampling_and_trace.py
+
 import numpy as np
 import open3d as o3d
 

--- a/examples/Python/Advanced/load_save_viewpoint.py
+++ b/examples/Python/Advanced/load_save_viewpoint.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advanced/camera_trajectory.py
+# examples/Python/Advanced/load_save_viewpoint.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Advanced/mesh_deformation.py
+++ b/examples/Python/Advanced/mesh_deformation.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advamced/mesh_deformation.py
+# examples/Python/Advanced/mesh_deformation.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Advanced/mesh_deformation.py
+++ b/examples/Python/Advanced/mesh_deformation.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Basic/mesh_subdivision.py
+# examples/Python/Advamced/mesh_deformation.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Advanced/mesh_voxelization.py
+++ b/examples/Python/Advanced/mesh_voxelization.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Advanced/mesh_voxelization.py
+
 import os
 import sys
 import urllib.request

--- a/examples/Python/Advanced/pointcloud_outlier_removal.py
+++ b/examples/Python/Advanced/pointcloud_outlier_removal.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advanced/outlier_removal.py
+# examples/Python/Advanced/pointcloud_outlier_removal.py
 
 import open3d as o3d
 

--- a/examples/Python/Advanced/rgbd_integration_uniform.py
+++ b/examples/Python/Advanced/rgbd_integration_uniform.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Advanced/rgbd_integration_uniform.py
+
 import open3d as o3d
 from trajectory_io import read_trajectory
 import numpy as np

--- a/examples/Python/Advanced/surface_reconstruction_alpha_shape.py
+++ b/examples/Python/Advanced/surface_reconstruction_alpha_shape.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Advanced/surface_reconstruction_ball_pivoting.py
+# examples/Python/Advanced/surface_reconstruction_alpha_shape.py
 
 import open3d as o3d
 import numpy as np

--- a/examples/Python/Advanced/voxel_carving.py
+++ b/examples/Python/Advanced/voxel_carving.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Advanced/voxel_carving.py
+
 import open3d as o3d
 import numpy as np
 import os

--- a/examples/Python/Basic/hidden_point_removal.py
+++ b/examples/Python/Basic/hidden_point_removal.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Basic/hidden_point_removal.py
+
 import numpy as np
 import open3d as o3d
 import meshes

--- a/examples/Python/Basic/mesh_connected_components.py
+++ b/examples/Python/Basic/mesh_connected_components.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/Basic/mesh_connected_components.py
+
 import open3d as o3d
 import numpy as np
 import copy

--- a/examples/Python/Basic/mesh_filter.py
+++ b/examples/Python/Basic/mesh_filter.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Basic/mesh_filtering.py
+# examples/Python/Basic/mesh_filter.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Basic/mesh_io.py
+++ b/examples/Python/Basic/mesh_io.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Basic/mesh_io.py
+
 import numpy as np
 import open3d as o3d
 import os

--- a/examples/Python/Basic/transformation.py
+++ b/examples/Python/Basic/transformation.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Utility/visualization.py
+# examples/Python/Utility/transformation.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Misc/color_image.py
+++ b/examples/Python/Misc/color_image.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/color_image.py
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.image as mpimg

--- a/examples/Python/Misc/evaluate_geometric_feature.py
+++ b/examples/Python/Misc/evaluate_geometric_feature.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/evaluate_geometric_feature.py
+
 import open3d as o3d
 import numpy as np
 

--- a/examples/Python/Misc/feature.py
+++ b/examples/Python/Misc/feature.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/feature.py
+
 import numpy as np
 import open3d as o3d
 

--- a/examples/Python/Misc/meshes.py
+++ b/examples/Python/Misc/meshes.py
@@ -2,7 +2,7 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
-# examples/Python/Basic/meshes.py
+# examples/Python/Misc/meshes.py
 
 import numpy as np
 import open3d as o3d

--- a/examples/Python/Misc/pose_graph_optimization.py
+++ b/examples/Python/Misc/pose_graph_optimization.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/pose_graph_optimization.py
+
 import open3d as o3d
 import numpy as np
 

--- a/examples/Python/Misc/sampling.py
+++ b/examples/Python/Misc/sampling.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/sampling.py
+
 import open3d as o3d
 import os, sys
 sys.path.append("../Utility")

--- a/examples/Python/Misc/vector.py
+++ b/examples/Python/Misc/vector.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/Misc/vector.py
+
 import copy
 import numpy as np
 import open3d as o3d

--- a/examples/Python/ReconstructionSystem/debug/pairwise_pc_alignment.py
+++ b/examples/Python/ReconstructionSystem/debug/pairwise_pc_alignment.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/ReconstructionSystem/debug/pairwise_pc_alignment.py
+
 import argparse
 import json
 import sys

--- a/examples/Python/ReconstructionSystem/debug/pairwise_rgbd_alignment.py
+++ b/examples/Python/ReconstructionSystem/debug/pairwise_rgbd_alignment.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/ReconstructionSystem/debug/pairwise_rgbd_alignment.py
+
 import argparse
 import json
 import sys

--- a/examples/Python/ReconstructionSystem/debug/visualize_alignment.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_alignment.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/ReconstructionSystem/debug/visualize_alignment.py
+
 import numpy as np
 import json
 import argparse

--- a/examples/Python/ReconstructionSystem/debug/visualize_fragments.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_fragments.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/ReconstructionSystem/debug/visualize_fragment.py
+
 import argparse
 import json
 import sys

--- a/examples/Python/ReconstructionSystem/debug/visualize_pointcloud.py
+++ b/examples/Python/ReconstructionSystem/debug/visualize_pointcloud.py
@@ -2,6 +2,8 @@
 # The MIT License (MIT)
 # See license file or visit www.open3d.org for details
 
+# examples/Python/ReconstructionSystem/debug/visualize_pointcloud.py
+
 import argparse
 import json
 import math

--- a/examples/Python/ReconstructionSystem/scripts/synchronize_frames.py
+++ b/examples/Python/ReconstructionSystem/scripts/synchronize_frames.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/scripts/synchronize_frames.py
+
 import math
 import os
 import sys

--- a/examples/Python/ReconstructionSystem/sensors/azure_kinect_mkv_reader.py
+++ b/examples/Python/ReconstructionSystem/sensors/azure_kinect_mkv_reader.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/sensors/azure_kinect_mkv_reader.py
+
 import argparse
 import open3d as o3d
 import os

--- a/examples/Python/ReconstructionSystem/sensors/azure_kinect_recorder.py
+++ b/examples/Python/ReconstructionSystem/sensors/azure_kinect_recorder.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/sensors/azure_kinect_recorder.py
+
 import argparse
 import datetime
 import open3d as o3d

--- a/examples/Python/ReconstructionSystem/sensors/azure_kinect_viewer.py
+++ b/examples/Python/ReconstructionSystem/sensors/azure_kinect_viewer.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/sensors/azure_kinect_viewer.py
+
 import argparse
 import open3d as o3d
 

--- a/examples/Python/ReconstructionSystem/sensors/realsense_pcd_visualizer.py
+++ b/examples/Python/ReconstructionSystem/sensors/realsense_pcd_visualizer.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/sensors/realsense_pcd_visualizer.py
+
 # pyrealsense2 is required.
 # Please see instructions in https://github.com/IntelRealSense/librealsense/tree/master/wrappers/python
 import pyrealsense2 as rs

--- a/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
+++ b/examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
@@ -1,3 +1,9 @@
+# Open3D: www.open3d.org
+# The MIT License (MIT)
+# See license file or visit www.open3d.org for details
+
+# examples/Python/ReconstructionSystem/sensors/realsense_recorder.py
+
 # pyrealsense2 is required.
 # Please see instructions in https://github.com/IntelRealSense/librealsense/tree/master/wrappers/python
 import pyrealsense2 as rs


### PR DESCRIPTION
This PR fixes inconsistency appearing in documentation of python examples. Specifically:
- Fixes error in path / filenames written in the documentation
- Adds license information in missing files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1511)
<!-- Reviewable:end -->
