### PR TITLE
Fix SyntaxWarning: replace 'is' with '==' for literals.

### DIFF
--- a/examples/Python/ReconstructionSystem/make_fragments.py
+++ b/examples/Python/ReconstructionSystem/make_fragments.py
@@ -40,7 +40,7 @@ def register_one_rgbd_pair(s, t, color_files, depth_files, intrinsic,
 
     option = o3d.odometry.OdometryOption()
     option.max_depth_diff = config["max_depth_diff"]
-    if abs(s - t) is not 1:
+    if abs(s - t) != 1:
         if with_opencv:
             success_5pt, odo_init = pose_estimation(source_rgbd_image,
                                                     target_rgbd_image,

--- a/examples/Python/ReconstructionSystem/opencv_pose_estimation.py
+++ b/examples/Python/ReconstructionSystem/opencv_pose_estimation.py
@@ -36,7 +36,7 @@ def pose_estimation(source_rgbd_image, target_rgbd_image,
                          patchSize=31)  # to save time
     [kp_s, des_s] = orb.detectAndCompute(color_cv_s, None)
     [kp_t, des_t] = orb.detectAndCompute(color_cv_t, None)
-    if len(kp_s) is 0 or len(kp_t) is 0:
+    if len(kp_s) == 0 or len(kp_t) == 0:
         return success, trans
 
     bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)


### PR DESCRIPTION
The Python gives the following warnings when using the original code:

```
OpenCV is detected. Using ORB + 5pt algorithm
/home/hzxie/Development/Open3D/examples/Python/ReconstructionSystem/opencv_pose_estimation.py:39: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

with the following command:

```
python run_system.py config/tutorial.json --make
```

Now, the warning is gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1664)
<!-- Reviewable:end -->
