### PR TITLE
mixed regular and anvanded indexing, and pybind

### DIFF
--- a/src/Open3D/Core/Tensor.h
+++ b/src/Open3D/Core/Tensor.h
@@ -144,7 +144,11 @@ public:
         return *this;
     }
 
-    /// Pythonic __getitem__ for tensor, returning a new view.
+    /// Pythonic __getitem__ for tensor.
+    ///
+    /// Returns a view of the original tensor, if TensorKey is
+    /// TensorKeyMode::Index or TensorKeyMode::Slice. Returns a copy if the
+    /// TensorKey contains TensorKeyMode::IndexTensor (advanced indexing).
     ///
     /// For example, in numpy:
     /// ```python
@@ -161,7 +165,11 @@ public:
     /// ```
     Tensor GetItem(const TensorKey& tk) const;
 
-    /// Pythonic __getitem__ for tensor, returning a new view.
+    /// Pythonic __getitem__ for tensor.
+    ///
+    /// Returns a view of the original tensor, if TensorKey only contains
+    /// TensorKeyMode::Index or TensorKeyMode::Slice. Returns a copy if the
+    /// TensorKey contains IndexTensor (advanced indexing).
     ///
     /// For example, in numpy:
     /// ```python
@@ -322,16 +330,6 @@ public:
     ///
     /// We use the Numpy advanced indexing symnatics, see:
     /// https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
-    ///
-    /// Note: Only support 1D index tensors.
-    /// Note: Only support advanced indices are all next to each other. E.g.
-    /// ```
-    /// A = np.ones((10, 20, 30, 40, 50))
-    /// A[:, [1, 2], [2, 3], :, :]  # Supported,
-    ///                               output_shape: [10, 2, 40, 50]
-    ///                               slice_map:    [0, -1, 3, 4]
-    /// A[:, [1, 2], :, [2, 3], :]  # No suport, output_shape: [2, 10, 30, 50]
-    ///                             # For this case, a transpose op is necessary
     /// ```
     Tensor IndexGet(const std::vector<Tensor>& index_tensors) const;
 

--- a/src/Open3D/Core/TensorKey.cpp
+++ b/src/Open3D/Core/TensorKey.cpp
@@ -25,10 +25,94 @@
 // ----------------------------------------------------------------------------
 
 #include "Open3D/Core/TensorKey.h"
