### PR TITLE
Tensor creation shortcuts and scalr value op

### DIFF
--- a/src/Open3D/Core/Kernel/CUDALauncher.cuh
+++ b/src/Open3D/Core/Kernel/CUDALauncher.cuh
@@ -70,6 +70,9 @@ public:
         OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
         int64_t n = indexer.NumWorkloads();
+        if (n == 0) {
+            return;
+        }
         int64_t items_per_block = default_block_size * default_thread_size;
         int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
@@ -89,6 +92,9 @@ public:
         OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
         int64_t n = indexer.NumWorkloads();
+        if (n == 0) {
+            return;
+        }
         int64_t items_per_block = default_block_size * default_thread_size;
         int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
@@ -109,6 +115,9 @@ public:
         OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
         int64_t n = indexer.NumWorkloads();
+        if (n == 0) {
+            return;
+        }
         int64_t items_per_block = default_block_size * default_thread_size;
         int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 

--- a/src/Open3D/Core/Tensor.cpp
+++ b/src/Open3D/Core/Tensor.cpp
@@ -73,6 +73,24 @@ Tensor& Tensor::operator=(Tensor&& other) && {
     return *this;
 }
 
+Tensor Tensor::Empty(const SizeVector& shape,
+                     Dtype dtype,
+                     const Device& device) {
+    return Tensor(shape, dtype, device);
+}
+
+Tensor Tensor::Zeros(const SizeVector& shape,
+                     Dtype dtype,
+                     const Device& device) {
+    return Full(shape, 0, dtype, device);
+}
+
+Tensor Tensor::Ones(const SizeVector& shape,
+                    Dtype dtype,
+                    const Device& device) {
+    return Full(shape, 1, dtype, device);
+}
+
 Tensor Tensor::GetItem(const TensorKey& tk) const {
     if (tk.GetMode() == TensorKey::TensorKeyMode::Index) {
         return IndexExtract(0, tk.GetIndex());

--- a/src/Open3D/Core/Tensor.h
+++ b/src/Open3D/Core/Tensor.h
@@ -145,6 +145,32 @@ public:
         return *this;
     }
 
+    /// Create a tensor with uninitilized values.
+    static Tensor Empty(const SizeVector& shape,
+                        Dtype dtype,
+                        const Device& device = Device("CPU:0"));
+
+    /// Create a tensor fill with specified value.
+    template <typename T>
+    static Tensor Full(const SizeVector& shape,
+                       T fill_value,
+                       Dtype dtype,
+                       const Device& device = Device("CPU:0")) {
+        Tensor t = Empty(shape, dtype, device);
+        t.Fill(fill_value);
+        return t;
+    }
+
+    /// Create a tensor fill with zeros.
+    static Tensor Zeros(const SizeVector& shape,
+                        Dtype dtype,
+                        const Device& device = Device("CPU:0"));
+
+    /// Create a tensor fill with ones.
+    static Tensor Ones(const SizeVector& shape,
+                       Dtype dtype,
+                       const Device& device = Device("CPU:0"));
+
     /// Pythonic __getitem__ for tensor.
     ///
     /// Returns a view of the original tensor, if TensorKey is

--- a/src/Open3D/Core/Tensor.h
+++ b/src/Open3D/Core/Tensor.h
@@ -262,7 +262,7 @@ public:
     /// \brief Fill the whole Tensor with a scalar value, the scalar will be
     /// casted to the Tensor's dtype.
     template <typename T>
-    void Fill(const T& v) {
+    void Fill(T v) {
         DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(GetDtype(), [&]() {
             scalar_t casted_v = static_cast<scalar_t>(v);
             Tensor tmp(std::vector<scalar_t>({casted_v}), SizeVector({}),
@@ -407,39 +407,103 @@ public:
 
     /// Adds a tensor and returns the resulting tensor.
     Tensor Add(const Tensor& value) const;
+    template <typename T>
+    Tensor Add(T scalar_value) const {
+        return Add(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator+(const Tensor& value) const { return Add(value); }
+    template <typename T>
+    Tensor operator+(T scalar_value) const {
+        return Add(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Inplace version of Tensor::Add. Adds a tensor to the current tensor and
     /// returns the current tensor.
     Tensor Add_(const Tensor& value);
+    template <typename T>
+    Tensor Add_(T scalar_value) {
+        return Add_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator+=(const Tensor& value) { return Add_(value); }
+    template <typename T>
+    Tensor operator+=(T scalar_value) {
+        return Add_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Substracts a tensor and returns the resulting tensor.
     Tensor Sub(const Tensor& value) const;
+    template <typename T>
+    Tensor Sub(T scalar_value) const {
+        return Sub(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator-(const Tensor& value) const { return Sub(value); }
+    template <typename T>
+    Tensor operator-(T scalar_value) const {
+        return Sub(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Inplace version of Tensor::Sub. Substracts a tensor to the current
     /// tensor and returns the current tensor.
     Tensor Sub_(const Tensor& value);
+    template <typename T>
+    Tensor Sub_(T scalar_value) {
+        return Sub_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator-=(const Tensor& value) { return Sub_(value); }
+    template <typename T>
+    Tensor operator-=(T scalar_value) {
+        return Sub_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Multiplies a tensor and returns the resulting tensor.
     Tensor Mul(const Tensor& value) const;
+    template <typename T>
+    Tensor Mul(T scalar_value) const {
+        return Mul(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator*(const Tensor& value) const { return Mul(value); }
+    template <typename T>
+    Tensor operator*(T scalar_value) const {
+        return Mul(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Inplace version of Tensor::Mul. Multiplies a tensor to the current
     /// tensor and returns the current tensor.
     Tensor Mul_(const Tensor& value);
+    template <typename T>
+    Tensor Mul_(T scalar_value) {
+        return Mul_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator*=(const Tensor& value) { return Mul_(value); }
+    template <typename T>
+    Tensor operator*=(T scalar_value) {
+        return Mul_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Divides a tensor and returns the resulting tensor.
     Tensor Div(const Tensor& value) const;
+    template <typename T>
+    Tensor Div(T scalar_value) const {
+        return Div(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator/(const Tensor& value) const { return Div(value); }
+    template <typename T>
+    Tensor operator/(T scalar_value) const {
+        return Div(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Inplace version of Tensor::Div. Divides a tensor to the current
     /// tensor and returns the current tensor.
     Tensor Div_(const Tensor& value);
+    template <typename T>
+    Tensor Div_(T scalar_value) {
+        return Div_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
     Tensor operator/=(const Tensor& value) { return Div_(value); }
+    template <typename T>
+    Tensor operator/=(T scalar_value) {
+        return Div_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+    }
 
     /// Returns the sum of the tensor along the given \p dims.
     /// \param dims A list of dimensions to be reduced.
@@ -788,6 +852,26 @@ inline std::vector<bool> Tensor::ToFlatVector() const {
             values_uchar.begin(), values_uchar.end(), values.begin(),
             [](unsigned char v) -> bool { return static_cast<bool>(v); });
     return values;
+}
+
+template <typename T>
+Tensor operator+(T scalar_lhs, const Tensor& rhs) {
+    return rhs + scalar_lhs;
+}
+
+template <typename T>
+Tensor operator-(T scalar_lhs, const Tensor& rhs) {
+    return Tensor::Full({}, scalar_lhs, rhs.GetDtype(), rhs.GetDevice()) - rhs;
+}
+
+template <typename T>
+Tensor operator*(T scalar_lhs, const Tensor& rhs) {
+    return rhs * scalar_lhs;
+}
+
+template <typename T>
+Tensor operator/(T scalar_lhs, const Tensor& rhs) {
+    return Tensor::Full({}, scalar_lhs, rhs.GetDtype(), rhs.GetDevice()) / rhs;
 }
 
 }  // namespace open3d

--- a/src/Open3D/Core/Tensor.h
+++ b/src/Open3D/Core/Tensor.h
@@ -409,12 +409,12 @@ public:
     Tensor Add(const Tensor& value) const;
     template <typename T>
     Tensor Add(T scalar_value) const {
-        return Add(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Add(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator+(const Tensor& value) const { return Add(value); }
     template <typename T>
     Tensor operator+(T scalar_value) const {
-        return Add(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Add(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Inplace version of Tensor::Add. Adds a tensor to the current tensor and
@@ -422,24 +422,24 @@ public:
     Tensor Add_(const Tensor& value);
     template <typename T>
     Tensor Add_(T scalar_value) {
-        return Add_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Add_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator+=(const Tensor& value) { return Add_(value); }
     template <typename T>
     Tensor operator+=(T scalar_value) {
-        return Add_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Add_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Substracts a tensor and returns the resulting tensor.
     Tensor Sub(const Tensor& value) const;
     template <typename T>
     Tensor Sub(T scalar_value) const {
-        return Sub(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Sub(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator-(const Tensor& value) const { return Sub(value); }
     template <typename T>
     Tensor operator-(T scalar_value) const {
-        return Sub(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Sub(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Inplace version of Tensor::Sub. Substracts a tensor to the current
@@ -447,24 +447,24 @@ public:
     Tensor Sub_(const Tensor& value);
     template <typename T>
     Tensor Sub_(T scalar_value) {
-        return Sub_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Sub_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator-=(const Tensor& value) { return Sub_(value); }
     template <typename T>
     Tensor operator-=(T scalar_value) {
-        return Sub_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Sub_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Multiplies a tensor and returns the resulting tensor.
     Tensor Mul(const Tensor& value) const;
     template <typename T>
     Tensor Mul(T scalar_value) const {
-        return Mul(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Mul(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator*(const Tensor& value) const { return Mul(value); }
     template <typename T>
     Tensor operator*(T scalar_value) const {
-        return Mul(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Mul(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Inplace version of Tensor::Mul. Multiplies a tensor to the current
@@ -472,24 +472,24 @@ public:
     Tensor Mul_(const Tensor& value);
     template <typename T>
     Tensor Mul_(T scalar_value) {
-        return Mul_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Mul_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator*=(const Tensor& value) { return Mul_(value); }
     template <typename T>
     Tensor operator*=(T scalar_value) {
-        return Mul_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Mul_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Divides a tensor and returns the resulting tensor.
     Tensor Div(const Tensor& value) const;
     template <typename T>
     Tensor Div(T scalar_value) const {
-        return Div(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Div(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator/(const Tensor& value) const { return Div(value); }
     template <typename T>
     Tensor operator/(T scalar_value) const {
-        return Div(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Div(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Inplace version of Tensor::Div. Divides a tensor to the current
@@ -497,12 +497,12 @@ public:
     Tensor Div_(const Tensor& value);
     template <typename T>
     Tensor Div_(T scalar_value) {
-        return Div_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Div_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
     Tensor operator/=(const Tensor& value) { return Div_(value); }
     template <typename T>
     Tensor operator/=(T scalar_value) {
-        return Div_(Tensor::Full(shape_, scalar_value, dtype_, GetDevice()));
+        return Div_(Tensor::Full({}, scalar_value, dtype_, GetDevice()));
     }
 
     /// Returns the sum of the tensor along the given \p dims.

--- a/src/Python/open3d/core.py
+++ b/src/Python/open3d/core.py
@@ -113,6 +113,67 @@ class Tensor(open3d_pybind.Tensor):
             raise TypeError(f"Invalid type {type(key)} for getitem.")
         return self
 
+    @staticmethod
+    @cast_to_py_tensor
+    def empty(shape, dtype, device=o3d.Device("CPU:0")):
+        """
+        Create a tensor with uninitilized values.
+
+        Args:
+            shape (list, tuple, o3d.SizeVector): Shape of the tensor.
+            dtype (o3d.Dtype): Data type of the tensor.
+            device (o3d.Device): Device where the tensor is created.
+        """
+        if not isinstance(shape, o3d.SizeVector):
+            shape = o3d.SizeVector(shape)
+        return super(Tensor, Tensor).empty(shape, dtype, device)
+
+    @staticmethod
+    @cast_to_py_tensor
+    def full(shape, fill_value, dtype, device=o3d.Device("CPU:0")):
+        """
+        Create a tensor with fill with the specified value.
+
+        Args:
+            shape (list, tuple, o3d.SizeVector): Shape of the tensor.
+            fill_value (scalar): The value to be filled.
+            dtype (o3d.Dtype): Data type of the tensor.
+            device (o3d.Device): Device where the tensor is created.
+        """
+        if not isinstance(shape, o3d.SizeVector):
+            shape = o3d.SizeVector(shape)
+        return super(Tensor, Tensor).full(shape, fill_value, dtype, device)
+
+    @staticmethod
+    @cast_to_py_tensor
+    def zeros(shape, dtype, device=o3d.Device("CPU:0")):
+        """
+        Create a tensor with fill with zeros.
+
+        Args:
+            shape (list, tuple, o3d.SizeVector): Shape of the tensor.
+            dtype (o3d.Dtype): Data type of the tensor.
+            device (o3d.Device): Device where the tensor is created.
+        """
+        if not isinstance(shape, o3d.SizeVector):
+            shape = o3d.SizeVector(shape)
+        return super(Tensor, Tensor).zeros(shape, dtype, device)
+
+    @staticmethod
+    @cast_to_py_tensor
+    def ones(shape, dtype, device=o3d.Device("CPU:0")):
+        """
+        Create a tensor with fill with ones.
+
+        Args:
+            shape (list, tuple, o3d.SizeVector): Shape of the tensor.
+            dtype (o3d.Dtype): Data type of the tensor.
+            device (o3d.Device): Device where the tensor is created.
+        """
+        if not isinstance(shape, o3d.SizeVector):
+            shape = o3d.SizeVector(shape)
+        return super(Tensor, Tensor).ones(shape, dtype, device)
+
     @cast_to_py_tensor
     def cuda(self, device_id=0):
         """

--- a/src/Python/open3d/core.py
+++ b/src/Python/open3d/core.py
@@ -470,16 +470,25 @@ class Tensor(open3d_pybind.Tensor):
     def __add__(self, value):
         return self.add(value)
 
+    def __radd__(self, value):
+        return self.add(value)
+
     def __iadd__(self, value):
         return self.add_(value)
 
     def __sub__(self, value):
         return self.sub(value)
 
+    def __rsub__(self, value):
+        return o3d.Tensor.full((), value, self.dtype, self.device) - self
+
     def __isub__(self, value):
         return self.sub_(value)
 
     def __mul__(self, value):
+        return self.mul(value)
+
+    def __rmul__(self, value):
         return self.mul(value)
 
     def __imul__(self, value):
@@ -489,6 +498,9 @@ class Tensor(open3d_pybind.Tensor):
         # True div and floor div are the same for Tensor.
         return self.div(value)
 
+    def __rtruediv__(self, value):
+        return o3d.Tensor.full((), value, self.dtype, self.device) / self
+
     def __itruediv__(self, value):
         # True div and floor div are the same for Tensor.
         return self.div_(value)
@@ -496,6 +508,10 @@ class Tensor(open3d_pybind.Tensor):
     def __floordiv__(self, value):
         # True div and floor div are the same for Tensor.
         return self.div(value)
+
+    def __rfloordiv__(self, value):
+        # True div and floor div are the same for Tensor.
+        return o3d.Tensor.full((), value, self.dtype, self.device) // self
 
     def __ifloordiv__(self, value):
         # True div and floor div are the same for Tensor.

--- a/src/Python/open3d_pybind/core/tensor.cpp
+++ b/src/Python/open3d_pybind/core/tensor.cpp
@@ -254,14 +254,81 @@ void pybind_core_tensor(py::module& m) {
     tensor.def("to", &Tensor::To);
 
     // Binary element-wise ops
-    tensor.def("add", &Tensor::Add);
-    tensor.def("add_", &Tensor::Add_);
-    tensor.def("sub", &Tensor::Sub);
-    tensor.def("sub_", &Tensor::Sub_);
-    tensor.def("mul", &Tensor::Mul);
-    tensor.def("mul_", &Tensor::Mul_);
-    tensor.def("div", &Tensor::Div);
-    tensor.def("div_", &Tensor::Div_);
+    tensor.def("add", [](const Tensor& self, const Tensor& other) {
+        return self.Add(other);
+    });
+    tensor.def("add", &Tensor::Add<float>);
+    tensor.def("add", &Tensor::Add<double>);
+    tensor.def("add", &Tensor::Add<int32_t>);
+    tensor.def("add", &Tensor::Add<int64_t>);
+    tensor.def("add", &Tensor::Add<uint8_t>);
+    tensor.def("add", &Tensor::Add<bool>);
+    tensor.def("add_", [](Tensor& self, const Tensor& other) {
+        return self.Add_(other);
+    });
+    tensor.def("add_", &Tensor::Add_<float>);
+    tensor.def("add_", &Tensor::Add_<double>);
+    tensor.def("add_", &Tensor::Add_<int32_t>);
+    tensor.def("add_", &Tensor::Add_<int64_t>);
+    tensor.def("add_", &Tensor::Add_<uint8_t>);
+    tensor.def("add_", &Tensor::Add_<bool>);
+
+    tensor.def("sub", [](const Tensor& self, const Tensor& other) {
+        return self.Sub(other);
+    });
+    tensor.def("sub", &Tensor::Sub<float>);
+    tensor.def("sub", &Tensor::Sub<double>);
+    tensor.def("sub", &Tensor::Sub<int32_t>);
+    tensor.def("sub", &Tensor::Sub<int64_t>);
+    tensor.def("sub", &Tensor::Sub<uint8_t>);
+    tensor.def("sub", &Tensor::Sub<bool>);
+    tensor.def("sub_", [](Tensor& self, const Tensor& other) {
+        return self.Sub_(other);
+    });
+    tensor.def("sub_", &Tensor::Sub_<float>);
+    tensor.def("sub_", &Tensor::Sub_<double>);
+    tensor.def("sub_", &Tensor::Sub_<int32_t>);
+    tensor.def("sub_", &Tensor::Sub_<int64_t>);
+    tensor.def("sub_", &Tensor::Sub_<uint8_t>);
+    tensor.def("sub_", &Tensor::Sub_<bool>);
+
+    tensor.def("mul", [](const Tensor& self, const Tensor& other) {
+        return self.Mul(other);
+    });
+    tensor.def("mul", &Tensor::Mul<float>);
+    tensor.def("mul", &Tensor::Mul<double>);
+    tensor.def("mul", &Tensor::Mul<int32_t>);
+    tensor.def("mul", &Tensor::Mul<int64_t>);
+    tensor.def("mul", &Tensor::Mul<uint8_t>);
+    tensor.def("mul", &Tensor::Mul<bool>);
+    tensor.def("mul_", [](Tensor& self, const Tensor& other) {
+        return self.Mul_(other);
+    });
+    tensor.def("mul_", &Tensor::Mul_<float>);
+    tensor.def("mul_", &Tensor::Mul_<double>);
+    tensor.def("mul_", &Tensor::Mul_<int32_t>);
+    tensor.def("mul_", &Tensor::Mul_<int64_t>);
+    tensor.def("mul_", &Tensor::Mul_<uint8_t>);
+    tensor.def("mul_", &Tensor::Mul_<bool>);
+
+    tensor.def("div", [](const Tensor& self, const Tensor& other) {
+        return self.Div(other);
+    });
+    tensor.def("div", &Tensor::Div<float>);
+    tensor.def("div", &Tensor::Div<double>);
+    tensor.def("div", &Tensor::Div<int32_t>);
+    tensor.def("div", &Tensor::Div<int64_t>);
+    tensor.def("div", &Tensor::Div<uint8_t>);
+    tensor.def("div", &Tensor::Div<bool>);
+    tensor.def("div_", [](Tensor& self, const Tensor& other) {
+        return self.Div_(other);
+    });
+    tensor.def("div_", &Tensor::Div_<float>);
+    tensor.def("div_", &Tensor::Div_<double>);
+    tensor.def("div_", &Tensor::Div_<int32_t>);
+    tensor.def("div_", &Tensor::Div_<int64_t>);
+    tensor.def("div_", &Tensor::Div_<uint8_t>);
+    tensor.def("div_", &Tensor::Div_<bool>);
 
     // Binary boolean element-wise ops
     tensor.def("logical_and", &Tensor::LogicalAnd);
@@ -319,5 +386,7 @@ void pybind_core_tensor(py::module& m) {
     tensor.def("argmax_", &Tensor::ArgMax);
 
     tensor.def("__repr__",
+               [](const Tensor& tensor) { return tensor.ToString(); });
+    tensor.def("__str__",
                [](const Tensor& tensor) { return tensor.ToString(); });
 }

--- a/src/Python/open3d_pybind/core/tensor.cpp
+++ b/src/Python/open3d_pybind/core/tensor.cpp
@@ -77,6 +77,17 @@ void pybind_core_tensor(py::module& m) {
         return t;
     }));
 
+    // Tensor creation API
+    tensor.def_static("empty", &Tensor::Empty);
+    tensor.def_static("full", &Tensor::Full<float>);
+    tensor.def_static("full", &Tensor::Full<double>);
+    tensor.def_static("full", &Tensor::Full<int32_t>);
+    tensor.def_static("full", &Tensor::Full<int64_t>);
+    tensor.def_static("full", &Tensor::Full<uint8_t>);
+    tensor.def_static("full", &Tensor::Full<bool>);
+    tensor.def_static("zeros", &Tensor::Zeros);
+    tensor.def_static("ones", &Tensor::Ones);
+
     // Tensor copy
     tensor.def("shallow_copy_from", &Tensor::ShallowCopyFrom);
 

--- a/src/UnitTest/Core/Tensor.cpp
+++ b/src/UnitTest/Core/Tensor.cpp
@@ -1975,3 +1975,80 @@ TEST_P(TensorPermuteDevices, Ne) {
     a.Ne_(b);
     EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({0, 1, 1, 1}));
 }
+
+TEST_P(TensorPermuteDevices, CreationEmpty) {
+    Device device = GetParam();
+
+    Tensor a = Tensor::Empty({}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({}));
+    EXPECT_EQ(a.NumElements(), 1);
+
+    a = Tensor::Empty({0}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({0}));
+    EXPECT_EQ(a.NumElements(), 0);
+
+    a = Tensor::Empty({1}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({1}));
+    EXPECT_EQ(a.NumElements(), 1);
+
+    a = Tensor::Empty({0, 1}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({0, 1}));
+    EXPECT_EQ(a.NumElements(), 0);
+
+    a = Tensor::Empty({2, 3}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({2, 3}));
+    EXPECT_EQ(a.NumElements(), 6);
+}
+
+TEST_P(TensorPermuteDevices, CreationFull) {
+    Device device = GetParam();
+
+    const float fill_value = 100;
+    Tensor a = Tensor::Full({}, fill_value, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({}));
+    EXPECT_EQ(a.NumElements(), 1);
+    EXPECT_EQ(a.ToFlatVector<float>(),
+              std::vector<float>(a.NumElements(), fill_value));
+
+    a = Tensor::Full({0}, fill_value, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({0}));
+    EXPECT_EQ(a.NumElements(), 0);
+    EXPECT_EQ(a.ToFlatVector<float>(),
+              std::vector<float>(a.NumElements(), fill_value));
+
+    a = Tensor::Full({1}, fill_value, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({1}));
+    EXPECT_EQ(a.NumElements(), 1);
+    EXPECT_EQ(a.ToFlatVector<float>(),
+              std::vector<float>(a.NumElements(), fill_value));
+
+    a = Tensor::Full({0, 1}, fill_value, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({0, 1}));
+    EXPECT_EQ(a.NumElements(), 0);
+    EXPECT_EQ(a.ToFlatVector<float>(),
+              std::vector<float>(a.NumElements(), fill_value));
+
+    a = Tensor::Full({2, 3}, fill_value, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({2, 3}));
+    EXPECT_EQ(a.NumElements(), 6);
+    EXPECT_EQ(a.ToFlatVector<float>(),
+              std::vector<float>(a.NumElements(), fill_value));
+}
+
+TEST_P(TensorPermuteDevices, CreationZeros) {
+    Device device = GetParam();
+
+    Tensor a = Tensor::Zeros({2, 3}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({2, 3}));
+    EXPECT_EQ(a.NumElements(), 6);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>(a.NumElements(), 0));
+}
+
+TEST_P(TensorPermuteDevices, CreationOnes) {
+    Device device = GetParam();
+
+    Tensor a = Tensor::Ones({2, 3}, Dtype::Float32, device);
+    EXPECT_EQ(a.GetShape(), SizeVector({2, 3}));
+    EXPECT_EQ(a.NumElements(), 6);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>(a.NumElements(), 1));
+}

--- a/src/UnitTest/Core/Tensor.cpp
+++ b/src/UnitTest/Core/Tensor.cpp
@@ -2052,3 +2052,89 @@ TEST_P(TensorPermuteDevices, CreationOnes) {
     EXPECT_EQ(a.NumElements(), 6);
     EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>(a.NumElements(), 1));
 }
+
+TEST_P(TensorPermuteDevices, ScalarOperatorOverload) {
+    Device device = GetParam();
+    Tensor a;
+    Tensor b;
+
+    // +
+    a = Tensor::Ones({2}, Dtype::Float32, device);
+    b = a.Add(1);
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({2, 2}));
+    b = a + 1;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({2, 2}));
+    b = 1 + a;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({2, 2}));
+    b = a + true;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({2, 2}));
+
+    // +=
+    a = Tensor::Ones({2}, Dtype::Float32, device);
+    a.Add_(1);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({2, 2}));
+    a += 1;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({3, 3}));
+    a += true;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({4, 4}));
+
+    // -
+    a = Tensor::Ones({2}, Dtype::Float32, device);
+    b = a.Sub(1);
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({0, 0}));
+    b = a - 1;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({0, 0}));
+    b = 10 - a;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({9, 9}));
+    b = a - true;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({0, 0}));
+
+    // -=
+    a = Tensor::Ones({2}, Dtype::Float32, device);
+    a.Sub_(1);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({0, 0}));
+    a -= 1;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({-1, -1}));
+    a -= true;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({-2, -2}));
+
+    // *
+    a = Tensor::Full({2}, 2, Dtype::Float32, device);
+    b = a.Mul(10);
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({20, 20}));
+    b = a * 10;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({20, 20}));
+    b = 10 * a;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({20, 20}));
+    b = a * true;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({2, 2}));
+
+    // *=
+    a = Tensor::Full({2}, 2, Dtype::Float32, device);
+    a.Mul_(10);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({20, 20}));
+    a *= 10;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({200, 200}));
+    a *= true;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({200, 200}));
+
+    // /
+    a = Tensor::Full({2}, 20, Dtype::Float32, device);
+    b = a.Div(2);
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({10, 10}));
+    b = a / 2;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({10, 10}));
+    b = 10 / a;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({0.5, 0.5}));
+    b = a / true;
+    EXPECT_EQ(b.ToFlatVector<float>(), std::vector<float>({20, 20}));
+
+    // /=
+    a = Tensor::Full({2}, 20, Dtype::Float32, device);
+    a.Div_(2);
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({10, 10}));
+    a /= 2;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({5, 5}));
+    a /= true;
+    EXPECT_EQ(a.ToFlatVector<float>(), std::vector<float>({5, 5}));
+}

--- a/src/UnitTest/Python/test_core.py
+++ b/src/UnitTest/Python/test_core.py
@@ -54,6 +54,28 @@ def list_devices():
     return devices
 
 
+def test_creation():
+    # Shape takes tuple, list or o3d.SizeVector
+    t = o3d.Tensor.empty((2, 3), o3d.Dtype.Float32)
+    assert t.shape == o3d.SizeVector([2, 3])
+    t = o3d.Tensor.empty([2, 3], o3d.Dtype.Float32)
+    assert t.shape == o3d.SizeVector([2, 3])
+    t = o3d.Tensor.empty(o3d.SizeVector([2, 3]), o3d.Dtype.Float32)
+    assert t.shape == o3d.SizeVector([2, 3])
+
+    # Test zeros and ones
+    t = o3d.Tensor.zeros((2, 3), o3d.Dtype.Float32)
+    np.testing.assert_equal(t.numpy(), np.zeros((2, 3), dtype=np.float32))
+    t = o3d.Tensor.ones((2, 3), o3d.Dtype.Float32)
+    np.testing.assert_equal(t.numpy(), np.ones((2, 3), dtype=np.float32))
+
+    # Automatic casting of dtype.
+    t = o3d.Tensor.full((2,), False, o3d.Dtype.Float32)
+    np.testing.assert_equal(t.numpy(), np.full((2,), False, dtype=np.float32))
+    t = o3d.Tensor.full((2,), 3.5, o3d.Dtype.UInt8)
+    np.testing.assert_equal(t.numpy(), np.full((2,), 3.5, dtype=np.uint8))
+
+
 def test_dtype():
     dtype = o3d.Dtype.Int32
     assert o3d.DtypeUtil.byte_size(dtype) == 4

--- a/src/UnitTest/Python/test_core.py
+++ b/src/UnitTest/Python/test_core.py
@@ -747,3 +747,91 @@ def test_comparision_ops():
     np.testing.assert_equal((o3_a <= o3_b).numpy(), np_a <= np_b)
     np.testing.assert_equal((o3_a == o3_b).numpy(), np_a == np_b)
     np.testing.assert_equal((o3_a != o3_b).numpy(), np_a != np_b)
+
+
+def test_scalar_op():
+    # +
+    a = o3d.Tensor.ones((2, 3), o3d.Dtype.Float32)
+    b = a.add(1)
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 2))
+    b = a + 1
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 2))
+    b = 1 + a
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 2))
+    b = a + True
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 2))
+
+    # +=
+    a = o3d.Tensor.ones((2, 3), o3d.Dtype.Float32)
+    a.add_(1)
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 2))
+    a += 1
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 3))
+    a += True
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 4))
+
+    # -
+    a = o3d.Tensor.ones((2, 3), o3d.Dtype.Float32)
+    b = a.sub(1)
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 0))
+    b = a - 1
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 0))
+    b = 10 - a
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 9))
+    b = a - True
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 0))
+
+    # -=
+    a = o3d.Tensor.ones((2, 3), o3d.Dtype.Float32)
+    a.sub_(1)
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 0))
+    a -= 1
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), -1))
+    a -= True
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), -2))
+
+    # *
+    a = o3d.Tensor.full((2, 3), 2, o3d.Dtype.Float32)
+    b = a.mul(10)
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 20))
+    b = a * 10
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 20))
+    b = 10 * a
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 20))
+    b = a * True
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 2))
+
+    # *=
+    a = o3d.Tensor.full((2, 3), 2, o3d.Dtype.Float32)
+    a.mul_(10)
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 20))
+    a *= 10
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 200))
+    a *= True
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 200))
+
+    # /
+    a = o3d.Tensor.full((2, 3), 20, o3d.Dtype.Float32)
+    b = a.div(2)
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 10))
+    b = a / 2
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 10))
+    b = a // 2
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 10))
+    b = 10 / a
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 0.5))
+    b = 10 // a
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 0.5))
+    b = a / True
+    np.testing.assert_equal(b.numpy(), np.full((2, 3), 20))
+
+    # /=
+    a = o3d.Tensor.full((2, 3), 20, o3d.Dtype.Float32)
+    a.div_(2)
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 10))
+    a /= 2
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 5))
+    a //= 2
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 2.5))
+    a /= True
+    np.testing.assert_equal(a.numpy(), np.full((2, 3), 2.5))


### PR DESCRIPTION
```python
# Tensor creation
a = o3d.Tensor.empty((2 ,3), o3d.Dtype.Float32)
a = o3d.Tensor.ones((2 ,3), o3d.Dtype.Float32)
a = o3d.Tensor.zeros((2 ,3), o3d.Dtype.Float32)
a = o3d.Tensor.full((2 ,3), 100, o3d.Dtype.Float32)

# Works for +, -, *, /
b = a + 1
b = a + True  # auto cast scalar
b = 1 - a
a += 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1779)
<!-- Reviewable:end -->
