### PR TITLE
Fix VoxelGrid.voxels bug #1535

### DIFF
--- a/src/Open3D/Geometry/VoxelGrid.cpp
+++ b/src/Open3D/Geometry/VoxelGrid.cpp
@@ -356,5 +356,14 @@ VoxelGrid &VoxelGrid::CarveSilhouette(
     return *this;
 }
 
+std::vector<Voxel> VoxelGrid::GetVoxels() const {
+    std::vector<Voxel> result;
+    result.reserve(voxels_.size());
+    for (const auto &keyval : voxels_) {
+        result.push_back(keyval.second);
+    }
+    return result;
+}
+
 }  // namespace geometry
 }  // namespace open3d

--- a/src/Open3D/Geometry/VoxelGrid.h
+++ b/src/Open3D/Geometry/VoxelGrid.h
@@ -237,6 +237,11 @@ public:
             const Eigen::Vector3d &min_bound,
             const Eigen::Vector3d &max_bound);
 
+    /// Returns List of ``Voxel``: Voxels contained in voxel grid.
+    /// Changes to the voxels returned from this method are not reflected in
+    /// the voxel grid.
+    std::vector<Voxel> GetVoxels() const;
+
 public:
     /// Size of the voxel.
     double voxel_size_ = 0.0;

--- a/src/Python/open3d_pybind/geometry/voxelgrid.cpp
+++ b/src/Python/open3d_pybind/geometry/voxelgrid.cpp
@@ -85,8 +85,10 @@ void pybind_voxelgrid(py::module &m) {
                  })
             .def(py::self + py::self)
             .def(py::self += py::self)
-            .def_readwrite("voxels", &geometry::VoxelGrid::voxels_,
-                           "List of ``Voxel``: Voxels contained in voxel grid")
+            .def("get_voxels", &geometry::VoxelGrid::GetVoxels,
+                 "Returns List of ``Voxel``: Voxels contained in voxel grid. "
+                 "Changes to the voxels returned from this method"
+                 "are not reflected in the voxel grid.")
             .def("has_colors", &geometry::VoxelGrid::HasColors,
                  "Returns ``True`` if the voxel grid contains voxel colors.")
             .def("has_voxels", &geometry::VoxelGrid::HasVoxels,


### PR DESCRIPTION
I found a bug that can't use open3d.geometry.VoxelGrid.voxels same as #1535 .
Thanks to @noahstier, I changed to get voxels of unordered_map by function.

Without this PR
```
In [11]: voxel_grid.voxels
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-11-d7484a89cc11> in <module>()
----> 1 voxel_grid.voxels

TypeError: unhashable type: 'numpy.ndarray'
```

With this PR
```
In [11]:: voxel_grid.voxels()
[geometry::Voxel with grid_index: (16, 25, 12), color: (0.6, 0.654902, 0.623529),                                                                                                                                                     
 geometry::Voxel with grid_index: (27, 66, 22), color: (0.0666667, 0.0784314, 0.0745098),                                                                                                                                             
 geometry::Voxel with grid_index: (18, 12, 9), color: (0.660392, 0.697255, 0.680784),                                                                                                                                                 
 
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1688)
<!-- Reviewable:end -->
