### PR TITLE
Minor doc fix

### DIFF
--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -111,7 +111,6 @@ compilation options to ``OFF``:
 
 - ``BUILD_PYBIND11``
 - ``BUILD_PYTHON_MODULE``
-- ``BUILD_PYTHON_TUTORIALS``
 
 .. _compilation_ubuntu_config:
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -42,7 +42,7 @@ compilation time. Otherwise, the dependencies can also be build from source, see
 2. Setup Python binding environments
 ````````````````````````````````````
 
-This step is only required Python support for Open3D is needed.
+This step is only required if Python support for Open3D is needed.
 We use `pybind11 <https://github.com/pybind/pybind11>`_ for the Python
 binding. Please refer to
 `pybind11 document page <http://pybind11.readthedocs.io/en/stable/faq.html>`_


### PR DESCRIPTION
In this PR,
a17b64f is minor fix.

5efe7f2 removes `BUILD_PYTHON_TUTORIALS` at **Compiling from source** section. Looks like that options is actually not present in any cmake as of now.

Let me know if I am wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1513)
<!-- Reviewable:end -->
