### PR TITLE
fix colormap segfault and refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - pip install -U yapf==0.28.0
         - make check-style
 
-    # Build headless and docs 
+    # Build headless and docs
     - os: linux
       dist: bionic
       sudo: true
@@ -60,7 +60,7 @@ matrix:
         - which python
         - python -V
         - pip install -U -q sphinx sphinx-rtd-theme nbsphinx Pillow
-        - cmake -DPYTHON_EXECUTABLE=`which python` -DENABLE_HEADLESS_RENDERING=ON -DBUILD_GLEW=ON -DBUILD_GLFW=ON -DWITH_OPENMP=OFF ..
+        - cmake -DPYTHON_EXECUTABLE=`which python` -DENABLE_HEADLESS_RENDERING=ON -DBUILD_GLEW=ON -DBUILD_GLFW=ON -DWITH_OPENMP=ON ..
         - make install-pip-package -j$NPROC
         - make -j$NPROC
         - bin/GLInfo

--- a/src/Open3D/ColorMap/ColorMapOptimization.h
+++ b/src/Open3D/ColorMap/ColorMapOptimization.h
@@ -59,7 +59,7 @@ public:
             double non_rigid_anchor_point_weight = 0.316,
             int maximum_iteration = 300,
             double maximum_allowable_depth = 2.5,
-            double depth_threshold_for_visiblity_check = 0.03,
+            double depth_threshold_for_visibility_check = 0.03,
             double depth_threshold_for_discontinuity_check = 0.1,
             int half_dilation_kernel_size_for_discontinuity_map = 3,
             int image_boundary_margin = 10,
@@ -69,8 +69,8 @@ public:
           non_rigid_anchor_point_weight_(non_rigid_anchor_point_weight),
           maximum_iteration_(maximum_iteration),
           maximum_allowable_depth_(maximum_allowable_depth),
-          depth_threshold_for_visiblity_check_(
-                  depth_threshold_for_visiblity_check),
+          depth_threshold_for_visibility_check_(
+                  depth_threshold_for_visibility_check),
           depth_threshold_for_discontinuity_check_(
                   depth_threshold_for_discontinuity_check),
           half_dilation_kernel_size_for_discontinuity_map_(
@@ -106,9 +106,9 @@ public:
     double maximum_allowable_depth_;
     /// Parameter to check the visibility of a point. When the difference of a
     /// point’s depth value in the RGB-D image and the point’s depth value in
-    /// the 3D mesh is greater than depth_threshold_for_visiblity_check, the
+    /// the 3D mesh is greater than depth_threshold_for_visibility_check, the
     /// point is marked as invisible to the camera producing the RGB-D image.
-    double depth_threshold_for_visiblity_check_;
+    double depth_threshold_for_visibility_check_;
     /// Parameter to check the visibility of a point. It’s often desirable to
     /// ignore points where there is an abrupt change in depth value. First the
     /// depth gradient image is computed, points are considered to be invisible

--- a/src/Open3D/ColorMap/ColorMapOptimizationJacobian.cpp
+++ b/src/Open3D/ColorMap/ColorMapOptimizationJacobian.cpp
@@ -44,11 +44,11 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualRigid(
         const std::shared_ptr<geometry::Image>& images_dy,
         const Eigen::Matrix4d& intrinsic,
         const Eigen::Matrix4d& extrinsic,
-        const std::vector<int>& visiblity_image_to_vertex,
+        const std::vector<int>& visibility_image_to_vertex,
         const int image_boundary_margin) {
     J_r.setZero();
     r = 0;
-    int vid = visiblity_image_to_vertex[row];
+    int vid = visibility_image_to_vertex[row];
     Eigen::Vector3d x = mesh.vertices_[vid];
     Eigen::Vector4d g = extrinsic * Eigen::Vector4d(x(0), x(1), x(2), 1);
     Eigen::Vector4d uv = intrinsic * g;
@@ -88,14 +88,14 @@ void ColorMapOptimizationJacobian::ComputeJacobianAndResidualNonRigid(
         const ImageWarpingField& warping_fields_init,
         const Eigen::Matrix4d& intrinsic,
         const Eigen::Matrix4d& extrinsic,
-        const std::vector<int>& visiblity_image_to_vertex,
+        const std::vector<int>& visibility_image_to_vertex,
         const int image_boundary_margin) {
     J_r.setZero();
     pattern.setZero();
     r = 0;
     int anchor_w = warping_fields.anchor_w_;
     double anchor_step = warping_fields.anchor_step_;
-    int vid = visiblity_image_to_vertex[row];
+    int vid = visibility_image_to_vertex[row];
     Eigen::Vector3d V = mesh.vertices_[vid];
     Eigen::Vector4d G = extrinsic * Eigen::Vector4d(V(0), V(1), V(2), 1);
     Eigen::Vector4d L = intrinsic * G;

--- a/src/Open3D/ColorMap/ColorMapOptimizationJacobian.h
+++ b/src/Open3D/ColorMap/ColorMapOptimizationJacobian.h
@@ -65,7 +65,7 @@ public:
             const std::shared_ptr<geometry::Image>& images_dy,
             const Eigen::Matrix4d& intrinsic,
             const Eigen::Matrix4d& extrinsic,
-            const std::vector<int>& visiblity_image_to_vertex,
+            const std::vector<int>& visibility_image_to_vertex,
             const int image_boundary_margin);
 
     /// Function to compute i-th row of J and r
@@ -86,7 +86,7 @@ public:
             const ImageWarpingField& warping_fields_init,
             const Eigen::Matrix4d& intrinsic,
             const Eigen::Matrix4d& extrinsic,
-            const std::vector<int>& visiblity_image_to_vertex,
+            const std::vector<int>& visibility_image_to_vertex,
             const int image_boundary_margin);
 };
 }  // namespace color_map

