### PR TITLE
cconv filter backprop implementation and tf op

### DIFF
--- a/src/Open3D/ML/ContinuousConv/Detail/ContinuousConvBackpropFilter.h
+++ b/src/Open3D/ML/ContinuousConv/Detail/ContinuousConvBackpropFilter.h
@@ -1,0 +1,395 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+#include <mutex>
+#include "CoordinateTransformation.h"
+#include "tbb/parallel_for.h"
+
+namespace open3d {
+namespace ml {
+namespace detail {
+
+// Implementation of CConvBackropFilterCPU
+template <class TReal,
+          class TIndex,
+          InterpolationMode INTERPOLATION,
+          CoordinateMapping MAPPING,
+          bool ALIGN_CORNERS,
+          bool INDIVIDUAL_EXTENT,
+          bool ISOTROPIC_EXTENT,
+          bool POINT_IMPORTANCE>
+void _CConvBackropFilterCPU(TReal* filter_backprop,
+                            const std::vector<int>& filter_dims,
+                            size_t num_out,
+                            const TReal* out_positions,
+                            size_t num_inp,
+                            const TReal* inp_positions,
+                            const TReal* inp_features,
+                            const TReal* inp_importance,
+                            size_t num_indices,
+                            const TIndex* neighbors_index,
+                            const TReal* neighbors_importance,
+                            const int64_t* neighbors_row_splits,
+                            const TReal* extents,
+                            const TReal* offsets,
+                            const TReal* out_features_gradient,
+                            bool normalize) {
+    const bool NEIGHBOR_IMPORTANCE = neighbors_importance;
+    const int VECSIZE = 32;
+    typedef Eigen::Array<TReal, VECSIZE, 1> Vec_t;
+    typedef InterpolationVec<TReal, VECSIZE, INTERPOLATION> InterpolationVec_t;
+    InterpolationVec_t interpolation;
+
+    const int in_channels = filter_dims[filter_dims.size() - 2];
+    const int out_channels = filter_dims[filter_dims.size() - 1];
+
+    int spatial_filter_size = 1;
+    for (int i = 0; i < 3; ++i) spatial_filter_size *= filter_dims[i];
+    const int total_filter_size =
+            spatial_filter_size * in_channels * out_channels;
+    Eigen::Array<int, 3, 1> filter_size_xyz(filter_dims[2], filter_dims[1],
+                                            filter_dims[0]);
+
+    memset(filter_backprop, 0, sizeof(TReal) * total_filter_size);
+    std::mutex filter_backprop_mutex;
+
+    tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, num_out, 32),
+            [&](const tbb::blocked_range<size_t>& r) {
+
+                int range_length = r.end() - r.begin();
+
+                Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic> B(
+                        in_channels * spatial_filter_size, range_length);
+                B.setZero();
+                Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic> C(
+                        out_channels, range_length);
+
+                typedef Eigen::Array<TReal, VECSIZE, Eigen::Dynamic> Matrix;
+                Matrix infeat(VECSIZE, in_channels);
+
+                Eigen::Array<TReal, 3, 1> offsets_(offsets[0], offsets[1],
+                                                   offsets[2]);
+
+                Eigen::Array<TReal, VECSIZE, 3> inv_extents;
+                if (INDIVIDUAL_EXTENT == false) {
+                    if (ISOTROPIC_EXTENT) {
+                        inv_extents = 1 / extents[0];
+                    } else {
+                        inv_extents.col(0) = 1 / extents[0];
+                        inv_extents.col(1) = 1 / extents[1];
+                        inv_extents.col(2) = 1 / extents[2];
+                    }
+                }
+
+                for (size_t out_idx = r.begin(); out_idx != r.end();
+                     ++out_idx) {
+                    const int out_col = out_idx - r.begin();
+                    const size_t neighbor_start = neighbors_row_splits[out_idx];
+                    const size_t neighbor_end =
+                            neighbors_row_splits[out_idx + 1];
+                    TReal normalizer = 0;
+
+                    if (INDIVIDUAL_EXTENT) {
+                        if (ISOTROPIC_EXTENT) {
+                            inv_extents = 1 / extents[out_idx];
+                        } else {
+                            inv_extents.col(0) = 1 / extents[3 * out_idx + 0];
+                            inv_extents.col(1) = 1 / extents[3 * out_idx + 1];
+                            inv_extents.col(2) = 1 / extents[3 * out_idx + 2];
+                        }
+                    }
+
+                    typename InterpolationVec_t::Weight_t interp_weights;
+                    typename InterpolationVec_t::Idx_t interp_indices;
+
+                    int vec_valid_count = 0;
+                    Vec_t x, y, z;
+
+                    // set to zero to avoid problems with vectors with less than
+                    // VECSIZE valid entries
+                    x.setZero();
+                    y.setZero();
+                    z.setZero();
+                    for (size_t n = neighbor_start; n < neighbor_end; ++n) {
+                        const size_t inp_idx = neighbors_index[n];
+                        const int i = vec_valid_count;
+                        x(i) = inp_positions[inp_idx * 3 + 0] -
+                               out_positions[out_idx * 3 + 0];
+                        y(i) = inp_positions[inp_idx * 3 + 1] -
+                               out_positions[out_idx * 3 + 1];
+                        z(i) = inp_positions[inp_idx * 3 + 2] -
+                               out_positions[out_idx * 3 + 2];
+
+                        const TReal n_importance =
+                                (NEIGHBOR_IMPORTANCE ? neighbors_importance[n]
+                                                     : 1);
+                        normalizer += n_importance;
+
+                        for (int ic = 0; ic < in_channels; ++ic)
+                            infeat(i, ic) =
+                                    inp_features[inp_idx * in_channels + ic];
+
+                        TReal importance = 1;
+                        if (POINT_IMPORTANCE)
+                            importance = inp_importance[inp_idx];
+                        if (NEIGHBOR_IMPORTANCE) importance *= n_importance;
+
+                        if (POINT_IMPORTANCE || NEIGHBOR_IMPORTANCE) {
+                            for (int ic = 0; ic < in_channels; ++ic)
+                                infeat(i, ic) *= importance;
+                        }
+
+                        ++vec_valid_count;
+                        if (vec_valid_count == VECSIZE) {
+                            ComputeFilterCoordinates<ALIGN_CORNERS, MAPPING>(
+                                    x, y, z, filter_size_xyz, inv_extents,
+                                    offsets_);
+                            interpolation.Interpolate(
+                                    interp_weights, interp_indices, x, y, z,
+                                    filter_size_xyz, in_channels);
+                            for (int k = 0; k < VECSIZE; ++k)
+                                for (int j = 0; j < InterpolationVec_t::Size();
+                                     ++j) {
+                                    for (int ic = 0; ic < in_channels; ++ic)
+                                        B(interp_indices(j, k) + ic, out_col) +=
+                                                interp_weights(j, k) *
+                                                infeat(k, ic);
+                                }
+                            vec_valid_count = 0;
+                        }
+                    }
+                    if (vec_valid_count) {
+                        ComputeFilterCoordinates<ALIGN_CORNERS, MAPPING>(
+                                x, y, z, filter_size_xyz, inv_extents,
+                                offsets_);
+                        interpolation.Interpolate(interp_weights,
+                                                  interp_indices, x, y, z,
+                                                  filter_size_xyz, in_channels);
+                        for (int k = 0; k < vec_valid_count; ++k)
+                            for (int j = 0; j < InterpolationVec_t::Size();
+                                 ++j) {
+                                for (int ic = 0; ic < in_channels; ++ic)
+                                    B(interp_indices(j, k) + ic, out_col) +=
+                                            interp_weights(j, k) *
+                                            infeat(k, ic);
+                            }
+                    }
+
+                    C.col(out_col) = Eigen::Map<
+                            const Eigen::Array<TReal, Eigen::Dynamic, 1>>(
+                            out_features_gradient + out_idx * out_channels,
+                            out_channels, 1);
+
+                    if (normalize && normalizer != 0)
+                        C.col(out_col) /= normalizer;
+
+                }  // out_idx
+
+                Eigen::Matrix<TReal, Eigen::Dynamic, Eigen::Dynamic> A(
+                        out_channels, spatial_filter_size * in_channels);
+
+                A = C * B.transpose();
+
+                {
+                    std::lock_guard<std::mutex> lock(filter_backprop_mutex);
+                    int linear_i = 0;
+                    for (int j = 0; j < spatial_filter_size * in_channels; ++j)
+                        for (int i = 0; i < out_channels; ++i, ++linear_i) {
+                            filter_backprop[linear_i] += A(i, j);
+                        }
+                }
+
+            });
+}
+
+/// Computes the backprop for the filter of a continuous convolution.
+///
+/// \param temp    Pointer to temporary memory. If nullptr then the required
+///        size of temporary memory will be written to \p temp_size and no
+///        work is done. This function can make use of more memory and
+///        returns the maximum size that can be used in max_temp_size.
+///
+/// \param temp_size    The size of the temporary memory in bytes. This is
+///        used as an output if temp is nullptr and returns the minimum temp
+///        size required.
+///
+/// \param max_temp_size    This is used as an output if temp is nullptr and
+///        returns the maximum temp size that can be used.
+///
+/// \param texture_alignment    The texture alignment in bytes. This is used
+///        for allocating segments within the temporary memory.
+///
+/// \param filter_backrop    Output array for the computed filter gradient
+///        with shape [depth,height,witdth, inp channels, out channels]
+///
+/// \param filter_dims    The sizes of the filter dimensions. The size of
+///        filter_dims must be 5. The order is
+///        [depth, height, width, inp channels, out channels].
+///
+/// \param num_out    The number of output points.
+///
+/// \param out_positions    The positions of the output points. The shape is
+///        [num_out, 3].
+///
+/// \param num_inp    The number of input points.
+///
+/// \param inp_positions    The positions of the input points. The shape is
+///        [num_inp, 3].
+///
+/// \param inp_features    The input features with shape
+///        [num_inp, in_channels].
+///
+/// \param inp_importance    Optional importance for each input point with
+///        shape [num_inp]. Set to null to disable.
+///
+/// \param neighbors_index_size    The size of the neighbors_index array.
+///
+/// \param neighbors_index    The array with lists of neighbors for each
+///        output point. The start and end of each sublist is defined by
+///        \p neighbors_row_splits.
+///
+/// \param neighbors_importance    Optional importance for each entry in
+///        \p neighbors_index. Set to null to disable.
+///
+/// \param neighbors_row_splits   The prefix sum which defines the start
+///        and end of the sublists in \p neighbors_index. The size of the
+///        array is \p num_out + 1.
+///
+/// \param extents    The spatial extents of the filter in coordinate units.
+///        extents can be a scalar or a 1D array of shape [num_out] or a
+///        2D array of shape [num_out,3]. The shape depends on
+///        \p individual_extent and \p isotropic_extent.
+///
+/// \param offsets    A single 3D vector used in the filter coordinate
+///        computation. The shape is [3].
+///
+/// \param interpolation    The interpolation mode. Either LINEAR or
+///        NEAREST_NEIGHBOR.
+///
+/// \param coordinate_mapping    The coordinate mapping function. One of
+///        IDENTITY, BALL_TO_CUBE_RADIAL, BALL_TO_CUBE_VOLUME_PRESERVING.
+///
+/// \param align_corners    If true then the voxel centers of the outer voxels
+///        of the filter array are mapped to the boundary of the filter shape.
+///        If false then the boundary of the filter array is mapped to the
+///        boundary of the filter shape.
+///
+/// \param individual_extent    If true each output point has an individual
+///        extent.
+///
+/// \param isotropic_extent    If true each then the extent is isotropic for
+///        each output point.
+///
+/// \param normalize    If true then the output features are normalized either
+///        by the number of points (neighbors_importance is null) or by the sum
+///        of the respective values in neighbors_importance.
+///
+template <class TReal, class TIndex>
+void CConvBackpropFilterCPU(TReal* filter_backprop,
+                            const std::vector<int>& filter_dims,
+                            size_t num_out,
+                            const TReal* out_positions,
+                            size_t num_inp,
+                            const TReal* inp_positions,
+                            const TReal* inp_features,
+                            const TReal* inp_importance,
+                            size_t num_indices,
+                            const TIndex* neighbors_index,
+                            const TReal* neighbors_importance,
+                            const int64_t* neighbors_row_splits,
+                            const TReal* extents,
+                            const TReal* offsets,
+                            const TReal* out_features_gradient,
+                            InterpolationMode interpolation,
+                            CoordinateMapping coordinate_mapping,
+                            bool align_corners,
+                            bool individual_extent,
+                            bool isotropic_extent,
+                            bool normalize) {
+    bool has_importance = inp_importance;
+
+#define FN_PARAMETERS                                                    \
+    filter_backprop, filter_dims, num_out, out_positions, num_inp,       \
+            inp_positions, inp_features, inp_importance, num_indices,    \
+            neighbors_index, neighbors_importance, neighbors_row_splits, \
+            extents, offsets, out_features_gradient, normalize
+
+#define CALL_TEMPLATE(INTERPOLATION, MAPPING, ALIGN_CORNERS,               \
+                      INDIVIDUAL_EXTENT, ISOTROPIC_EXTENT, HAS_IMPORTANCE) \
+    if (INTERPOLATION == interpolation && MAPPING == coordinate_mapping && \
+        ALIGN_CORNERS == align_corners &&                                  \
+        INDIVIDUAL_EXTENT == individual_extent &&                          \
+        ISOTROPIC_EXTENT == isotropic_extent &&                            \
+        HAS_IMPORTANCE == has_importance)                                  \
+        _CConvBackropFilterCPU<TReal, TIndex, INTERPOLATION, MAPPING,      \
+                               ALIGN_CORNERS, INDIVIDUAL_EXTENT,           \
+                               ISOTROPIC_EXTENT, HAS_IMPORTANCE>(          \
+                FN_PARAMETERS);
+
+#define CALL_TEMPLATE2(INTERPOLATION, MAPPING)                       \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, true, true, true)    \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, true, true, false)   \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, true, false, true)   \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, true, false, false)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, false, true, true)   \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, false, true, false)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, false, false, true)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, true, false, false, false) \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, true, true, true)   \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, true, true, false)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, true, false, true)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, true, false, false) \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, false, true, true)  \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, false, true, false) \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, false, false, true) \
+    CALL_TEMPLATE(INTERPOLATION, MAPPING, false, false, false, false)
+
+#define CALL_TEMPLATE3(INTERPOLATION)                                     \
+    CALL_TEMPLATE2(INTERPOLATION, CoordinateMapping::BALL_TO_CUBE_RADIAL) \
+    CALL_TEMPLATE2(INTERPOLATION,                                         \
+                   CoordinateMapping::BALL_TO_CUBE_VOLUME_PRESERVING)     \
+    CALL_TEMPLATE2(INTERPOLATION, CoordinateMapping::IDENTITY)
+
+#define CALL_TEMPLATE4                               \
+    CALL_TEMPLATE3(InterpolationMode::LINEAR)        \
+    CALL_TEMPLATE3(InterpolationMode::LINEAR_BORDER) \
+    CALL_TEMPLATE3(InterpolationMode::NEAREST_NEIGHBOR)
+
+    CALL_TEMPLATE4
+
+#undef CALL_TEMPLATE
+#undef CALL_TEMPLATE2
+#undef CALL_TEMPLATE3
+#undef CALL_TEMPLATE4
+
+#undef FN_PARAMETERS
+}
+
+}  // namespace detail
+}  // namespace ml
+}  // namespace open3d