+#include "Open3D/Core/Tensor.h"
 #include "Open3D/Utility/Console.h"
 
 namespace open3d {
 
 NoneType None;
+
+TensorKey TensorKey::Index(int64_t index) {
+    return TensorKey(TensorKeyMode::Index, index, 0, 0, 0, false, false, false,
+                     Tensor());
+}
+
+TensorKey TensorKey::Slice(int64_t start, int64_t stop, int64_t step) {
+    return Slice(start, stop, step, false, false, false);
+}
+
+TensorKey TensorKey::Slice(int64_t start, int64_t stop, NoneType step) {
+    return Slice(start, stop, 0, false, false, true);
+}
+
+TensorKey TensorKey::Slice(int64_t start, NoneType stop, int64_t step) {
+    return Slice(start, 0, step, false, true, false);
+}
+
+TensorKey TensorKey::Slice(int64_t start, NoneType stop, NoneType step) {
+    return Slice(start, 0, 0, false, true, true);
+}
+
+TensorKey TensorKey::Slice(NoneType start, int64_t stop, int64_t step) {
+    return Slice(0, stop, step, true, false, false);
+}
+
+TensorKey TensorKey::Slice(NoneType start, int64_t stop, NoneType step) {
+    return Slice(0, stop, 0, true, false, true);
+}
+
+TensorKey TensorKey::Slice(NoneType start, NoneType stop, int64_t step) {
+    return Slice(0, 0, step, true, true, false);
+}
+
+TensorKey TensorKey::Slice(NoneType start, NoneType stop, NoneType step) {
+    return Slice(0, 0, 0, true, true, true);
+}
+
+TensorKey TensorKey::IndexTensor(const Tensor& index_tensor) {
+    return TensorKey(TensorKeyMode::IndexTensor, 0, 0, 0, 0, false, false,
+                     false, index_tensor);
+}
+
+std::shared_ptr<Tensor> TensorKey::GetIndexTensor() const {
+    AssertMode(TensorKeyMode::IndexTensor);
+    return index_tensor_;
+}
+
+TensorKey TensorKey::UpdateWithDimSize(int64_t dim_size) const {
+    AssertMode(TensorKeyMode::Slice);
+    return TensorKey(TensorKeyMode::Slice, 0, start_is_none_ ? 0 : start_,
+                     stop_is_none_ ? dim_size : stop_,
+                     step_is_none_ ? 1 : step_, false, false, false, Tensor());
+}
+
+TensorKey TensorKey::Slice(int64_t start,
+                           int64_t stop,
+                           int64_t step,
+                           bool start_is_none,
+                           bool stop_is_none,
+                           bool step_is_none) {
+    return TensorKey(TensorKeyMode::Slice, 0, start, stop, step, start_is_none,
+                     stop_is_none, step_is_none, Tensor());
+}
+
+TensorKey::TensorKey(TensorKeyMode mode,
+                     int64_t index,
+                     int64_t start,
+                     int64_t stop,
+                     int64_t step,
+                     bool start_is_none,
+                     bool stop_is_none,
+                     bool step_is_none,
+                     const Tensor& index_tensor)
+    : mode_(mode),
+      index_(index),
+      start_(start),
+      stop_(stop),
+      step_(step),
+      start_is_none_(start_is_none),
+      stop_is_none_(stop_is_none),
+      step_is_none_(step_is_none),
+      index_tensor_(std::make_shared<Tensor>(index_tensor)){};
 
 };  // namespace open3d

--- a/src/Python/open3d_pybind/core/tensor.cpp
+++ b/src/Python/open3d_pybind/core/tensor.cpp
@@ -227,17 +227,18 @@ void pybind_core_tensor(py::module& m) {
     });
 
     tensor.def("_getitem_vector",
-               [](const Tensor& tensor, std::vector<TensorKey> tks) {
+               [](const Tensor& tensor, const std::vector<TensorKey>& tks) {
                    return tensor.GetItem(tks);
                });
 
-    // Only need to bind the "set everything" case.
-    // In Python, __setitem__(self, key, value) is decpomposed to
-    // t = self.__getitem__(key)
-    // t[:] = value
-    tensor.def("_setitem", [](Tensor& tensor, const Tensor& value) {
-        return tensor.SetItem(value);
-    });
+    tensor.def("_setitem",
+               [](Tensor& tensor, const TensorKey& tk, const Tensor& value) {
+                   return tensor.SetItem(tk, value);
+               });
+
+    tensor.def("_setitem_vector",
+               [](Tensor& tensor, const std::vector<TensorKey>& tks,
+                  const Tensor& value) { return tensor.SetItem(tks, value); });
 
     // Casting
     tensor.def("to", &Tensor::To);

--- a/src/Python/open3d_pybind/core/tensor_key.cpp
+++ b/src/Python/open3d_pybind/core/tensor_key.cpp
@@ -28,6 +28,7 @@
 #include "open3d_pybind/docstring.h"
 #include "open3d_pybind/open3d_pybind.h"
 
+#include "Open3D/Core/Tensor.h"
 #include "Open3D/Core/TensorKey.h"
 
 using namespace open3d;
@@ -74,4 +75,5 @@ void pybind_core_tensor_key(py::module& m) {
                           [](NoneType start, NoneType stop, NoneType step) {
                               return TensorKey::Slice(start, stop, step);
                           });
+    tensor_key.def_static("index_tensor", &TensorKey::IndexTensor);
 }


### PR DESCRIPTION
Support for mixed indexing, slicing and advanced indexing:
e.g.
```python
o3_dst = o3_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1613)
<!-- Reviewable:end -->
