### PR TITLE
Fix typos

### DIFF
--- a/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
+++ b/src/Open3D/Geometry/SurfaceReconstructionBallPivoting.cpp
@@ -318,7 +318,7 @@ public:
         bool ret = normal.dot(v0->normal_) > -1e-16 &&
                    normal.dot(v1->normal_) > -1e-16 &&
                    normal.dot(v2->normal_) > -1e-16;
-        utility::LogDebug("[IsCompatible] retuns = {}", ret);
+        utility::LogDebug("[IsCompatible] returns = {}", ret);
         return ret;
     }
 
@@ -389,7 +389,7 @@ public:
                                      mp, candidate->point_, tgt->point_,
                                      opp->point_) < 1e-12)) {
                 utility::LogDebug(
-                        "[FindCandidateVertex] candidate {:d} is interesecting "
+                        "[FindCandidateVertex] candidate {:d} is intersecting "
                         "the existing triangle",
                         candidate->idx_);
                 continue;

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -501,7 +501,7 @@ public:
     /// decreasing alpha value the shape schrinks and creates cavities.
     /// See Edelsbrunner and Muecke, "Three-Dimensional Alpha Shapes", 1994.
     /// \param pcd PointCloud for what the alpha shape should be computed.
-    /// \param alpha parameter to controll the shape. A very big value will
+    /// \param alpha parameter to control the shape. A very big value will
     /// give a shape close to the convex hull.
     /// \param tetra_mesh If not a nullptr, than uses this to construct the
     /// alpha shape. Otherwise, ComputeDelaunayTetrahedralization is called.

--- a/src/Open3D/Geometry/TriangleMeshDeformation.cpp
+++ b/src/Open3D/Geometry/TriangleMeshDeformation.cpp
@@ -147,7 +147,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::DeformAsRigidAsPossible(
             if (Rs[i].determinant() <= 0) {
                 utility::LogError(
                         "[DeformAsRigidAsPossible] something went wrong with "
-                        "updateing R");
+                        "updating R");
             }
         }
 

--- a/src/Open3D/Registration/GlobalOptimization.cpp
+++ b/src/Open3D/Registration/GlobalOptimization.cpp
@@ -442,7 +442,7 @@ bool ValidatePoseGraph(const PoseGraph &pose_graph) {
             valid = true;
         if (!valid) {
             utility::LogWarning(
-                    "Invalid PoseGraph - an edge references an invalide "
+                    "Invalid PoseGraph - an edge references an invalid "
                     "node.");
             return false;
         }

--- a/src/Python/open3d_pybind/geometry/trianglemesh.cpp
+++ b/src/Python/open3d_pybind/geometry/trianglemesh.cpp
@@ -288,7 +288,7 @@ void pybind_trianglemesh(py::module &m) {
                  &geometry::TriangleMesh::ClusterConnectedTriangles,
                  "Function that clusters connected triangles, i.e., triangles "
                  "that are connected via edges are assigned the same cluster "
-                 "index.  This function retuns an array that contains the "
+                 "index.  This function returns an array that contains the "
                  "cluster index per triangle, a second array contains the "
                  "number of triangles per cluster, and a third vector contains "
                  "the surface area per cluster.")
@@ -618,7 +618,7 @@ void pybind_trianglemesh(py::module &m) {
             m, "TriangleMesh", "simplify_quadric_decimation",
             {{"target_number_of_triangles",
               "The number of triangles that the simplified mesh should have. "
-              "It is not guranteed that this number will be reached."}});
+              "It is not guaranteed that this number will be reached."}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "cluster_connected_triangles");
@@ -663,7 +663,7 @@ void pybind_trianglemesh(py::module &m) {
               "PointCloud from whicht the TriangleMesh surface is "
               "reconstructed."},
              {"alpha",
-              "Parameter to controll the shape. A very big value will give a "
+              "Parameter to control the shape. A very big value will give a "
               "shape close to the convex hull."},
              {"tetra_mesh",
               "If not None, than uses this to construct the alpha shape. "

--- a/src/Python/open3d_pybind/registration/registration.cpp
+++ b/src/Python/open3d_pybind/registration/registration.cpp
@@ -341,7 +341,7 @@ must hold true for all edges.)");
             .def_readwrite("distance_threshold",
                            &registration::CorrespondenceCheckerBasedOnDistance::
                                    distance_threshold_,
-                           "Distance threashold for the check.");
+                           "Distance threshold for the check.");
 
     // open3d.registration.CorrespondenceCheckerBasedOnNormal:
     // CorrespondenceChecker


### PR DESCRIPTION
This is a trivial PR that merely fixes a few typos. These have come up
while preparing Open3D packages for Debian as hints from Lintian, the
Debian package linter.

This PR is part of issue #1770 to make it easier to package Open3D for
(Linux) distributions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1773)
<!-- Reviewable:end -->
