### PR TITLE
Fix incorrect file name in a ReconstructionSystem document

### DIFF
--- a/docs/tutorial/ReconstructionSystem/system_overview.rst
+++ b/docs/tutorial/ReconstructionSystem/system_overview.rst
@@ -36,7 +36,7 @@ Put all color images in the ``image`` folder, and all depth images in the ``dept
     cd examples/Python/ReconstructionSystem/
     python run_system.py [config_file] [--make] [--register] [--refine] [--integrate]
 
-``config_file`` has parameters and file paths. For example, ReconstructionSystem/config/redwood.json has the following script.
+``config_file`` has parameters and file paths. For example, ReconstructionSystem/config/tutorial.json has the following script.
 
 .. literalinclude:: ../../../examples/Python/ReconstructionSystem/config/tutorial.json
    :language: json


### PR DESCRIPTION
- `redwood.json` is required in `docs/tutorial/ReconstructionSystem/system_overview.rst`, but the correct filename is `tutorial.json`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1699)
<!-- Reviewable:end -->
