### PR TITLE
fix auto & warning (as error) for clang 10

### DIFF
--- a/examples/Cpp/EvaluateFeatureMatch.cpp
+++ b/examples/Cpp/EvaluateFeatureMatch.cpp
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
                      total_correspondence_num, total_point_num,
                      total_correspondence_num * 100.0 / total_point_num);
 
-    for (const auto feature : features) {
+    for (const auto &feature : features) {
         utility::LogInfo("Evaluate feature {}.", feature);
         std::vector<KDTreeFlannFeature> feature_trees(pcd_names.size());
 #ifdef _OPENMP


### PR DESCRIPTION
Fixes error on clang 10 (default clang for ubuntu 20.04)

```cpp
/home/yixing/repo/Open3D/examples/Cpp/EvaluateFeatureMatch.cpp:232:21: error: loop variable 'feature' of type 'const std::__cxx11::basic_string<char>' c
reates a copy from type 'const std::__cxx11::basic_string<char>' [-Werror,-Wrange-loop-construct]                                                       
    for (const auto feature : features) {                                   
                    ^                 
/home/yixing/repo/Open3D/examples/Cpp/EvaluateFeatureMatch.cpp:232:10: note: use reference type 'const std::__cxx11::basic_string<char> &' to prevent co
pying                                 
    for (const auto feature : features) {                                   
         ^~~~~~~~~~~~~~~~~~~~         
                    &                 
1 error generated.                    
make[2]: *** [examples/Cpp/CMakeFiles/EvaluateFeatureMatch.dir/build.make:63: examples/Cpp/CMakeFiles/EvaluateFeatureMatch.dir/EvaluateFeatureMatch.cpp.
o] Error 1                            
make[1]: *** [CMakeFiles/Makefile2:2271: examples/Cpp/CMakeFiles/EvaluateFeatureMatch.dir/all] Error 2                                                  
make[1]: *** Waiting for unfinished jobs....  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1924)
<!-- Reviewable:end -->
