### PR TITLE
Added get_surface_area to TriangleMesh python interface

### DIFF
--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -241,6 +241,11 @@ void pybind_trianglemesh(py::module &m) {
                          geometry::TriangleMesh::Crop,
                  "Function to crop input TriangleMesh into output TriangleMesh",
                  "bounding_box"_a)
+            .def("get_surface_area",
+                 (double (geometry::TriangleMesh::*)() const) &
+                         geometry::TriangleMesh::GetSurfaceArea,
+                 "Function that computes the surface area of the mesh, i.e. "
+                 "the sum of the individual triangle surfaces.")
             .def("sample_points_uniformly",
                  &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",


### PR DESCRIPTION
This PR exposes the GetSurfaceArea function from TriangleMesh to python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1540)
<!-- Reviewable:end -->
