### PR TITLE
Rotate Overload

### DIFF
--- a/src/Open3D/Geometry/Geometry3D.cpp
+++ b/src/Open3D/Geometry/Geometry3D.cpp
@@ -34,6 +34,10 @@
 namespace open3d {
 namespace geometry {
 
+Geometry3D& Geometry3D::Rotate(const Eigen::Matrix3d& R) {
+    return Rotate(R, GetCenter());
+}
+
 Eigen::Vector3d Geometry3D::ComputeMinBound(
         const std::vector<Eigen::Vector3d>& points) const {
     if (points.empty()) {

--- a/src/Open3D/Geometry/Geometry3D.h
+++ b/src/Open3D/Geometry/Geometry3D.h
@@ -95,6 +95,8 @@ public:
     virtual Geometry3D& Rotate(const Eigen::Matrix3d& R,
                                const Eigen::Vector3d& center) = 0;
 
+    virtual Geometry3D& Rotate(const Eigen::Matrix3d& R);
+
     /// Get Rotation Matrix from XYZ RotationType.
     static Eigen::Matrix3d GetRotationMatrixFromXYZ(
             const Eigen::Vector3d& rotation);

--- a/src/Python/open3d_pybind/geometry/geometry.cpp
+++ b/src/Python/open3d_pybind/geometry/geometry.cpp
@@ -127,6 +127,9 @@ void pybind_geometry_classes(py::module &m) {
                  "center"_a)
             .def("rotate", &geometry::Geometry3D::Rotate,
                  "Apply rotation to the geometry coordinates and normals.",
+                 "R"_a)
+            .def("rotate", &geometry::Geometry3D::Rotate,
+                 "Apply rotation to the geometry coordinates and normals.",
                  "R"_a, "center"_a)
             .def_static("get_rotation_matrix_from_xyz",
                         &geometry::Geometry3D::GetRotationMatrixFromXYZ,

--- a/src/Python/open3d_pybind/geometry/geometry.cpp
+++ b/src/Python/open3d_pybind/geometry/geometry.cpp
@@ -125,10 +125,15 @@ void pybind_geometry_classes(py::module &m) {
             .def("scale", &geometry::Geometry3D::Scale,
                  "Apply scaling to the geometry coordinates.", "scale"_a,
                  "center"_a)
-            .def("rotate", &geometry::Geometry3D::Rotate,
+            .def("rotate",
+                 [](geometry::Geometry3D &geom, const Eigen::Matrix3d &R) {
+                     geom.Rotate(R);
+                 },
                  "Apply rotation to the geometry coordinates and normals.",
                  "R"_a)
-            .def("rotate", &geometry::Geometry3D::Rotate,
+            .def("rotate",
+                 [](geometry::Geometry3D &geom, const Eigen::Matrix3d &R,
+                    const Eigen::Vector3d &center) { geom.Rotate(R, center); },
                  "Apply rotation to the geometry coordinates and normals.",
                  "R"_a, "center"_a)
             .def_static("get_rotation_matrix_from_xyz",


### PR DESCRIPTION
Overload `rotate` method so that center parameter is optional.
Addressing comment https://github.com/intel-isl/Open3D/pull/1774#issuecomment-635206007

@yxlao I think the doc extraction from overloaded pybind methods does not work well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1920)
<!-- Reviewable:end -->
