### PR TITLE
linux build with Filament: libstdc++ and libc++ and python library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,10 @@ elseif (UNIX)
     message(STATUS "Compiling on Unix")
     message(STATUS "Disable RealSense since it is not fully supported on Linux.")
     set(BUILD_LIBREALSENSE OFF)
+    if (ENABLE_GUI)
+        message(STATUS "Compiling with Filament: specifically link -lstdc++ before -lc++")
+        list(INSERT 3RDPARTY_LIBRARIES 0 "-lstdc++")
+    endif ()
 endif ()
 
 # Set OpenMP


### PR DESCRIPTION
Current gui using Filament links against libc++, that causes any thrown exceptions from our library to crash the running python process.  Here's a sample:
$ python
Python 3.6.9 (default, Apr 18 2020, 01:56:04) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import open3d as o3d
>>> import numpy as np
>>> a=np.ones((2, 4), dtype=np.int32)
>>> o3d.utility.Vector3dVector(a)
terminating with uncaught exception of type pybind11::cast_error: Unable to cast Python instance to C++ type (compile in debug mode for details)
Aborted (core dumped)

additionally, if you load our library (first), it causes any thrown exception from any other C++ library to crash the running python process.  For example, if you have pytorch:
$ python
Python 3.6.9 (default, Apr 18 2020, 01:56:04) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import open3d as o3d
>>> import torch
>>> x=torch.rand(1,2)
>>> x.dot(x)
Segmentation fault (core dumped)

Having libstdc++.so listed in dynamic dependencies of the binary before libc++.so appears to resolve this issue, probably by loading and exposing conflicted symbols from libstdc++ and skipping them from libc++, making it compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1757)
<!-- Reviewable:end -->
