### PR TITLE
Workaround Open3DViewer image export issue

### DIFF
--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.cpp
@@ -26,13 +26,6 @@
 
 #include "FilamentRenderToBuffer.h"
 
-#include "FilamentEngine.h"
-#include "FilamentRenderer.h"
-#include "FilamentScene.h"
-#include "FilamentView.h"
-
-#include "Open3D/Utility/Console.h"
-
 #include <filament/Engine.h>
 #include <filament/RenderableManager.h>
 #include <filament/Renderer.h>
@@ -41,6 +34,12 @@
 #include <filament/Texture.h>
 #include <filament/View.h>
 #include <filament/Viewport.h>
+
+#include "FilamentEngine.h"
+#include "FilamentRenderer.h"
+#include "FilamentScene.h"
+#include "FilamentView.h"
+#include "Open3D/Utility/Console.h"
 
 namespace open3d {
 namespace visualization {
@@ -52,9 +51,7 @@ FilamentRenderToBuffer::FilamentRenderToBuffer(filament::Engine& engine)
 
 FilamentRenderToBuffer::FilamentRenderToBuffer(filament::Engine& engine,
                                                FilamentRenderer& parent)
-    : parent_(&parent),
-      engine_(engine) {
-
+    : parent_(&parent), engine_(engine) {
     renderer_ = engine_.createRenderer();
 }
 

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.h
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.h
@@ -59,12 +59,11 @@ public:
 private:
     friend class FilamentRenderer;
 
-    FilamentRenderer*    parent_    = nullptr;
-    filament::Engine&    engine_;
-    filament::Renderer*  renderer_  = nullptr;
+    FilamentRenderer* parent_ = nullptr;
+    filament::Engine& engine_;
+    filament::Renderer* renderer_ = nullptr;
     filament::SwapChain* swapchain_ = nullptr;
-    FilamentView*        view_      = nullptr;
-
+    FilamentView* view_ = nullptr;
 
     std::size_t width_ = 0;
     std::size_t height_ = 0;

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.h
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentRenderToBuffer.h
@@ -59,11 +59,12 @@ public:
 private:
     friend class FilamentRenderer;
 
-    FilamentRenderer* parent_ = nullptr;
-    filament::Engine& engine_;
-    filament::Renderer* renderer_ = nullptr;
+    FilamentRenderer*    parent_    = nullptr;
+    filament::Engine&    engine_;
+    filament::Renderer*  renderer_  = nullptr;
     filament::SwapChain* swapchain_ = nullptr;
-    std::unique_ptr<FilamentView> view_;
+    FilamentView*        view_      = nullptr;
+
 
     std::size_t width_ = 0;
     std::size_t height_ = 0;

--- a/src/Open3D/Visualization/Rendering/Renderer.cpp
+++ b/src/Open3D/Visualization/Rendering/Renderer.cpp
@@ -87,7 +87,6 @@ void Renderer::RenderToImage(
         Scene* scene,
         std::function<void(std::shared_ptr<geometry::Image>)> cb) {
     auto render = CreateBufferRenderer();
-    render->SetDimensions(width, height);
     render->CopySettings(view);
     render->RequestFrame(
             scene,


### PR DESCRIPTION
Keep copy of View in FilamentRenderToBuffer instead of creating an internal version and copying settings from the provided View.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1790)
<!-- Reviewable:end -->
