### PR TITLE
Merged some materials, don't revert mouse controls to default, name app Open3D.app

### DIFF
--- a/src/Apps/CMakeLists.txt
+++ b/src/Apps/CMakeLists.txt
@@ -1,6 +1,6 @@
-macro(APP APP_NAME)
+macro(APP SRC_DIR APP_NAME TARGET_NAME)
     set(APPS_DIR "${PROJECT_SOURCE_DIR}/src/Apps")
-    set(SOURCE_DIR "${APPS_DIR}/${APP_NAME}")
+    set(SOURCE_DIR "${APPS_DIR}/${SRC_DIR}")
 
     file(GLOB SOURCE_FILES "${SOURCE_DIR}/*.cpp")
     file(GLOB HEADER_FILES "${SOURCE_DIR}/*.h")
@@ -16,31 +16,33 @@ macro(APP APP_NAME)
         set(INFO_PLIST "${SOURCE_DIR}/Info.plist.in")
         
         set(MACOSX_BUNDLE_NAME ${APP_NAME})
+        set(MACOSX_BUNDLE_EXECUTABLE_NAME ${APP_NAME})
         set(MACOSX_BUNDLE_GUI_IDENTIFIER com.intel-isl.open3d.${APP_NAME})
         set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
         set(MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION_THREE_NUMBER})
         set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_THREE_NUMBER})
         set(MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION_THREE_NUMBER})
         set(MACOSX_BUNDLE_COPYRIGHT "Copyright (C) 2020 by Open3D")
-        add_executable(${APP_NAME} ${SOURCE_FILES} ${HEADER_FILES})
-        set_target_properties(${APP_NAME} PROPERTIES
+        add_executable(${TARGET_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+        set_target_properties(${TARGET_NAME} PROPERTIES
                               MACOSX_BUNDLE TRUE
                               MACOSX_BUNDLE_INFO_PLIST "${INFO_PLIST}"
                               XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" # disable
+                              OUTPUT_NAME ${APP_NAME}
                              )
     else()
         set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${APP_NAME}")
-        add_executable(${APP_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+        add_executable(${TARGET_NAME} ${SOURCE_FILES} ${HEADER_FILES})
     endif()
-    add_dependencies(${APP_NAME} GuiResources)
+    add_dependencies(${TARGET_NAME} GuiResources)
 
     set(DEPENDENCIES "${ARGN}")
     foreach(DEPENDENCY IN LISTS DEPENDENCIES)
-        target_link_libraries(${APP_NAME} ${DEPENDENCY})
+        target_link_libraries(${TARGET_NAME} ${DEPENDENCY})
     endforeach()
 
-    set_target_properties(${APP_NAME} PROPERTIES FOLDER "Apps")
-    ShowAndAbortOnWarning(${APP_NAME})
+    set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Apps")
+    ShowAndAbortOnWarning(${TARGET_NAME})
 
     # Copy the resource files. This needs to be done as a post-build step
     # because on macOS, we don't know the bundle directory until build time
@@ -55,18 +57,18 @@ macro(APP APP_NAME)
     # $<TARGET_BUNDLE_DIR> does not exist at config time, so we need to
     # duplicate the post build step on macOS and non-macOS
     if (APPLE)
-        add_custom_command(TARGET "${APP_NAME}"
+        add_custom_command(TARGET "${TARGET_NAME}"
             POST_BUILD
             # copy the resource files into the bundle
-            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_BUNDLE_DIR:${APP_NAME}>/${RESOURCE_DIR_NAME}"
-            COMMAND ${CMAKE_COMMAND} -E copy ${RESOURCE_FILES} "$<TARGET_BUNDLE_DIR:${APP_NAME}>/${RESOURCE_DIR_NAME}"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/${RESOURCE_DIR_NAME}"
+            COMMAND ${CMAKE_COMMAND} -E copy ${RESOURCE_FILES} "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/${RESOURCE_DIR_NAME}"
             # copy external libraries (e.g. SDL into the bundle and fixup
             # the search paths
-            COMMAND ${APPS_DIR}/fixup_macosx_bundle.sh "$<TARGET_BUNDLE_DIR:${APP_NAME}>"
+            COMMAND ${APPS_DIR}/fixup_macosx_bundle.sh "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>"
         )
     else ()
         set(APP_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-        add_custom_command(TARGET "${APP_NAME}"
+        add_custom_command(TARGET "${TARGET_NAME}"
             POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_DIR}/${RESOURCE_DIR_NAME}"
             COMMAND ${CMAKE_COMMAND} -E copy ${RESOURCE_FILES} "${APP_DIR}/${RESOURCE_DIR_NAME}"
@@ -75,5 +77,5 @@ macro(APP APP_NAME)
 endmacro(APP)
 
 if (ENABLE_GUI)
-    APP(Open3DViewer ${CMAKE_PROJECT_NAME})
+    APP(Open3DViewer Open3D Open3DViewer ${CMAKE_PROJECT_NAME})
 endif()

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -476,26 +476,6 @@ struct GuiVisualizer::Impl {
               0.0f,
               0.0f,
               3.0f}},
-            {"Copper",
-             {visualization::MaterialInstanceHandle::kBad,
-              {0.955f, 0.637f, 0.538f},
-              1.0f,
-              0.3f,
-              0.9f,
-              0.0f,
-              0.0f,
-              0.0f,
-              3.0f}},
-            {"Iron",
-             {visualization::MaterialInstanceHandle::kBad,
-              {0.560f, 0.570f, 0.580f},
-              1.0f,
-              0.5f,
-              0.9f,
-              0.0f,
-              0.0f,
-              0.0f,
-              3.0f}},
             {"Plastic",
              {visualization::MaterialInstanceHandle::kBad,
               {1.0f, 1.0f, 1.0f},
@@ -1461,7 +1441,6 @@ void GuiVisualizer::SetGeometry(
     impl_->scene->SetModel(impl_->settings.hAxes, objects);
 
     impl_->scene->SetupCamera(60.0, bounds, bounds.GetCenter().cast<float>());
-    impl_->SetMouseControls(*this, gui::SceneWidget::Controls::ROTATE_OBJ);
 }
 
 void GuiVisualizer::Layout(const gui::Theme &theme) {


### PR DESCRIPTION
The CMake target and source directory name are still Open3DViewer, both to avoid confusion with the name of the library and because you can't have two targets named identically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1726)
<!-- Reviewable:end -->
