### PR TITLE
only update single geometry in Visualizer::AddGeometry and Visualizer::RemoveGeometry

### DIFF
--- a/src/Open3D/Visualization/Visualizer/Visualizer.cpp
+++ b/src/Open3D/Visualization/Visualizer/Visualizer.cpp
@@ -380,7 +380,7 @@ bool Visualizer::AddGeometry(
     utility::LogDebug(
             "Add geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
-    return UpdateGeometry();
+    return UpdateGeometry(geometry_ptr);
 }
 
 bool Visualizer::RemoveGeometry(
@@ -404,7 +404,7 @@ bool Visualizer::RemoveGeometry(
     utility::LogDebug(
             "Remove geometry and update bounding box to {}",
             view_control_ptr_->GetBoundingBox().GetPrintInfo().c_str());
-    return UpdateGeometry();
+    return UpdateGeometry(geometry_ptr);
 }
 
 bool Visualizer::ClearGeometries() {


### PR DESCRIPTION
This fixes an old PR #1392

Significant speedups when `AddGeometry` or `RemoveGeometry` is called when there are many other geometries in the scene.

Not sure why, but the previous PR had some missing changes, which are here now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1945)
<!-- Reviewable:end -->
