### PR TITLE
Make documentation buildable without Git source tree

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,9 +29,12 @@ import shutil
 
 
 def get_git_short_hash():
-    rc = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
-    rc = rc.decode("utf-8").strip()
-    return rc
+    try:
+        rc = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        rc = rc.decode("utf-8").strip()
+        return rc
+    except subprocess.CalledProcessError:
+        return "unknown"
 
 
 # Import open3d raw python package with the highest priority


### PR DESCRIPTION
The call to 'git rev-parse' will have a non-zero exit code when called
outside a Git working copy, aborting the documentation build. This patch
makes the documentation buildable from non-Git source trees, such as
tarballs.

This PR is part of issue #1770 to make it easier to package Open3D for
(Linux) distributions.