### PR TITLE
fix Windows Kinect compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ src/Open3D/Open3DConfig.h
 src/Open3D/Visualization/Shader/Shader.h
 util/pip_package/setup.py
 
+# CMake temp file from Visual Studio
+CMakeSettings.json
+
 # Temp directories
 build*/
 cmake-build-debug/

--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -55,17 +55,17 @@ if (BUILD_AZURE_KINECT)
     # Export the following variables:
     # - k4a_INCLUDE_DIRS
     if (WIN32)
-        # We assume k4a 1.2.0 is installed in the default directory
+        # We assume k4a 1.4.0 is installed in the default directory
         if (K4A_INCLUDE_DIR)
             set(k4a_INCLUDE_DIRS ${K4A_INCLUDE_DIR})
         else()
-            set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.2.0\\sdk\\include")
+            set(k4a_INCLUDE_DIRS "C:\\Program Files\\Azure Kinect SDK v1.4.0\\sdk\\include")
         endif()
     else()
         # Attempt 1: system-wide installed K4a
         # The property names are tested with k4a 1.2, future versions might work
-        find_package(k4a 1.2 QUIET)
-        find_package(k4arecord 1.2 QUIET)
+        find_package(k4a QUIET)
+        find_package(k4arecord QUIET)
         if (k4a_FOUND)
             get_target_property(k4a_INCLUDE_DIRS k4a::k4a INTERFACE_INCLUDE_DIRECTORIES)
         endif()

--- a/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.cpp
+++ b/src/Open3D/IO/Sensor/AzureKinect/AzureKinectSensor.cpp
@@ -86,7 +86,8 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
     }
 
     // open device
-    if (K4A_FAILED(k4a_plugin::k4a_device_open(sensor_index, &device_))) {
+    if (K4A_FAILED(k4a_plugin::k4a_device_open(
+                static_cast<uint32_t>(sensor_index), &device_))) {
         utility::LogWarning(
                 "Runtime error: k4a_plugin::k4a_device_open() failed");
         return false;


### PR DESCRIPTION
Fixes #1708 

- Fix Windows compilation warning (as error)
- Update cmake to support k4a 1.4 include path on Windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1796)
<!-- Reviewable:end -->