--- a/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.cpp
+++ b/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.cpp
@@ -1,0 +1,90 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "ContinuousConvBackpropFilterOpKernel.h"
+#include "Open3D/ML/ContinuousConv/Detail/ContinuousConvBackpropFilter.h"
+
+using namespace open3d;
+using namespace open3d::ml::detail;
+using namespace tensorflow;
+
+template <class TReal, class TIndex>
+class ContinuousConvBackpropFilterOpKernelCPU
+    : public ContinuousConvBackpropFilterOpKernel<TIndex> {
+public:
+    explicit ContinuousConvBackpropFilterOpKernelCPU(
+            OpKernelConstruction* construction)
+        : ContinuousConvBackpropFilterOpKernel<TIndex>(construction) {}
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& filter,
+                const tensorflow::Tensor& out_positions,
+                const tensorflow::Tensor& extents,
+                const tensorflow::Tensor& offset,
+                const tensorflow::Tensor& inp_positions,
+                const tensorflow::Tensor& inp_features,
+                const tensorflow::Tensor& inp_importance,
+                const tensorflow::Tensor& neighbors_index,
+                const tensorflow::Tensor& neighbors_importance,
+                const tensorflow::Tensor& neighbors_row_splits,
+                const tensorflow::Tensor& out_features_gradient,
+                const std::vector<int>& filter_dims,
+                const bool individual_extents,
+                const bool isotropic_extents,
+                const bool point_importances,
+                const bool has_neighbors_importances,
+                tensorflow::Tensor& filter_backprop) {
+        CConvBackpropFilterCPU<TReal, TIndex>(
+                filter_backprop.flat<TReal>().data(), filter_dims,
+                out_positions.shape().dim_size(0),
+                out_positions.flat<TReal>().data(),
+                inp_positions.shape().dim_size(0),
+                inp_positions.flat<TReal>().data(),
+                inp_features.flat<TReal>().data(),
+                point_importances ? inp_importance.flat<TReal>().data()
+                                  : nullptr,
+                neighbors_index.shape().dim_size(0),
+                (TIndex*)neighbors_index.flat<TIndex>().data(),
+                has_neighbors_importances
+                        ? neighbors_importance.flat<TReal>().data()
+                        : nullptr,
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                extents.flat<TReal>().data(), offset.flat<TReal>().data(),
+                out_features_gradient.flat<TReal>().data(), this->interpolation,
+                this->coordinate_mapping, this->align_corners,
+                individual_extents, isotropic_extents, this->normalize);
+    }
+};
+
+#define REG_KB(type, indextype)                           \
+    REGISTER_KERNEL_BUILDER(                              \
+            Name("Open3DContinuousConvBackpropFilter")    \
+                    .Device(DEVICE_CPU)                   \
+                    .TypeConstraint<type>("TReal")        \
+                    .TypeConstraint<indextype>("TIndex"), \
+            ContinuousConvBackpropFilterOpKernelCPU<type, indextype>);
+REG_KB(float, int32)
+#undef REG_KB

