### PR TITLE
Supports multiple textures in .obj file

### DIFF
--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -52,7 +52,8 @@ TriangleMesh &TriangleMesh::Clear() {
     triangle_normals_.clear();
     adjacency_list_.clear();
     triangle_uvs_.clear();
-    texture_.Clear();
+    triangle_material_ids_.clear();
+    textures_.clear();
     return *this;
 }
 

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -93,9 +93,10 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (HasAdjacencyList()) {
         ComputeAdjacencyList();
     }
-    if (HasTriangleUvs() || HasTexture()) {
+    if (HasTriangleUvs() || HasTexture() || HasTriangleMateriaIds()) {
         utility::LogError(
-                "[TriangleMesh] copy of uvs and texture is not implemented "
+                "[TriangleMesh] copy of uvs and texture and per-triangle "
+                "material ids is not implemented "
                 "yet");
     }
     return (*this);

--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -93,7 +93,7 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (HasAdjacencyList()) {
         ComputeAdjacencyList();
     }
-    if (HasTriangleUvs() || HasTexture() || HasTriangleMateriaIds()) {
+    if (HasTriangleUvs() || HasTextures() || HasTriangleMaterialIds()) {
         utility::LogError(
                 "[TriangleMesh] copy of uvs and texture and per-triangle "
                 "material ids is not implemented "

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -28,6 +28,7 @@
 
 #include <Eigen/Core>
 #include <memory>
+#include <numeric>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -80,7 +81,12 @@ public:
         return HasTriangles() && triangle_uvs_.size() == 3 * triangles_.size();
     }
 
-    bool HasTexture() const { return !texture_.IsEmpty(); }
+    bool HasTexture() const {
+        bool is_all_texture_valid = std::accumulate(
+                textures_.begin(), textures_.end(), true,
+                [](bool a, const Image &b) { return a && !b.IsEmpty(); });
+        return !textures_.empty() && is_all_texture_valid;
+    }
 
     TriangleMesh &NormalizeNormals() {
         MeshBase::NormalizeNormals();
@@ -615,7 +621,8 @@ public:
     std::vector<Eigen::Vector3d> triangle_normals_;
     std::vector<std::unordered_set<int>> adjacency_list_;
     std::vector<Eigen::Vector2d> triangle_uvs_;
-    Image texture_;
+    std::vector<int> triangle_material_ids_;
+    std::vector<Image> textures_;
 };
 
 }  // namespace geometry

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -88,6 +88,11 @@ public:
         return !textures_.empty() && is_all_texture_valid;
     }
 
+    bool HasTriangleMateriaIds() const {
+        return HasTriangles() &&
+               triangle_material_ids_.size() == triangles_.size();
+    }
+
     TriangleMesh &NormalizeNormals() {
         MeshBase::NormalizeNormals();
         for (size_t i = 0; i < triangle_normals_.size(); i++) {

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -81,14 +81,14 @@ public:
         return HasTriangles() && triangle_uvs_.size() == 3 * triangles_.size();
     }
 
-    bool HasTexture() const {
+    bool HasTextures() const {
         bool is_all_texture_valid = std::accumulate(
                 textures_.begin(), textures_.end(), true,
                 [](bool a, const Image &b) { return a && !b.IsEmpty(); });
         return !textures_.empty() && is_all_texture_valid;
     }
 
-    bool HasTriangleMateriaIds() const {
+    bool HasTriangleMaterialIds() const {
         return HasTriangles() &&
                triangle_material_ids_.size() == triangles_.size();
     }

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -228,7 +228,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     // write faces with (possibly multiple) material ids
     // map faces with material ids
     std::map<int, std::vector<size_t>> material_id_faces_map;
-    if (mesh.HasTriangleMateriaIds()) {
+    if (mesh.HasTriangleMaterialIds()) {
         for (size_t i = 0; i < mesh.triangle_material_ids_.size(); ++i) {
             int mi = mesh.triangle_material_ids_[i];
             auto it = material_id_faces_map.find(mi);
@@ -304,7 +304,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
         mtl_file << "Ka 1.000 1.000 1.000" << std::endl;
         mtl_file << "Kd 1.000 1.000 1.000" << std::endl;
         mtl_file << "Ks 0.000 0.000 0.000" << std::endl;
-        if (write_triangle_uvs && mesh.HasTexture()) {
+        if (write_triangle_uvs && mesh.HasTextures()) {
             std::string tex_filename = parent_dir + mtl_name + ".png";
             if (!io::WriteImage(tex_filename,
                                 *mesh.textures_[i].FlipVertical())) {
@@ -318,7 +318,7 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     }
 
     // write the default material
-    if (!mesh.HasTexture()) {
+    if (!mesh.HasTextures()) {
         std::string mtl_name = object_name + "_0";
         mtl_file << "newmtl " << mtl_name << std::endl;
         mtl_file << "Ka 1.000 1.000 1.000" << std::endl;

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -186,9 +186,8 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     file << "# number of vertices: " << mesh.vertices_.size() << std::endl;
     file << "# number of triangles: " << mesh.triangles_.size() << std::endl;
 
-    // always write material name in obj file, regardless of uvs or textures
+    // always write material filename in obj file, regardless of uvs or textures
     file << "mtllib " << object_name << ".mtl" << std::endl;
-    file << "usemtl " << object_name << std::endl;
 
     utility::ConsoleProgressBar progress_bar(
             mesh.vertices_.size() + mesh.triangles_.size(),
@@ -226,32 +225,59 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
         }
     }
 
-    for (size_t tidx = 0; tidx < mesh.triangles_.size(); ++tidx) {
-        const Eigen::Vector3i& triangle = mesh.triangles_[tidx];
-        if (write_vertex_normals && write_triangle_uvs) {
-            file << "f ";
-            file << triangle(0) + 1 << "/" << 3 * tidx + 1 << "/"
-                 << triangle(0) + 1 << " ";
-            file << triangle(1) + 1 << "/" << 3 * tidx + 2 << "/"
-                 << triangle(1) + 1 << " ";
-            file << triangle(2) + 1 << "/" << 3 * tidx + 3 << "/"
-                 << triangle(2) + 1 << std::endl;
-        } else if (!write_vertex_normals && write_triangle_uvs) {
-            file << "f ";
-            file << triangle(0) + 1 << "/" << 3 * tidx + 1 << " ";
-            file << triangle(1) + 1 << "/" << 3 * tidx + 2 << " ";
-            file << triangle(2) + 1 << "/" << 3 * tidx + 3 << std::endl;
-        } else if (write_vertex_normals && !write_triangle_uvs) {
-            file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1 << " "
-                 << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
-                 << triangle(2) + 1 << "//" << triangle(2) + 1 << std::endl;
-        } else {
-            file << "f " << triangle(0) + 1 << " " << triangle(1) + 1 << " "
-                 << triangle(2) + 1 << std::endl;
+    // write faces with (possibly multiple) material ids
+    // map faces with material ids
+    std::map<int, std::vector<size_t>> material_id_faces_map;
+    if (mesh.HasTriangleMateriaIds()) {
+        for (size_t i = 0; i < mesh.triangle_material_ids_.size(); ++i) {
+            int mi = mesh.triangle_material_ids_[i];
+            auto it = material_id_faces_map.find(mi);
+            if (it == material_id_faces_map.end()) {
+                material_id_faces_map[mi] = {i};
+            } else {
+                it->second.push_back(i);
+            }
         }
-        ++progress_bar;
+    } else {  // every face falls to the default material
+        material_id_faces_map[0].resize(mesh.triangles_.size());
+        std::iota(material_id_faces_map[0].begin(),
+                  material_id_faces_map[0].end(), 0);
     }
 
+    // enumerate ids and their corresponding faces
+    for (auto it = material_id_faces_map.begin();
+         it != material_id_faces_map.end(); ++it) {
+        // write the mtl name
+        std::string mtl_name = object_name + "_" + std::to_string(it->first);
+        file << "usemtl " << mtl_name << std::endl;
+
+        // write the corresponding faces
+        for (auto tidx : it->second) {
+            const Eigen::Vector3i& triangle = mesh.triangles_[tidx];
+            if (write_vertex_normals && write_triangle_uvs) {
+                file << "f ";
+                file << triangle(0) + 1 << "/" << 3 * tidx + 1 << "/"
+                     << triangle(0) + 1 << " ";
+                file << triangle(1) + 1 << "/" << 3 * tidx + 2 << "/"
+                     << triangle(1) + 1 << " ";
+                file << triangle(2) + 1 << "/" << 3 * tidx + 3 << "/"
+                     << triangle(2) + 1 << std::endl;
+            } else if (!write_vertex_normals && write_triangle_uvs) {
+                file << "f ";
+                file << triangle(0) + 1 << "/" << 3 * tidx + 1 << " ";
+                file << triangle(1) + 1 << "/" << 3 * tidx + 2 << " ";
+                file << triangle(2) + 1 << "/" << 3 * tidx + 3 << std::endl;
+            } else if (write_vertex_normals && !write_triangle_uvs) {
+                file << "f " << triangle(0) + 1 << "//" << triangle(0) + 1
+                     << " " << triangle(1) + 1 << "//" << triangle(1) + 1 << " "
+                     << triangle(2) + 1 << "//" << triangle(2) + 1 << std::endl;
+            } else {
+                file << "f " << triangle(0) + 1 << " " << triangle(1) + 1 << " "
+                     << triangle(2) + 1 << std::endl;
+            }
+            ++progress_bar;
+        }
+    }
     // end of writing obj.
     //////
 
@@ -260,9 +286,8 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     std::string parent_dir =
             utility::filesystem::GetFileParentDirectory(filename);
     std::string mtl_filename = parent_dir + object_name + ".mtl";
-    std::string tex_filename = parent_dir + object_name + ".png";
 
-    // write standard material info to mtl file
+    // write headers
     std::ofstream mtl_file(mtl_filename.c_str(), std::ios::out);
     if (!mtl_file) {
         utility::LogWarning(
@@ -271,25 +296,34 @@ bool WriteTriangleMeshToOBJ(const std::string& filename,
     }
     mtl_file << "# Created by Open3D " << std::endl;
     mtl_file << "# object name: " << object_name << std::endl;
-    mtl_file << "newmtl " << object_name << std::endl;
-    mtl_file << "Ka 1.000 1.000 1.000" << std::endl;
-    mtl_file << "Kd 1.000 1.000 1.000" << std::endl;
-    mtl_file << "Ks 0.000 0.000 0.000" << std::endl;
 
-    if (write_triangle_uvs && mesh.HasTexture()) {
-        if (mesh.textures_.size() > 1) {
-            utility::LogWarning(
-                    "Write OBJ only supports one texture, others will be "
-                    "ignored.");
+    // write textures (if existing)
+    for (size_t i = 0; i < mesh.textures_.size(); ++i) {
+        std::string mtl_name = object_name + "_" + std::to_string(i);
+        mtl_file << "newmtl " << mtl_name << std::endl;
+        mtl_file << "Ka 1.000 1.000 1.000" << std::endl;
+        mtl_file << "Kd 1.000 1.000 1.000" << std::endl;
+        mtl_file << "Ks 0.000 0.000 0.000" << std::endl;
+        if (write_triangle_uvs && mesh.HasTexture()) {
+            std::string tex_filename = parent_dir + mtl_name + ".png";
+            if (!io::WriteImage(tex_filename,
+                                *mesh.textures_[i].FlipVertical())) {
+                utility::LogWarning(
+                        "Write OBJ successful, but failed to write texture "
+                        "file.");
+                return true;
+            }
+            mtl_file << "map_Kd " << mtl_name << ".png\n";
         }
+    }
 
-        if (!io::WriteImage(tex_filename, *mesh.textures_[0].FlipVertical())) {
-            utility::LogWarning(
-                    "Write OBJ successful, but failed to write texture "
-                    "file.");
-            return true;
-        }
-        mtl_file << "map_Kd " << object_name << ".png";
+    // write the default material
+    if (!mesh.HasTexture()) {
+        std::string mtl_name = object_name + "_0";
+        mtl_file << "newmtl " << mtl_name << std::endl;
+        mtl_file << "Ka 1.000 1.000 1.000" << std::endl;
+        mtl_file << "Kd 1.000 1.000 1.000" << std::endl;
+        mtl_file << "Ks 0.000 0.000 0.000" << std::endl;
     }
 
     return true;

--- a/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
+++ b/src/Open3D/Visualization/Shader/GeometryRenderer.cpp
@@ -257,14 +257,14 @@ bool TriangleMeshRenderer::Render(const RenderOption &option,
             success &= normal_mesh_shader_.Render(mesh, option, view);
         } else if (option.mesh_color_option_ ==
                            RenderOption::MeshColorOption::Color &&
-                   mesh.HasTriangleUvs() && mesh.HasTexture()) {
+                   mesh.HasTriangleUvs() && mesh.HasTextures()) {
             success &= texture_phong_mesh_shader_.Render(mesh, option, view);
         } else {
             success &= phong_mesh_shader_.Render(mesh, option, view);
         }
     } else {  // if normals are not ready
         if (option.mesh_color_option_ == RenderOption::MeshColorOption::Color &&
-            mesh.HasTriangleUvs() && mesh.HasTexture()) {
+            mesh.HasTriangleUvs() && mesh.HasTextures()) {
             success &= texture_simple_mesh_shader_.Render(mesh, option, view);
         } else {
             success &= simple_mesh_shader_.Render(mesh, option, view);

--- a/src/Open3D/Visualization/Shader/TexturePhongShader.h
+++ b/src/Open3D/Visualization/Shader/TexturePhongShader.h
@@ -72,11 +72,8 @@ protected:
 
 protected:
     GLuint vertex_position_;
-    GLuint vertex_position_buffer_;
     GLuint vertex_uv_;
-    GLuint vertex_uv_buffer_;
     GLuint vertex_normal_;
-    GLuint vertex_normal_buffer_;
     GLuint MVP_;
     GLuint V_;
     GLuint M_;
@@ -88,7 +85,15 @@ protected:
     GLuint light_ambient_;
 
     GLuint diffuse_texture_;
-    GLuint diffuse_texture_buffer_;
+
+    int num_materials_;
+    std::vector<int> array_offsets_;
+    std::vector<GLsizei> draw_array_sizes_;
+
+    std::vector<GLuint> vertex_position_buffers_;
+    std::vector<GLuint> vertex_uv_buffers_;
+    std::vector<GLuint> vertex_normal_buffers_;
+    std::vector<GLuint> diffuse_texture_buffers_;
 
     // At most support 4 lights
     GLHelper::GLMatrix4f light_position_world_data_;

--- a/src/Open3D/Visualization/Shader/TextureSimpleShader.h
+++ b/src/Open3D/Visualization/Shader/TextureSimpleShader.h
@@ -68,12 +68,17 @@ protected:
 
 protected:
     GLuint vertex_position_;
-    GLuint vertex_position_buffer_;
     GLuint vertex_uv_;
-    GLuint vertex_uv_buffer_;
     GLuint texture_;
-    GLuint texture_buffer_;
     GLuint MVP_;
+
+    int num_materials_;
+    std::vector<int> array_offsets_;
+    std::vector<GLsizei> draw_array_sizes_;
+
+    std::vector<GLuint> vertex_position_buffers_;
+    std::vector<GLuint> vertex_uv_buffers_;
+    std::vector<GLuint> texture_buffers_;
 };
 
 class TextureSimpleShaderForTriangleMesh : public TextureSimpleShader {

--- a/src/Open3D/Visualization/Utility/GLHelper.h
+++ b/src/Open3D/Visualization/Utility/GLHelper.h
@@ -36,10 +36,16 @@
 #include <GLFW/glfw3.h>
 #include <Eigen/Core>
 #include <string>
+#include <unordered_map>
 
 namespace open3d {
 namespace visualization {
 namespace GLHelper {
+
+const static std::unordered_map<int, GLenum> texture_format_map_ = {
+        {1, GL_RED}, {3, GL_RGB}, {4, GL_RGBA}};
+const static std::unordered_map<int, GLenum> texture_type_map_ = {
+        {1, GL_UNSIGNED_BYTE}, {2, GL_UNSIGNED_SHORT}, {4, GL_FLOAT}};
 
 typedef Eigen::Matrix<GLfloat, 3, 1, Eigen::ColMajor> GLVector3f;
 typedef Eigen::Matrix<GLfloat, 4, 1, Eigen::ColMajor> GLVector4f;

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -57,9 +57,11 @@ void pybind_trianglemesh(py::module &m) {
                              mesh.vertices_.size(), mesh.triangles_.size());
 
                      if (mesh.HasTexture()) {
-                         info += fmt::format(", and ({}, {}) texture.",
-                                             mesh.texture_.width_,
-                                             mesh.texture_.height_);
+                         info += fmt::format(", and textures of size ");
+                         for (auto &tex : mesh.textures_) {
+                             info += fmt::format("({}, {}) ", tex.width_,
+                                                 tex.height_);
+                         }
                      } else {
                          info += ".";
                      }
@@ -445,8 +447,8 @@ void pybind_trianglemesh(py::module &m) {
                            "``numpy.asarray()`` to access data: List of "
                            "uvs denoted by the index of points forming "
                            "the triangle.")
-            .def_readwrite("texture", &geometry::TriangleMesh::texture_,
-                           "open3d.geometry.Image: The texture image.");
+            .def_readwrite("textures", &geometry::TriangleMesh::textures_,
+                           "open3d.geometry.Image: The texture images.");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "compute_adjacency_list");
     docstring::ClassMethodDocInject(m, "TriangleMesh",

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -56,7 +56,7 @@ void pybind_trianglemesh(py::module &m) {
                              "triangles",
                              mesh.vertices_.size(), mesh.triangles_.size());
 
-                     if (mesh.HasTexture()) {
+                     if (mesh.HasTextures()) {
                          info += fmt::format(", and textures of size ");
                          for (auto &tex : mesh.textures_) {
                              info += fmt::format("({}, {}) ", tex.width_,
@@ -173,7 +173,10 @@ void pybind_trianglemesh(py::module &m) {
                  "Returns ``True`` if the mesh contains adjacency normals.")
             .def("has_triangle_uvs", &geometry::TriangleMesh::HasTriangleUvs,
                  "Returns ``True`` if the mesh contains uv coordinates.")
-            .def("has_texture", &geometry::TriangleMesh::HasTexture,
+            .def("has_triangle_material_ids",
+                 &geometry::TriangleMesh::HasTriangleMaterialIds,
+                 "Returns ``True`` if the mesh contains material ids.")
+            .def("has_textures", &geometry::TriangleMesh::HasTextures,
                  "Returns ``True`` if the mesh contains a texture image.")
             .def("normalize_normals", &geometry::TriangleMesh::NormalizeNormals,
                  "Normalize both triangle normals and vertex normals to legnth "
@@ -462,7 +465,9 @@ void pybind_trianglemesh(py::module &m) {
               "Set to ``True`` to normalize the normal to length 1."}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "has_triangles");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "has_triangle_uvs");
-    docstring::ClassMethodDocInject(m, "TriangleMesh", "has_texture");
+    docstring::ClassMethodDocInject(m, "TriangleMesh",
+                                    "has_triangle_material_ids");
+    docstring::ClassMethodDocInject(m, "TriangleMesh", "has_textures");
     docstring::ClassMethodDocInject(m, "TriangleMesh", "has_vertex_colors");
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "has_vertex_normals",


### PR DESCRIPTION
Enhancement of PR #1194.

This PR supports loading multiple textures for one single mesh, addressing #1484. 
![ScreenCapture_2020-02-16-13-39-58](https://user-images.githubusercontent.com/6127282/74611264-26a12e00-50c8-11ea-9a0b-fbadf5fe058d.png)

Major changes:
- Added property `material_ids` per face in `TriangleMesh` supported by tinyobjloader.
- Supports rendering multiple textures in several passes.

**Note**: due to the general API design in the IO module, an `.obj` containing multiple `shapes` is still not supported.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1517)
<!-- Reviewable:end -->
