### PR TITLE
Fix broken resizing on macOS

### DIFF
--- a/src/Open3D/GUI/Window.cpp
+++ b/src/Open3D/GUI/Window.cpp
@@ -658,6 +658,12 @@ Window::DrawResult Window::DrawOnce(float dtSec) {
 void Window::OnResize() {
     impl_->needsLayout = true;
 
+#if __APPLE__
+    // We need to recreate the swap chain after resizing a window on macOS
+    // otherwise things look very wrong.
+    impl_->renderer->UpdateSwapChain();
+#endif  // __APPLE__
+
     impl_->imgui.imguiBridge->onWindowResized(*this);
 
     auto size = GetSize();

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.h
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.h
@@ -62,6 +62,8 @@ public:
     Scene* GetScene(const SceneHandle& id) const override;
     void DestroyScene(const SceneHandle& id) override;
 
+    void UpdateSwapChain() override;
+
     void BeginFrame() override;
     void Draw() override;
     void EndFrame() override;

--- a/src/Open3D/Visualization/Rendering/Renderer.h
+++ b/src/Open3D/Visualization/Rendering/Renderer.h
@@ -67,6 +67,8 @@ public:
     virtual Scene* GetScene(const SceneHandle& id) const = 0;
     virtual void DestroyScene(const SceneHandle& id) = 0;
 
+    virtual void UpdateSwapChain() = 0;
+
     virtual void BeginFrame() = 0;
     virtual void Draw() = 0;
     virtual void EndFrame() = 0;


### PR DESCRIPTION
We need to recreate the swap chain on macOS, or else Filament draws into the wrong rectangle (it's too small when shrinking, and too big when expanding).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1572)
<!-- Reviewable:end -->