--- a/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.cu
+++ b/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.cu
@@ -1,0 +1,139 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#define EIGEN_USE_GPU
+#include "ContinuousConvBackpropFilterOpKernel.h"
+#include "Open3D/Core/CUDAUtils.h"
+#include "Open3D/ML/ContinuousConv/Detail/ContinuousConvBackpropFilter.cuh"
+
+using namespace open3d;
+using namespace open3d::ml::detail;
+using namespace tensorflow;
+
+template <class TReal, class TIndex>
+class ContinuousConvBackpropFilterOpKernelCUDA
+    : public ContinuousConvBackpropFilterOpKernel<TIndex> {
+public:
+    explicit ContinuousConvBackpropFilterOpKernelCUDA(
+            OpKernelConstruction* construction)
+        : ContinuousConvBackpropFilterOpKernel<TIndex>(construction) {
+        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+    }
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& filter,
+                const tensorflow::Tensor& out_positions,
+                const tensorflow::Tensor& extents,
+                const tensorflow::Tensor& offset,
+                const tensorflow::Tensor& inp_positions,
+                const tensorflow::Tensor& inp_features,
+                const tensorflow::Tensor& inp_importance,
+                const tensorflow::Tensor& neighbors_index,
+                const tensorflow::Tensor& neighbors_importance,
+                const tensorflow::Tensor& neighbors_row_splits,
+                const tensorflow::Tensor& out_features_gradient,
+                const std::vector<int>& filter_dims,
+                const bool individual_extents,
+                const bool isotropic_extents,
+                const bool point_importances,
+                const bool has_neighbors_importances,
+                tensorflow::Tensor& filter_backprop) {
+        auto device = context->eigen_gpu_device();
+
+        void* temp_ptr = nullptr;
+        size_t temp_size = 0;
+        size_t max_temp_size = 0;
+
+        // determine temp_size
+        CConvBackpropFilterCUDA<TReal, TIndex>(
+                device.stream(), temp_ptr, temp_size, max_temp_size,
+                texture_alignment, filter_backprop.flat<TReal>().data(),
+                filter_dims, out_positions.shape().dim_size(0),
+                out_positions.flat<TReal>().data(),
+                inp_positions.shape().dim_size(0),
+                inp_positions.flat<TReal>().data(),
+                inp_features.flat<TReal>().data(),
+                point_importances ? inp_importance.flat<TReal>().data()
+                                  : nullptr,
+                neighbors_index.shape().dim_size(0),
+                (TIndex*)neighbors_index.flat<TIndex>().data(),
+                has_neighbors_importances
+                        ? neighbors_importance.flat<TReal>().data()
+                        : nullptr,
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                extents.flat<TReal>().data(), offset.flat<TReal>().data(),
+                out_features_gradient.flat<TReal>().data(), this->interpolation,
+                this->coordinate_mapping, this->align_corners,
+                individual_extents, isotropic_extents, this->normalize);
+
+        temp_size =
+                std::max(std::min(size_t(this->max_temp_mem_MB) * 1024 * 1024,
+                                  max_temp_size),
+                         temp_size);
+
+        Tensor temp_tensor;
+        TensorShape temp_shape({ssize_t(temp_size)});
+        OP_REQUIRES_OK(context,
+                       context->allocate_temp(DataTypeToEnum<uint8_t>::v(),
+                                              temp_shape, &temp_tensor));
+        temp_ptr = temp_tensor.flat<uint8_t>().data();
+
+        // actually run the operation
+        CConvBackpropFilterCUDA<TReal, TIndex>(
+                device.stream(), temp_ptr, temp_size, max_temp_size,
+                texture_alignment, filter_backprop.flat<TReal>().data(),
+                filter_dims, out_positions.shape().dim_size(0),
+                out_positions.flat<TReal>().data(),
+                inp_positions.shape().dim_size(0),
+                inp_positions.flat<TReal>().data(),
+                inp_features.flat<TReal>().data(),
+                point_importances ? inp_importance.flat<TReal>().data()
+                                  : nullptr,
+                neighbors_index.shape().dim_size(0),
+                (TIndex*)neighbors_index.flat<TIndex>().data(),
+                has_neighbors_importances
+                        ? neighbors_importance.flat<TReal>().data()
+                        : nullptr,
+                (int64_t*)neighbors_row_splits.flat<int64>().data(),
+                extents.flat<TReal>().data(), offset.flat<TReal>().data(),
+                out_features_gradient.flat<TReal>().data(), this->interpolation,
+                this->coordinate_mapping, this->align_corners,
+                individual_extents, isotropic_extents, this->normalize);
+    }
+
+private:
+    int texture_alignment;
+};
+
+#define REG_KB(type, indextype)                           \
+    REGISTER_KERNEL_BUILDER(                              \
+            Name("Open3DContinuousConvBackpropFilter")    \
+                    .Device(DEVICE_GPU)                   \
+                    .TypeConstraint<type>("TReal")        \
+                    .TypeConstraint<indextype>("TIndex"), \
+            ContinuousConvBackpropFilterOpKernelCUDA<type, indextype>);
+REG_KB(float, int32)
+#undef REG_KB

