### PR TITLE
expose UniformTSDFVolume's origin in Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Avoid cstdlib random generators in ransac registration, use C++11 random instead.
 * Fixed a bug in open3d::geometry::TriangleMesh::ClusterConnectedTriangles.
 * Added option BUILD_BENCHMARKS for building microbenchmarks
+* Extend Python API of UniformTSDFVolume to allow setting the origin
 
 ## 0.9.0
 

--- a/src/Python/open3d_pybind/integration/integration.cpp
+++ b/src/Python/open3d_pybind/integration/integration.cpp
@@ -130,6 +130,13 @@ In SIGGRAPH, 1996)");
                              length, resolution, sdf_trunc, color_type);
                  }),
                  "length"_a, "resolution"_a, "sdf_trunc"_a, "color_type"_a)
+            .def(py::init([](double length, int resolution, double sdf_trunc,
+                             integration::TSDFVolumeColorType color_type,
+                             Eigen::Vector3d origin) {
+                     return new integration::UniformTSDFVolume(
+                             length, resolution, sdf_trunc, color_type, origin);
+                 }),
+                 "length"_a, "resolution"_a, "sdf_trunc"_a, "color_type"_a, "origin"_a)
             .def("__repr__",
                  [](const integration::UniformTSDFVolume &vol) {
                      return std::string("integration::UniformTSDFVolume ") +

--- a/src/Python/open3d_pybind/integration/integration.cpp
+++ b/src/Python/open3d_pybind/integration/integration.cpp
@@ -136,7 +136,8 @@ In SIGGRAPH, 1996)");
                      return new integration::UniformTSDFVolume(
                              length, resolution, sdf_trunc, color_type, origin);
                  }),
-                 "length"_a, "resolution"_a, "sdf_trunc"_a, "color_type"_a, "origin"_a)
+                 "length"_a, "resolution"_a, "sdf_trunc"_a, "color_type"_a,
+                 "origin"_a)
             .def("__repr__",
                  [](const integration::UniformTSDFVolume &vol) {
                      return std::string("integration::UniformTSDFVolume ") +


### PR DESCRIPTION
Extend Python API to enable the creation of UniformTSDFVolume whose origin is not (0, 0, 0).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1762)
<!-- Reviewable:end -->
