### PR TITLE
Implemented text events with GLFW

### DIFF
--- a/src/Open3D/GUI/Window.h
+++ b/src/Open3D/GUI/Window.h
@@ -142,6 +142,7 @@ private:
     static void MouseScrollCallback(GLFWwindow* window, double dx, double dy);
     static void KeyCallback(
             GLFWwindow* window, int key, int scancode, int action, int mods);
+    static void CharCallback(GLFWwindow* window, unsigned int utf32char);
     static void DragDropCallback(GLFWwindow*, int count, const char* paths[]);
     static void CloseCallback(GLFWwindow* window);
     static void UpdateAfterEvent(Window* w);


### PR DESCRIPTION
This fixes not being able to type text into a text box, for the main reason that ImGUI does not use key events to enter characters (since that does not work well with much beyond ASCII), and GLFW's character event wasn't hooked up. (Testing: the only text widget currently in the app is the file name when saving an image on Linux)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1754)
<!-- Reviewable:end -->