--- a/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.h
+++ b/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOpKernel.h
@@ -1,0 +1,216 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+#pragma once
+
+#include "Open3D/ML/ContinuousConv/Detail/ContinuousConvTypes.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+template <class TIndex>
+class ContinuousConvBackpropFilterOpKernel : public tensorflow::OpKernel {
+public:
+    explicit ContinuousConvBackpropFilterOpKernel(
+            tensorflow::OpKernelConstruction* construction)
+        : OpKernel(construction) {
+        using namespace tensorflow;
+        using namespace open3d::ml::detail;
+        OP_REQUIRES_OK(construction,
+                       construction->GetAttr("align_corners", &align_corners));
+        OP_REQUIRES_OK(construction,
+                       construction->GetAttr("normalize", &normalize));
+
+        std::string interpolation_str;
+        OP_REQUIRES_OK(construction, construction->GetAttr("interpolation",
+                                                           &interpolation_str));
+
+        if (interpolation_str == "linear")
+            interpolation = InterpolationMode::LINEAR;
+        else if (interpolation_str == "linear_border")
+            interpolation = InterpolationMode::LINEAR_BORDER;
+        else
+            interpolation = InterpolationMode::NEAREST_NEIGHBOR;
+
+        std::string mapping_str;
+        OP_REQUIRES_OK(construction, construction->GetAttr("coordinate_mapping",
+                                                           &mapping_str));
+
+        if (mapping_str == "ball_to_cube_radial")
+            coordinate_mapping = CoordinateMapping::BALL_TO_CUBE_RADIAL;
+        else if (mapping_str == "ball_to_cube_volume_preserving")
+            coordinate_mapping =
+                    CoordinateMapping::BALL_TO_CUBE_VOLUME_PRESERVING;
+        else
+            coordinate_mapping = CoordinateMapping::IDENTITY;
+
+        OP_REQUIRES_OK(construction, construction->GetAttr("max_temp_mem_MB",
+                                                           &max_temp_mem_MB));
+    }
+
+    void Compute(tensorflow::OpKernelContext* context) override {
+        using namespace tensorflow;
+        static_assert(sizeof(int64) == sizeof(int64_t),
+                      "int64 type is not compatible");
+        const Tensor& filter = context->input(0);
+
+        const Tensor& out_positions = context->input(1);
+        OP_REQUIRES(context,
+                    out_positions.shape().dim_size(0) <=
+                            std::numeric_limits<TIndex>::max(),
+                    errors::InvalidArgument("Too many output points"));
+
+        const Tensor& extents = context->input(2);
+        OP_REQUIRES(context, extents.shape().dims() == 2,
+                    errors::InvalidArgument("extents must be a rank 2 tensor"));
+        OP_REQUIRES(context,
+                    extents.shape().dim_size(0) ==
+                                    out_positions.shape().dim_size(0) ||
+                            extents.shape().dim_size(0) == 1,
+                    errors::InvalidArgument("number of extents must match the "
+                                            "number of out_positions or must "
+                                            "be 1"));
+        OP_REQUIRES(context,
+                    extents.shape().dim_size(1) == 3 ||
+                            extents.shape().dim_size(1) == 1,
+                    errors::InvalidArgument(
+                            "number of components for extents must be 3 or 1"));
+
+        const Tensor& offset = context->input(3);
+        OP_REQUIRES(context, offset.shape().dims() == 1,
+                    errors::InvalidArgument("offset must be a rank 1 tensor"));
+        OP_REQUIRES(context, offset.shape().dim_size(0) == 3,
+                    errors::InvalidArgument("offset length must be 3"));
+
+        const Tensor& inp_positions = context->input(4);
+        OP_REQUIRES(context,
+                    inp_positions.shape().dim_size(0) <=
+                            std::numeric_limits<TIndex>::max(),
+                    errors::InvalidArgument("Too many input points"));
+
+        const Tensor& inp_features = context->input(5);
+
+        const Tensor& inp_importance = context->input(6);
+
+        const Tensor& neighbors_index = context->input(7);
+
+        const Tensor& neighbors_importance = context->input(8);
+
+        const Tensor& neighbors_row_splits = context->input(9);
+
+        const Tensor& out_features_gradient = context->input(10);
+
+        OP_REQUIRES(
+                context,
+                inp_positions.shape().dim_size(0) ==
+                        inp_features.shape().dim_size(0),
+                errors::InvalidArgument("first dim of inp_positions does not "
+                                        "match the first dim of inp_features"));
+
+        OP_REQUIRES(context,
+                    inp_positions.shape().dim_size(0) ==
+                                    inp_importance.shape().dim_size(0) ||
+                            inp_importance.shape().dim_size(0) == 0,
+                    errors::InvalidArgument("first dim of inp_positions does "
+                                            "not match the first dim of "
+                                            "inp_importance"));
+
+        OP_REQUIRES(context,
+                    neighbors_importance.shape().dim_size(0) ==
+                                    neighbors_index.shape().dim_size(0) ||
+                            neighbors_importance.shape().dim_size(0) == 0,
+                    errors::InvalidArgument("first dim of neighbors_importance "
+                                            "does not match the first dim of "
+                                            "neighbors_index"));
+
+        OP_REQUIRES(
+                context,
+                filter.shape().dim_size(3) == inp_features.shape().dim_size(1),
+                errors::InvalidArgument("number of input channels in filter "
+                                        "and inp_features does not match"));
+
+        OP_REQUIRES(context,
+                    out_features_gradient.shape().dim_size(0) ==
+                            out_positions.shape().dim_size(0),
+                    errors::InvalidArgument("first dim of out_positions, does "
+                                            "not match the first dim of "
+                                            "out_features_gradient"));
+
+        TensorShape filter_backprop_shape(filter.shape());
+        Tensor* filter_backprop = nullptr;
+        OP_REQUIRES_OK(context,
+                       context->allocate_output(0, filter_backprop_shape,
+                                                &filter_backprop));
+
+        std::vector<int> filter_dims({
+                int(filter.shape().dim_size(0)),
+                int(filter.shape().dim_size(1)),
+                int(filter.shape().dim_size(2)),
+                int(filter.shape().dim_size(3)),
+                int(filter.shape().dim_size(4)),
+        });
+
+        bool individual_extents = extents.shape().dim_size(0) ==
+                                          out_positions.shape().dim_size(0) &&
+                                  extents.shape().dim_size(0) > 1;
+
+        bool isotropic_extents = extents.shape().dim_size(1) == 1;
+
+        bool point_importances = inp_importance.shape().dim_size(0) != 0;
+
+        bool has_neighbors_importances =
+                neighbors_importance.shape().dim_size(0) != 0;
+
+        Kernel(context, filter, out_positions, extents, offset, inp_positions,
+               inp_features, inp_importance, neighbors_index,
+               neighbors_importance, neighbors_row_splits,
+               out_features_gradient, filter_dims, individual_extents,
+               isotropic_extents, point_importances, has_neighbors_importances,
+               *filter_backprop);
+    }
+
+    virtual void Kernel(tensorflow::OpKernelContext* context,
+                        const tensorflow::Tensor& filter,
+                        const tensorflow::Tensor& out_positions,
+                        const tensorflow::Tensor& extents,
+                        const tensorflow::Tensor& offset,
+                        const tensorflow::Tensor& inp_positions,
+                        const tensorflow::Tensor& inp_features,
+                        const tensorflow::Tensor& inp_importance,
+                        const tensorflow::Tensor& neighbors_index,
+                        const tensorflow::Tensor& neighbors_importance,
+                        const tensorflow::Tensor& neighbors_row_splits,
+                        const tensorflow::Tensor& out_features_gradient,
+                        const std::vector<int>& filter_dims,
+                        const bool individual_extents,
+                        const bool isotropic_extents,
+                        const bool point_importances,
+                        const bool has_neighbors_importances,
+                        tensorflow::Tensor& filter_backprop) = 0;
+
+public:
+    bool align_corners;
+    bool normalize;
+    open3d::ml::detail::InterpolationMode interpolation;
+    open3d::ml::detail::CoordinateMapping coordinate_mapping;
+    int max_temp_mem_MB;
+};

