### PR TITLE
Lineset rendering

### DIFF
--- a/src/Open3D/GUI/Materials/lines.mat
+++ b/src/Open3D/GUI/Materials/lines.mat
@@ -1,0 +1,14 @@
+material {
+    name : lines,
+    requires : [
+        color
+    ],
+    shadingModel : unlit
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        material.baseColor = getColor();
+    }
+}

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentGeometryBuffersBuilder.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentGeometryBuffersBuilder.cpp
@@ -26,20 +26,9 @@
 
 #include "FilamentGeometryBuffersBuilder.h"
 
-#include "Open3D/Geometry/BoundingVolume.h"
+#include "Open3D/Geometry/LineSet.h"
 #include "Open3D/Geometry/PointCloud.h"
 #include "Open3D/Geometry/TriangleMesh.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
-
-#include <filament/Engine.h>
-#include <filament/Scene.h>
-#include <filament/TransformManager.h>
-#include <filament/geometry/SurfaceOrientation.h>
-
-#include <map>
-
-using namespace filament;
 
 namespace open3d {
 namespace visualization {
@@ -56,6 +45,10 @@ std::unique_ptr<GeometryBuffersBuilder> GeometryBuffersBuilder::GetBuilder(
         case GT::PointCloud:
             return std::make_unique<PointCloudBuffersBuilder>(
                     static_cast<const geometry::PointCloud&>(geometry));
+
+        case GT::LineSet:
+            return std::make_unique<LineSetBuffersBuilder>(
+                    static_cast<const geometry::LineSet&>(geometry));
         default:
             break;
     }
@@ -67,158 +60,6 @@ void GeometryBuffersBuilder::DeallocateBuffer(void* buffer,
                                               size_t size,
                                               void* userPtr) {
     free(buffer);
-}
-
-// ===
-
-namespace {
-struct ColoredVertex {
-    math::float3 position = {0.f, 0.f, 0.f};
-    math::float4 color = {1.f, 1.f, 1.f, 1.f};
-    math::quatf tangent = {0.f, 0.f, 0.f, 0.f};
-
-    static size_t GetPositionOffset() {
-        return offsetof(ColoredVertex, position);
-    }
-    static size_t GetColorOffset() { return offsetof(ColoredVertex, color); }
-    static size_t GetTangentOffset() {
-        return offsetof(ColoredVertex, tangent);
-    }
-
-    void SetVertexPosition(const Eigen::Vector3d& pos) {
-        auto floatPos = pos.cast<float>();
-        position.x = floatPos(0);
-        position.y = floatPos(1);
-        position.z = floatPos(2);
-    }
-
-    void SetVertexColor(const Eigen::Vector3d& c) {
-        auto floatColor = c.cast<float>();
-        color.x = floatColor(0);
-        color.y = floatColor(1);
-        color.z = floatColor(2);
-    }
-};
-}  // namespace
-
-PointCloudBuffersBuilder::PointCloudBuffersBuilder(
-        const geometry::PointCloud& geometry)
-    : geometry_(geometry) {}
-
-RenderableManager::PrimitiveType PointCloudBuffersBuilder::GetPrimitiveType()
-        const {
-    return RenderableManager::PrimitiveType::POINTS;
-}
-
-GeometryBuffersBuilder::Buffers PointCloudBuffersBuilder::ConstructBuffers() {
-    auto& engine = EngineInstance::GetInstance();
-    auto& resourceManager = EngineInstance::GetResourceManager();
-
-    const size_t nVertices = geometry_.points_.size();
-
-    // We use CUSTOM0 for tangents instead of TANGENTS attribute
-    // because Filament would optimize out anything about normals and lightning
-    // from unlit materials. But our shader for normals visualizing is unlit, so
-    // we need to use this workaround.
-    VertexBuffer* vbuf = VertexBuffer::Builder()
-                                 .bufferCount(1)
-                                 .vertexCount(nVertices)
-                                 .attribute(VertexAttribute::POSITION, 0,
-                                            VertexBuffer::AttributeType::FLOAT3,
-                                            ColoredVertex::GetPositionOffset(),
-                                            sizeof(ColoredVertex))
-                                 .normalized(VertexAttribute::COLOR)
-                                 .attribute(VertexAttribute::COLOR, 0,
-                                            VertexBuffer::AttributeType::FLOAT4,
-                                            ColoredVertex::GetColorOffset(),
-                                            sizeof(ColoredVertex))
-                                 .attribute(VertexAttribute::CUSTOM0, 0,
-                                            VertexBuffer::AttributeType::FLOAT4,
-                                            ColoredVertex::GetTangentOffset(),
-                                            sizeof(ColoredVertex))
-                                 .build(engine);
-
-    VertexBufferHandle vbHandle;
-    if (vbuf) {
-        vbHandle = resourceManager.AddVertexBuffer(vbuf);
-    } else {
-        return {};
-    }
-
-    // Converting vertex normals to float base
-    std::vector<Eigen::Vector3f> normals;
-    normals.resize(nVertices);
-    for (size_t i = 0; i < nVertices; ++i) {
-        normals[i] = geometry_.normals_[i].cast<float>();
-    }
-
-    // Converting normals to Filament type - quaternions
-    size_t tangentsBytesCount = nVertices * 4 * sizeof(float);
-    auto float4VTangents =
-            static_cast<math::quatf*>(malloc(tangentsBytesCount));
-    auto orientation =
-            filament::geometry::SurfaceOrientation::Builder()
-                    .vertexCount(nVertices)
-                    .normals(reinterpret_cast<math::float3*>(normals.data()))
-                    .build();
-    orientation.getQuats(float4VTangents, nVertices);
-
-    size_t verticesBytesCount = nVertices * sizeof(ColoredVertex);
-    auto* vertices = static_cast<ColoredVertex*>(malloc(verticesBytesCount));
-    for (size_t i = 0; i < geometry_.points_.size(); ++i) {
-        ColoredVertex& element = vertices[i];
-        element.SetVertexPosition(geometry_.points_[i]);
-        element.SetVertexColor(geometry_.colors_[i]);
-        element.tangent = float4VTangents[i];
-    }
-
-    free(float4VTangents);
-
-    VertexBuffer::BufferDescriptor vertexbufferDescriptor(vertices,
-                                                          verticesBytesCount);
-    vertexbufferDescriptor.setCallback(
-            GeometryBuffersBuilder::DeallocateBuffer);
-    vbuf->setBufferAt(engine, 0, std::move(vertexbufferDescriptor));
-
-    size_t indicesBytesCount = nVertices * sizeof(IndexType);
-    auto* uintIndices = static_cast<IndexType*>(malloc(indicesBytesCount));
-    for (std::uint32_t i = 0; i < nVertices; ++i) {
-        uintIndices[i] = i;
-    }
-
-    auto ibHandle =
-            resourceManager.CreateIndexBuffer(nVertices, sizeof(IndexType));
-    if (!ibHandle) {
-        free(uintIndices);
-        return {};
-    }
-
-    auto ibuf = resourceManager.GetIndexBuffer(ibHandle).lock();
-
-    // Moving copied indices to IndexBuffer
-    // they will be freed later with freeBufferDescriptor
-    IndexBuffer::BufferDescriptor indicesDescriptor(uintIndices,
-                                                    indicesBytesCount);
-    indicesDescriptor.setCallback(GeometryBuffersBuilder::DeallocateBuffer);
-    ibuf->setBuffer(engine, std::move(indicesDescriptor));
-
-    return std::make_tuple(vbHandle, ibHandle);
-}
-
-filament::Box PointCloudBuffersBuilder::ComputeAABB() {
-    auto geometryAABB = geometry_.GetAxisAlignedBoundingBox();
-
-    const filament::math::float3 min(geometryAABB.min_bound_.x(),
-                                     geometryAABB.min_bound_.y(),
-                                     geometryAABB.min_bound_.z());
-    const filament::math::float3 max(geometryAABB.max_bound_.x(),
-                                     geometryAABB.max_bound_.y(),
-                                     geometryAABB.max_bound_.z());
-
-    filament::Box aabb;
-    aabb.set(min, max);
-
-    return aabb;
 }
 
 }  // namespace visualization

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentGeometryBuffersBuilder.h
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentGeometryBuffersBuilder.h
@@ -38,6 +38,7 @@ namespace open3d {
 
 namespace geometry {
 class Geometry3D;
+class LineSet;
 class PointCloud;
 class TriangleMesh;
 }  // namespace geometry
@@ -89,6 +90,20 @@ public:
 
 private:
     const geometry::PointCloud& geometry_;
+};
+
+class LineSetBuffersBuilder : public GeometryBuffersBuilder {
+public:
+    explicit LineSetBuffersBuilder(const geometry::LineSet& geometry);
+
+    filament::RenderableManager::PrimitiveType GetPrimitiveType()
+            const override;
+
+    Buffers ConstructBuffers() override;
+    filament::Box ComputeAABB() override;
+
+private:
+    const geometry::LineSet& geometry_;
 };
 
 }  // namespace visualization

