### PR TITLE
Filament Warning Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules/
 _vimrc_local.vim
 .vs/
 .vscode/
+.clangd/
 
 # Build artifacts
 **/package-lock.json

--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -1712,6 +1712,10 @@ bool GuiVisualizer::LoadGeometry(const std::string &path) {
             }
             geometry = mesh;
         }
+        // Make sure the mesh has texture coordinates
+        if (!mesh->HasTriangleUvs()) {
+            mesh->triangle_uvs_.resize(mesh->triangles_.size() * 3, {0.0, 0.0});
+        }
     } else {
         // LogError throws an exception, which we don't want, because this might
         // be a point cloud.


### PR DESCRIPTION
Adds UVs to triangle meshes that don't have any.

NOTE: I also added .clangd/ to .gitignore. This is an unrelated change but anyone using clangd as a language server will end up with a bunch of index files in a .clangd directory in the root of the project. I added .clangd/ to my local copy of .gitignore a while ago and thought others might find it useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1835)
<!-- Reviewable:end -->
