### PR TITLE
Set gcs bucket lifecycle

### DIFF
--- a/.travis/gcs.lifecycle.json
+++ b/.travis/gcs.lifecycle.json
@@ -1,0 +1,9 @@
+{
+    "rule":
+    [
+      {
+        "action": {"type": "Delete"},
+        "condition": {"age": 7}
+      }
+    ]
+}

--- a/.travis/readme.md
+++ b/.travis/readme.md
@@ -38,7 +38,16 @@
    # Grant public read permission
    # The current user must have appropriate permission, you may do this in the web interface
    gsutil acl ch -u AllUsers:R gs://open3d-docs/
+
+   # Set object life cycle
+   # https://cloud.google.com/storage/docs/managing-lifecycles#delete_an_object
+   gsutil lifecycle set gcs.lifecycle.json gs://open3d-docs/
    ```
+
+   Objects will be stored in the bucket for one week. Currently, the
+   documentation server fetches the latest docs from `master` branch every hour.
+   If the documentation server fails to fetch the docs matching the `master`
+   commit id, the last successfully fetched docs will be displayed.
 
 3. Create service account
 


### PR DESCRIPTION
This has already been applied to our gcs bucket. The PR is for documentation purposes.

Under the extreme case, we can have 36 docs builds a day (since it takes 40 mins to build). Each build produces 0.17GB docs. Under this scenario, the maximum storage size is 36 * 0.17 * 7 = 42.84 GB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1849)
<!-- Reviewable:end -->
