### PR TITLE
Fix crash when using Export Current Image in Open3D

### DIFF
--- a/src/Open3D/GUI/Window.cpp
+++ b/src/Open3D/GUI/Window.cpp
@@ -511,7 +511,12 @@ void Window::ShowDialog(std::shared_ptr<Dialog> dlg) {
     dlg->Layout(GetTheme());
 }
 
-void Window::CloseDialog() { impl_->activeDialog.reset(); }
+void Window::CloseDialog() {
+    if (impl_->focusWidget == impl_->activeDialog.get()) {
+        SetFocusWidget(nullptr);
+    }
+    impl_->activeDialog.reset();
+}
 
 void Window::ShowMessageBox(const char* title, const char* message) {
     auto em = GetTheme().fontSize;


### PR DESCRIPTION
To reproduce crash, select "Export Current Image", type in a filename, click "Save" and once the dialog has disappeared press any key before doing anything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1761)
<!-- Reviewable:end -->
