### PR TITLE
Add option to skip ipynb docs, fix python and cpp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the open-source community.
 [![Build Status](https://travis-ci.org/intel-isl/Open3D.svg?branch=master)](https://travis-ci.org/intel-isl/)
 [![Build status](https://ci.appveyor.com/api/projects/status/3hasjo041lv6srsi/branch/master?svg=true)](https://ci.appveyor.com/project/yxlao/open3d/branch/master)
 
-#### Core features of Open3D includes:
+**Core features of Open3D include:**
 
 * 3D data structures
 * 3D data processing algorithms

--- a/cpp/pybind/core/dtype.cpp
+++ b/cpp/pybind/core/dtype.cpp
@@ -33,7 +33,7 @@
 namespace open3d {
 
 void pybind_core_dtype(py::module &m) {
-    py::enum_<core::Dtype>(m, "Dtype")
+    py::enum_<core::Dtype>(m, "Dtype", "Open3D data types.")
             .value("Undefined", core::Dtype::Undefined)
             .value("Float32", core::Dtype::Float32)
             .value("Float64", core::Dtype::Float64)
@@ -43,7 +43,7 @@ void pybind_core_dtype(py::module &m) {
             .value("Bool", core::Dtype::Bool)
             .export_values();
 
-    py::class_<core::DtypeUtil> dtype_util(m, "DtypeUtil");
+    py::class_<core::DtypeUtil> dtype_util(m, "DtypeUtil", "Dtype utilities.");
     dtype_util.def(py::init<>()).def("byte_size", &core::DtypeUtil::ByteSize);
 }
 

--- a/cpp/pybind/core/size_vector.cpp
+++ b/cpp/pybind/core/size_vector.cpp
@@ -36,7 +36,7 @@ void pybind_core_size_vector(py::module &m) {
     py::class_<core::SizeVector> size_vector(
             m, "SizeVector",
             "SizeVector is a vector of int64_t for "
-            "specifying shape, strides and etc.");
+            "specifying shape, strides, etc.");
 
     size_vector.def(py::init(
             [](py::array_t<int64_t, py::array::c_style | py::array::forcecast>

--- a/cpp/pybind/core/tensor_key.cpp
+++ b/cpp/pybind/core/tensor_key.cpp
@@ -34,7 +34,7 @@
 namespace open3d {
 
 void pybind_core_tensor_key(py::module& m) {
-    py::class_<core::NoneType> none_type(m, "NoneType");
+    py::class_<core::NoneType> none_type(m, "NoneType", "Open3D None type.");
     none_type.def(py::init([]() { return new core::NoneType(); }));
 
     py::class_<core::TensorKey> tensor_key(m, "TensorKey");

--- a/cpp/pybind/pipelines/color_map/color_map.cpp
+++ b/cpp/pybind/pipelines/color_map/color_map.cpp
@@ -193,7 +193,8 @@ void pybind_color_map_methods(py::module &m) {
 }
 
 void pybind_color_map(py::module &m) {
-    py::module m_submodule = m.def_submodule("color_map");
+    py::module m_submodule =
+            m.def_submodule("color_map", "Color map optimization pipeline.");
     pybind_color_map_classes(m_submodule);
     pybind_color_map_methods(m_submodule);
 }

--- a/cpp/pybind/pipelines/integration/integration.cpp
+++ b/cpp/pybind/pipelines/integration/integration.cpp
@@ -239,7 +239,8 @@ void pybind_integration_methods(py::module &m) {
 }
 
 void pybind_integration(py::module &m) {
-    py::module m_submodule = m.def_submodule("integration");
+    py::module m_submodule =
+            m.def_submodule("integration", "Integration pipeline.");
     pybind_integration_classes(m_submodule);
     pybind_integration_methods(m_submodule);
 }

--- a/cpp/pybind/pipelines/odometry/odometry.cpp
+++ b/cpp/pybind/pipelines/odometry/odometry.cpp
@@ -220,7 +220,7 @@ void pybind_odometry_methods(py::module &m) {
 }
 
 void pybind_odometry(py::module &m) {
-    py::module m_submodule = m.def_submodule("odometry");
+    py::module m_submodule = m.def_submodule("odometry", "Odometry pipeline.");
     pybind_odometry_classes(m_submodule);
     pybind_odometry_methods(m_submodule);
 }

--- a/cpp/pybind/pipelines/registration/registration.cpp
+++ b/cpp/pybind/pipelines/registration/registration.cpp
@@ -649,7 +649,8 @@ void pybind_registration_methods(py::module &m) {
 }
 
 void pybind_registration(py::module &m) {
-    py::module m_submodule = m.def_submodule("registration");
+    py::module m_submodule =
+            m.def_submodule("registration", "Registration pipeline.");
     pybind_registration_classes(m_submodule);
     pybind_registration_methods(m_submodule);
 

--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -1,6 +1,6 @@
 .. _builddocs:
 
-Building Documentation
+Building documentation
 ======================
 
 The main documentation and Python documentation is written in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,10 @@ extensions = [
     'm2r',
 ]
 
+if os.environ["skip_notebooks"] == "true":
+    print("Skipping Jupyter notebooks")
+    extensions = [e for e in extensions if e != "nbsphinx"]
+
 # Allow for more time for notebook cell evaluation
 nbsphinx_timeout = 6000
 # nbsphinx_allow_errors = True

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -1,0 +1,10 @@
+.. _cpp_api:
+
+C++ documentation
+=================
+
+Please refer to the following pages for Open3D C++ API.
+
+- Full C++ API documentation: `Open3D C++ Doxygen documentation <./cpp_api/index.html>`_
+- Linking Open3D to your C++ projects: :ref:`cplusplus_example_project`
+- Compiling Open3D from source: :ref:`compilation`

--- a/docs/documented_modules.txt
+++ b/docs/documented_modules.txt
@@ -1,0 +1,12 @@
+# Parsed by make_docs.py
+open3d.camera
+open3d.core
+open3d.geometry
+open3d.io
+open3d.pipelines
+open3d.pipelines.color_map
+open3d.pipelines.integration
+open3d.pipelines.odometry
+open3d.pipelines.registration
+open3d.utility
+open3d.visualization

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,6 +1,6 @@
 .. _getting_started:
 
-Getting Started
+Getting started
 ###############
 
 .. _install_open3d_python:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,8 @@ Open3D: A Modern Library for 3D Data Processing
 
 .. _python_api_index:
 
+.. Note: when adding new modules, please also update documented_modules.txt.
+
 .. toctree::
     :maxdepth: 1
     :caption: Python API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,14 @@ Open3D: A Modern Library for 3D Data Processing
     tutorial/docker/index
     tutorial/reference
 
+.. _cpp_api_index:
+
+.. toctree::
+    :maxdepth: 1
+    :caption: C++ API
+
+    cpp
+
 .. _python_api_index:
 
 .. toctree::

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,6 +1,3 @@
 .. _introduction:
 
-About Open3D
-============
-
 .. mdinclude:: ../README.md

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -240,7 +240,7 @@ class SphinxDocsBuilder:
     def __init__(self, html_output_dir, is_release, skip_notebooks):
         # Get the modules for which we want to build the documentation.
         # We use the modules listed in the index.rst file here.
-        self.documented_modules = self._get_module_names_from_index_rst()
+        self.documented_modules = self._get_documented_module_names()
 
         # self.documented_modules = "open3d.pybind"  # Points to the open3d.so
         # self.c_module_relative = "open3d"  # The relative module reference to open3d.so
@@ -250,26 +250,18 @@ class SphinxDocsBuilder:
         self.skip_notebooks = skip_notebooks
 
     @staticmethod
-    def _get_module_names_from_index_rst():
+    def _get_documented_module_names():
         """Reads the modules of the python api from the index.rst"""
-        module_names = [
-            "open3d.camera",
-            "open3d.core",
-            "open3d.geometry",
-            "open3d.io",
-            "open3d.pipelines",
-            "open3d.pipelines.color_map",
-            "open3d.pipelines.integration",
-            "open3d.pipelines.odometry",
-            "open3d.pipelines.registration",
-            "open3d.utility",
-            "open3d.visualization",
-        ]
-        # with open("index.rst", "r") as f:
-        #     for line in f:
-        #         m = re.match("^\s*python_api/(.*)\s*$", line)
-        #         if m:
-        #             module_names.append(m.group(1))
+        module_names = []
+        with open("documented_modules.txt", "r") as f:
+            for line in f:
+                print(line)
+                m = re.match("^(open3d\..*)\s*$", line)
+                if m:
+                    module_names.append(m.group(1))
+        print("Documented modules:")
+        for module_name in module_names:
+            print("-", module_name)
         return module_names
 
     def run(self):

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -35,7 +35,7 @@ import subprocess
 import sys
 import importlib
 import os
-from inspect import getmembers, isbuiltin, isclass, ismodule
+import inspect
 import shutil
 import warnings
 import weakref
@@ -76,11 +76,10 @@ class PyAPIDocsBuilder:
 
         for module_name in self.module_names:
             module = self._get_open3d_module(module_name)
-            PyAPIDocsBuilder._generate_sub_module_class_function_docs(
-                module_name, module, self.output_dir)
+            self._generate_module_class_function_docs(module_name, module,
+                                                      self.output_dir)
 
-    @staticmethod
-    def _get_open3d_module(full_module_name):
+    def _get_open3d_module(self, full_module_name):
         """Returns the module object for the given module path"""
         import open3d  # make sure the root module is loaded
 
@@ -98,27 +97,25 @@ class PyAPIDocsBuilder:
                 current_module = getattr(current_module, sub_module_name)
             return current_module
 
-    @staticmethod
-    def _generate_function_doc(sub_module_full_name, function_name,
+    def _generate_function_doc(self, full_module_name, function_name,
                                output_path):
         # print("Generating docs: %s" % (output_path,))
         out_string = ""
-        out_string += "%s.%s" % (sub_module_full_name, function_name)
+        out_string += "%s.%s" % (full_module_name, function_name)
         out_string += "\n" + "-" * len(out_string)
-        out_string += "\n\n" + ".. currentmodule:: %s" % sub_module_full_name
+        out_string += "\n\n" + ".. currentmodule:: %s" % full_module_name
         out_string += "\n\n" + ".. autofunction:: %s" % function_name
         out_string += "\n"
 
         with open(output_path, "w") as f:
             f.write(out_string)
 
-    @staticmethod
-    def _generate_class_doc(sub_module_full_name, class_name, output_path):
+    def _generate_class_doc(self, full_module_name, class_name, output_path):
         # print("Generating docs: %s" % (output_path,))
         out_string = ""
-        out_string += "%s.%s" % (sub_module_full_name, class_name)
+        out_string += "%s.%s" % (full_module_name, class_name)
         out_string += "\n" + "-" * len(out_string)
-        out_string += "\n\n" + ".. currentmodule:: %s" % sub_module_full_name
+        out_string += "\n\n" + ".. currentmodule:: %s" % full_module_name
         out_string += "\n\n" + ".. autoclass:: %s" % class_name
         out_string += "\n    :members:"
         out_string += "\n    :undoc-members:"
@@ -128,16 +125,16 @@ class PyAPIDocsBuilder:
         with open(output_path, "w") as f:
             f.write(out_string)
 
-    @staticmethod
-    def _generate_sub_module_doc(sub_module_full_name, class_names,
-                                 function_names, sub_module_doc_path):
+    def _generate_module_doc(self, full_module_name, class_names,
+                             function_names, sub_module_names,
+                             sub_module_doc_path):
         # print("Generating docs: %s" % (sub_module_doc_path,))
         class_names = sorted(class_names)
         function_names = sorted(function_names)
         out_string = ""
-        out_string += sub_module_full_name
+        out_string += full_module_name
         out_string += "\n" + "-" * len(out_string)
-        out_string += "\n\n" + ".. currentmodule:: %s" % sub_module_full_name
+        out_string += "\n\n" + ".. currentmodule:: %s" % full_module_name
 
         if len(class_names) > 0:
             out_string += "\n\n**Classes**"
@@ -155,7 +152,15 @@ class PyAPIDocsBuilder:
                 out_string += "\n    " + "%s" % (function_name,)
             out_string += "\n"
 
-        obj_names = class_names + function_names
+        if len(sub_module_names) > 0:
+            out_string += "\n\n**Modules**"
+            out_string += "\n\n.. autosummary::"
+            out_string += "\n"
+            for sub_module_name in sub_module_names:
+                out_string += "\n    " + "%s" % (sub_module_name,)
+            out_string += "\n"
+
+        obj_names = class_names + function_names + sub_module_names
         if len(obj_names) > 0:
             out_string += "\n\n.. toctree::"
             out_string += "\n    :hidden:"
@@ -163,7 +168,7 @@ class PyAPIDocsBuilder:
             for obj_name in obj_names:
                 out_string += "\n    %s <%s.%s>" % (
                     obj_name,
-                    sub_module_full_name,
+                    full_module_name,
                     obj_name,
                 )
             out_string += "\n"
@@ -171,38 +176,53 @@ class PyAPIDocsBuilder:
         with open(sub_module_doc_path, "w") as f:
             f.write(out_string)
 
-    @staticmethod
-    def _generate_sub_module_class_function_docs(sub_module_full_name,
-                                                 sub_module, output_dir):
-        print("Generating docs for submodule: %s" % sub_module_full_name)
+    def _generate_module_class_function_docs(self, full_module_name, module,
+                                             output_dir):
+        print("Generating docs for submodule: %s" % full_module_name)
 
         # Class docs
         class_names = [
-            obj[0] for obj in getmembers(sub_module) if isclass(obj[1])
+            obj[0]
+            for obj in inspect.getmembers(module)
+            if inspect.isclass(obj[1])
         ]
         for class_name in class_names:
-            file_name = "%s.%s.rst" % (sub_module_full_name, class_name)
+            file_name = "%s.%s.rst" % (full_module_name, class_name)
             output_path = os.path.join(output_dir, file_name)
-            PyAPIDocsBuilder._generate_class_doc(sub_module_full_name,
-                                                 class_name, output_path)
+            self._generate_class_doc(full_module_name, class_name, output_path)
 
         # Function docs
         function_names = [
-            obj[0] for obj in getmembers(sub_module) if isbuiltin(obj[1])
+            obj[0]
+            for obj in inspect.getmembers(module)
+            if inspect.isbuiltin(obj[1])
         ]
         for function_name in function_names:
-            file_name = "%s.%s.rst" % (sub_module_full_name, function_name)
+            file_name = "%s.%s.rst" % (full_module_name, function_name)
             output_path = os.path.join(output_dir, file_name)
-            PyAPIDocsBuilder._generate_function_doc(sub_module_full_name,
-                                                    function_name, output_path)
+            self._generate_function_doc(full_module_name, function_name,
+                                        output_path)
 
-        # Submodule docs
+        # Submodule docs, only supports 2-level nesting
+        # (i.e. open3d.pipeline.registration)
+        sub_module_names = [
+            obj[0]
+            for obj in inspect.getmembers(module)
+            if inspect.ismodule(obj[1])
+        ]
+        documented_sub_module_names = [
+            sub_module_name for sub_module_name in sub_module_names if "%s.%s" %
+            (full_module_name, sub_module_name) in self.module_names
+        ]
+
+        # Path
         sub_module_doc_path = os.path.join(output_dir,
-                                           sub_module_full_name + ".rst")
-        PyAPIDocsBuilder._generate_sub_module_doc(
-            sub_module_full_name,
+                                           full_module_name + ".rst")
+        self._generate_module_doc(
+            full_module_name,
             class_names,
             function_names,
+            documented_sub_module_names,
             sub_module_doc_path,
         )
 
@@ -217,7 +237,7 @@ class SphinxDocsBuilder:
     (3) Calls `sphinx-build` with the user argument
     """
 
-    def __init__(self, html_output_dir, is_release):
+    def __init__(self, html_output_dir, is_release, skip_notebooks):
         # Get the modules for which we want to build the documentation.
         # We use the modules listed in the index.rst file here.
         self.documented_modules = self._get_module_names_from_index_rst()
@@ -227,16 +247,29 @@ class SphinxDocsBuilder:
         self.python_api_output_dir = "python_api"
         self.html_output_dir = html_output_dir
         self.is_release = is_release
+        self.skip_notebooks = skip_notebooks
 
     @staticmethod
     def _get_module_names_from_index_rst():
         """Reads the modules of the python api from the index.rst"""
-        module_names = []
-        with open("index.rst", "r") as f:
-            for line in f:
-                m = re.match("^\s*python_api/(.*)\s*$", line)
-                if m:
-                    module_names.append(m.group(1))
+        module_names = [
+            "open3d.camera",
+            "open3d.core",
+            "open3d.geometry",
+            "open3d.io",
+            "open3d.pipelines",
+            "open3d.pipelines.color_map",
+            "open3d.pipelines.integration",
+            "open3d.pipelines.odometry",
+            "open3d.pipelines.registration",
+            "open3d.utility",
+            "open3d.visualization",
+        ]
+        # with open("index.rst", "r") as f:
+        #     for line in f:
+        #         m = re.match("^\s*python_api/(.*)\s*$", line)
+        #         if m:
+        #             module_names.append(m.group(1))
         return module_names
 
     def run(self):
@@ -287,8 +320,17 @@ class SphinxDocsBuilder:
                 ".",
                 build_dir,
             ]
+
+        sphinx_env = os.environ.copy()
+        sphinx_env[
+            "skip_notebooks"] = "true" if self.skip_notebooks else "false"
+
         print('Calling: "%s"' % " ".join(cmd))
-        subprocess.check_call(cmd, stdout=sys.stdout, stderr=sys.stderr)
+        print('Env: "%s"' % sphinx_env)
+        subprocess.check_call(cmd,
+                              env=sphinx_env,
+                              stdout=sys.stdout,
+                              stderr=sys.stderr)
 
 
 class DoxygenDocsBuilder:
@@ -315,17 +357,15 @@ class DoxygenDocsBuilder:
 class JupyterDocsBuilder:
 
     def __init__(self, current_file_dir, clean_notebooks, execute_notebooks):
-        """
-        execute_notebooks is one of {"auto", "always"}
-        """
-        if execute_notebooks not in {"auto", "always"}:
-            raise ValueError(f"Invalid execute option: {execute_notebooks}.")
         self.clean_notebooks = clean_notebooks
         self.execute_notebooks = execute_notebooks
         self.current_file_dir = current_file_dir
         print("Notebook execution mode: {}".format(self.execute_notebooks))
 
     def run(self):
+        if self.execute_notebooks == "never":
+            return
+
         # Setting os.environ["CI"] will disable interactive (blocking) mode in
         # Jupyter notebooks
         os.environ["CI"] = "true"
@@ -421,7 +461,7 @@ if __name__ == "__main__":
         "--execute_notebooks",
         dest="execute_notebooks",
         default="auto",
-        help="Jupyter notebook execution mode, one of {auto, always}.",
+        help="Jupyter notebook execution mode, one of {auto, always, never}.",
     )
     parser.add_argument(
         "--sphinx",
@@ -446,6 +486,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    # Sanity checks
+    if args.execute_notebooks not in {"auto", "always", "never"}:
+        raise ValueError(f"Invalid execute option: {execute_notebooks}.")
+
     pwd = os.path.dirname(os.path.realpath(__file__))
 
     # Clear output dir if new docs are to be built
@@ -467,7 +511,9 @@ if __name__ == "__main__":
                                  args.execute_notebooks)
         jdb.run()
         print("Building Sphinx docs")
-        sdb = SphinxDocsBuilder(html_output_dir, args.is_release)
+        skip_notebooks = args.execute_notebooks == "never"
+        sdb = SphinxDocsBuilder(html_output_dir, args.is_release,
+                                skip_notebooks)
         sdb.run()
     else:
         print("Sphinx build disabled, use --sphinx to enable")

--- a/docs/tutorial/C++/cplusplus_interface.rst
+++ b/docs/tutorial/C++/cplusplus_interface.rst
@@ -1,7 +1,7 @@
-.. _cplusplus_interface_tutorial:
+.. _cplusplus_example_project:
 
-C++ interface
--------------
+Building C++ projects with Open3D
+---------------------------------
 
 This page explains how to create a CMake based C++ project using the Open3D C++ interface.
 

--- a/python/open3d/core.py
+++ b/python/open3d/core.py
@@ -28,6 +28,9 @@ def _numpy_dtype_to_dtype(numpy_dtype):
 
 
 class SizeVector(o3d.pybind.core.SizeVector):
+    """
+    SizeVector is a vector of integers for specifying shape, strides, etc.
+    """
 
     def __init__(self, values=None):
         if values is None:


### PR DESCRIPTION
- Add option to skip jupyter notebook docs at `make_docs.py` to speed up debugging
- Fix python docs, especially for `open3d.pipelines.*`
- Add standalone page for C++ API docs
- Fix cases and remove duplicated "about" page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1988)
<!-- Reviewable:end -->
