### PR TITLE
Support additional texture maps

### DIFF
--- a/src/Open3D/GUI/Materials/defaultLit.mat
+++ b/src/Open3D/GUI/Materials/defaultLit.mat
@@ -12,11 +12,15 @@ material {
         { type : float,     name : clearCoatRoughness },
         { type : float,     name : anisotropy },
         { type : float,     name : pointSize },
-	{ type : sampler2d, name : albedo },
-	{ type : sampler2d, name : metallicMap },
-	{ type : sampler2d, name : roughnessMap },
-	{ type : sampler2d, name : normalMap },
-	{ type : sampler2d, name : ambientOcclusionMap }
+        { type : sampler2d, name : albedo },
+        { type : sampler2d, name : metallicMap },
+        { type : sampler2d, name : roughnessMap },
+        { type : sampler2d, name : normalMap },
+        { type : sampler2d, name : ambientOcclusionMap },
+        { type : sampler2d, name : reflectanceMap },
+        { type : sampler2d, name : clearCoatMap },
+        { type : sampler2d, name : clearCoatRoughnessMap },
+        { type : sampler2d, name : anisotropyMap }
     ],
     requires : [
         color, uv0
@@ -33,17 +37,21 @@ fragment {
     void material(inout MaterialInputs material) {
         // Modifications to normal must be done before prepareMaterial call
         material.normal = texture(materialParams_normalMap, getUV0()).xyz * 2.0 - 1.0;
-	material.normal.y *= -1.0; // NOTE: including this line because Filament samples do
-	
+        material.normal.y *= -1.0; // NOTE: including this line because Filament samples do
+
         prepareMaterial(material);
 
         material.baseColor.rgb = getColor().rgb*materialParams.baseColor * texture(materialParams_albedo, getUV0()).rgb;
         material.metallic = materialParams.baseMetallic * texture(materialParams_metallicMap, getUV0()).r;
         material.roughness = materialParams.baseRoughness * texture(materialParams_roughnessMap, getUV0()).r;
-	material.ambientOcclusion = texture(materialParams_ambientOcclusionMap, getUV0()).r;
-        material.reflectance = materialParams.reflectance;
-        material.clearCoat = materialParams.clearCoat;
-        material.clearCoatRoughness = materialParams.clearCoatRoughness;
-        material.anisotropy = materialParams.anisotropy;
+        material.ambientOcclusion = texture(materialParams_ambientOcclusionMap, getUV0()).r;
+        //material.reflectance = materialParams.reflectance;
+        //material.clearCoat = materialParams.clearCoat;
+        //material.clearCoatRoughness = materialParams.clearCoatRoughness;
+        //material.anisotropy = materialParams.anisotropy;
+        material.reflectance = materialParams.reflectance * texture(materialParams_reflectanceMap, getUV0()).r;
+        material.clearCoat = materialParams.clearCoat * texture(materialParams_clearCoatMap, getUV0()).r;
+        material.clearCoatRoughness = materialParams.clearCoatRoughness * texture(materialParams_clearCoatRoughnessMap, getUV0()).r;
+        material.anisotropy = materialParams.anisotropy * texture(materialParams_anisotropyMap, getUV0()).r;
     }
 }

--- a/src/Open3D/Geometry/TriangleMesh.h
+++ b/src/Open3D/Geometry/TriangleMesh.h
@@ -801,11 +801,20 @@ public:
         MaterialParameter baseColor;
         float baseMetallic = 0.f;
         float baseRoughness = 1.f;
+        float baseReflectance = 0.5f;
+        float baseClearCoat = 0.f;
+        float baseClearCoatRoughness = 0.f;
+        float baseAnisotropy = 0.f;
+
         std::shared_ptr<Image> albedo;
         std::shared_ptr<Image> normalMap;
         std::shared_ptr<Image> ambientOcclusion;
         std::shared_ptr<Image> metallic;
         std::shared_ptr<Image> roughness;
+        std::shared_ptr<Image> reflectance;
+        std::shared_ptr<Image> clearCoat;
+        std::shared_ptr<Image> clearCoatRoughness;
+        std::shared_ptr<Image> anisotropy;
 
         std::unordered_map<std::string, MaterialParameter> floatParameters;
         std::unordered_map<std::string, Image> additionalMaps;

--- a/src/Open3D/IO/FileFormat/FileOBJ.cpp
+++ b/src/Open3D/IO/FileFormat/FileOBJ.cpp
@@ -195,6 +195,10 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
             meshMaterial.roughness = textureLoader(material.roughness_texname);
         }
 
+        if (!material.sheen_texname.empty()) {
+            meshMaterial.reflectance = textureLoader(material.sheen_texname);
+        }
+
         // NOTE: We want defaults of 0.0 and 1.0 for baseMetallic and
         // baseRoughness respectively but 0.0 is a valid value for both and
         // tiny_obj_loader defaults to 0.0 for both. So, we will assume that
