### PR TITLE
Reset IBL intensity when IBL is re-enabled

### DIFF
--- a/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/GuiVisualizer.cpp
@@ -1201,6 +1201,8 @@ GuiVisualizer::GuiVisualizer(
         impl_->settings_.SetCustomProfile();
         if (checked) {
             render_scene->SetIndirectLight(impl_->settings_.ibl);
+            render_scene->SetIndirectLightIntensity(
+                    impl_->settings_.wgt_ibl_intensity->GetDoubleValue());
         } else {
             render_scene->SetIndirectLight(IndirectLightHandle());
         }


### PR DESCRIPTION
Fixes issue of IBL appearing to stop working when you disable IBL, switch IBL maps, then re-enable IBL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1866)
<!-- Reviewable:end -->
