### PR TITLE
Add seed argument to mesh sampling functions (#1682)

### DIFF
--- a/src/Open3D/Geometry/TriangleMesh.cpp
+++ b/src/Open3D/Geometry/TriangleMesh.cpp
@@ -443,8 +443,8 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
     bool has_vert_normal = HasVertexNormals();
     bool has_vert_color = HasVertexColors();
     if (seed == -1) {
-      std::random_device rd;
-      seed = rd();
+        std::random_device rd;
+        seed = rd();
     }
     std::mt19937 mt(seed);
     std::uniform_real_distribution<double> dist(0.0, 1.0);
@@ -495,7 +495,9 @@ std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformlyImpl(
 }
 
 std::shared_ptr<PointCloud> TriangleMesh::SamplePointsUniformly(
-        size_t number_of_points, bool use_triangle_normal /* = false */, int seed /* = -1 */) {
+        size_t number_of_points,
+        bool use_triangle_normal /* = false */,
+        int seed /* = -1 */) {
     if (number_of_points <= 0) {
         utility::LogError("[SamplePointsUniformly] number_of_points <= 0");
     }

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -359,7 +359,9 @@ public:
     /// if necessary. \param seed Sets the seed value used in the random
     /// generator, set to -1 to use a random seed value with each function call.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points, bool use_triangle_normal = false, int seed = -1);
+            size_t number_of_points,
+            bool use_triangle_normal = false,
+            int seed = -1);
 
     /// Function to sample \param number_of_points points (blue noise).
     /// Based on the method presented in Yuksel, "Sample Elimination for

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -349,7 +349,8 @@ public:
             size_t number_of_points,
             std::vector<double> &triangle_areas,
             double surface_area,
-            bool use_triangle_normal);
+            bool use_triangle_normal,
+            int seed = -1);
 
     /// Function to sample \param number_of_points points uniformly from the
     /// mesh. \param use_triangle_normal Set to true to assign the triangle
@@ -357,7 +358,7 @@ public:
     /// normals. The triangle normals will be computed and added to the mesh
     /// if necessary.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
-            size_t number_of_points, bool use_triangle_normal = false);
+            size_t number_of_points, bool use_triangle_normal = false, int seed = -1);
 
     /// Function to sample \param number_of_points points (blue noise).
     /// Based on the method presented in Yuksel, "Sample Elimination for
@@ -373,7 +374,8 @@ public:
             size_t number_of_points,
             double init_factor = 5,
             const std::shared_ptr<PointCloud> pcl_init = nullptr,
-            bool use_triangle_normal = false);
+            bool use_triangle_normal = false,
+            int seed = -1);
 
     /// Function to subdivide triangle mesh using the simple midpoint algorithm.
     /// Each triangle is subdivided into four triangles per iteration and the

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -350,13 +350,14 @@ public:
             std::vector<double> &triangle_areas,
             double surface_area,
             bool use_triangle_normal,
-            int seed = -1);
+            int seed);
 
     /// Function to sample \param number_of_points points uniformly from the
     /// mesh. \param use_triangle_normal Set to true to assign the triangle
     /// normals to the returned points instead of the interpolated vertex
     /// normals. The triangle normals will be computed and added to the mesh
-    /// if necessary.
+    /// if necessary. \param seed Sets the seed value used in the random
+    /// generator, set to -1 to use a random seed value with each function call.
     std::shared_ptr<PointCloud> SamplePointsUniformly(
             size_t number_of_points, bool use_triangle_normal = false, int seed = -1);
 
@@ -369,7 +370,8 @@ public:
     /// \param use_triangle_normal Set to true to assign the triangle
     /// normals to the returned points instead of the interpolated vertex
     /// normals. The triangle normals will be computed and added to the mesh
-    /// if necessary.
+    /// if necessary. \param seed Sets the seed value used in the random
+    /// generator, set to -1 to use a random seed value with each function call.
     std::shared_ptr<PointCloud> SamplePointsPoissonDisk(
             size_t number_of_points,
             double init_factor = 5,

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -572,7 +572,10 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."}});
+              "necessary."},
+             {"seed",
+              "Seed value used in the random generator, set to -1 to use a "
+              "random seed value with each function call."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "sample_points_poisson_disk",
             {{"number_of_points", "Number of points that should be sampled."},
@@ -586,7 +589,10 @@ void pybind_trianglemesh(py::module &m) {
               "If True assigns the triangle normals instead of the "
               "interpolated vertex normals to the returned points. The "
               "triangle normals will be computed and added to the mesh if "
-              "necessary."}});
+              "necessary."},
+             {"seed",
+              "Seed value used in the random generator, set to -1 to use a "
+              "random seed value with each function call."}});
     docstring::ClassMethodDocInject(
             m, "TriangleMesh", "subdivide_midpoint",
             {{"number_of_iterations",

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -248,7 +248,8 @@ void pybind_trianglemesh(py::module &m) {
             .def("sample_points_uniformly",
                  &geometry::TriangleMesh::SamplePointsUniformly,
                  "Function to uniformly sample points from the mesh.",
-                 "number_of_points"_a = 100, "use_triangle_normal"_a = false)
+                 "number_of_points"_a = 100, "use_triangle_normal"_a = false,
+                 "seed"_a = -1)
             .def("sample_points_poisson_disk",
                  &geometry::TriangleMesh::SamplePointsPoissonDisk,
                  "Function to sample points from the mesh, where each point "
@@ -258,7 +259,7 @@ void pybind_trianglemesh(py::module &m) {
                  "noise). Method is based on Yuksel, \"Sample Elimination for "
                  "Generating Poisson Disk Sample Sets\", EUROGRAPHICS, 2015.",
                  "number_of_points"_a, "init_factor"_a = 5, "pcl"_a = nullptr,
-                 "use_triangle_normal"_a = false)
+                 "use_triangle_normal"_a = false, "seed"_a = -1)
             .def("subdivide_midpoint",
                  &geometry::TriangleMesh::SubdivideMidpoint,
                  "Function subdivide mesh using midpoint algorithm.",


### PR DESCRIPTION
This MR adds an additional argument to the `TriangleMesh::SamplePoints...` methods that is used to set the seed for the random number generator. The argument defaults to `-1`, which is a magic value that keeps the current functionality (the random number generator seed being set to a random number; thus, producing a new sequence which each trial). Any value besides `-1` will be used as the seed and will produce the same random number sequence for each trail. 

This MR addresses issue #1682 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1683)
<!-- Reviewable:end -->
