### PR TITLE
Suppress developer warning for OpenGL library with CMAKE_VERSION >= 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,17 @@ if (ENABLE_HEADLESS_RENDERING)
     endif()
 endif()
 
+if (POLICY CMP0072)
+    cmake_policy(SET CMP0072 NEW)
+    if (BUILD_EIGEN3
+        OR BUILD_FLANN
+        OR BUILD_GLEW
+        OR BUILD_GLFW
+        OR BUILD_PNG)
+        cmake_policy(SET CMP0072 OLD)
+    endif()
+endif()
+
 # Set OS-specific things here
 if (WIN32)
     # can't hide the unit testing option on Windows only


### PR DESCRIPTION
A minor change in CMakeLists.txt
Looks like building glew/glfw from source always requires the legacy OpenGL library to be linked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1628)
<!-- Reviewable:end -->
