### PR TITLE
set macos sdk to 10.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 cmake_minimum_required(VERSION 3.8.0) # 3.8.0 to enable CUDA native support
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CUDA_STANDARD 11)
+set (CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 
 add_custom_target(build_all_3rd_party_libs
     COMMAND ${CMAKE_COMMAND} -E echo "Custom target build_all_3rd_party_libs reached."


### PR DESCRIPTION
before:
```
open3d-0.10.0.0-cp36-cp36m-macosx_10_15_x86_64.whl
```

after:
```
open3d-0.10.0.0-cp36-cp36m-macosx_10_9_x86_64.whl
```

10.9 is selected based on considerations specified in:
- https://github.com/MacPython/wiki/wiki/Spinning-wheels#question-will-pip-give-me-a-broken-wheel
- https://github.com/matthew-brett/multibuild

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1867)
<!-- Reviewable:end -->
