### PR TITLE
Adds render current view to file

### DIFF
--- a/src/Open3D/GUI/FileDialog.cpp
+++ b/src/Open3D/GUI/FileDialog.cpp
@@ -425,7 +425,7 @@ void FileDialog::OnDone() {
     if (this->impl_->onDone) {
         auto dir = this->impl_->CalcCurrentDirectory();
         utility::filesystem::ChangeWorkingDirectory(dir);
-        auto name = this->impl_->GetSelectedEntry().GetName();
+        auto name = this->impl_->filename->GetText();
         this->impl_->onDone((dir + "/" + name).c_str());
     } else {
         utility::LogError("FileDialog: need to call SetOnDone()");

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.cpp
@@ -237,8 +237,8 @@ void FilamentRenderer::RemoveSkybox(const SkyboxHandle& id) {
     resourceManager_.Destroy(id);
 }
 
-std::unique_ptr<RenderToBuffer> FilamentRenderer::CreateBufferRenderer() {
-    auto renderer = std::make_unique<FilamentRenderToBuffer>(engine_, *this);
+std::shared_ptr<RenderToBuffer> FilamentRenderer::CreateBufferRenderer() {
+    auto renderer = std::make_shared<FilamentRenderToBuffer>(engine_, *this);
     bufferRenderers_.insert(renderer.get());
     return std::move(renderer);
 }

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.h
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderer.h
@@ -87,7 +87,8 @@ public:
     SkyboxHandle AddSkybox(const ResourceLoadRequest& request) override;
     void RemoveSkybox(const SkyboxHandle& id) override;
 
-    std::unique_ptr<RenderToBuffer> CreateBufferRenderer() override;
+    std::shared_ptr<visualization::RenderToBuffer> CreateBufferRenderer()
+            override;
 
     // Removes scene from scenes list and draws it last
     // WARNING: will destroy previous gui scene if there was any

--- a/src/Open3D/Visualization/Rendering/RenderToBuffer.h
+++ b/src/Open3D/Visualization/Rendering/RenderToBuffer.h
@@ -52,6 +52,8 @@ public:
     virtual void SetDimensions(std::size_t width, std::size_t height) = 0;
     virtual void CopySettings(const View* view) = 0;
     virtual View& GetView() = 0;
+    // BufferReadyCallback does not need to free Buffer::bytes.
+    // It should also not cache the pointer.
     virtual void RequestFrame(Scene* scene, BufferReadyCallback cb) = 0;
 };
 

--- a/src/Open3D/Visualization/Rendering/Renderer.cpp
+++ b/src/Open3D/Visualization/Rendering/Renderer.cpp
@@ -26,6 +26,9 @@
 
 #include "Renderer.h"
 
+#include "RenderToBuffer.h"
+
+#include "Open3D/Geometry/Image.h"
 #include "Open3D/Utility/Console.h"
 
 namespace open3d {
@@ -77,12 +80,12 @@ ResourceLoadRequest::ResourceLoadRequest(const char* aPath,
       path(aPath),
       errorCallback(std::move(aErrorCallback)) {}
 
-void Renderer::RenderToBuffer(
+void Renderer::RenderToImage(
         std::size_t width,
         std::size_t height,
         View* view,
         Scene* scene,
-        std::function<void(const visualization::RenderToBuffer::Buffer&)> cb) {
+        std::function<void(std::shared_ptr<geometry::Image>)> cb) {
     auto render = CreateBufferRenderer();
     render->SetDimensions(width, height);
     render->CopySettings(view);
@@ -91,7 +94,14 @@ void Renderer::RenderToBuffer(
             // the shared_ptr (render) is const unless the lambda
             // is made mutable
             [render, cb](const RenderToBuffer::Buffer& buffer) mutable {
-                cb(buffer);
+                auto image = std::make_shared<geometry::Image>();
+                image->width_ = buffer.width;
+                image->height_ = buffer.height;
+                image->num_of_channels_ = 3;
+                image->bytes_per_channel_ = 1;
+                image->data_ = std::vector<uint8_t>(buffer.bytes,
+                                                    buffer.bytes + buffer.size);
+                cb(image);
                 render = nullptr;
             });
 }

--- a/src/Open3D/Visualization/Rendering/Renderer.cpp
+++ b/src/Open3D/Visualization/Rendering/Renderer.cpp
@@ -77,5 +77,24 @@ ResourceLoadRequest::ResourceLoadRequest(const char* aPath,
       path(aPath),
       errorCallback(std::move(aErrorCallback)) {}
 
+void Renderer::RenderToBuffer(
+        std::size_t width,
+        std::size_t height,
+        View* view,
+        Scene* scene,
+        std::function<void(const visualization::RenderToBuffer::Buffer&)> cb) {
+    auto render = CreateBufferRenderer();
+    render->SetDimensions(width, height);
+    render->CopySettings(view);
+    render->RequestFrame(
+            scene,
+            // the shared_ptr (render) is const unless the lambda
+            // is made mutable
+            [render, cb](const RenderToBuffer::Buffer& buffer) mutable {
+                cb(buffer);
+                render = nullptr;
+            });
+}
+
 }  // namespace visualization
 }  // namespace open3d

--- a/src/Open3D/Visualization/Rendering/Renderer.h
+++ b/src/Open3D/Visualization/Rendering/Renderer.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "MaterialModifier.h"
+#include "RenderToBuffer.h"
 #include "RendererHandle.h"
 
 namespace open3d {
@@ -37,7 +38,6 @@ class Image;
 
 namespace visualization {
 
-class RenderToBuffer;
 class Scene;
 
 class ResourceLoadRequest {
@@ -93,7 +93,13 @@ public:
     virtual SkyboxHandle AddSkybox(const ResourceLoadRequest& request) = 0;
     virtual void RemoveSkybox(const SkyboxHandle& id) = 0;
 
-    virtual std::unique_ptr<RenderToBuffer> CreateBufferRenderer() = 0;
+    virtual std::shared_ptr<RenderToBuffer> CreateBufferRenderer() = 0;
+
+    void RenderToBuffer(std::size_t width,
+                        std::size_t height,
+                        View* view,
+                        Scene* scene,
+                        std::function<void(const RenderToBuffer::Buffer&)> cb);
 };
 
 }  // namespace visualization

--- a/src/Open3D/Visualization/Rendering/Renderer.h
+++ b/src/Open3D/Visualization/Rendering/Renderer.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "MaterialModifier.h"
-#include "RenderToBuffer.h"
 #include "RendererHandle.h"
 
 namespace open3d {
@@ -38,7 +37,9 @@ class Image;
 
 namespace visualization {
 
+class RenderToBuffer;
 class Scene;
+class View;
 
 class ResourceLoadRequest {
 public:
@@ -95,11 +96,12 @@ public:
 
     virtual std::shared_ptr<RenderToBuffer> CreateBufferRenderer() = 0;
 
-    void RenderToBuffer(std::size_t width,
-                        std::size_t height,
-                        View* view,
-                        Scene* scene,
-                        std::function<void(const RenderToBuffer::Buffer&)> cb);
+    void RenderToImage(
+            std::size_t width,
+            std::size_t height,
+            View* view,
+            Scene* scene,
+            std::function<void(std::shared_ptr<geometry::Image>)> cb);
 };
 
 }  // namespace visualization

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -55,8 +55,6 @@
 #include "Open3D/Visualization/Rendering/RendererStructs.h"
 #include "Open3D/Visualization/Rendering/Scene.h"
 
-#include <thread>
-
 #define LOAD_IN_NEW_WINDOW 0
 
 namespace open3d {
@@ -1118,18 +1116,15 @@ bool GuiVisualizer::LoadGeometry(const std::string &path) {
 void GuiVisualizer::ExportCurrentImage(int width,
                                        int height,
                                        const std::string &path) {
-    GetRenderer().RenderToBuffer(
+    GetRenderer().RenderToImage(
             width, height, impl_->scene->GetView(), impl_->scene->GetScene(),
-            [path](const visualization::RenderToBuffer::Buffer
-                           &buffer) mutable {
-                geometry::Image image;
-                image.width_ = buffer.width;
-                image.height_ = buffer.height;
-                image.num_of_channels_ = 3;
-                image.bytes_per_channel_ = 1;
-                image.data_ = std::vector<uint8_t>(buffer.bytes,
-                                                   buffer.bytes + buffer.size);
-                io::WriteImage(path, image);
+            [this, path](std::shared_ptr<geometry::Image> image) mutable {
+                if (!io::WriteImage(path, *image)) {
+                    this->ShowMessageBox(
+                            "Error", (std::string("Could not write image to ") +
+                                      path + ".")
+                                             .c_str());
+                }
             });
 }
 

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.h
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.h
@@ -63,8 +63,7 @@ public:
     bool SetIBL(const char* path);
 
     bool LoadGeometry(const std::string& path);
-    void ExportRGB(const std::string& path);
-    void ExportDepth(const std::string& path);
+    void ExportCurrentImage(int width, int height, const std::string& path);
 
     void Layout(const gui::Theme& theme) override;
 


### PR DESCRIPTION
I changed CreateBufferRenderer() to return a shared_ptr rather than unique_ptr because you can't put a unique_ptr in a lambda (it makes it non-copyable), which makes it troublesome to delete it once you're done. It wasn't obvious how to get a shared_ptr in a lambda that was reset()able, either, so I added Renderer::RenderToBuffer() so that other people won't have to discover obscure C++ details like that you can have mutable lambdas.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1616)
<!-- Reviewable:end -->