--- a/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.h
+++ b/src/Open3D/ColorMap/TriangleMeshAndImageUtilities.h
@@ -63,7 +63,7 @@ CreateVertexAndImageVisibility(
         const std::vector<std::shared_ptr<geometry::Image>>& images_mask,
         const camera::PinholeCameraTrajectory& camera,
         double maximum_allowable_depth,
-        double depth_threshold_for_visiblity_check);
+        double depth_threshold_for_visibility_check);
 
 template <typename T>
 std::tuple<bool, T> QueryImageIntensity(
@@ -89,7 +89,7 @@ void SetProxyIntensityForVertex(
         const std::vector<std::shared_ptr<geometry::Image>>& images_gray,
         const std::vector<ImageWarpingField>& warping_field,
         const camera::PinholeCameraTrajectory& camera,
-        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        const std::vector<std::vector<int>>& visibility_vertex_to_image,
         std::vector<double>& proxy_intensity,
         int image_boundary_margin);
 
@@ -97,7 +97,7 @@ void SetProxyIntensityForVertex(
         const geometry::TriangleMesh& mesh,
         const std::vector<std::shared_ptr<geometry::Image>>& images_gray,
         const camera::PinholeCameraTrajectory& camera,
-        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        const std::vector<std::vector<int>>& visibility_vertex_to_image,
         std::vector<double>& proxy_intensity,
         int image_boundary_margin);
 
@@ -105,7 +105,7 @@ void SetGeometryColorAverage(
         geometry::TriangleMesh& mesh,
         const std::vector<std::shared_ptr<geometry::Image>>& images_rgbd,
         const camera::PinholeCameraTrajectory& camera,
-        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        const std::vector<std::vector<int>>& visibility_vertex_to_image,
         int image_boundary_margin = 10,
         int invisible_vertex_color_knn = 3);
 
@@ -114,7 +114,7 @@ void SetGeometryColorAverage(
         const std::vector<std::shared_ptr<geometry::Image>>& images_rgbd,
         const std::vector<ImageWarpingField>& warping_fields,
         const camera::PinholeCameraTrajectory& camera,
-        const std::vector<std::vector<int>>& visiblity_vertex_to_image,
+        const std::vector<std::vector<int>>& visibility_vertex_to_image,
         int image_boundary_margin = 10,
         int invisible_vertex_color_knn = 3);
 }  // namespace color_map

