### PR TITLE
Fix problems with double-clicking

### DIFF
--- a/src/Open3D/GUI/Window.h
+++ b/src/Open3D/GUI/Window.h
@@ -120,8 +120,8 @@ protected:
 
 private:
     enum DrawResult { NONE, REDRAW };
-    DrawResult OnDraw(float dtSec);
-    Widget::DrawResult DrawOnce(float dtSec, bool isLayoutPass);
+    DrawResult OnDraw();
+    Widget::DrawResult DrawOnce(bool isLayoutPass);
     void OnResize();
     void OnMouseEvent(const MouseEvent& e);
     void OnKeyEvent(const KeyEvent& e);


### PR DESCRIPTION
ImGUI uses the delta time parameter when drawing to compute double-click time, but what we were passing had no relationship to the actual time that had passed.

Testing:  double-click on a directory or model in the file dialog box on Linux. Previously it would take three clicks to enter a directory or load a model, now a proper double-click should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1756)
<!-- Reviewable:end -->
