### PR TITLE
Docs/read utf 8 fix

### DIFF
--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -372,7 +372,7 @@ class JupyterDocsBuilder:
         # Execute Jupyter notebooks
         for nb_path in nb_paths:
             print("[Processing notebook {}]".format(nb_path.name))
-            with open(nb_path) as f:
+            with open(nb_path, encoding="utf-8") as f:
                 nb = nbformat.read(f, as_version=4)
 
             # https://github.com/spatialaudio/nbsphinx/blob/master/src/nbsphinx.py


### PR DESCRIPTION
Fixes #1933 

Specified utf-8 as the nb encoding format (which is same as the format these are written in)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1935)
<!-- Reviewable:end -->
