### PR TITLE
avoid deduplication of the -gencode option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,8 @@ if (BUILD_CUDA_MODULE)
         else()
             cuda_select_nvcc_arch_flags(CUDA_GENCODES "${CUDA_ARCH}")
         endif()
+        # make CUDA_GENCODES a string to avoid deduplication in target_compile_options
+        string( REPLACE ";" " " CUDA_GENCODES "${CUDA_GENCODES}")
     else()
         set(BUILD_CUDA_MODULE OFF)
         message(STATUS "No CUDA support")


### PR DESCRIPTION
This PR fixes a problem if cuda code is compiled for multiple archs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1960)
<!-- Reviewable:end -->