--- a/src/Open3D/Visualization/Rendering/Filament/LineSetBuffers.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/LineSetBuffers.cpp
@@ -1,0 +1,223 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "FilamentGeometryBuffersBuilder.h"
+
+#include "FilamentEngine.h"
+#include "FilamentResourceManager.h"
+#include "Open3D/Geometry/BoundingVolume.h"
+#include "Open3D/Geometry/LineSet.h"
+
+#include <Eigen/Core>
+
+#include <map>
+
+using namespace filament;
+
+namespace open3d {
+namespace visualization {
+
+namespace {
+struct ColoredVertex {
+    math::float3 position = {0.f, 0.f, 0.f};
+    math::float4 color = {1.f, 1.f, 1.f, 1.f};
+
+    static size_t GetPositionOffset() {
+        return offsetof(ColoredVertex, position);
+    }
+    static size_t GetColorOffset() { return offsetof(ColoredVertex, color); }
+
+    void SetVertexPosition(const Eigen::Vector3d& pos) {
+        auto floatPos = pos.cast<float>();
+        position.x = floatPos(0);
+        position.y = floatPos(1);
+        position.z = floatPos(2);
+    }
+
+    void SetVertexColor(const Eigen::Vector3d& c) {
+        auto floatColor = c.cast<float>();
+        color.x = floatColor(0);
+        color.y = floatColor(1);
+        color.z = floatColor(2);
+    }
+};
+
+}  // namespace
+
+LineSetBuffersBuilder::LineSetBuffersBuilder(const geometry::LineSet& geometry)
+    : geometry_(geometry) {}
+
+RenderableManager::PrimitiveType LineSetBuffersBuilder::GetPrimitiveType()
+        const {
+    return RenderableManager::PrimitiveType::LINES;
+}
+
+LineSetBuffersBuilder::Buffers LineSetBuffersBuilder::ConstructBuffers() {
+    auto& engine = EngineInstance::GetInstance();
+    auto& resourceManager = EngineInstance::GetResourceManager();
+
+    struct LookupKey {
+        LookupKey() = default;
+        explicit LookupKey(const Eigen::Vector3d& pos,
+                           const Eigen::Vector3d& color) {
+            values[0] = pos.x();
+            values[1] = pos.y();
+            values[2] = pos.z();
+            values[3] = color.x();
+            values[4] = color.y();
+            values[5] = color.z();
+        }
+
+        bool operator<(const LookupKey& other) const {
+            for (std::uint8_t i = 0; i < 6; ++i) {
+                double diff = abs(values[i] - other.values[i]);
+                if (diff > kEpsilon) {
+                    return values[i] < other.values[i];
+                }
+            }
+
+            return false;
+        }
+
+        const double kEpsilon = 0.00001;
+        double values[6] = {0};
+    };
+
+    // <source, real>
+    std::map<LookupKey, std::pair<GeometryBuffersBuilder::IndexType,
+                                  GeometryBuffersBuilder::IndexType>>
+            indexLookup;
+
+    const size_t linesCount = geometry_.lines_.size();
+    const size_t verticesBytesCount = linesCount * 2 * sizeof(ColoredVertex);
+    auto* vertices = static_cast<ColoredVertex*>(malloc(verticesBytesCount));
+
+    const size_t indicesBytesCount = linesCount * 2 * sizeof(IndexType);
+    auto* indices = static_cast<IndexType*>(malloc(indicesBytesCount));
+
+    const bool hasColors = geometry_.HasColors();
+    Eigen::Vector3d kWhite(1.0, 1.0, 1.0);
+    size_t vertexIndex = 0;
+    for (size_t i = 0; i < linesCount; ++i) {
+        const auto& line = geometry_.lines_[i];
+
+        for (size_t j = 0; j < 2; ++j) {
+            size_t index = line(j);
+
+            auto& color = kWhite;
+            if (hasColors) {
+                color = geometry_.colors_[i];
+            }
+            const auto& pos = geometry_.points_[index];
+
+            LookupKey lookupKey(pos, color);
+            auto found = indexLookup.find(lookupKey);
+            if (found != indexLookup.end()) {
+                index = found->second.second;
+            } else {
+                auto& element = vertices[vertexIndex];
+
+                element.SetVertexPosition(pos);
+                element.SetVertexColor(color);
+
+                indexLookup[lookupKey] = {index, vertexIndex};
+                index = vertexIndex;
+
+                ++vertexIndex;
+            }
+
+            indices[2 * i + j] = index;
+        }
+    }
+
+    const size_t verticesCount = vertexIndex;
+
+    VertexBuffer* vbuf = VertexBuffer::Builder()
+                                 .bufferCount(1)
+                                 .vertexCount(verticesCount)
+                                 .attribute(VertexAttribute::POSITION, 0,
+                                            VertexBuffer::AttributeType::FLOAT3,
+                                            ColoredVertex::GetPositionOffset(),
+                                            sizeof(ColoredVertex))
+                                 .normalized(VertexAttribute::COLOR)
+                                 .attribute(VertexAttribute::COLOR, 0,
+                                            VertexBuffer::AttributeType::FLOAT4,
+                                            ColoredVertex::GetColorOffset(),
+                                            sizeof(ColoredVertex))
+                                 .build(engine);
+
+    VertexBufferHandle vbHandle;
+    if (vbuf) {
+        vbHandle = resourceManager.AddVertexBuffer(vbuf);
+    } else {
+        free(vertices);
+        free(indices);
+        return {};
+    }
+
+    VertexBuffer::BufferDescriptor vertexbufferDescriptor(
+            vertices, verticesCount * sizeof(ColoredVertex));
+    vertexbufferDescriptor.setCallback(
+            GeometryBuffersBuilder::DeallocateBuffer);
+    vbuf->setBufferAt(engine, 0, std::move(vertexbufferDescriptor));
+
+    const size_t indicesCount = linesCount * 2;
+    auto ibHandle =
+            resourceManager.CreateIndexBuffer(indicesCount, sizeof(IndexType));
+    if (!ibHandle) {
+        free(indices);
+        return {};
+    }
+
+    auto ibuf = resourceManager.GetIndexBuffer(ibHandle).lock();
+
+    // Moving copied indices to IndexBuffer
+    // they will be freed later with freeBufferDescriptor
+    IndexBuffer::BufferDescriptor indicesDescriptor(indices, indicesBytesCount);
+    indicesDescriptor.setCallback(GeometryBuffersBuilder::DeallocateBuffer);
+    ibuf->setBuffer(engine, std::move(indicesDescriptor));
+
+    return std::make_tuple(vbHandle, ibHandle);
+}
+
+Box LineSetBuffersBuilder::ComputeAABB() {
+    const auto geometryAABB = geometry_.GetAxisAlignedBoundingBox();
+
+    const filament::math::float3 min(geometryAABB.min_bound_.x(),
+                                     geometryAABB.min_bound_.y(),
+                                     geometryAABB.min_bound_.z());
+    const filament::math::float3 max(geometryAABB.max_bound_.x(),
+                                     geometryAABB.max_bound_.y(),
+                                     geometryAABB.max_bound_.z());
+
+    Box aabb;
+    aabb.set(min, max);
+
+    return aabb;
+}
+
+}  // namespace visualization
+}  // namespace open3d