--- a/src/Python/open3d_pybind/color_map/color_map.cpp
+++ b/src/Python/open3d_pybind/color_map/color_map.cpp
@@ -90,14 +90,14 @@ void pybind_color_map_classes(py::module &m) {
                     "Select a proper value to include necessary points while "
                     "ignoring unwanted points such as the background.")
             .def_readwrite(
-                    "depth_threshold_for_visiblity_check",
+                    "depth_threshold_for_visibility_check",
                     &color_map::ColorMapOptimizationOption::
-                            depth_threshold_for_visiblity_check_,
+                            depth_threshold_for_visibility_check_,
                     "float: (Default ``0.03``) Parameter for point visibility "
                     "check. When the difference of a point's depth "
                     "value in the RGB-D image and the point's depth "
                     "value in the 3D mesh is greater than "
-                    "``depth_threshold_for_visiblity_check``, the "
+                    "``depth_threshold_for_visibility_check``, the "
                     "point is marked as invisible to the camera producing "
                     "the RGB-D image.")
             .def_readwrite(
@@ -153,7 +153,7 @@ void pybind_color_map_classes(py::module &m) {
                     "- non_rigid_anchor_point_weight: {}\n"
                     "- maximum_iteration: {}\n"
                     "- maximum_allowable_depth: {}\n"
-                    "- depth_threshold_for_visiblity_check: {}\n"
+                    "- depth_threshold_for_visibility_check: {}\n"
                     "- depth_threshold_for_discontinuity_check: {}\n"
                     "- half_dilation_kernel_size_for_discontinuity_map: {}\n"
                     "- image_boundary_margin: {}\n"
@@ -163,7 +163,7 @@ void pybind_color_map_classes(py::module &m) {
                     to.non_rigid_anchor_point_weight_,
                     to.maximum_iteration_,
                     to.maximum_allowable_depth_,
-                    to.depth_threshold_for_visiblity_check_,
+                    to.depth_threshold_for_visibility_check_,
                     to.depth_threshold_for_discontinuity_check_,
                     to.half_dilation_kernel_size_for_discontinuity_map_,
                     to.image_boundary_margin_,

--- a/src/UnitTest/ColorMap/ColorMapOptimizationOption.cpp
+++ b/src/UnitTest/ColorMap/ColorMapOptimizationOption.cpp
@@ -47,7 +47,7 @@ TEST(ColorMapOptimizationOption, DISABLED_Constructor) {
     // unit_test::THRESHOLD_1E_6); EXPECT_NEAR(300, option.maximum_iteration_,
     // unit_test::THRESHOLD_1E_6); EXPECT_NEAR(2.5,
     // option.maximum_allowable_depth_, unit_test::THRESHOLD_1E_6);
-    // EXPECT_NEAR(0.03, option.depth_threshold_for_visiblity_check_,
+    // EXPECT_NEAR(0.03, option.depth_threshold_for_visibility_check_,
     // unit_test::THRESHOLD_1E_6); EXPECT_NEAR(0.1,
     // option.depth_threshold_for_discontinuity_check_,
     // unit_test::THRESHOLD_1E_6);

--- a/src/UnitTest/Python/test_color_map.py
+++ b/src/UnitTest/Python/test_color_map.py
@@ -1,0 +1,105 @@
+import open3d as o3d
+import numpy as np
+import re
+import os
+import sys
+import urllib
+import zipfile
+
+
+def get_file_list(path, extension=None):
+
+    def sorted_alphanum(file_list_ordered):
+        convert = lambda text: int(text) if text.isdigit() else text
+        alphanum_key = lambda key: [
+            convert(c) for c in re.split('([0-9]+)', key)
+        ]
+        return sorted(file_list_ordered, key=alphanum_key)
+
+    if extension is None:
+        file_list = [
+            path + f
+            for f in os.listdir(path)
+            if os.path.isfile(os.path.join(path, f))
+        ]
+    else:
+        file_list = [
+            path + f
+            for f in os.listdir(path)
+            if os.path.isfile(os.path.join(path, f)) and
+            os.path.splitext(f)[1] == extension
+        ]
+    file_list = sorted_alphanum(file_list)
+    return file_list
+
+
+def download_fountain_dataset():
+
+    def relative_path(path):
+        script_path = os.path.realpath(__file__)
+        script_dir = os.path.dirname(script_path)
+        return os.path.join(script_dir, path)
+
+    fountain_path = relative_path("../../../examples/TestData/fountain_small")
+    fountain_zip_path = relative_path("../../../examples/TestData/fountain.zip")
+    if not os.path.exists(fountain_path):
+        print("downloading fountain dataset")
+        url = "https://storage.googleapis.com/isl-datasets/open3d-dev/fountain.zip"
+        urllib.request.urlretrieve(url, fountain_zip_path)
+        print("extract fountain dataset")
+        with zipfile.ZipFile(fountain_zip_path, "r") as zip_ref:
+            zip_ref.extractall(os.path.dirname(fountain_path))
+        os.remove(fountain_zip_path)
+    return fountain_path
+
+
+def test_color_map():
+    path = download_fountain_dataset()
+    depth_image_path = get_file_list(os.path.join(path, "depth/"),
+                                     extension=".png")
+    color_image_path = get_file_list(os.path.join(path, "image/"),
+                                     extension=".jpg")
+    assert (len(depth_image_path) == len(color_image_path))
+
+    rgbd_images = []
+    for i in range(len(depth_image_path)):
+        depth = o3d.io.read_image(os.path.join(depth_image_path[i]))
+        color = o3d.io.read_image(os.path.join(color_image_path[i]))
+        rgbd_image = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            color, depth, convert_rgb_to_intensity=False)
+        rgbd_images.append(rgbd_image)
+
+    camera = o3d.io.read_pinhole_camera_trajectory(
+        os.path.join(path, "scene/key.log"))
+    mesh = o3d.io.read_triangle_mesh(
+        os.path.join(path, "scene", "integrated.ply"))
+
+    # Computes averaged color without optimization
+    option = o3d.color_map.ColorMapOptimizationOption()
+    option.maximum_iteration = 0
+    with o3d.utility.VerbosityContextManager(
+            o3d.utility.VerbosityLevel.Debug) as cm:
+        o3d.color_map.color_map_optimization(mesh, rgbd_images, camera, option)
+
+    # Rigid Optimization
+    option.maximum_iteration = 5
+    option.non_rigid_camera_coordinate = False
+    with o3d.utility.VerbosityContextManager(
+            o3d.utility.VerbosityLevel.Debug) as cm:
+        o3d.color_map.color_map_optimization(mesh, rgbd_images, camera, option)
+
+    # Non-rigid Optimization
+    option.maximum_iteration = 5
+    option.non_rigid_camera_coordinate = True
+    with o3d.utility.VerbosityContextManager(
+            o3d.utility.VerbosityLevel.Debug) as cm:
+        o3d.color_map.color_map_optimization(mesh, rgbd_images, camera, option)
+
+    # Black box test with hard-coded result values. The results of
+    # color_map_optimization are deterministic. This test ensures the
+    # refactored code produced same output. This is only valid for using
+    # exactly the same inputs and optimization options.
+    vertex_colors = np.asarray(mesh.vertex_colors)
+    assert vertex_colors.shape == (536872, 3)
+    np.testing.assert_allclose(np.mean(vertex_colors, axis=0),
+                               [0.40307181, 0.37264626, 0.5436129])

--- a/src/UnitTest/Python/test_color_map.py
+++ b/src/UnitTest/Python/test_color_map.py
@@ -96,9 +96,9 @@ def test_color_map():
         o3d.color_map.color_map_optimization(mesh, rgbd_images, camera, option)
 
     # Black box test with hard-coded result values. The results of
-    # color_map_optimization are deterministic. This test ensures the
-    # refactored code produced same output. This is only valid for using
-    # exactly the same inputs and optimization options.
+    # color_map_optimization are deterministic. This test ensures the refactored
+    # code produces the same output. This is only valid for using exactly the
+    # same inputs and optimization options.
     vertex_colors = np.asarray(mesh.vertex_colors)
     assert vertex_colors.shape == (536872, 3)
     np.testing.assert_allclose(np.mean(vertex_colors, axis=0),


### PR DESCRIPTION
Looks like the segfault is mainly due to the `LogDebug` statement inside OpenMP. Here's the stack trace:
```bash
(lldb) up
frame #13: 0x00007ffff374135f open3d_pybind.cpython-37m-x86_64-linux-gnu.so`::.omp_outlined.() at TriangleMeshAndImageUtilities.cpp:105
   102                  viscnt++;
   103              }
   104          }
-> 105          utility::LogDebug("[cam {:d}] {:.5f} percents are visible", c,
   106                            double(viscnt) / n_vertex * 100);
   107          fflush(stdout);
   108      }
```

After the fix, I ran the unit tests for 100 times with prints, no segfault occurred.

Changes:
- Move print outside of OpenMP
- Add color map python test
- Fix spellings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1813)
<!-- Reviewable:end -->