--- a/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOps.cpp
+++ b/src/Open3D/ML/TensorFlow/ContinuousConv/ContinuousConvBackpropFilterOps.cpp
@@ -1,0 +1,260 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Open3DContinuousConvBackpropFilter")
+        .Attr("T: {float, double}")
+        .Attr("T2: {int32, int64}")
+        .Attr("align_corners: bool = true")
+        .Attr("coordinate_mapping: {'ball_to_cube_radial', "
+              "'ball_to_cube_volume_preserving', 'identity'} = "
+              "'ball_to_cube_radial'")
+        .Attr("normalize: bool = false")
+        .Attr("interpolation: {'linear', 'linear_border', 'nearest_neighbor'} "
+              "= 'linear'")
+        .Attr("max_temp_mem_MB: int = 64")
+        .Attr("debug: bool = false")
+        .Input("filters: T")           // [depth, height, width, in_ch, out_ch]
+        .Input("out_positions: T")     // [num_points_out, 3]
+        .Input("extents: T")           // [num_points_out, 3]
+        .Input("offset: T")            // [3]
+        .Input("inp_positions: T")     // [num_points_in, 3]
+        .Input("inp_features: T")      // [num_points_in, in_ch]
+        .Input("inp_importance: T")    // [num_points_in]
+        .Input("neighbors_index: T2")  // [?]
+        .Input("neighbors_importance: T")      // [?]
+        .Input("neighbors_row_splits: int64")  // [num_points_out]
+        .Input("out_features_gradient: T")     // [num_points_out, out_ch]
+        .Output("filter_backprop : T")  // [depth, height, width, in_ch, out_ch]
+        .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+            using namespace ::tensorflow::shape_inference;
+            ShapeHandle filters_shape, out_positions_shape, extents_shape,
+                    offset_shape, inp_positions_shape, inp_features_shape,
+                    inp_importance_shape, neighbors_index_shape,
+                    neighbors_importance_shape, neighbors_row_splits_shape,
+                    out_features_gradient_shape;
+
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 5, &filters_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(1), 2, &out_positions_shape));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 2, &extents_shape));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 1, &offset_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(4), 2, &inp_positions_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(5), 2, &inp_features_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(6), 1, &inp_importance_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(7), 1, &neighbors_index_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(8), 1, &neighbors_importance_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(9), 1, &neighbors_row_splits_shape));
+            TF_RETURN_IF_ERROR(
+                    c->WithRank(c->input(10), 2, &out_features_gradient_shape));
+
+            //
+            // check if dimensions make sense between tensors
+            //
+            if (c->RankKnown(out_positions_shape) &&
+                c->RankKnown(neighbors_row_splits_shape)) {
+                DimensionHandle d;
+                DimensionHandle num_out;
+                TF_RETURN_IF_ERROR(c->Subtract(
+                        c->Dim(neighbors_row_splits_shape, 0), 1, &num_out));
+                TF_RETURN_IF_ERROR(
+                        c->Merge(c->Dim(out_positions_shape, 0), num_out, &d));
+            }
+
+            if (c->RankKnown(inp_positions_shape) &&
+                c->RankKnown(inp_features_shape)) {
+                DimensionHandle d;
+                TF_RETURN_IF_ERROR(c->Merge(c->Dim(inp_positions_shape, 0),
+                                            c->Dim(inp_features_shape, 0), &d));
+            }
+
+            if (c->RankKnown(filters_shape) &&
+                c->RankKnown(inp_features_shape)) {
+                DimensionHandle d;
+                TF_RETURN_IF_ERROR(c->Merge(c->Dim(filters_shape, 3),
+                                            c->Dim(inp_features_shape, 1), &d));
+            }
+
+            if (c->RankKnown(extents_shape)) {
+                DimensionHandle d;
+                Status s1 = c->WithValue(c->Dim(extents_shape, 1), 1, &d);
+                Status s2 = c->WithValue(c->Dim(extents_shape, 1), 3, &d);
+
+                if (!s1.ok() && !s2.ok())
+                    TF_RETURN_WITH_CONTEXT_IF_ERROR(
+                            c->WithValue(c->Dim(extents_shape, 1), 3, &d),
+                            "extents must have 3 components or 1 component");
+            }
+
+            if (c->RankKnown(offset_shape)) {
+                DimensionHandle d;
+                TF_RETURN_IF_ERROR(
+                        c->WithValue(c->Dim(offset_shape, 0), 3, &d));
+            }
+
+            //
+            // check if the filter shape is valid
+            //
+            for (int i = 0; i < 3; ++i) {
+                if (c->ValueKnown(c->Dim(filters_shape, i))) {
+                    int64_t n = c->Value(c->Dim(filters_shape, i));
+                    if (n < 1)
+                        return Status(error::INVALID_ARGUMENT,
+                                      "Each filter dimension must be >= 1");
+                }
+            }
+
+            // check shape of the incoming gradient 'out_features_gradient'
+            if (c->RankKnown(out_features_gradient_shape)) {
+                DimensionHandle first_dim = c->UnknownDim();
+                if (c->RankKnown(out_positions_shape)) {
+                    TF_RETURN_IF_ERROR(c->Merge(c->Dim(out_positions_shape, 0),
+                                                first_dim, &first_dim));
+                }
+
+                DimensionHandle second_dim = c->UnknownDim();
+                if (c->RankKnown(filters_shape)) {
+                    TF_RETURN_IF_ERROR(c->Merge(c->Dim(filters_shape, 4),
+                                                second_dim, &second_dim));
+                }
+                ShapeHandle features_grad_shape =
+                        c->MakeShape({first_dim, second_dim});
+
+                ShapeHandle s;
+                TF_RETURN_IF_ERROR(c->Merge(features_grad_shape,
+                                            out_features_gradient_shape, &s));
+            }
+
+            c->set_output(0, filters_shape);
+            return Status::OK();
+        })
+        .Doc(R"doc(
+Computes the backprop for the filter of the ContinuousConv
+
+align_corners:
+  If True the outer voxel centers of the filter grid are aligned with the boundady of the spatial shape.
+
+
+coordinate_mapping:
+  Defines how the relative positions of the neighbors are mapped before computing
+  filter indices.
+  For all mappings relative coordinates will be scaled with the inverse extent, 
+  i.e. the extent becomes a unit cube.
+  After that one of the following mappings will be applied:
+    'ball_to_cube_radial': maps a unit ball to a unit cube by radial stretching.
+    'ball_to_cube_volume_preserving': maps a unit ball to a unit cube preserving the volume.
+    'identity': the identity mapping.
+  Use 'ball_to_cube_radial' for a spherical or ellipsoidal filter window 
+  and 'identiy' for a rectangular filter window.
+
+
+normalize:
+  If True the output feature values will be normalized by the number of neighbors.
+
+
+interpolation:
+  If interpolation is 'linear' then each filter value lookup is a trilinear interpolation.
+  If interpolation is 'nearest_neighbor' only the spatially closest value is considered. 
+  This makes the filter and therefore the convolution discontinuous.
+
+
+max_temp_mem_MB:
+  Defines the maximum temporary memory in megabytes to be used for the GPU implementation.
+  More memory means fewer kernel invocations.
+
+
+filters:
+  The filter parameters. 
+  The shape of the filter is [depth, height, width, in_ch, out_ch].
+  The dimensions 'depth', 'height', 'width' define the spatial resolution of
+  the filter. The spatial size of the filter is defined by the parameter
+  'extents'.
+    
+
+out_positions:
+  A 2D tensor with the 3D point positions of each output point.
+  The coordinates for each point is a vector with format [x,y,z].
+
+
+extents:
+  The extent defines the spatial size of the filter for each output point. 
+  It is a 2D vector of the form [[x_size, y_size, z_size], ..].
+  For 'ball to cube' coordinate mappings the extent defines the bounding box
+  of the ball.
+  Broadcasting is supported for all axes. E.g. providing only the extent for a
+  single point as well as only providing 'x_size' is valid.
+
+
+offset:
+  A 1D tensor which defines the offset in voxel units to shift the input points.
+  Offsets will be ignored if align_corners is True.
+
+
+inp_positions:
+  A 2D tensor with the 3D point positions of each input point.
+  The coordinates for each point is a vector with format [x,y,z].
+
+
+inp_features:
+  A 2D tensor which stores a feature vector for each input point.
+
+
+neighbors_index:
+  The neighbors_index stores a list of indices of neighbors for each output point as nested lists.
+  The start and end of each list can be computed using 'neighbors_row_splits'.
+
+
+neighbors_importance:
+  Tensor of the same shape as 'neighbors_index' with a scalar value that is used to scale
+  the features of each neighbor.
+
+
+neighbors_row_splits:
+  The exclusive prefix sum of the neighbor count for the output points including
+  the total neighbor count as the last element. The size of this array is the 
+  number of output points + 1.
+
+
+out_features_gradient:
+  A Tensor with the gradient for the outputs of the DCConv in the forward pass.
+
+
+filter_backprop:
+  The gradients for the filter
+
+)doc");


### PR DESCRIPTION
This PR adds the filter backprop for the convolution and the tf op.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1575)
<!-- Reviewable:end -->
