### PR TITLE
Option for using the triangle normal for sampled points

### DIFF
--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -429,7 +429,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::FilterSmoothTaubin(
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
         size_t number_of_points,
         std::vector<double> &triangle_areas,
-        double surface_area) const {
+        double surface_area,
+        bool use_triangle_normal) const {
     // triangle areas to cdf
     triangle_areas[0] /= surface_area;
     for (size_t tidx = 1; tidx < triangles_.size(); ++tidx) {
@@ -445,7 +446,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
     std::uniform_real_distribution<double> dist(0.0, 1.0);
     auto pcd = std::make_shared<PointCloud>();
     pcd->points_.resize(number_of_points);
-    if (has_vert_normal) {
+    if (has_vert_normal || use_triangle_normal) {
         pcd->normals_.resize(number_of_points);
     }
     if (has_vert_color) {
@@ -465,10 +466,41 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
             pcd->points_[point_idx] = a * vertices_[triangle(0)] +
                                       b * vertices_[triangle(1)] +
                                       c * vertices_[triangle(2)];
-            if (has_vert_normal) {
+            if (has_vert_normal && !use_triangle_normal) {
                 pcd->normals_[point_idx] = a * vertex_normals_[triangle(0)] +
                                            b * vertex_normals_[triangle(1)] +
                                            c * vertex_normals_[triangle(2)];
+            }
+            if (use_triangle_normal) {
+                // compute all cross products and use most stable solution
+                Eigen::Vector3d e01 =
+                        vertices_[triangle(1)] - vertices_[triangle(0)];
+                Eigen::Vector3d e12 =
+                        vertices_[triangle(2)] - vertices_[triangle(1)];
+                Eigen::Vector3d e20 =
+                        vertices_[triangle(0)] - vertices_[triangle(2)];
+
+                Eigen::Vector3d cross0 = e01.cross(e20);
+                double length_cross0 = cross0.norm();
+
+                Eigen::Vector3d cross1 = e12.cross(e01);
+                double length_cross1 = cross1.norm();
+
+                Eigen::Vector3d cross2 = e20.cross(e12);
+                double length_cross2 = cross2.norm();
+
+                Eigen::Vector3d tri_normal;
+                if (length_cross0 > length_cross1 &&
+                    length_cross0 > length_cross2) {
+                    tri_normal = -cross0 / length_cross0;
+                } else if (length_cross1 > length_cross0 &&
+                           length_cross1 > length_cross2) {
+                    tri_normal = -cross1 / length_cross1;
+                } else {
+                    tri_normal = -cross2 / length_cross2;
+                }
+
+                pcd->normals_[point_idx] = tri_normal;
             }
             if (has_vert_color) {
                 pcd->colors_[point_idx] = a * vertex_colors_[triangle(0)] +
@@ -484,7 +516,7 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
-        size_t number_of_points) const {
+        size_t number_of_points, bool use_triangle_normal /* = false */) const {
     if (number_of_points <= 0) {
         utility::LogError("[SamplePointsUniformly] number_of_points <= 0");
     }
@@ -498,13 +530,14 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
     double surface_area = GetSurfaceArea(triangle_areas);
 
     return SamplePointsUniformlyImpl(number_of_points, triangle_areas,
-                                     surface_area);
+                                     surface_area, use_triangle_normal);
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
         size_t number_of_points,
         double init_factor /* = 5 */,
-        const std::shared_ptr<PointCloud> pcl_init /* = nullptr */) const {
+        const std::shared_ptr<PointCloud> pcl_init /* = nullptr */,
+        bool use_triangle_normal /* = false */) const {
     if (number_of_points <= 0) {
         utility::LogError("[SamplePointsPoissonDisk] number_of_points <= 0");
     }
@@ -531,7 +564,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsPoissonDisk(
     std::shared_ptr<PointCloud> pcl;
     if (pcl_init == nullptr) {
         pcl = SamplePointsUniformlyImpl(size_t(init_factor * number_of_points),
-                                        triangle_areas, surface_area);
+                                        triangle_areas, surface_area,
+                                        use_triangle_normal);
     } else {
         pcl = std::make_shared<PointCloud>();
         pcl->points_ = pcl_init->points_;

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -314,13 +314,15 @@ public:
             size_t number_of_points,
             std::vector<double> &triangle_areas,
             double surface_area,
-            bool use_triangle_normal) const;
+            bool use_triangle_normal);
 
     /// Function to sample \param number_of_points points uniformly from the
-    /// mesh. \param use_triangle_normal Set to true to use the triangle normals
-    /// instead of the vertex normals.
+    /// mesh. \param use_triangle_normal Set to true to assign the triangle
+    /// normals to the returned points instead of the interpolated vertex
+    /// normals. The triangle normals will be computed and added to the mesh
+    /// if necessary.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points, bool use_triangle_normal = false) const;
+            size_t number_of_points, bool use_triangle_normal = false);
 
     /// Function to sample \param number_of_points points (blue noise).
     /// Based on the method presented in Yuksel, "Sample Elimination for
@@ -328,13 +330,15 @@ public:
     /// \param pcl_init is used for sample elimination if given, otherwise a
     /// PointCloud is first uniformly sampled with \param init_number_of_points
     /// x \param number_of_points number of points.
-    /// \param use_triangle_normal Set to true to use the triangle normals
-    /// instead of the vertex normals.
+    /// \param use_triangle_normal Set to true to assign the triangle
+    /// normals to the returned points instead of the interpolated vertex
+    /// normals. The triangle normals will be computed and added to the mesh
+    /// if necessary.
     std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
             size_t number_of_points,
             double init_factor = 5,
             const std::shared_ptr<PointCloud> pcl_init = nullptr,
-            bool use_triangle_normal = false) const;
+            bool use_triangle_normal = false);
 
     /// Function to subdivide triangle mesh using the simple midpoint algorithm.
     /// Each triangle is subdivided into four triangles per iteration and the

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -313,12 +313,14 @@ public:
     std::shared_ptr<PointCloud> SamplePointsUniformlyImpl(
             size_t number_of_points,
             std::vector<double> &triangle_areas,
-            double surface_area) const;
+            double surface_area,
+            bool use_triangle_normal) const;
 
     /// Function to sample \param number_of_points points uniformly from the
