### PR TITLE
Rendering modes fixes

### DIFF
--- a/src/Open3D/GUI/Materials/depth.mat
+++ b/src/Open3D/GUI/Materials/depth.mat
@@ -3,13 +3,14 @@ material {
     shadingModel : unlit,
     parameters : [
             { type : float,  name : cameraFar },
-            { type : float,  name : cameraNear }
+            { type : float,  name : cameraNear },
+            { type : float,  name : pointSize }
         ],
 }
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        gl_PointSize = 3.0;
+        gl_PointSize = materialParams.pointSize;
     }
 }
 
@@ -23,6 +24,6 @@ fragment {
         float eye_z = near * far / ((gl_FragCoord.z * (far - near)) - far);
         float linearZ = (eye_z + near) / (near - far);
 
-        material.baseColor.rgb = float3(linearZ);
+        material.baseColor.rgb = heatmap(4*linearZ);
     }
 }

--- a/src/Open3D/GUI/Materials/normals.mat
+++ b/src/Open3D/GUI/Materials/normals.mat
@@ -2,6 +2,10 @@ material {
     name : normals,
     shadingModel : unlit,
 
+    parameters : [
+        { type : float,  name : pointSize }
+    ],
+
     // We use this attribute for acquiring tangents from vertex buffer.
     // We can't use 'tangents' attribute, because it would be
     // stripped from unlit material.
@@ -16,13 +20,13 @@ material {
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        gl_PointSize = 3.0;
+        gl_PointSize = materialParams.pointSize;
 
         float4 tangentSpace = getCustom0();
         float3 normal;
         toTangentFrame(tangentSpace, normal);
 
-        material.normalWorld = getViewFromWorldMatrix()*getWorldFromModelMatrix()*float4(normal, 0.0);
+        material.normalWorld.xyz = getWorldFromModelNormalMatrix()*normal;
     }
 }
 

--- a/src/Open3D/GUI/SceneWidget.cpp
+++ b/src/Open3D/GUI/SceneWidget.cpp
@@ -45,7 +45,7 @@ namespace open3d {
 namespace gui {
 
 static const double NEAR_PLANE = 0.1;
-static const double MIN_FAR_PLANE = 20.0;
+static const double MIN_FAR_PLANE = 1.0;
 
 // ----------------------------------------------------------------------------
 class MouseInteractor {

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentResourceManager.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentResourceManager.cpp
@@ -611,6 +611,7 @@ void FilamentResourceManager::LoadDefaults() {
     const auto depthPath = resourceRoot + "/depth.filamat";
     const auto hDepth = CreateMaterial(ResourceLoadRequest(depthPath.data()));
     auto depthMat = materials_[hDepth];
+    depthMat->setDefaultParameter("pointSize", 3.f);
     materialInstances_[kDepthMaterial] =
             MakeShared(depthMat->createInstance(), engine_);
 
@@ -618,6 +619,7 @@ void FilamentResourceManager::LoadDefaults() {
     const auto hNormals =
             CreateMaterial(ResourceLoadRequest(normalsPath.data()));
     auto normalsMat = materials_[hNormals];
+    normalsMat->setDefaultParameter("pointSize", 3.f);
     materialInstances_[kNormalsMaterial] =
             MakeShared(normalsMat->createInstance(), engine_);
 

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -49,6 +49,7 @@
 #include "Open3D/Open3DConfig.h"
 #include "Open3D/Utility/Console.h"
 #include "Open3D/Utility/FileSystem.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
 #include "Open3D/Visualization/Rendering/RendererStructs.h"
 #include "Open3D/Visualization/Rendering/Scene.h"
 
@@ -446,18 +447,27 @@ GuiVisualizer::GuiVisualizer(
         mainGrid->AddChild(std::make_shared<gui::Label>("Point size"));
         impl_->materialSettings.wgtPointSize =
                 MakeSlider(gui::Slider::INT, 0.0, 10.0, 3);
-        impl_->materialSettings.wgtPointSize->OnValueChanged =
-                [this](double value) {
-                    for (const auto &pair : impl_->geometryMaterials) {
-                        auto &renderer = GetRenderer();
-                        renderer.ModifyMaterial(pair.second.lit.handle)
-                                .SetParameter("pointSize", (float)value)
-                                .Finish();
-                        renderer.ModifyMaterial(pair.second.unlit.handle)
-                                .SetParameter("pointSize", (float)value)
-                                .Finish();
-                    }
-                };
+        impl_->materialSettings.wgtPointSize
+                ->OnValueChanged = [this](double value) {
+            auto &renderer = GetRenderer();
+            for (const auto &pair : impl_->geometryMaterials) {
+                renderer.ModifyMaterial(pair.second.lit.handle)
+                        .SetParameter("pointSize", (float)value)
+                        .Finish();
+                renderer.ModifyMaterial(pair.second.unlit.handle)
+                        .SetParameter("pointSize", (float)value)
+                        .Finish();
+            }
+
+            renderer.ModifyMaterial(visualization::FilamentResourceManager::
+                                            kDepthMaterial)
+                    .SetParameter("pointSize", (float)value)
+                    .Finish();
+            renderer.ModifyMaterial(visualization::FilamentResourceManager::
+                                            kNormalsMaterial)
+                    .SetParameter("pointSize", (float)value)
+                    .Finish();
+        };
         mainGrid->AddChild(impl_->materialSettings.wgtPointSize);
 
         impl_->materialSettings.wgtBase->AddChild(mainGrid);


### PR DESCRIPTION
* Normals mapped to colors in world space
* Applied heatmap mapping to depth visualizer
* Point size now affects 'Normal map' and 'Depth' modes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1586)
<!-- Reviewable:end -->
