### PR TITLE
fix obb rotate and scale

### DIFF
--- a/cpp/open3d/geometry/BoundingVolume.cpp
+++ b/cpp/open3d/geometry/BoundingVolume.cpp
@@ -88,14 +88,14 @@ OrientedBoundingBox& OrientedBoundingBox::Translate(
 OrientedBoundingBox& OrientedBoundingBox::Scale(const double scale,
                                                 const Eigen::Vector3d& center) {
     extent_ *= scale;
-    center_ = center;
+    center_ = scale * (center_ - center) + center;
     return *this;
 }
 
 OrientedBoundingBox& OrientedBoundingBox::Rotate(
         const Eigen::Matrix3d& R, const Eigen::Vector3d& center) {
-    R_ = R;
-    center_ = center;
+    R_ = R * R_;
+    center_ = R * (center_ - center) + center;
     return *this;
 }
 

--- a/cpp/open3d/geometry/BoundingVolume.h
+++ b/cpp/open3d/geometry/BoundingVolume.h
@@ -79,23 +79,8 @@ public:
             const Eigen::Matrix4d& transformation) override;
     virtual OrientedBoundingBox& Translate(const Eigen::Vector3d& translation,
                                            bool relative = true) override;
-
-    /// \brief Scales the oriented bounding boxs.
-    /// The extent parameter is multiplied by the scale factor and
-    /// the center is set to the given parameter..
-    ///
-    /// \param scale The scale parameter that is multiplied to the
-    /// extent parameter of the oriented bounding box.
-    /// \param center New center of the oriented bounding box.
     virtual OrientedBoundingBox& Scale(const double scale,
                                        const Eigen::Vector3d& center) override;
-
-    /// \brief Rotates the oriented bounding boxs.
-    /// Sets the rotation and center of the oriented bounding box
-    /// to the given parameters.
-    ///
-    /// \param R New rotation matrix of the oriented bounding box.
-    /// \param center New center of the oriented bounding box.
     virtual OrientedBoundingBox& Rotate(const Eigen::Matrix3d& R,
                                         const Eigen::Vector3d& center) override;
 


### PR DESCRIPTION
Brought up in #1996, the `rotate` and `scale` function of `OrientedBoundingBox` does not conform with the other `rotate` and `scale` functions. This PR fixes this issue, i.e., if you rotate a point cloud that has a OrientedBoundingBox associated, calling rotate on this box with the same parameters will give you the expected result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/1999)
<!-- Reviewable:end -->