-    /// mesh
+    /// mesh. \param use_triangle_normal Set to true to use the triangle normals
+    /// instead of the vertex normals.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points) const;
+            size_t number_of_points, bool use_triangle_normal = false) const;
 
     /// Function to sample \param number_of_points points (blue noise).
     /// Based on the method presented in Yuksel, "Sample Elimination for
@@ -326,10 +328,13 @@ public:
     /// \param pcl_init is used for sample elimination if given, otherwise a
     /// PointCloud is first uniformly sampled with \param init_number_of_points
     /// x \param number_of_points number of points.
+    /// \param use_triangle_normal Set to true to use the triangle normals
+    /// instead of the vertex normals.
     std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
             size_t number_of_points,
             double init_factor = 5,
-            const std::shared_ptr<PointCloud> pcl_init = nullptr) const;
+            const std::shared_ptr<PointCloud> pcl_init = nullptr,
+            bool use_triangle_normal = false) const;
 
     /// Function to subdivide triangle mesh using the simple midpoint algorithm.
     /// Each triangle is subdivided into four triangles per iteration and the

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -244,7 +244,7 @@ void pybind_trianglemesh(py::module &m) {
             .def("sample_points_uniformly",
                  &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",
-                 "number_of_points"_a = 100)
+                 "number_of_points"_a = 100, "use_triangle_normal"_a = false)
             .def("sample_points_poisson_disk",
                  &geometry::TriangleMesh::SamplePointsPoissonDisk,
                  "Function to sample points from the mesh, where each point "
@@ -253,7 +253,8 @@ void pybind_trianglemesh(py::module &m) {
                  "(blue "
                  "noise). Method is based on Yuksel, \"Sample Elimination for "
                  "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
-                 "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr)
+                 "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr,
+                 "use_triangle_normal"_a = false)
             .def("subdivide_midpoint",
                  &geometry::TriangleMesh::SubdivideMidpoint,
                  "Function subdivide mesh using midpoint algorithm.",
@@ -551,7 +552,10 @@ void pybind_trianglemesh(py::module &m) {
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_uniformly",
             {{"number_of_points",
-              "Number of points that should be uniformly sampled."}});
+              "Number of points that should be uniformly sampled."},
+             {"use_triangle_normal",
+              "If True uses the triangle normals instead of the vertex "
+              "normals"}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_poisson_disk",
             {{"number_of_points", "Number of points that should be sampled."},
@@ -560,7 +564,10 @@ void pybind_trianglemesh(py::module &m) {
               "PointCloud is used for sample elimination."},
              {"pcl",
               "Initial PointCloud that is used for sample elimination. If this "
-              "parameter is provided the init_factor is ignored."}});
+              "parameter is provided the init_factor is ignored."},
+             {"use_triangle_normal",
+              "If True uses the triangle normals instead of the vertex "
+              "normals"}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "subdivide_midpoint",
             {{"number_of_iterations",

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -554,8 +554,10 @@ void pybind_trianglemesh(py::module &m) {
             {{"number_of_points",
               "Number of points that should be uniformly sampled."},
              {"use_triangle_normal",
-              "If True uses the triangle normals instead of the vertex "
-              "normals"}});
+              "If True assigns the triangle normals instead of the "
+              "interpolated vertex normals to the returned points. The "
+              "triangle normals will be computed and added to the mesh if "
+              "necessary."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_poisson_disk",
             {{"number_of_points", "Number of points that should be sampled."},
@@ -566,8 +568,10 @@ void pybind_trianglemesh(py::module &m) {
               "Initial PointCloud that is used for sample elimination. If this "
               "parameter is provided the init_factor is ignored."},
              {"use_triangle_normal",
-              "If True uses the triangle normals instead of the vertex "
-              "normals"}});
+              "If True assigns the triangle normals instead of the "
+              "interpolated vertex normals to the returned points. The "
+              "triangle normals will be computed and added to the mesh if "
+              "necessary."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "subdivide_midpoint",
             {{"number_of_iterations",

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -723,6 +723,29 @@ TEST(TriangleMesh, SamplePointsUniformly) {
         ExpectEQ(pcd_simple->colors_[pidx], Vector3d(1, 0, 0));
         ExpectEQ(pcd_simple->normals_[pidx], Vector3d(0, 1, 0));
     }
+
+    // use triangle normal instead of the vertex normals
+    pcd_simple = mesh_simple.SamplePointsUniformly(n_points, true);
+    EXPECT_TRUE(pcd_simple->points_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->normals_.size() == n_points);
+
+    for (size_t pidx = 0; pidx < n_points; ++pidx) {
+        ExpectEQ(pcd_simple->colors_[pidx], Vector3d(1, 0, 0));
+        ExpectEQ(pcd_simple->normals_[pidx], Vector3d(0, 0, 1));
+    }
+
+    // use triangle normal, this time the mesh has no vertex normals
+    mesh_simple.vertex_normals_.clear();
+    pcd_simple = mesh_simple.SamplePointsUniformly(n_points, true);
+    EXPECT_TRUE(pcd_simple->points_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
+    EXPECT_TRUE(pcd_simple->normals_.size() == n_points);
+
+    for (size_t pidx = 0; pidx < n_points; ++pidx) {
+        ExpectEQ(pcd_simple->colors_[pidx], Vector3d(1, 0, 0));
+        ExpectEQ(pcd_simple->normals_[pidx], Vector3d(0, 0, 1));
+    }
 }
 
 TEST(TriangleMesh, FilterSharpen) {

--- a/src/UnitTest/Geometry/TriangleMesh.cpp
+++ b/src/UnitTest/Geometry/TriangleMesh.cpp
@@ -725,7 +725,10 @@ TEST(TriangleMesh, SamplePointsUniformly) {
     }
 
     // use triangle normal instead of the vertex normals
+    EXPECT_TRUE(mesh_simple.HasTriangleNormals() == false);
     pcd_simple = mesh_simple.SamplePointsUniformly(n_points, true);
+    // the mesh now has triangle normals as a side effect.
+    EXPECT_TRUE(mesh_simple.HasTriangleNormals() == true);
     EXPECT_TRUE(pcd_simple->points_.size() == n_points);
     EXPECT_TRUE(pcd_simple->colors_.size() == n_points);
     EXPECT_TRUE(pcd_simple->normals_.size() == n_points);


### PR DESCRIPTION
This PR adds an option to SamplePointsUniformly() and SamplePointsPoissonDisk() for using the triangle normal instead of the interpolated vertex normals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1539)
<!-- Reviewable:end -->
