### PR TITLE
Fix white point clouds looking nearly invisible

### DIFF
--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -731,11 +731,17 @@ void GuiVisualizer::SetGeometry(
                 auto pcd =
                         std::static_pointer_cast<const geometry::PointCloud>(g);
 
-                if (pcd->HasColors()) {
-                    selectedMaterial = materials.unlit.handle;
-                } else {
-                    selectedMaterial = materials.lit.handle;
-                }
+                // This is troublesome:
+                // - some point clouds have no vertex color; they should be
+                //   unlit
+                // - some point clouds specify a vertex color of white;
+                //   they also need to be unlit
+                // - some point clouds have vertex colors that are real;
+                //   they should be unlit. Unfortunately, we can't tell the
+                //   the difference between these and the previous case,
+                //   and unlit with white vertices looks really bad. So we
+                //   always use lit for point clouds.
+                selectedMaterial = materials.lit.handle;
             } break;
             case geometry::Geometry::GeometryType::LineSet: {
                 selectedMaterial = materials.unlit.handle;


### PR DESCRIPTION
German decided that we need to use a lit material for point clouds, because if we use unlit for all-white point clouds they look really terrible, but there isn't a good way of telling the difference between those and point clouds that have real vertex colors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1587)
<!-- Reviewable:end -->
