### PR TITLE
Use the correct OpenGL Preference for CMAKE_VERSION >= 3.11

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -25,6 +25,17 @@ macro(INSTALL_HEADERS source)
             PATTERN     ".gitignore"    EXCLUDE)
 endmacro()
 
+if (POLICY CMP0072)
+    cmake_policy(SET CMP0072 NEW)
+    if (BUILD_EIGEN3
+        OR BUILD_FLANN
+        OR BUILD_GLEW
+        OR BUILD_GLFW
+        OR BUILD_PNG)
+        cmake_policy(SET CMP0072 OLD)
+    endif()
+endif()
+
 # dirent
 if (WIN32)
     message(STATUS "On windows, so using 3rdparty/dirent")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,13 @@
 # https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/
 
 cmake_minimum_required(VERSION 3.1)
+# Use the correct OpenGL Library preference if available
+if (POLICY CMP0072)
+    cmake_policy(SET CMP0072 NEW)
+endif()
+
 set (CMAKE_CXX_STANDARD 11)
+
 
 add_custom_target(build_all_3rd_party_libs
     COMMAND ${CMAKE_COMMAND} -E echo "Custom target build_all_3rd_party_libs reached."


### PR DESCRIPTION
Minor commit to suppress warning about OpenGL_GL_PREFERENCE when building from source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1625)
<!-- Reviewable:end -->
