### PR TITLE
Gui errissa open3d crash on invalid file on Linux

### DIFF
--- a/src/Apps/Open3DViewer/Open3DViewer.cpp
+++ b/src/Apps/Open3DViewer/Open3DViewer.cpp
@@ -61,10 +61,16 @@ bool LoadAndCreateWindow(const char *path) {
     }
     gui::Application::GetInstance().AddWindow(vis);  // add even if failed
 
+    // NOTE: gui::ShowNativeAlert crashes on Linux because ShowNativeAlert uses
+    // Application::ShowMessageBox but app isn't running yet. Errors will have
+    // been output to console and the typical Linux user will know to check
+    // console when the window shows up empty.
+#if defined(__APPLE__) || defined(_WIN32)
     if (!loaded && isPathValid) {
         auto err = std::string("Error reading geometry file '") + path + "'";
         gui::ShowNativeAlert(err.c_str());
     }
+#endif
 
     return loaded;
 }

--- a/src/Open3D/GUI/Application.cpp
+++ b/src/Open3D/GUI/Application.cpp
@@ -131,7 +131,7 @@ Application &Application::GetInstance() {
 }
 
 void Application::ShowMessageBox(const char *title, const char *message) {
-    utility::LogInfo("%s", message);
+    utility::LogInfof("%s", message);
 
     auto alert = std::make_shared<Window>("Alert", Window::FLAG_TOPMOST);
     auto em = alert->GetTheme().fontSize;

--- a/src/Open3D/IO/FileFormat/FilePLY.cpp
+++ b/src/Open3D/IO/FileFormat/FilePLY.cpp
@@ -396,7 +396,7 @@ bool ReadPointCloudFromPLY(const std::string &filename,
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
     if (!ply_file) {
-        utility::LogWarning("Read PLY failed: unable to open file: %s",
+        utility::LogWarningf("Read PLY failed: unable to open file: %s",
                             filename.c_str());
         return false;
     }

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -1516,7 +1516,7 @@ bool GuiVisualizer::LoadGeometry(const std::string &path) {
     } else {
         // LogError throws an exception, which we don't want, because this might
         // be a point cloud.
-        utility::LogWarning("Failed to read %s", path.c_str());
+        utility::LogInfof("%s appears to be a point cloud", path.c_str());
         mesh.reset();
     }
 
@@ -1536,7 +1536,7 @@ bool GuiVisualizer::LoadGeometry(const std::string &path) {
             cloud->NormalizeNormals();
             geometry = cloud;
         } else {
-            utility::LogWarning("Failed to read points %s", path.c_str());
+            utility::LogWarningf("Failed to read point cloud %s", path.c_str());
             cloud.reset();
         }
     }


### PR DESCRIPTION
On Linux Open3D app crashes if given a bad file on command line. Also, fixed a handful of log outputs that were using the Python-style formatting function instead of printf-style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1767)
<!-- Reviewable:end -->
