### PR TITLE
Changed Alpha and Stencil bit defaults to fix hang/crash with Nvidia …

### DIFF
--- a/src/Open3D/GUI/Window.cpp
+++ b/src/Open3D/GUI/Window.cpp
@@ -198,9 +198,13 @@ Window::Window(const std::string& title,
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    // NOTE: Setting alpha and stencil bits to match GLX standard default
+    // values. GLFW sets these internally to 8 and 8 respectively if not
+    // specified which causes problems with Filament on Linux with Nvidia binary
+    // driver
     glfwWindowHint(GLFW_ALPHA_BITS, 0);
     glfwWindowHint(GLFW_STENCIL_BITS, 0);
-    
+
 #if __APPLE__
     glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
 #endif

--- a/src/Open3D/GUI/Window.cpp
+++ b/src/Open3D/GUI/Window.cpp
@@ -198,6 +198,9 @@ Window::Window(const std::string& title,
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_ALPHA_BITS, 0);
+    glfwWindowHint(GLFW_STENCIL_BITS, 0);
+    
 #if __APPLE__
     glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
 #endif


### PR DESCRIPTION
…driver on Linux. Tested on Linux with Nvidia binary driver and Intel integrated graphics. Not yet tested on Windows or Mac.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1748)
<!-- Reviewable:end -->
