### PR TITLE
Fixed integration of app icon with FreeDesktop environments

### DIFF
--- a/src/Apps/CMakeLists.txt
+++ b/src/Apps/CMakeLists.txt
@@ -91,11 +91,12 @@ macro(APP SRC_DIR APP_NAME TARGET_NAME)
             install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${APP_NAME}.desktop"
                     DESTINATION "${DESKTOP_INSTALL_DIR}/applications")
             install(FILES "${SOURCE_DIR}/icon.svg"
-                    DESTINATION "${DESKTOP_INSTALL_DIR}/icons/hicolor/scalable"
+                    DESTINATION "${DESKTOP_INSTALL_DIR}/icons/hicolor/scalable/apps"
                     RENAME "${APP_NAME}.svg")
             install(FILES "${SOURCE_DIR}/${TARGET_NAME}.xml"
                     DESTINATION "${DESKTOP_INSTALL_DIR}/mime/packages"
                     RENAME "${APP_NAME}.xml")
+            # Various caches need to be updated for the app to become visible
             install(CODE "execute_process(COMMAND ${SOURCE_DIR}/postinstall-linux.sh)")
         endif()
     endif()

--- a/src/Apps/Open3DViewer/postinstall-linux.sh
+++ b/src/Apps/Open3DViewer/postinstall-linux.sh
@@ -3,8 +3,11 @@
 if [ $(id -u) = 0 ]; then
     update-mime-database /usr/share/mime # add new MIME types
     update-desktop-database # associate MIME -> app
+    gtk-update-icon-cache /usr/share/icons/hicolor || true
 else
     update-mime-database ~/.local/share/mime # add new MIME types
     update-desktop-database 2> /dev/null # associate MIME -> app
                                          # (junk confusing errors)
+    # Desktop Environments seem to scan ~/.local for icons so no need for
+    # gtk-update-icon-cache.
 fi


### PR DESCRIPTION
Installing app for all users requires updating icon cache, also we had the wrong path for the icon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1783)
<!-- Reviewable:end -->
