### PR TITLE
GUI: implements image widget

### DIFF
--- a/src/Open3D/GUI/Button.cpp
+++ b/src/Open3D/GUI/Button.cpp
@@ -38,6 +38,7 @@ namespace gui {
 
 struct Button::Impl {
     std::string title_;
+    std::shared_ptr<UIImage> image_;
     bool is_toggleable_ = false;
     bool is_on_ = false;
     std::function<void()> on_clicked_;
@@ -45,6 +46,10 @@ struct Button::Impl {
 
 Button::Button(const char* title) : impl_(new Button::Impl()) {
     impl_->title_ = title;
+}
+
+Button::Button(std::shared_ptr<UIImage> image) : impl_(new Button::Impl()) {
+    impl_->image_ = image;
 }
 
 Button::~Button() {}
@@ -66,11 +71,16 @@ void Button::SetOnClicked(std::function<void()> on_clicked) {
 }
 
 Size Button::CalcPreferredSize(const Theme& theme) const {
-    auto font = ImGui::GetFont();
-    auto em = std::ceil(ImGui::GetTextLineHeight());
-    auto size = font->CalcTextSizeA(theme.font_size, 10000, 10000,
-                                    impl_->title_.c_str());
-    return Size(std::ceil(size.x) + 2.0 * em, 2 * em);
+    if (impl_->image_) {
+        auto size = impl_->image_->CalcPreferredSize(theme);
+        return Size(size.width, size.height);
+    } else {
+        auto font = ImGui::GetFont();
+        auto em = std::ceil(ImGui::GetTextLineHeight());
+        auto size = font->CalcTextSizeA(theme.font_size, 10000, 10000,
+                                        impl_->title_.c_str());
+        return Size(std::ceil(size.x) + 2.0 * em, 2 * em);
+    }
 }
 
 Widget::DrawResult Button::Draw(const DrawContext& context) {
@@ -93,10 +103,24 @@ Widget::DrawResult Button::Draw(const DrawContext& context) {
                 util::colorToImgui(context.theme.button_on_active_color));
     }
     DrawImGuiPushEnabledState();
-    ImGui::SetCursorPos(
+    bool pressed = false;
+    if (impl_->image_) {
+        auto params = impl_->image_->CalcDrawParams(context.renderer, frame);
+        ImTextureID image_id =
+                reinterpret_cast<ImTextureID>(params.texture.GetId());
+        ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
+                                   params.pos_y - context.uiOffsetY));
+        pressed = ImGui::ImageButton(image_id,
+                                     ImVec2(params.width, params.height),
+                                     ImVec2(params.u0, params.v0),
+                                     ImVec2(params.u1, params.v1));
+    } else {
+        ImGui::SetCursorPos(
             ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
-    if (ImGui::Button(impl_->title_.c_str(),
-                      ImVec2(GetFrame().width, GetFrame().height))) {
+        pressed = ImGui::Button(impl_->title_.c_str(),
+                                ImVec2(GetFrame().width, GetFrame().height));
+    }
+    if (pressed) {
         if (impl_->is_toggleable_) {
             impl_->is_on_ = !impl_->is_on_;
         }

--- a/src/Open3D/GUI/Button.cpp
+++ b/src/Open3D/GUI/Button.cpp
@@ -110,13 +110,12 @@ Widget::DrawResult Button::Draw(const DrawContext& context) {
                 reinterpret_cast<ImTextureID>(params.texture.GetId());
         ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
                                    params.pos_y - context.uiOffsetY));
-        pressed = ImGui::ImageButton(image_id,
-                                     ImVec2(params.width, params.height),
-                                     ImVec2(params.u0, params.v0),
-                                     ImVec2(params.u1, params.v1));
+        pressed = ImGui::ImageButton(
+                image_id, ImVec2(params.width, params.height),
+                ImVec2(params.u0, params.v0), ImVec2(params.u1, params.v1));
     } else {
-        ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+        ImGui::SetCursorPos(ImVec2(frame.x - context.uiOffsetX,
+                                   frame.y - context.uiOffsetY));
         pressed = ImGui::Button(impl_->title_.c_str(),
                                 ImVec2(GetFrame().width, GetFrame().height));
     }

--- a/src/Open3D/GUI/Button.h
+++ b/src/Open3D/GUI/Button.h
@@ -26,9 +26,11 @@
 
 #pragma once
 
+#include "Open3D/GUI/Widget.h"
+
 #include <functional>
 
-#include "Open3D/GUI/Widget.h"
+#include "Open3D/GUI/UIImage.h"
 
 namespace open3d {
 namespace gui {
@@ -36,6 +38,7 @@ namespace gui {
 class Button : public Widget {
 public:
     explicit Button(const char* title);
+    explicit Button(std::shared_ptr<UIImage> image);
     ~Button();
 
     bool GetIsToggleable() const;

--- a/src/Open3D/GUI/ImageLabel.cpp
+++ b/src/Open3D/GUI/ImageLabel.cpp
@@ -26,82 +26,46 @@
 
 #include "Open3D/GUI/ImageLabel.h"
 
-#include <filament/Texture.h>
 #include <imgui.h>
-#include <string>
 
 #include "Open3D/GUI/Theme.h"
 #include "Open3D/GUI/Util.h"
-#include "Open3D/Geometry/Image.h"
-#include "Open3D/IO/ClassIO/ImageIO.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
-#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
-#include "Open3D/Visualization/Rendering/Renderer.h"
 
 namespace open3d {
 namespace gui {
 
 struct ImageLabel::Impl {
-    std::string image_path_;
-    ImageLabel::Scaling scaling_ = ImageLabel::Scaling::ASPECT;
-    std::shared_ptr<geometry::Image> image_data_;  // temporary storage
-    ImVec2 image_size_;
-    ImVec2 uv0_;
-    ImVec2 uv1_;
-    visualization::Renderer* renderer_;  // nullptr if texture_ isn't ours
-    visualization::TextureHandle texture_;
+    std::shared_ptr<UIImage> image_;
 };
 
 ImageLabel::ImageLabel(const char* image_path) : impl_(new ImageLabel::Impl()) {
-    impl_->image_path_ = image_path;
-    impl_->image_data_ = io::CreateImageFromFile(image_path);
-    if (impl_->image_data_ && impl_->image_data_->width_ == 0 &&
-        impl_->image_data_->height_ == 0) {
-        impl_->image_data_.reset();
-    } else {
-        impl_->image_size_ = ImVec2(float(impl_->image_data_->width_),
-                                    float(impl_->image_data_->height_));
-    }
-    impl_->uv0_ = ImVec2(0.0f, 0.0f);
-    impl_->uv1_ = ImVec2(1.0f, 1.0f);
-    impl_->renderer_ = nullptr;
+    impl_->image_ = std::make_shared<UIImage>(image_path);
 }
 
 ImageLabel::ImageLabel(visualization::TextureHandle texture_id,
-                       float u0 /*= 0.0f*/,
-                       float v0 /*= 0.0f*/,
-                       float u1 /*= 1.0f*/,
-                       float v1 /*= 1.0f*/)
-    : impl_(new ImageLabel::Impl()) {
-    auto& resource_manager =
-            visualization::EngineInstance::GetResourceManager();
-    auto tex_weak = resource_manager.GetTexture(texture_id);
-    auto tex_sh = tex_weak.lock();
-    if (tex_sh) {
-        float uvw = u1 - u0;
-        float uvh = v1 - v0;
-        impl_->image_size_ = ImVec2(uvw * float(tex_sh->getWidth()),
-                                    uvh* float(tex_sh->getHeight()));
-    }
-    impl_->uv0_ = ImVec2(u0, v0);
-    impl_->uv1_ = ImVec2(u1, v1);
-    impl_->renderer_ = nullptr;
-    impl_->texture_ = texture_id;
+                   float u0 /*= 0.0f*/,
+                   float v0 /*= 0.0f*/,
+                   float u1 /*= 1.0f*/,
+                   float v1 /*= 1.0f*/)
+: impl_(new ImageLabel::Impl()) {
+    impl_->image_ = std::make_shared<UIImage>(texture_id, u0, v0, u1, v1);
 }
 
-ImageLabel::~ImageLabel() {
-    if (impl_->renderer_) {
-        impl_->renderer_->RemoveTexture(impl_->texture_);
-    }
+ImageLabel::ImageLabel(std::shared_ptr<UIImage> image)
+: impl_(new ImageLabel::Impl()) {
+    impl_->image_ = image;
 }
 
-void ImageLabel::SetScaling(Scaling scaling) { impl_->scaling_ = scaling; }
-
-ImageLabel::Scaling ImageLabel::GetScaling() const { return impl_->scaling_; }
+ImageLabel::~ImageLabel() {}
 
 Size ImageLabel::CalcPreferredSize(const Theme& theme) const {
-    if (impl_->image_size_.x != 0.0f && impl_->image_size_.y != 0.0f) {
-        return Size(impl_->image_size_.x, impl_->image_size_.y);
+    Size pref;
+    if (impl_->image_) {
+        pref = impl_->image_->CalcPreferredSize(theme);
+    }
+
+    if (pref.width != 0 && pref.height != 0) {
+        return pref;
     } else {
         return Size(5 * theme.font_size, 5 * theme.font_size);
     }
@@ -111,61 +75,20 @@ void ImageLabel::Layout(const Theme& theme) { Super::Layout(theme); }
 
 Widget::DrawResult ImageLabel::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-
-    if (impl_->image_data_ &&
-        impl_->texture_ == visualization::TextureHandle::kBad) {
-        impl_->texture_ = context.renderer.AddTexture(impl_->image_data_);
-        if (impl_->texture_ != visualization::TextureHandle::kBad) {
-            impl_->renderer_ = &context.renderer;
-        } else {
-            impl_->texture_ = visualization::TextureHandle();
-        }
-        impl_->image_data_.reset();
+    UIImage::DrawParams params;  // .texture defaults to kBad handle
+    if (impl_->image_) {
+        params = impl_->image_->CalcDrawParams(context.renderer, frame);
     }
 
-    float width_px = impl_->image_size_.x;
-    float height_px = impl_->image_size_.y;
-    if (impl_->texture_ != visualization::TextureHandle::kBad) {
-        ImVec2 size, uv0, uv1;
-        switch (impl_->scaling_) {
-            case Scaling::NONE: {
-                float w = std::min(float(frame.width), width_px);
-                float h = std::min(float(frame.height), height_px);
-                size = ImVec2(w, h);
-                uv0 = impl_->uv0_;
-                uv1 = ImVec2(
-                        uv0.x + (impl_->uv1_.x - impl_->uv0_.x) * w / width_px,
-                        uv0.y + (impl_->uv1_.y - impl_->uv1_.y) * h /
-                                        height_px);
-                break;
-            }
-            case Scaling::ANY:
-                size = ImVec2(frame.width, frame.height);
-                uv0 = impl_->uv0_;
-                uv1 = impl_->uv1_;
-                break;
-            case Scaling::ASPECT: {
-                float aspect = width_px / height_px;
-                float w_at_height = float(frame.height) * aspect;
-                float h_at_width = float(frame.width) / aspect;
-                if (w_at_height <= frame.width) {
-                    size = ImVec2(w_at_height, float(frame.height));
-                } else {
-                    size = ImVec2(float(frame.width), h_at_width);
-                }
-                uv0 = impl_->uv0_;
-                uv1 = impl_->uv1_;
-                break;
-            }
-        }
-        float x = std::max(0.0f, (float(frame.width) - size.x) / 2.0f);
-        float y = std::max(0.0f, (float(frame.height) - size.y) / 2.0f);
-        ImVec2 pos(frame.x + x - context.uiOffsetX,
-                   frame.y + y - context.uiOffsetY);
+    if (params.texture != visualization::TextureHandle::kBad) {
         ImTextureID image_id =
-                reinterpret_cast<ImTextureID>(impl_->texture_.GetId());
-        ImGui::SetCursorPos(pos);
-        ImGui::Image(image_id, size, uv0, uv1);
+                reinterpret_cast<ImTextureID>(params.texture.GetId());
+        ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
+                                   params.pos_y - context.uiOffsetY));
+        ImGui::Image(image_id,
+                     ImVec2(params.width, params.height),
+                     ImVec2(params.u0, params.v0),
+                     ImVec2(params.u1, params.v1));
     } else {
         // Draw error message if we don't have an image, instead of
         // quietly failing or something.

--- a/src/Open3D/GUI/ImageLabel.cpp
+++ b/src/Open3D/GUI/ImageLabel.cpp
@@ -43,16 +43,16 @@ ImageLabel::ImageLabel(const char* image_path) : impl_(new ImageLabel::Impl()) {
 }
 
 ImageLabel::ImageLabel(visualization::TextureHandle texture_id,
-                   float u0 /*= 0.0f*/,
-                   float v0 /*= 0.0f*/,
-                   float u1 /*= 1.0f*/,
-                   float v1 /*= 1.0f*/)
-: impl_(new ImageLabel::Impl()) {
+                       float u0 /*= 0.0f*/,
+                       float v0 /*= 0.0f*/,
+                       float u1 /*= 1.0f*/,
+                       float v1 /*= 1.0f*/)
+    : impl_(new ImageLabel::Impl()) {
     impl_->image_ = std::make_shared<UIImage>(texture_id, u0, v0, u1, v1);
 }
 
 ImageLabel::ImageLabel(std::shared_ptr<UIImage> image)
-: impl_(new ImageLabel::Impl()) {
+    : impl_(new ImageLabel::Impl()) {
     impl_->image_ = image;
 }
 
@@ -85,8 +85,7 @@ Widget::DrawResult ImageLabel::Draw(const DrawContext& context) {
                 reinterpret_cast<ImTextureID>(params.texture.GetId());
         ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
                                    params.pos_y - context.uiOffsetY));
-        ImGui::Image(image_id,
-                     ImVec2(params.width, params.height),
+        ImGui::Image(image_id, ImVec2(params.width, params.height),
                      ImVec2(params.u0, params.v0),
                      ImVec2(params.u1, params.v1));
     } else {

--- a/src/Open3D/GUI/ImageLabel.cpp
+++ b/src/Open3D/GUI/ImageLabel.cpp
@@ -1,0 +1,206 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/GUI/ImageLabel.h"
+
+#include <filament/Texture.h>
+#include <imgui.h>
+#include <string>
+
+#include "Open3D/GUI/Theme.h"
+#include "Open3D/GUI/Util.h"
+#include "Open3D/Geometry/Image.h"
+#include "Open3D/IO/ClassIO/ImageIO.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
+#include "Open3D/Visualization/Rendering/Renderer.h"
+
+namespace open3d {
+namespace gui {
+
+struct ImageLabel::Impl {
+    std::string image_path_;
+    ImageLabel::Scaling scaling_ = ImageLabel::Scaling::ASPECT;
+    std::shared_ptr<geometry::Image> image_data_;  // temporary storage
+    ImVec2 image_size_;
+    ImVec2 uv0_;
+    ImVec2 uv1_;
+    visualization::Renderer* renderer_;  // nullptr if texture_ isn't ours
+    visualization::TextureHandle texture_;
+};
+
+ImageLabel::ImageLabel(const char* image_path) : impl_(new ImageLabel::Impl()) {
+    impl_->image_path_ = image_path;
+    impl_->image_data_ = io::CreateImageFromFile(image_path);
+    if (impl_->image_data_ && impl_->image_data_->width_ == 0 &&
+        impl_->image_data_->height_ == 0) {
+        impl_->image_data_.reset();
+    } else {
+        impl_->image_size_ = ImVec2(float(impl_->image_data_->width_),
+                                    float(impl_->image_data_->height_));
+    }
+    impl_->uv0_ = ImVec2(0.0f, 0.0f);
+    impl_->uv1_ = ImVec2(1.0f, 1.0f);
+    impl_->renderer_ = nullptr;
+}
+
+ImageLabel::ImageLabel(visualization::TextureHandle texture_id,
+                       float u0 /*= 0.0f*/,
+                       float v0 /*= 0.0f*/,
+                       float u1 /*= 1.0f*/,
+                       float v1 /*= 1.0f*/)
+    : impl_(new ImageLabel::Impl()) {
+    auto& resource_manager =
+            visualization::EngineInstance::GetResourceManager();
+    auto tex_weak = resource_manager.GetTexture(texture_id);
+    auto tex_sh = tex_weak.lock();
+    if (tex_sh) {
+        float uvw = u1 - u0;
+        float uvh = v1 - v0;
+        impl_->image_size_ = ImVec2(uvw * float(tex_sh->getWidth()),
+                                    uvh* float(tex_sh->getHeight()));
+    }
+    impl_->uv0_ = ImVec2(u0, v0);
+    impl_->uv1_ = ImVec2(u1, v1);
+    impl_->renderer_ = nullptr;
+    impl_->texture_ = texture_id;
+}
+
+ImageLabel::~ImageLabel() {
+    if (impl_->renderer_) {
+        impl_->renderer_->RemoveTexture(impl_->texture_);
+    }
+}
+
+void ImageLabel::SetScaling(Scaling scaling) { impl_->scaling_ = scaling; }
+
+ImageLabel::Scaling ImageLabel::GetScaling() const { return impl_->scaling_; }
+
+Size ImageLabel::CalcPreferredSize(const Theme& theme) const {
+    if (impl_->image_size_.x != 0.0f && impl_->image_size_.y != 0.0f) {
+        return Size(impl_->image_size_.x, impl_->image_size_.y);
+    } else {
+        return Size(5 * theme.font_size, 5 * theme.font_size);
+    }
+}
+
+void ImageLabel::Layout(const Theme& theme) { Super::Layout(theme); }
+
+Widget::DrawResult ImageLabel::Draw(const DrawContext& context) {
+    auto& frame = GetFrame();
+
+    if (impl_->image_data_ &&
+        impl_->texture_ == visualization::TextureHandle::kBad) {
+        impl_->texture_ = context.renderer.AddTexture(impl_->image_data_);
+        if (impl_->texture_ != visualization::TextureHandle::kBad) {
+            impl_->renderer_ = &context.renderer;
+        } else {
+            impl_->texture_ = visualization::TextureHandle();
+        }
+        impl_->image_data_.reset();
+    }
+
+    float width_px = impl_->image_size_.x;
+    float height_px = impl_->image_size_.y;
+    if (impl_->texture_ != visualization::TextureHandle::kBad) {
+        ImVec2 size, uv0, uv1;
+        switch (impl_->scaling_) {
+            case Scaling::NONE: {
+                float w = std::min(float(frame.width), width_px);
+                float h = std::min(float(frame.height), height_px);
+                size = ImVec2(w, h);
+                uv0 = impl_->uv0_;
+                uv1 = ImVec2(
+                        uv0.x + (impl_->uv1_.x - impl_->uv0_.x) * w / width_px,
+                        uv0.y + (impl_->uv1_.y - impl_->uv1_.y) * h /
+                                        height_px);
+                break;
+            }
+            case Scaling::ANY:
+                size = ImVec2(frame.width, frame.height);
+                uv0 = impl_->uv0_;
+                uv1 = impl_->uv1_;
+                break;
+            case Scaling::ASPECT: {
+                float aspect = width_px / height_px;
+                float w_at_height = float(frame.height) * aspect;
+                float h_at_width = float(frame.width) / aspect;
+                if (w_at_height <= frame.width) {
+                    size = ImVec2(w_at_height, float(frame.height));
+                } else {
+                    size = ImVec2(float(frame.width), h_at_width);
+                }
+                uv0 = impl_->uv0_;
+                uv1 = impl_->uv1_;
+                break;
+            }
+        }
+        float x = std::max(0.0f, (float(frame.width) - size.x) / 2.0f);
+        float y = std::max(0.0f, (float(frame.height) - size.y) / 2.0f);
+        ImVec2 pos(frame.x + x - context.uiOffsetX,
+                   frame.y + y - context.uiOffsetY);
+        ImTextureID image_id =
+                reinterpret_cast<ImTextureID>(impl_->texture_.GetId());
+        ImGui::SetCursorPos(pos);
+        ImGui::Image(image_id, size, uv0, uv1);
+    } else {
+        // Draw error message if we don't have an image, instead of
+        // quietly failing or something.
+        const char* error_text = "  Error\nloading\n image";
+        Color fg(1.0, 1.0, 1.0);
+        ImGui::GetWindowDrawList()->AddRectFilled(
+                ImVec2(frame.x, frame.y),
+                ImVec2(frame.GetRight(), frame.GetBottom()),
+                IM_COL32(255, 0, 0, 255));
+        ImGui::GetWindowDrawList()->AddRect(
+                ImVec2(frame.x, frame.y),
+                ImVec2(frame.GetRight(), frame.GetBottom()),
+                IM_COL32(255, 255, 255, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, util::colorToImgui(fg));
+
+        auto padding = ImGui::GetStyle().FramePadding;
+        float wrap_width = frame.width - std::ceil(2.0f * padding.x);
+        float wrapX = ImGui::GetCursorPos().x + wrap_width;
+        auto* font = ImGui::GetFont();
+        auto text_size = font->CalcTextSizeA(
+                context.theme.font_size, wrap_width, wrap_width, error_text);
+        float x = (float(frame.width) - text_size.x) / 2.0f;
+        float y = (float(frame.height) - text_size.y) / 2.0f;
+
+        ImGui::SetCursorPos(ImVec2(x + frame.x - context.uiOffsetX,
+                                   y + frame.y - context.uiOffsetY));
+        ImGui::PushTextWrapPos(wrapX);
+        ImGui::TextWrapped("%s", error_text);
+        ImGui::PopTextWrapPos();
+
+        ImGui::PopStyleColor();
+    }
+
+    return Widget::DrawResult::NONE;
+}
+
+}  // namespace gui
+}  // namespace open3d

--- a/src/Open3D/GUI/ImageLabel.h
+++ b/src/Open3D/GUI/ImageLabel.h
@@ -1,0 +1,73 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "Open3D/GUI/Widget.h"
+
+#include "Open3D/Visualization/Rendering/RendererHandle.h"
+
+namespace open3d {
+namespace gui {
+
+class ImageLabel : public Widget {
+    using Super = Widget;
+
+public:
+    /// Uses image from the specified path. Each ImageLabel will use one
+    /// draw call.
+    explicit ImageLabel(const char* image_path);
+    /// Uses an existing texture, using texture coordinates
+    /// (u0, v0) to (u1, v1). Does not deallocate texture on destruction.
+    /// This is useful for using an icon atlas to reduce draw calls.
+    explicit ImageLabel(visualization::TextureHandle texture_id,
+                        float u0 = 0.0f,
+                        float v0 = 0.0f,
+                        float u1 = 1.0f,
+                        float v1 = 1.0f);
+    ~ImageLabel();
+
+    enum class Scaling {
+        NONE,   /// No scaling, fixed size
+        ANY,    /// Scales to any size and aspect ratio
+        ASPECT  /// Scales to any size, but fixed aspect ratio (default)
+    };
+    void SetScaling(Scaling scaling);
+    Scaling GetScaling() const;
+
+    Size CalcPreferredSize(const Theme& theme) const override;
+
+    void Layout(const Theme& theme) override;
+
+    DrawResult Draw(const DrawContext& context) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace gui
+}  // namespace open3d

--- a/src/Open3D/GUI/ImguiFilamentBridge.cpp
+++ b/src/Open3D/GUI/ImguiFilamentBridge.cpp
@@ -341,7 +341,7 @@ public:
         }
         return false;
     }
-    
+
     bool operator!=(const ScissorRectKey& other) const {
         return !operator==(other);
     }

--- a/src/Open3D/GUI/ImguiFilamentBridge.cpp
+++ b/src/Open3D/GUI/ImguiFilamentBridge.cpp
@@ -335,11 +335,15 @@ public:
         id_ = tex_id;
     }
 
-    bool operator=(const ScissorRectKey& other) const {
+    bool operator==(const ScissorRectKey& other) const {
         if (id_ == other.id_) {
             return (rect_ == other.rect_);
         }
         return false;
+    }
+    
+    bool operator!=(const ScissorRectKey& other) const {
+        return !operator==(other);
     }
 
     bool operator<(const ScissorRectKey& other) const {

--- a/src/Open3D/GUI/ImguiFilamentBridge.cpp
+++ b/src/Open3D/GUI/ImguiFilamentBridge.cpp
@@ -61,7 +61,7 @@
 #include <cerrno>
 #include <cstddef>  // <filament/Engine> recursive includes needs this, std::size_t especially
 #include <iostream>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 #if !defined(WIN32)
@@ -78,6 +78,7 @@
 #include "Open3D/Visualization/Rendering/Filament/FilamentCamera.h"
 #include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
 #include "Open3D/Visualization/Rendering/Filament/FilamentRenderer.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
 #include "Open3D/Visualization/Rendering/Filament/FilamentScene.h"
 #include "Open3D/Visualization/Rendering/Filament/FilamentView.h"
 
@@ -181,28 +182,82 @@ static Material* LoadMaterialTemplate(const std::string& path, Engine& engine) {
             .build(engine);
 }
 
+class MaterialPool {
+public:
+    MaterialPool(){};
+
+    MaterialPool(filament::Engine* engine,
+                 filament::Material* material_template) {
+        engine_ = engine;
+        template_ = material_template;
+        reset();
+    }
+
+    // Drains the pool and deallocates all the objects.
+    void drain() {
+        for (auto* o : pool_) {
+            engine_->destroy(o);
+        }
+        pool_.clear();
+    }
+
+    // Invalidates all the pointers previously given out and "refills"
+    // the pool with them.
+    void reset() { next_index_ = 0; }
+
+    // Returns an object from the pool. The pool retains ownership.
+    filament::MaterialInstance* pull() {
+        if (next_index_ >= pool_.size()) {
+            pool_.push_back(template_->createInstance());
+        }
+        return pool_[next_index_++];
+    }
+
+private:
+    filament::Engine* engine_ = nullptr;             // we do not own this
+    filament::Material* template_ = nullptr;         // we do not own this
+    std::vector<filament::MaterialInstance*> pool_;  // we DO own these
+    size_t next_index_ = 0;
+};
+
+static const char* kUiBlitTexParamName = "albedo";
+static const char* kImageTexParamName = "image";
+
 struct ImguiFilamentBridge::Impl {
     // Bridge manages filament resources directly
-    filament::Material* material_ = nullptr;
+    filament::Material* uiblit_material_ = nullptr;
+    filament::Material* image_material_ = nullptr;
     std::vector<filament::VertexBuffer*> vertex_buffers_;
     std::vector<filament::IndexBuffer*> index_buffers_;
-    std::vector<filament::MaterialInstance*> material_instances_;
+
+    // Use material pools to avoid allocating materials during every draw
+    MaterialPool uiblit_pool_;
+    MaterialPool image_pool_;
 
     utils::Entity renderable_;
-    filament::Texture* texture_ = nullptr;
+    filament::Texture* font_texture_ = nullptr;
     bool has_synced_ = false;
 
-    visualization::FilamentView* view_ = nullptr;  // we do not own this
+    visualization::FilamentRenderer* renderer_ = nullptr;  // we do not own this
+    visualization::FilamentView* view_ = nullptr;          // we do not own this
 };
 
 ImguiFilamentBridge::ImguiFilamentBridge(
         visualization::FilamentRenderer* renderer, const Size& window_size)
     : impl_(new ImguiFilamentBridge::Impl()) {
+    impl_->renderer_ = renderer;
     // The UI needs a special material (just a pass-through blit)
     std::string resource_path = Application::GetInstance().GetResourcePath();
-    impl_->material_ =
+    impl_->uiblit_material_ =
             LoadMaterialTemplate(resource_path + "/ui_blit.filamat",
                                  visualization::EngineInstance::GetInstance());
+    impl_->image_material_ =
+            LoadMaterialTemplate(resource_path + "/img_blit.filamat",
+                                 visualization::EngineInstance::GetInstance());
+
+    auto& engine = visualization::EngineInstance::GetInstance();
+    impl_->uiblit_pool_ = MaterialPool(&engine, impl_->uiblit_material_);
+    impl_->image_pool_ = MaterialPool(&engine, impl_->image_material_);
 
     auto scene_handle = renderer->CreateScene();
     renderer->ConvertToGuiScene(scene_handle);
@@ -223,51 +278,41 @@ ImguiFilamentBridge::ImguiFilamentBridge(
     scene->GetNativeScene()->addEntity(impl_->renderable_);
 }
 
-ImguiFilamentBridge::ImguiFilamentBridge(filament::Engine* engine,
-                                         filament::Scene* scene,
-                                         filament::Material* uiblit_material)
-    : impl_(new ImguiFilamentBridge::Impl()) {
-    impl_->material_ = uiblit_material;
-
-    EntityManager& em = utils::EntityManager::get();
-    impl_->renderable_ = em.create();
-    scene->addEntity(impl_->renderable_);
-}
-
 void ImguiFilamentBridge::CreateAtlasTextureAlpha8(unsigned char* pixels,
                                                    int width,
                                                    int height,
                                                    int bytes_per_px) {
     auto& engine = visualization::EngineInstance::GetInstance();
 
-    engine.destroy(impl_->texture_);
+    engine.destroy(impl_->font_texture_);
 
     size_t size = (size_t)(width * height);
     Texture::PixelBufferDescriptor pb(pixels, size, Texture::Format::R,
                                       Texture::Type::UBYTE);
-    impl_->texture_ = Texture::Builder()
-                              .width((uint32_t)width)
-                              .height((uint32_t)height)
-                              .levels((uint8_t)1)
-                              .format(Texture::InternalFormat::R8)
-                              .sampler(Texture::Sampler::SAMPLER_2D)
-                              .build(engine);
-    impl_->texture_->setImage(engine, 0, std::move(pb));
+    impl_->font_texture_ = Texture::Builder()
+                                   .width((uint32_t)width)
+                                   .height((uint32_t)height)
+                                   .levels((uint8_t)1)
+                                   .format(Texture::InternalFormat::R8)
+                                   .sampler(Texture::Sampler::SAMPLER_2D)
+                                   .build(engine);
+    impl_->font_texture_->setImage(engine, 0, std::move(pb));
 
     TextureSampler sampler(TextureSampler::MinFilter::LINEAR,
                            TextureSampler::MagFilter::LINEAR);
-    impl_->material_->setDefaultParameter("albedo", impl_->texture_, sampler);
+    impl_->uiblit_material_->setDefaultParameter(kUiBlitTexParamName,
+                                                 impl_->font_texture_, sampler);
 }
 
 ImguiFilamentBridge::~ImguiFilamentBridge() {
     auto& engine = visualization::EngineInstance::GetInstance();
 
     engine.destroy(impl_->renderable_);
-    for (auto& mi : impl_->material_instances_) {
-        engine.destroy(mi);
-    }
-    engine.destroy(impl_->material_);
-    engine.destroy(impl_->texture_);
+    impl_->uiblit_pool_.drain();
+    impl_->image_pool_.drain();
+    engine.destroy(impl_->uiblit_material_);
+    engine.destroy(impl_->image_material_);
+    engine.destroy(impl_->font_texture_);
     for (auto& vb : impl_->vertex_buffers_) {
         engine.destroy(vb);
     }
@@ -278,14 +323,42 @@ ImguiFilamentBridge::~ImguiFilamentBridge() {
 
 // To help with mapping unique scissor rectangles to material instances, we
 // create a 64-bit key from a 4-tuple that defines an AABB in screen space.
-static uint64_t MakeScissorKey(int fb_height, const ImVec4& clip_rect) {
-    uint16_t left = (uint16_t)clip_rect.x;
-    uint16_t bottom = (uint16_t)(fb_height - clip_rect.w);
-    uint16_t width = (uint16_t)(clip_rect.z - clip_rect.x);
-    uint16_t height = (uint16_t)(clip_rect.w - clip_rect.y);
-    return ((uint64_t)left << 0ull) | ((uint64_t)bottom << 16ull) |
-           ((uint64_t)width << 32ull) | ((uint64_t)height << 48ull);
-}
+class ScissorRectKey {
+public:
+    ScissorRectKey(int fb_height, const ImVec4& clip_rect, ImTextureID tex_id) {
+        left_ = (uint16_t)clip_rect.x;
+        bottom_ = (uint16_t)(fb_height - clip_rect.w);
+        width_ = (uint16_t)(clip_rect.z - clip_rect.x);
+        height_ = (uint16_t)(clip_rect.w - clip_rect.y);
+        rect_ = ((uint64_t)left_ << 0ull) | ((uint64_t)bottom_ << 16ull) |
+                ((uint64_t)width_ << 32ull) | ((uint64_t)height_ << 48ull);
+        id_ = tex_id;
+    }
+
+    bool operator=(const ScissorRectKey& other) const {
+        if (id_ == other.id_) {
+            return (rect_ == other.rect_);
+        }
+        return false;
+    }
+
+    bool operator<(const ScissorRectKey& other) const {
+        if (id_ == other.id_) {
+            return (rect_ < other.rect_);
+        }
+        return (id_ < other.id_);
+    }
+
+    // Used for comparisons
+    uint64_t rect_;
+    ImTextureID id_;
+
+    // Not used for comparisons
+    uint16_t left_;
+    uint16_t bottom_;
+    uint16_t width_;
+    uint16_t height_;
+};
 
 void ImguiFilamentBridge::Update(ImDrawData* imgui_data) {
     impl_->has_synced_ = false;
@@ -307,36 +380,41 @@ void ImguiFilamentBridge::Update(ImDrawData* imgui_data) {
     // Count how many primitives we'll need, then create a Renderable builder.
     // Also count how many unique scissor rectangles are required.
     size_t num_prims = 0;
-    std::unordered_map<uint64_t, filament::MaterialInstance*> scissor_rects;
+    std::map<ScissorRectKey, filament::MaterialInstance*> scissor_rects;
     for (int idx = 0; idx < imgui_data->CmdListsCount; idx++) {
         const ImDrawList* cmds = imgui_data->CmdLists[idx];
         num_prims += cmds->CmdBuffer.size();
         for (const auto& pcmd : cmds->CmdBuffer) {
-            scissor_rects[MakeScissorKey(fbheight, pcmd.ClipRect)] = nullptr;
+            scissor_rects[ScissorRectKey(fbheight, pcmd.ClipRect,
+                                         pcmd.TextureId)] = nullptr;
         }
     }
     auto rbuilder = RenderableManager::Builder(num_prims);
     rbuilder.boundingBox({{0, 0, 0}, {10000, 10000, 10000}}).culling(false);
 
-    // Ensure that we have a material instance for each scissor rectangle.
-    size_t previous_size = impl_->material_instances_.size();
-    if (scissor_rects.size() > impl_->material_instances_.size()) {
-        impl_->material_instances_.resize(scissor_rects.size());
-        for (size_t i = previous_size; i < impl_->material_instances_.size();
-             i++) {
-            impl_->material_instances_[i] = impl_->material_->createInstance();
-        }
-    }
-
     // Push each unique scissor rectangle to a MaterialInstance.
-    size_t mat_index = 0;
+    impl_->uiblit_pool_.reset();
+    impl_->image_pool_.reset();
+    TextureSampler sampler(TextureSampler::MinFilter::LINEAR,
+                           TextureSampler::MagFilter::LINEAR);
     for (auto& pair : scissor_rects) {
-        pair.second = impl_->material_instances_[mat_index++];
-        uint32_t left = (pair.first >> 0ull) & 0xffffull;
-        uint32_t bottom = (pair.first >> 16ull) & 0xffffull;
-        uint32_t width = (pair.first >> 32ull) & 0xffffull;
-        uint32_t height = (pair.first >> 48ull) & 0xffffull;
-        pair.second->setScissor(left, bottom, width, height);
+        if (pair.first.id_ == 0) {
+            pair.second = impl_->uiblit_pool_.pull();
+            // Don't need to set texture, since we set the font texture
+            // as the default when we created this material.
+        } else {
+            pair.second = impl_->image_pool_.pull();
+            auto tex_id_long = reinterpret_cast<uintptr_t>(pair.first.id_);
+            auto tex_id = std::uint16_t(tex_id_long);
+            auto tex_handle = visualization::TextureHandle(tex_id);
+            auto tex = visualization::EngineInstance::GetResourceManager()
+                               .GetTexture(tex_handle);
+            auto tex_sh_ptr = tex.lock();
+            pair.second->setParameter(kImageTexParamName, tex_sh_ptr.get(),
+                                      sampler);
+        }
+        pair.second->setScissor(pair.first.left_, pair.first.bottom_,
+                                pair.first.width_, pair.first.height_);
     }
 
     // Recreate the Renderable component and point it to the vertex buffers.
@@ -354,7 +432,8 @@ void ImguiFilamentBridge::Update(ImDrawData* imgui_data) {
             if (pcmd.UserCallback) {
                 pcmd.UserCallback(cmds, &pcmd);
             } else {
-                uint64_t skey = MakeScissorKey(fbheight, pcmd.ClipRect);
+                auto skey =
+                        ScissorRectKey(fbheight, pcmd.ClipRect, pcmd.TextureId);
                 auto miter = scissor_rects.find(skey);
                 assert(miter != scissor_rects.end());
                 rbuilder.geometry(prim_index,

--- a/src/Open3D/GUI/ImguiFilamentBridge.h
+++ b/src/Open3D/GUI/ImguiFilamentBridge.h
@@ -75,10 +75,6 @@ class ImguiFilamentBridge {
 public:
     ImguiFilamentBridge(visualization::FilamentRenderer* renderer,
                         const Size& window_size);
-    // The constructor creates its own Scene and places it in the given View.
-    ImguiFilamentBridge(filament::Engine* engine,
-                        filament::Scene* scene,
-                        filament::Material* uiblit_material);
     ~ImguiFilamentBridge();
 
     // Helper method called after resolving fontPath; public so fonts can be

--- a/src/Open3D/GUI/Materials/img_blit.mat
+++ b/src/Open3D/GUI/Materials/img_blit.mat
@@ -1,0 +1,29 @@
+material {
+    name : imageBlit,
+    parameters : [
+        {
+            type : sampler2d,
+            name : image
+        }
+    ],
+    requires : [
+        uv0,
+        color
+    ],
+    shadingModel : unlit,
+    culling : none,
+    depthCulling: false,
+    blending : transparent
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        vec2 uv = getUV0();
+        uv.y = 1.0 - uv.y;
+        /* OpenGL spec 8.4.4.4 says that texture().a is 1.0 if there
+           is no alpha channel, so this shader can handle both RGB and RGBA
+           images */
+        material.baseColor = getColor() * texture(materialParams_image, uv);
+    }
+}

--- a/src/Open3D/GUI/UIImage.cpp
+++ b/src/Open3D/GUI/UIImage.cpp
@@ -71,10 +71,10 @@ UIImage::UIImage(const char* image_path) : impl_(new UIImage::Impl()) {
 }
 
 UIImage::UIImage(visualization::TextureHandle texture_id,
-                       float u0 /*= 0.0f*/,
-                       float v0 /*= 0.0f*/,
-                       float u1 /*= 1.0f*/,
-                       float v1 /*= 1.0f*/)
+                 float u0 /*= 0.0f*/,
+                 float v0 /*= 0.0f*/,
+                 float u1 /*= 1.0f*/,
+                 float v1 /*= 1.0f*/)
     : impl_(new UIImage::Impl()) {
     auto& resource_manager =
             visualization::EngineInstance::GetResourceManager();
@@ -84,7 +84,7 @@ UIImage::UIImage(visualization::TextureHandle texture_id,
         float uvw = u1 - u0;
         float uvh = v1 - v0;
         impl_->image_width_ = uvw * float(tex_sh->getWidth());
-        impl_->image_height_ = uvh* float(tex_sh->getHeight());
+        impl_->image_height_ = uvh * float(tex_sh->getHeight());
     }
     impl_->u0_ = u0;
     impl_->v0_ = v0;
@@ -106,8 +106,7 @@ UIImage::Scaling UIImage::GetScaling() const { return impl_->scaling_; }
 
 Size UIImage::CalcPreferredSize(const Theme& theme) const {
     if (impl_->image_width_ != 0.0f && impl_->image_height_ != 0.0f) {
-//        return Size(impl_->image_width_, impl_->image_height_);
-        return Size(impl_->image_width_, 0.75 * impl_->image_height_);
+        return Size(impl_->image_width_, impl_->image_height_);
     } else {
         return Size(0, 0);
     }
@@ -140,8 +139,10 @@ UIImage::DrawParams UIImage::CalcDrawParams(visualization::Renderer& renderer,
                 params.height = h;
                 params.u0 = impl_->u0_;
                 params.v0 = impl_->v0_;
-                params.u1 = impl_->u0_ + (impl_->u1_ - impl_->u0_) * w / width_px;
-                params.v1 = impl_->v0_ + (impl_->v1_ - impl_->v0_) * h / height_px;
+                params.u1 =
+                        impl_->u0_ + (impl_->u1_ - impl_->u0_) * w / width_px;
+                params.v1 =
+                        impl_->v0_ + (impl_->v1_ - impl_->v0_) * h / height_px;
                 break;
             }
             case Scaling::ANY:

--- a/src/Open3D/GUI/UIImage.cpp
+++ b/src/Open3D/GUI/UIImage.cpp
@@ -1,0 +1,192 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "Open3D/GUI/ImageLabel.h"
+
+#include <filament/Texture.h>
+#include <string>
+
+#include "Open3D/GUI/Theme.h"
+#include "Open3D/Geometry/Image.h"
+#include "Open3D/IO/ClassIO/ImageIO.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"
+#include "Open3D/Visualization/Rendering/Filament/FilamentResourceManager.h"
+#include "Open3D/Visualization/Rendering/Renderer.h"
+
+namespace open3d {
+namespace gui {
+
+struct UIImage::Impl {
+    std::string image_path_;
+    UIImage::Scaling scaling_ = UIImage::Scaling::ASPECT;
+    std::shared_ptr<geometry::Image> image_data_;  // temporary storage
+    float image_width_;
+    float image_height_;
+    float u0_;
+    float v0_;
+    float u1_;
+    float v1_;
+    visualization::Renderer* renderer_;  // nullptr if texture_ isn't ours
+    visualization::TextureHandle texture_;
+};
+
+UIImage::UIImage(const char* image_path) : impl_(new UIImage::Impl()) {
+    impl_->image_path_ = image_path;
+    impl_->image_data_ = io::CreateImageFromFile(image_path);
+    if (impl_->image_data_ && impl_->image_data_->width_ == 0 &&
+        impl_->image_data_->height_ == 0) {
+        impl_->image_data_.reset();
+    } else {
+        impl_->image_width_ = float(impl_->image_data_->width_);
+        impl_->image_height_ = float(impl_->image_data_->height_);
+    }
+    impl_->u0_ = 0.0f;
+    impl_->v0_ = 0.0f;
+    impl_->u1_ = 1.0f;
+    impl_->v1_ = 1.0f;
+    impl_->renderer_ = nullptr;
+}
+
+UIImage::UIImage(visualization::TextureHandle texture_id,
+                       float u0 /*= 0.0f*/,
+                       float v0 /*= 0.0f*/,
+                       float u1 /*= 1.0f*/,
+                       float v1 /*= 1.0f*/)
+    : impl_(new UIImage::Impl()) {
+    auto& resource_manager =
+            visualization::EngineInstance::GetResourceManager();
+    auto tex_weak = resource_manager.GetTexture(texture_id);
+    auto tex_sh = tex_weak.lock();
+    if (tex_sh) {
+        float uvw = u1 - u0;
+        float uvh = v1 - v0;
+        impl_->image_width_ = uvw * float(tex_sh->getWidth());
+        impl_->image_height_ = uvh* float(tex_sh->getHeight());
+    }
+    impl_->u0_ = u0;
+    impl_->v0_ = v0;
+    impl_->u1_ = u1;
+    impl_->v1_ = v1;
+    impl_->renderer_ = nullptr;
+    impl_->texture_ = texture_id;
+}
+
+UIImage::~UIImage() {
+    if (impl_->renderer_) {
+        impl_->renderer_->RemoveTexture(impl_->texture_);
+    }
+}
+
+void UIImage::SetScaling(Scaling scaling) { impl_->scaling_ = scaling; }
+
+UIImage::Scaling UIImage::GetScaling() const { return impl_->scaling_; }
+
+Size UIImage::CalcPreferredSize(const Theme& theme) const {
+    if (impl_->image_width_ != 0.0f && impl_->image_height_ != 0.0f) {
+//        return Size(impl_->image_width_, impl_->image_height_);
+        return Size(impl_->image_width_, 0.75 * impl_->image_height_);
+    } else {
+        return Size(0, 0);
+    }
+}
+
+UIImage::DrawParams UIImage::CalcDrawParams(visualization::Renderer& renderer,
+                                            const Rect& frame) const {
+    if (impl_->image_data_ &&
+        impl_->texture_ == visualization::TextureHandle::kBad) {
+        impl_->texture_ = renderer.AddTexture(impl_->image_data_);
+        if (impl_->texture_ != visualization::TextureHandle::kBad) {
+            impl_->renderer_ = &renderer;
+        } else {
+            impl_->texture_ = visualization::TextureHandle();
+        }
+        impl_->image_data_.reset();
+    }
+
+    DrawParams params;
+    params.texture = impl_->texture_;
+
+    float width_px = impl_->image_width_;
+    float height_px = impl_->image_height_;
+    if (impl_->texture_ != visualization::TextureHandle::kBad) {
+        switch (impl_->scaling_) {
+            case Scaling::NONE: {
+                float w = std::min(float(frame.width), width_px);
+                float h = std::min(float(frame.height), height_px);
+                params.width = w;
+                params.height = h;
+                params.u0 = impl_->u0_;
+                params.v0 = impl_->v0_;
+                params.u1 = impl_->u0_ + (impl_->u1_ - impl_->u0_) * w / width_px;
+                params.v1 = impl_->v0_ + (impl_->v1_ - impl_->v0_) * h / height_px;
+                break;
+            }
+            case Scaling::ANY:
+                params.width = frame.width;
+                params.height = frame.height;
+                params.u0 = impl_->u0_;
+                params.v0 = impl_->v0_;
+                params.u1 = impl_->u1_;
+                params.v1 = impl_->v1_;
+                break;
+            case Scaling::ASPECT: {
+                float aspect = width_px / height_px;
+                float w_at_height = float(frame.height) * aspect;
+                float h_at_width = float(frame.width) / aspect;
+                if (w_at_height <= frame.width) {
+                    params.width = w_at_height;
+                    params.height = float(frame.height);
+                } else {
+                    params.width = float(frame.width);
+                    params.height = h_at_width;
+                }
+                params.u0 = impl_->u0_;
+                params.v0 = impl_->v0_;
+                params.u1 = impl_->u1_;
+                params.v1 = impl_->v1_;
+                break;
+            }
+        }
+        float x = std::max(0.0f, (float(frame.width) - params.width) / 2.0f);
+        float y = std::max(0.0f, (float(frame.height) - params.height) / 2.0f);
+        params.pos_x = frame.x + x;
+        params.pos_y = frame.y + y;
+    } else {
+        params.pos_x = float(frame.x);
+        params.pos_y = float(frame.y);
+        params.width = float(frame.width);
+        params.height = float(frame.height);
+        params.u0 = 0.0f;
+        params.v0 = 0.0f;
+        params.u1 = 1.0f;
+        params.v1 = 1.0f;
+    }
+
+    return params;
+}
+
+}  // namespace gui
+}  // namespace open3d

--- a/src/Open3D/GUI/UIImage.h
+++ b/src/Open3D/GUI/UIImage.h
@@ -26,40 +26,49 @@
 
 #pragma once
 
-#include "Open3D/GUI/Widget.h"
-
-#include "Open3D/GUI/UIImage.h"
+#include "Open3D/Visualization/Rendering/RendererHandle.h"
 
 namespace open3d {
 namespace gui {
 
-class ImageLabel : public Widget {
-    using Super = Widget;
-
+class UIImage {
 public:
-    ImageLabel();
     /// Uses image from the specified path. Each ImageLabel will use one
     /// draw call.
-    explicit ImageLabel(const char* image_path);
+    explicit UIImage(const char* image_path);
     /// Uses an existing texture, using texture coordinates
     /// (u0, v0) to (u1, v1). Does not deallocate texture on destruction.
     /// This is useful for using an icon atlas to reduce draw calls.
-    explicit ImageLabel(visualization::TextureHandle texture_id,
-                        float u0 = 0.0f,
-                        float v0 = 0.0f,
-                        float u1 = 1.0f,
-                        float v1 = 1.0f);
-    ImageLabel(std::shared_ptr<UIImage> image);
-    ~ImageLabel();
+    explicit UIImage(visualization::TextureHandle texture_id,
+                     float u0 = 0.0f,
+                     float v0 = 0.0f,
+                     float u1 = 1.0f,
+                     float v1 = 1.0f);
+    ~UIImage();
 
-    std::shared_ptr<UIImage> GetImage() const;
-    void SetImage(std::shared_ptr<UIImage> image);
+    enum class Scaling {
+        NONE,   /// No scaling, fixed size
+        ANY,    /// Scales to any size and aspect ratio
+        ASPECT  /// Scales to any size, but fixed aspect ratio (default)
+    };
+    void SetScaling(Scaling scaling);
+    Scaling GetScaling() const;
 
-    Size CalcPreferredSize(const Theme& theme) const override;
+    Size CalcPreferredSize(const Theme& theme) const;
 
-    void Layout(const Theme& theme) override;
-
-    DrawResult Draw(const DrawContext& context) override;
+    struct DrawParams {
+        float pos_x;
+        float pos_y;
+        float width;
+        float height;
+        float u0;
+        float v0;
+        float u1;
+        float v1;
+        visualization::TextureHandle texture;
+    };
+    DrawParams CalcDrawParams(visualization::Renderer& renderer,
+                              const Rect& frame) const;
 
 private:
     struct Impl;

--- a/src/Open3D/GUI/UIImage.h
+++ b/src/Open3D/GUI/UIImage.h
@@ -57,14 +57,16 @@ public:
     Size CalcPreferredSize(const Theme& theme) const;
 
     struct DrawParams {
-        float pos_x;
-        float pos_y;
-        float width;
-        float height;
-        float u0;
-        float v0;
-        float u1;
-        float v1;
+        // Default values are to make GCC happy and contented,
+        // pos and size don't have reasonable defaults.
+        float pos_x = 0.0f;
+        float pos_y = 0.0f;
+        float width = 0.0f;
+        float height = 0.0f;
+        float u0 = 0.0f;
+        float v0 = 0.0f;
+        float u1 = 1.0f;
+        float v1 = 1.0f;
         visualization::TextureHandle texture;
     };
     DrawParams CalcDrawParams(visualization::Renderer& renderer,

--- a/src/Open3D/GUI/Widget.h
+++ b/src/Open3D/GUI/Widget.h
@@ -32,6 +32,11 @@
 #include "Open3D/GUI/Gui.h"
 
 namespace open3d {
+
+namespace visualization {
+class Renderer;
+}  // namespace visualization
+
 namespace gui {
 
 class Color;
@@ -42,6 +47,7 @@ struct Theme;
 
 struct DrawContext {
     const Theme& theme;
+    visualization::Renderer& renderer;
     int uiOffsetX;
     int uiOffsetY;
     int screenWidth;

--- a/src/Open3D/GUI/Window.cpp
+++ b/src/Open3D/GUI/Window.cpp
@@ -702,7 +702,8 @@ Widget::DrawResult Window::DrawOnce(bool is_layout_pass) {
 
     auto size = GetSize();
     int em = theme.font_size;  // em = font size in digital type (see Wikipedia)
-    DrawContext dc{theme, 0, 0, size.width, size.height, em, dt_sec};
+    DrawContext dc{theme,      *impl_->renderer_, 0,  0,
+                   size.width, size.height,       em, dt_sec};
 
     // Draw all the widgets. These will get recorded by ImGui.
     size_t win_idx = 0;

--- a/src/Open3D/Open3D.h.in
+++ b/src/Open3D/Open3D.h.in
@@ -39,6 +39,7 @@
 #include "Open3D/GUI/Combobox.h"
 #include "Open3D/GUI/Dialog.h"
 #include "Open3D/GUI/Gui.h"
+#include "Open3D/GUI/ImageLabel.h"
 #include "Open3D/GUI/Label.h"
 #include "Open3D/GUI/Layout.h"
 #include "Open3D/GUI/Menu.h"

--- a/src/Open3D/Visualization/Rendering/RendererHandle.h
+++ b/src/Open3D/Visualization/Rendering/RendererHandle.h
@@ -82,6 +82,10 @@ struct REHandle_abstract {
         return id == other.id && type == other.type;
     }
 
+    bool operator!=(const REHandle_abstract& other) const {
+        return !operator==(other);
+    }
+
     bool operator<(const REHandle_abstract& other) const {
         return Hash() < other.Hash();
     }
@@ -132,15 +136,13 @@ struct REHandle : public REHandle_abstract {
 
     REHandle() : REHandle_abstract(entityType, REHandle_abstract::kBadId) {}
     REHandle(const REHandle& other) : REHandle_abstract(entityType, other.id) {}
+    // Don't use this constructor unless you know what you are doing
+    explicit REHandle(std::uint16_t id) : REHandle_abstract(entityType, id) {}
 
     REHandle& operator=(const REHandle& other) {
         id = other.id;
         return *this;
     }
-
-private:
-    explicit REHandle(const std::uint16_t aId)
-        : REHandle_abstract(entityType, aId) {}
 };
 
 template <EntityType entityType>


### PR DESCRIPTION
This PR lets us display images in the UI. Each image costs another draw call. Open3D cannot currently load images with transparency (but in theory should work if it does). The UI does not use any images, so this is currently unused; you can test by adding some variation of the following to GuiVisualizer.cpp:

```
#include “Open3D/GUI/ImageLabel.h”
#include "Open3D/Visualization/Rendering/Filament/FilamentEngine.h"

settings.wgt_base->AddChild(std::make_shared<gui::ImageLabel>(
                            "path/to/test.png"));

auto &rsrc_mgr = visualization::EngineInstance::GetResourceManager();
auto texture = rsrc_mgr.CreateTexture("path/to/test.png");
settings.wgt_base->AddChild(std::make_shared<gui::ImageLabel>(
                                texture, 0.25, 0.125, 0.75, 0.625));
```

See attached test.png. 

![test](https://user-images.githubusercontent.com/2333353/82617331-98d05580-9b84-11ea-8dc8-a3eb5d8f4e48.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1881)
<!-- Reviewable:end -->