--- a/src/Open3D/Visualization/Rendering/Filament/PointCloudBuffers.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/PointCloudBuffers.cpp
@@ -1,0 +1,194 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "FilamentGeometryBuffersBuilder.h"
+
+#include "FilamentEngine.h"
+#include "FilamentResourceManager.h"
+#include "Open3D/Geometry/BoundingVolume.h"
+#include "Open3D/Geometry/PointCloud.h"
+
+#include <Eigen/Core>
+
+#include <filament/geometry/SurfaceOrientation.h>
+
+using namespace filament;
+
+namespace open3d {
+namespace visualization {
+
+namespace {
+struct ColoredVertex {
+    math::float3 position = {0.f, 0.f, 0.f};
+    math::float4 color = {1.f, 1.f, 1.f, 1.f};
+    math::quatf tangent = {0.f, 0.f, 0.f, 0.f};
+
+    static size_t GetPositionOffset() {
+        return offsetof(ColoredVertex, position);
+    }
+    static size_t GetColorOffset() { return offsetof(ColoredVertex, color); }
+    static size_t GetTangentOffset() {
+        return offsetof(ColoredVertex, tangent);
+    }
+
+    void SetVertexPosition(const Eigen::Vector3d& pos) {
+        auto floatPos = pos.cast<float>();
+        position.x = floatPos(0);
+        position.y = floatPos(1);
+        position.z = floatPos(2);
+    }
+
+    void SetVertexColor(const Eigen::Vector3d& c) {
+        auto floatColor = c.cast<float>();
+        color.x = floatColor(0);
+        color.y = floatColor(1);
+        color.z = floatColor(2);
+    }
+};
+}  // namespace
+
+PointCloudBuffersBuilder::PointCloudBuffersBuilder(
+        const geometry::PointCloud& geometry)
+    : geometry_(geometry) {}
+
+RenderableManager::PrimitiveType PointCloudBuffersBuilder::GetPrimitiveType()
+        const {
+    return RenderableManager::PrimitiveType::POINTS;
+}
+
+GeometryBuffersBuilder::Buffers PointCloudBuffersBuilder::ConstructBuffers() {
+    auto& engine = EngineInstance::GetInstance();
+    auto& resourceManager = EngineInstance::GetResourceManager();
+
+    const size_t nVertices = geometry_.points_.size();
+
+    // We use CUSTOM0 for tangents instead of TANGENTS attribute
+    // because Filament would optimize out anything about normals and lightning
+    // from unlit materials. But our shader for normals visualizing is unlit, so
+    // we need to use this workaround.
+    VertexBuffer* vbuf = VertexBuffer::Builder()
+                                 .bufferCount(1)
+                                 .vertexCount(nVertices)
+                                 .attribute(VertexAttribute::POSITION, 0,
+                                            VertexBuffer::AttributeType::FLOAT3,
+                                            ColoredVertex::GetPositionOffset(),
+                                            sizeof(ColoredVertex))
+                                 .normalized(VertexAttribute::COLOR)
+                                 .attribute(VertexAttribute::COLOR, 0,
+                                            VertexBuffer::AttributeType::FLOAT4,
+                                            ColoredVertex::GetColorOffset(),
+                                            sizeof(ColoredVertex))
+                                 .attribute(VertexAttribute::CUSTOM0, 0,
+                                            VertexBuffer::AttributeType::FLOAT4,
+                                            ColoredVertex::GetTangentOffset(),
+                                            sizeof(ColoredVertex))
+                                 .build(engine);
+
+    VertexBufferHandle vbHandle;
+    if (vbuf) {
+        vbHandle = resourceManager.AddVertexBuffer(vbuf);
+    } else {
+        return {};
+    }
+
+    // Converting vertex normals to float base
+    std::vector<Eigen::Vector3f> normals;
+    normals.resize(nVertices);
+    for (size_t i = 0; i < nVertices; ++i) {
+        normals[i] = geometry_.normals_[i].cast<float>();
+    }
+
+    // Converting normals to Filament type - quaternions
+    const size_t tangentsBytesCount = nVertices * 4 * sizeof(float);
+    auto float4VTangents =
+            static_cast<math::quatf*>(malloc(tangentsBytesCount));
+    auto orientation =
+            filament::geometry::SurfaceOrientation::Builder()
+                    .vertexCount(nVertices)
+                    .normals(reinterpret_cast<math::float3*>(normals.data()))
+                    .build();
+    orientation.getQuats(float4VTangents, nVertices);
+
+    const size_t verticesBytesCount = nVertices * sizeof(ColoredVertex);
+    auto* vertices = static_cast<ColoredVertex*>(malloc(verticesBytesCount));
+    for (size_t i = 0; i < geometry_.points_.size(); ++i) {
+        ColoredVertex& element = vertices[i];
+        element.SetVertexPosition(geometry_.points_[i]);
+        element.SetVertexColor(geometry_.colors_[i]);
+        element.tangent = float4VTangents[i];
+    }
+
+    free(float4VTangents);
+
+    VertexBuffer::BufferDescriptor vertexbufferDescriptor(vertices,
+                                                          verticesBytesCount);
+    vertexbufferDescriptor.setCallback(
+            GeometryBuffersBuilder::DeallocateBuffer);
+    vbuf->setBufferAt(engine, 0, std::move(vertexbufferDescriptor));
+
+    const size_t indicesBytesCount = nVertices * sizeof(IndexType);
+    auto* uintIndices = static_cast<IndexType*>(malloc(indicesBytesCount));
+    for (std::uint32_t i = 0; i < nVertices; ++i) {
+        uintIndices[i] = i;
+    }
+
+    auto ibHandle =
+            resourceManager.CreateIndexBuffer(nVertices, sizeof(IndexType));
+    if (!ibHandle) {
+        free(uintIndices);
+        return {};
+    }
+
+    auto ibuf = resourceManager.GetIndexBuffer(ibHandle).lock();
+
+    // Moving copied indices to IndexBuffer
+    // they will be freed later with freeBufferDescriptor
+    IndexBuffer::BufferDescriptor indicesDescriptor(uintIndices,
+                                                    indicesBytesCount);
+    indicesDescriptor.setCallback(GeometryBuffersBuilder::DeallocateBuffer);
+    ibuf->setBuffer(engine, std::move(indicesDescriptor));
+
+    return std::make_tuple(vbHandle, ibHandle);
+}
+
+filament::Box PointCloudBuffersBuilder::ComputeAABB() {
+    const auto geometryAABB = geometry_.GetAxisAlignedBoundingBox();
+
+    const filament::math::float3 min(geometryAABB.min_bound_.x(),
+                                     geometryAABB.min_bound_.y(),
+                                     geometryAABB.min_bound_.z());
+    const filament::math::float3 max(geometryAABB.max_bound_.x(),
+                                     geometryAABB.max_bound_.y(),
+                                     geometryAABB.max_bound_.z());
+
+    Box aabb;
+    aabb.set(min, max);
+
+    return aabb;
+}
+
+}  // namespace visualization
+}  // namespace open3d