@@ -205,8 +209,15 @@ bool ReadTriangleMeshFromOBJ(const std::string& filename,
             meshMaterial.baseRoughness = material.roughness;
         }
 
-        // NOTE: PBR OBJ 'extension' supports additional parameters that could
-        // be useful in the future. See tiny_obj_loader.h for details.
+        if (material.sheen > 0.f) {
+            meshMaterial.baseReflectance = material.sheen;
+        }
+
+        // NOTE: We will unconditionally copy the following parameters because
+        // the TinyObj defaults match Open3D's internal defaults
+        meshMaterial.baseClearCoat = material.clearcoat_thickness;
+        meshMaterial.baseClearCoatRoughness = material.clearcoat_roughness;
+        meshMaterial.baseAnisotropy = material.anisotropy;
     }
 
     return true;

--- a/src/Open3D/Visualization/Rendering/Filament/FilamentResourceManager.cpp
+++ b/src/Open3D/Visualization/Rendering/Filament/FilamentResourceManager.cpp
@@ -674,6 +674,11 @@ void FilamentResourceManager::LoadDefaults() {
     litMat->setDefaultParameter("roughnessMap", texture, defaultSampler);
     litMat->setDefaultParameter("normalMap", normalMap, defaultSampler);
     litMat->setDefaultParameter("ambientOcclusionMap", texture, defaultSampler);
+    litMat->setDefaultParameter("reflectanceMap", texture, defaultSampler);
+    litMat->setDefaultParameter("clearCoatMap", texture, defaultSampler);
+    litMat->setDefaultParameter("clearCoatRoughnessMap", texture,
+                                defaultSampler);
+    litMat->setDefaultParameter("anisotropyMap", texture, defaultSampler);
     materials_[kDefaultLit] = MakeShared(litMat, engine_);
 
     const auto unlitPath = resourceRoot + "/defaultUnlit.filamat";

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -484,11 +484,17 @@ struct GuiVisualizer::Impl {
     };
 
     struct TextureMaps {
-        TextureHandle albedoMap;
-        TextureHandle normalMap;
-        TextureHandle ambientOcclusionMap;
-        TextureHandle roughnessMap;
-        TextureHandle metallicMap;
+        TextureHandle albedoMap = FilamentResourceManager::kDefaultTexture;
+        TextureHandle normalMap = FilamentResourceManager::kDefaultNormalMap;
+        TextureHandle ambientOcclusionMap =
+                FilamentResourceManager::kDefaultTexture;
+        TextureHandle roughnessMap = FilamentResourceManager::kDefaultTexture;
+        TextureHandle metallicMap = FilamentResourceManager::kDefaultTexture;
+        TextureHandle reflectanceMap = FilamentResourceManager::kDefaultTexture;
+        TextureHandle clearCoatMap = FilamentResourceManager::kDefaultTexture;
+        TextureHandle clearCoatRoughnessMap =
+                FilamentResourceManager::kDefaultTexture;
+        TextureHandle anisotropyMap = FilamentResourceManager::kDefaultTexture;
     };
 
     struct Materials {
@@ -620,6 +626,11 @@ struct GuiVisualizer::Impl {
                 FilamentResourceManager::kDefaultTexture;
         defaults.maps.roughnessMap = FilamentResourceManager::kDefaultTexture;
         defaults.maps.metallicMap = FilamentResourceManager::kDefaultTexture;
+        defaults.maps.reflectanceMap = FilamentResourceManager::kDefaultTexture;
+        defaults.maps.clearCoatMap = FilamentResourceManager::kDefaultTexture;
+        defaults.maps.clearCoatRoughnessMap =
+                FilamentResourceManager::kDefaultTexture;
+        defaults.maps.anisotropyMap = FilamentResourceManager::kDefaultTexture;
         this->settings.currentMaterials = defaults;
 
         auto hLit = renderer.AddMaterialInstance(this->hLitMaterial);
@@ -646,6 +657,17 @@ struct GuiVisualizer::Impl {
                         .SetTexture("roughnessMap", defaults.maps.roughnessMap,
                                     TextureSamplerParameters::Pretty())
                         .SetTexture("metallicMap", defaults.maps.metallicMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("reflectanceMap",
+                                    defaults.maps.reflectanceMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("clearCoatMap", defaults.maps.clearCoatMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("clearCoatRoughnessMap",
+                                    defaults.maps.clearCoatRoughnessMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("anisotropyMap",
+                                    defaults.maps.anisotropyMap,
                                     TextureSamplerParameters::Pretty())
                         .Finish();
 
@@ -682,12 +704,7 @@ struct GuiVisualizer::Impl {
         this->settings.currentMaterials.unlit.baseColor = material.baseColor;
 
         // Update maps
-        this->settings.currentMaterials.maps.albedoMap = maps.albedoMap;
-        this->settings.currentMaterials.maps.normalMap = maps.normalMap;
-        this->settings.currentMaterials.maps.ambientOcclusionMap =
-                maps.ambientOcclusionMap;
-        this->settings.currentMaterials.maps.roughnessMap = maps.roughnessMap;
-        this->settings.currentMaterials.maps.metallicMap = maps.metallicMap;
+        this->settings.currentMaterials.maps = maps;
 
         // update materials
         this->settings.currentMaterials.lit.handle =
@@ -706,6 +723,15 @@ struct GuiVisualizer::Impl {
                         .SetTexture("roughnessMap", maps.roughnessMap,
                                     TextureSamplerParameters::Pretty())
                         .SetTexture("metallicMap", maps.metallicMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("reflectanceMap", maps.reflectanceMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("clearCoatMap", maps.clearCoatMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("clearCoatRoughnessMap",
+                                    maps.clearCoatRoughnessMap,
+                                    TextureSamplerParameters::Pretty())
+                        .SetTexture("anisotropyMap", maps.anisotropyMap,
                                     TextureSamplerParameters::Pretty())
                         .Finish();
         this->settings.currentMaterials.unlit.handle =
@@ -1515,51 +1541,57 @@ void GuiVisualizer::SetGeometry(
                     material.baseColor.z() = mesh_material.baseColor.b;
                     material.roughness = mesh_material.baseRoughness;
 
-                    if (mesh_material.albedo &&
-                        mesh_material.albedo->HasData()) {
+                    auto is_map_valid =
+                            [](std::shared_ptr<geometry::Image> map) -> bool {
+                        return map && map->HasData();
+                    };
+
+                    if (is_map_valid(mesh_material.albedo)) {
                         maps.albedoMap =
                                 GetRenderer().AddTexture(mesh_material.albedo);
-                    } else {
-                        maps.albedoMap =
-                                FilamentResourceManager::kDefaultTexture;
                     }
-                    if (mesh_material.normalMap &&
-                        mesh_material.normalMap->HasData()) {
+                    if (is_map_valid(mesh_material.normalMap)) {
                         maps.normalMap = GetRenderer().AddTexture(
                                 mesh_material.normalMap);
                         albedo_only = false;
-                    } else {
-                        maps.normalMap =
-                                FilamentResourceManager::kDefaultNormalMap;
                     }
-                    if (mesh_material.ambientOcclusion &&
-                        mesh_material.ambientOcclusion->HasData()) {
+                    if (is_map_valid(mesh_material.ambientOcclusion)) {
                         maps.ambientOcclusionMap = GetRenderer().AddTexture(
                                 mesh_material.ambientOcclusion);
                         albedo_only = false;
-                    } else {
-                        maps.ambientOcclusionMap =
-                                FilamentResourceManager::kDefaultTexture;
                     }
-                    if (mesh_material.roughness &&
-                        mesh_material.roughness->HasData()) {
+                    if (is_map_valid(mesh_material.roughness)) {
                         maps.roughnessMap = GetRenderer().AddTexture(
                                 mesh_material.roughness);
                         albedo_only = false;
-                    } else {
-                        maps.roughnessMap =
-                                FilamentResourceManager::kDefaultTexture;
                     }
-                    if (mesh_material.metallic &&
-                        mesh_material.metallic->HasData()) {
+                    if (is_map_valid(mesh_material.metallic)) {
                         material.metallic = 1.f;
                         maps.metallicMap = GetRenderer().AddTexture(
                                 mesh_material.metallic);
                         albedo_only = false;
                     } else {
                         material.metallic = 0.f;
-                        maps.metallicMap =
-                                FilamentResourceManager::kDefaultTexture;
+                    }
+                    if (is_map_valid(mesh_material.reflectance)) {
+                        maps.reflectanceMap = GetRenderer().AddTexture(
+                                mesh_material.reflectance);
+                        albedo_only = false;
+                    }
+                    if (is_map_valid(mesh_material.clearCoat)) {
+                        maps.clearCoatMap = GetRenderer().AddTexture(
+                                mesh_material.clearCoat);
+                        albedo_only = false;
+                    }
+                    if (is_map_valid(mesh_material.clearCoatRoughness)) {
+                        maps.clearCoatRoughnessMap = GetRenderer().AddTexture(
+                                mesh_material.clearCoatRoughness);
+                        albedo_only = false;
+                    }
+                    if (is_map_valid(mesh_material.anisotropy)) {
+                        maps.anisotropyMap = GetRenderer().AddTexture(
+                                mesh_material.anisotropy);
+                        albedo_only = false;
                     }
                     impl_->SetMaterialsToCurrentSettings(GetRenderer(),
                                                          material, maps);


### PR DESCRIPTION
This PR adds support in defaultLit shader for reflectance, clear coat, clear coat roughness, and anisotropy maps. Only reflectance maps (map_Ps) are supported by the OBJ loader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1817)
<!-- Reviewable:end -->
