### PR TITLE
Fix bug reading multi-threading config

### DIFF
--- a/examples/Python/ReconstructionSystem/make_fragments.py
+++ b/examples/Python/ReconstructionSystem/make_fragments.py
@@ -173,7 +173,7 @@ def run(config):
     n_fragments = int(math.ceil(float(n_files) / \
             config['n_frames_per_fragment']))
 
-    if config["python_multi_threading"].lower()=='true':
+    if config["python_multi_threading"].lower() == "true":
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess

--- a/examples/Python/ReconstructionSystem/make_fragments.py
+++ b/examples/Python/ReconstructionSystem/make_fragments.py
@@ -173,7 +173,7 @@ def run(config):
     n_fragments = int(math.ceil(float(n_files) / \
             config['n_frames_per_fragment']))
 
-    if config["python_multi_threading"]:
+    if config["python_multi_threading"].lower()=='true':
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess

--- a/examples/Python/ReconstructionSystem/refine_registration.py
+++ b/examples/Python/ReconstructionSystem/refine_registration.py
@@ -140,7 +140,7 @@ def make_posegraph_for_refined_scene(ply_file_names, config):
         matching_results[s * n_files + t] = \
                 matching_result(s, t, edge.transformation)
 
-    if config["python_multi_threading"]:
+    if config["python_multi_threading"].lower()=='true':
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess

--- a/examples/Python/ReconstructionSystem/refine_registration.py
+++ b/examples/Python/ReconstructionSystem/refine_registration.py
@@ -140,7 +140,7 @@ def make_posegraph_for_refined_scene(ply_file_names, config):
         matching_results[s * n_files + t] = \
                 matching_result(s, t, edge.transformation)
 
-    if config["python_multi_threading"].lower()=='true':
+    if config["python_multi_threading"].lower() == "true":
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess

--- a/examples/Python/ReconstructionSystem/register_fragments.py
+++ b/examples/Python/ReconstructionSystem/register_fragments.py
@@ -144,7 +144,7 @@ def make_posegraph_for_scene(ply_file_names, config):
         for t in range(s + 1, n_files):
             matching_results[s * n_files + t] = matching_result(s, t)
 
-    if config["python_multi_threading"]:
+    if config["python_multi_threading"].lower()=='true':
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess

--- a/examples/Python/ReconstructionSystem/register_fragments.py
+++ b/examples/Python/ReconstructionSystem/register_fragments.py
@@ -144,7 +144,7 @@ def make_posegraph_for_scene(ply_file_names, config):
         for t in range(s + 1, n_files):
             matching_results[s * n_files + t] = matching_result(s, t)
 
-    if config["python_multi_threading"].lower()=='true':
+    if config["python_multi_threading"].lower() == "true":
         from joblib import Parallel, delayed
         import multiprocessing
         import subprocess


### PR DESCRIPTION
The condition `if config["python_multi_threading"]:` is true even when `config["python_multi_threading"]` is set `False` or `false` or anything.

This PR fixes that bug present in the reconstruction example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1901)
<!-- Reviewable:end -->