--- a/src/Open3D/Visualization/Rendering/Filament/TriangleMeshBuffers.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/TriangleMeshBuffers.cpp
@@ -25,15 +25,12 @@
 // ----------------------------------------------------------------------------
 
 #include "FilamentGeometryBuffersBuilder.h"
+
+#include "FilamentEngine.h"
+#include "FilamentResourceManager.h"
 #include "Open3D/Geometry/BoundingVolume.h"
 #include "Open3D/Geometry/TriangleMesh.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
 
-#include <filament/Engine.h>
-#include <filament/Scene.h>
-#include <filament/TransformManager.h>
-#include <filament/filament/MaterialEnums.h>
 #include <filament/geometry/SurfaceOrientation.h>
 
 #include <map>
@@ -248,8 +245,8 @@ std::tuple<vbdata, ibdata> CreateTexturedBuffers(
         bool operator<(const LookupKey& other) const {
             for (std::uint8_t i = 0; i < 5; ++i) {
                 double diff = abs(values[i] - other.values[i]);
-                if (diff > kEpsilon && values[i] < other.values[i]) {
-                    return true;
+                if (diff > kEpsilon) {
+                    return values[i] < other.values[i];
                 }
             }
 
@@ -300,8 +297,12 @@ std::tuple<vbdata, ibdata> CreateTexturedBuffers(
                 TexturedVertex& element = texturedVertices[index];
                 SetVertexPosition(element, pos);
                 element.tangent = tangents[sourceIndex];
-                SetVertexColor(element, geometry.vertex_colors_[sourceIndex]);
                 SetVertexUV(element, uv);
+
+                if (geometry.HasVertexColors()) {
+                    SetVertexColor(element,
+                                   geometry.vertex_colors_[sourceIndex]);
+                }
             }
 
             indexData.bytes[3 * i + j] = index;
@@ -419,7 +420,7 @@ filament::Box TriangleMeshBuffersBuilder::ComputeAABB() {
                                      geometryAABB.max_bound_.y(),
                                      geometryAABB.max_bound_.z());
 
-    filament::Box aabb;
+    Box aabb;
     aabb.set(min, max);
 
     return aabb;


### PR DESCRIPTION
Added rendering of LineSet objects and new material for them.
Fixed a bug with algorithm for excluding duplicate vertices in TriangleMesh and LineSet geometries. This fix is located at `TriangleMeshBuffers.cpp:252`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1514)
<!-- Reviewable:end -->
