### PR TITLE
fix bug: binary op output must fit in the output tensor

### DIFF
--- a/src/Open3D/Core/Kernel/BinaryEW.cpp
+++ b/src/Open3D/Core/Kernel/BinaryEW.cpp
@@ -48,6 +48,7 @@ void BinaryEW(const Tensor& lhs,
               const Tensor& rhs,
               Tensor& dst,
               BinaryEWOpCode op_code) {
+    // lhs, rhs and dst must be on the same device.
     for (auto device :
          std::vector<Device>({rhs.GetDevice(), dst.GetDevice()})) {
         if (lhs.GetDevice() != device) {
@@ -55,6 +56,17 @@ void BinaryEW(const Tensor& lhs,
                               lhs.GetDevice().ToString(), device.ToString());
         }
     }
+
+    // broadcast(lhs.shape, rhs.shape) must be dst.shape.
+    const SizeVector broadcasted_input_shape =
+            shape_util::BroadcastedShape(lhs.GetShape(), rhs.GetShape());
+    if (broadcasted_input_shape != dst.GetShape()) {
+        utility::LogError(
+                "The broadcasted input shape {} does not match the output "
+                "shape {}.",
+                broadcasted_input_shape, dst.GetShape());
+    }
+
     Device::DeviceType device_type = lhs.GetDevice().GetType();
     if (device_type == Device::DeviceType::CPU) {
         BinaryEWCPU(lhs, rhs, dst, op_code);

--- a/src/UnitTest/Core/Tensor.cpp
+++ b/src/UnitTest/Core/Tensor.cpp
@@ -1040,6 +1040,26 @@ TEST_P(TensorPermuteDevices, Add_) {
               std::vector<float>({10, 12, 14, 16, 18, 20}));
 }
 
+TEST_P(TensorPermuteDevices, Add_BroadcastException) {
+    // A.shape = (   3, 4)
+    // B.shape = (2, 3, 4)
+    // A += B should throw exception.
+    // B += A is fine.
+    Device device = GetParam();
+    Tensor a(std::vector<float>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}), {3, 4},
+             Dtype::Float32, device);
+    Tensor b(std::vector<float>({0,  1,  2,  3,  4,  5,  6,  7,
+                                 8,  9,  10, 11, 12, 13, 14, 15,
+                                 16, 17, 18, 19, 20, 21, 22, 23}),
+             {2, 3, 4}, Dtype::Float32, device);
+    EXPECT_THROW(a += b, std::runtime_error);
+    b += a;
+    EXPECT_EQ(b.ToFlatVector<float>(),
+              std::vector<float>({0,  2,  4,  6,  8,  10, 12, 14,
+                                  16, 18, 20, 22, 12, 14, 16, 18,
+                                  20, 22, 24, 26, 28, 30, 32, 34}));
+}
+
 TEST_P(TensorPermuteDevices, Sub) {
     Device device = GetParam();
     Tensor a(std::vector<float>({10, 12, 14, 16, 18, 20}), {2, 3},


### PR DESCRIPTION
```
// A.shape = (   3, 4)
// B.shape = (2, 3, 4)
// A += B should throw exception.
// B += A is fine.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1777)
<!-- Reviewable:end -->
