### PR TITLE
Adds menu option on macOS to make Open3D viewer default for file types

### DIFF
--- a/cpp/apps/Open3DViewer/Open3DViewer.cpp
+++ b/cpp/apps/Open3DViewer/Open3DViewer.cpp
@@ -40,26 +40,6 @@ namespace {
 static const std::string gUsage = "Usage: Open3DViewer [meshfile|pointcloud]";
 }  // namespace
 
-void LoadAndCreateWindow(const char *path) {
-    static int x = 50, y = 50;
-
-    bool is_path_valid = (path && path[0] != '\0');
-    std::vector<std::shared_ptr<const Geometry>> empty;
-    std::string title = "Open3D";
-    if (is_path_valid) {
-        title += " - ";
-        title += path;
-    }
-    auto vis =
-            std::make_shared<GuiVisualizer>(empty, title, WIDTH, HEIGHT, x, y);
-    x += 20;  // so next window (if any) doesn't hide this one
-    y += 20;
-    if (is_path_valid) {
-        vis->LoadGeometry(path);
-    }
-    gui::Application::GetInstance().AddWindow(vis);
-}
-
 int Run(int argc, const char *argv[]) {
     const char *path = nullptr;
     if (argc > 1) {
@@ -72,7 +52,12 @@ int Run(int argc, const char *argv[]) {
     auto &app = gui::Application::GetInstance();
     app.Initialize(argc, argv);
 
-    LoadAndCreateWindow(path);
+    auto vis = std::make_shared<GuiVisualizer>("Open3D", WIDTH, HEIGHT);
+    bool is_path_valid = (path && path[0] != '\0');
+    if (is_path_valid) {
+        vis->LoadGeometry(path);
+    }
+    gui::Application::GetInstance().AddWindow(vis);
 
     app.Run();
 

--- a/cpp/apps/Open3DViewer/Open3DViewer.h
+++ b/cpp/apps/Open3DViewer/Open3DViewer.h
@@ -39,4 +39,3 @@ class GuiVisualizer;
 #define HEIGHT 960
 
 int Run(int argc, const char *argv[]);
-void LoadAndCreateWindow(const char *path);

--- a/cpp/open3d/visualization/gui/Menu.cpp
+++ b/cpp/open3d/visualization/gui/Menu.cpp
@@ -112,12 +112,10 @@ void Menu::AddMenu(const char *name, std::shared_ptr<Menu> submenu) {
     InsertMenu(impl_->items_.size(), name, submenu);
 }
 
-void Menu::AddSeparator() {
-    InsertSeparator(impl_->items_.size());
-}
+void Menu::AddSeparator() { InsertSeparator(impl_->items_.size()); }
 
 void Menu::InsertItem(int index,
-                      const char* name,
+                      const char *name,
                       ItemId item_id /*= NO_ITEM*/,
                       KeyName key /*= KEY_NONE*/) {
     for (auto &kv : impl_->id2idx_) {
@@ -131,7 +129,7 @@ void Menu::InsertItem(int index,
 }
 
 void Menu::InsertMenu(int index,
-                      const char* name,
+                      const char *name,
                       std::shared_ptr<Menu> submenu) {
     for (auto &kv : impl_->id2idx_) {
         if (int(kv.second) >= index) {
@@ -142,7 +140,7 @@ void Menu::InsertMenu(int index,
             impl_->items_.begin() + index,
             {NO_ITEM, name, KEY_NONE, submenu, submenu->impl_.get()});
 }
-    
+
 void Menu::InsertSeparator(int index) {
     for (auto &kv : impl_->id2idx_) {
         if (int(kv.second) >= index) {
@@ -154,9 +152,7 @@ void Menu::InsertSeparator(int index) {
             {NO_ITEM, "", KEY_NONE, nullptr, nullptr, false, false, true});
 }
 
-int Menu::GetNumberOfItems() const {
-    return int(impl_->items_.size());
-}
+int Menu::GetNumberOfItems() const { return int(impl_->items_.size()); }
 
 bool Menu::IsEnabled(ItemId item_id) const {
     auto *item = impl_->FindMenuItem(item_id);

--- a/cpp/open3d/visualization/gui/Menu.cpp
+++ b/cpp/open3d/visualization/gui/Menu.cpp
@@ -119,6 +119,48 @@ void Menu::AddSeparator() {
             {NO_ITEM, "", KEY_NONE, nullptr, nullptr, false, false, true});
 }
 
+void Menu::InsertItem(int index,
+                      const char* name,
+                      ItemId item_id = NO_ITEM,
+                      KeyName key = KEY_NONE) {
+    for (auto &kv : impl_->id2idx) {
+        if (kv.second >= index) {
+            kv.second += 1;
+        }
+    }
+    impl_->id2idx_[itemId] = impl_->items_.size();
+    impl_->items_.insert(impl_->items_.begin() + index,
+                         {itemId, name, key, nullptr});
+}
+
+void Menu::InsertMenu(int index,
+                      const char* name,
+                      std::shared_ptr<Menu> submenu) {
+    for (auto &kv : impl_->id2idx) {
+        if (kv.second >= index) {
+            kv.second += 1;
+        }
+    }
+    impl_->items_.insert(
+            impl_->items_.begin() + index,
+            {NO_ITEM, name, KEY_NONE, submenu, submenu->impl_.get()});
+}
+    
+void Menu::InsertSeparator(int index) {
+    for (auto &kv : impl_->id2idx) {
+        if (kv.second >= index) {
+            kv.second += 1;
+        }
+    }
+    impl_->items_.insert(
+            impl_->items_.begin() + index,
+            {NO_ITEM, "", KEY_NONE, nullptr, nullptr, false, false, true});
+}
+
+int Menu::GetNumberOfItems() const {
+    return int(impl_->items_.size());
+}
+
 bool Menu::IsEnabled(ItemId item_id) const {
     auto *item = impl_->FindMenuItem(item_id);
     if (item) {

--- a/cpp/open3d/visualization/gui/Menu.cpp
+++ b/cpp/open3d/visualization/gui/Menu.cpp
@@ -105,39 +105,36 @@ void *Menu::GetNativePointer() { return nullptr; }
 void Menu::AddItem(const char *name,
                    ItemId itemId /*= NO_ITEM*/,
                    KeyName key /*= KEY_NONE*/) {
-    impl_->id2idx_[itemId] = impl_->items_.size();
-    impl_->items_.push_back({itemId, name, key, nullptr});
+    InsertItem(impl_->items_.size(), name, itemId, key);
 }
 
 void Menu::AddMenu(const char *name, std::shared_ptr<Menu> submenu) {
-    impl_->items_.push_back(
-            {NO_ITEM, name, KEY_NONE, submenu, submenu->impl_.get()});
+    InsertMenu(impl_->items_.size(), name, submenu);
 }
 
 void Menu::AddSeparator() {
-    impl_->items_.push_back(
-            {NO_ITEM, "", KEY_NONE, nullptr, nullptr, false, false, true});
+    InsertSeparator(impl_->items_.size());
 }
 
 void Menu::InsertItem(int index,
                       const char* name,
-                      ItemId item_id = NO_ITEM,
-                      KeyName key = KEY_NONE) {
-    for (auto &kv : impl_->id2idx) {
-        if (kv.second >= index) {
+                      ItemId item_id /*= NO_ITEM*/,
+                      KeyName key /*= KEY_NONE*/) {
+    for (auto &kv : impl_->id2idx_) {
+        if (int(kv.second) >= index) {
             kv.second += 1;
         }
     }
-    impl_->id2idx_[itemId] = impl_->items_.size();
+    impl_->id2idx_[item_id] = impl_->items_.size();
     impl_->items_.insert(impl_->items_.begin() + index,
-                         {itemId, name, key, nullptr});
+                         {item_id, name, key, nullptr});
 }
 
 void Menu::InsertMenu(int index,
                       const char* name,
                       std::shared_ptr<Menu> submenu) {
-    for (auto &kv : impl_->id2idx) {
-        if (kv.second >= index) {
+    for (auto &kv : impl_->id2idx_) {
+        if (int(kv.second) >= index) {
             kv.second += 1;
         }
     }
@@ -147,8 +144,8 @@ void Menu::InsertMenu(int index,
 }
     
 void Menu::InsertSeparator(int index) {
-    for (auto &kv : impl_->id2idx) {
-        if (kv.second >= index) {
+    for (auto &kv : impl_->id2idx_) {
+        if (int(kv.second) >= index) {
             kv.second += 1;
         }
     }

--- a/cpp/open3d/visualization/gui/Menu.h
+++ b/cpp/open3d/visualization/gui/Menu.h
@@ -55,6 +55,15 @@ public:
     void AddMenu(const char* name, std::shared_ptr<Menu> submenu);
     void AddSeparator();
 
+    void InsertItem(int index,
+                    const char* name,
+                    ItemId item_id = NO_ITEM,
+                    KeyName key = KEY_NONE);
+    void InsertMenu(int index, const char* name, std::shared_ptr<Menu> submenu);
+    void InsertSeparator(int index);
+
+    int GetNumberOfItems() const;
+
     /// Searches the menu hierarchy down from this menu to find the item
     /// and returns true if the item is enabled.
     bool IsEnabled(ItemId item_id) const;

--- a/cpp/open3d/visualization/gui/MenuMacOS.mm
+++ b/cpp/open3d/visualization/gui/MenuMacOS.mm
@@ -96,6 +96,21 @@ void* Menu::GetNativePointer() { return impl_->menu_; }
 void Menu::AddItem(const char *name,
                    ItemId item_id /*= NO_ITEM*/,
                    KeyName key /*= KEY_NONE*/) {
+    InsertItem(impl_->menu_.numberOfItems, name, item_id, key);
+}
+
+void Menu::AddMenu(const char *name, std::shared_ptr<Menu> submenu) {
+    InsertMenu(impl_->menu_.numberOfItems, name, submenu);
+}
+
+void Menu::AddSeparator() {
+    [impl_->menu_ addItem: [NSMenuItem separatorItem]];
+}
+
+void Menu::InsertItem(int index,
+                      const char* name,
+                      ItemId item_id /*= NO_ITEM*/,
+                      KeyName key /*= KEY_NONE*/) {
     std::string shortcut;
     shortcut += char(key);
     NSString *objc_shortcut = [NSString stringWithUTF8String:shortcut.c_str()];
@@ -107,22 +122,35 @@ void Menu::AddItem(const char *name,
         Application::GetInstance().OnMenuItemSelected(item_id);
     }];
     item.tag = item_id;
-    [impl_->menu_ addItem:item];
+    if (index < impl_->menu_.numberOfItems) {
+        [impl_->menu_ insertItem:item atIndex: index];
+    } else {
+        [impl_->menu_ addItem:item];
+    }
 }
 
-void Menu::AddMenu(const char *name, std::shared_ptr<Menu> submenu) {
+void Menu::InsertMenu(int index, const char* name,
+                      std::shared_ptr<Menu> submenu) {
     submenu->impl_->menu_.title = [NSString stringWithUTF8String:name];
     auto item = [[NSMenuItem alloc]
                  initWithTitle:[NSString stringWithUTF8String:name]
                         action:nil
                  keyEquivalent:@""];
-    [impl_->menu_ addItem:item];
+    if (index < impl_->menu_.numberOfItems) {
+        [impl_->menu_ insertItem:item atIndex: index];
+    } else {
+        [impl_->menu_ addItem:item];
+    }
     [impl_->menu_ setSubmenu:submenu->impl_->menu_ forItem:item];
-    impl_->submenus_.push_back(submenu);
+    impl_->submenus_.insert(impl_->submenus_.begin() + index, submenu);
 }
 
-void Menu::AddSeparator() {
-    [impl_->menu_ addItem: [NSMenuItem separatorItem]];
+void Menu::InsertSeparator(int index) {
+    [impl_->menu_ insertItem: [NSMenuItem separatorItem] atIndex: index];
+}
+
+int Menu::GetNumberOfItems() const {
+    return impl_->menu_.numberOfItems;
 }
 
 bool Menu::IsEnabled(ItemId item_id) const {

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -30,6 +30,7 @@
 #include <filament/Engine.h>
 #include <imgui.h>
 #include <imgui_internal.h>  // so we can examine the current context
+#include <algorithm>
 #include <cmath>
 #include <queue>
 #include <unordered_map>
@@ -167,7 +168,8 @@ struct Window::Impl {
     Widget* mouse_grabber_widget_ = nullptr;  // only if not ImGUI widget
     Widget* focus_widget_ =
             nullptr;  // only used if ImGUI isn't taking keystrokes
-    bool wants_auto_size_and_center_ = false;
+    bool wants_auto_size_ = false;
+    bool wants_auto_center_ = false;
     bool needs_layout_ = true;
     bool is_resizing_ = false;
 };
@@ -188,10 +190,9 @@ Window::Window(const std::string& title,
                int height,
                int flags /*= 0*/)
     : impl_(new Window::Impl()) {
-    if (x == CENTERED_X || y == CENTERED_Y || width == AUTOSIZE_WIDTH ||
-        height == AUTOSIZE_HEIGHT) {
-        impl_->wants_auto_size_and_center_ = true;
-    }
+    impl_->wants_auto_center_ = (x == CENTERED_X || y == CENTERED_Y);
+    impl_->wants_auto_size_ = (width == AUTOSIZE_WIDTH || height == AUTOSIZE_HEIGHT);
+
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
@@ -206,8 +207,8 @@ Window::Window(const std::string& title,
 #if __APPLE__
     glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_TRUE);
 #endif
-    glfwWindowHint(GLFW_VISIBLE,
-                   impl_->wants_auto_size_and_center_ ? GLFW_TRUE : GLFW_FALSE);
+    bool visible = (impl_->wants_auto_size_ || impl_->wants_auto_center_);
+    glfwWindowHint(GLFW_VISIBLE, visible ? GLFW_TRUE : GLFW_FALSE);
     glfwWindowHint(GLFW_FLOATING,
                    ((flags & FLAG_TOPMOST) != 0 ? GLFW_TRUE : GLFW_FALSE));
 
@@ -821,11 +822,13 @@ void Window::OnResize() {
     io.DisplayFramebufferScale.x = 1.0f;
     io.DisplayFramebufferScale.y = 1.0f;
 
-    if (impl_->wants_auto_size_and_center_) {
-        impl_->wants_auto_size_and_center_ = false;
+    if (impl_->wants_auto_size_ || impl_->wants_auto_center_) {
         int screen_width = 1024;  // defaults in case monitor == nullptr
         int screen_height = 768;
         auto* monitor = glfwGetWindowMonitor(impl_->window_);
+        if (!monitor) {
+            monitor = glfwGetPrimaryMonitor();
+        }
         if (monitor) {
             const GLFWvidmode* mode = glfwGetVideoMode(monitor);
             if (mode) {
@@ -833,16 +836,32 @@ void Window::OnResize() {
                 screen_height = mode->height;
             }
         }
-        ImGui::NewFrame();
-        ImGui::PushFont(impl_->imgui_.system_font);
-        auto pref = CalcPreferredSize();
-        Size size(pref.width / this->impl_->imgui_.scaling,
-                  pref.height / this->impl_->imgui_.scaling);
-        glfwSetWindowSize(impl_->window_, size.width, size.height);
-        glfwSetWindowPos(impl_->window_, (screen_width - size.width) / 2,
-                         (screen_height - size.height) / 2);
-        ImGui::PopFont();
-        ImGui::EndFrame();
+
+        int w = GetOSFrame().width;
+        int h = GetOSFrame().height;
+
+        if (impl_->wants_auto_size_) {
+            ImGui::NewFrame();
+            ImGui::PushFont(impl_->imgui_.system_font);
+            auto pref = CalcPreferredSize();
+            ImGui::PopFont();
+            ImGui::EndFrame();
+
+            w = std::min(screen_width,
+                         int(std::round(pref.width / impl_->imgui_.scaling)));
+            h = std::min(screen_height,
+                         int(std::round(pref.height / impl_->imgui_.scaling)));
+            glfwSetWindowSize(impl_->window_, w, h);
+        }
+
+        if (impl_->wants_auto_center_) {
+            glfwSetWindowPos(impl_->window_, (screen_width - w) / 2,
+                             (screen_height - h) / 2);
+        }
+
+        impl_->wants_auto_size_ = false;
+        impl_->wants_auto_center_ = false;
+
         OnResize();
     }
 

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -191,7 +191,8 @@ Window::Window(const std::string& title,
                int flags /*= 0*/)
     : impl_(new Window::Impl()) {
     impl_->wants_auto_center_ = (x == CENTERED_X || y == CENTERED_Y);
-    impl_->wants_auto_size_ = (width == AUTOSIZE_WIDTH || height == AUTOSIZE_HEIGHT);
+    impl_->wants_auto_size_ =
+            (width == AUTOSIZE_WIDTH || height == AUTOSIZE_HEIGHT);
 
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -64,6 +64,9 @@ static constexpr int CENTERED_Y = -10000;
 static constexpr int AUTOSIZE_WIDTH = 0;
 static constexpr int AUTOSIZE_HEIGHT = 0;
 
+static constexpr int FALLBACK_MONITOR_WIDTH = 1024;
+static constexpr int FALLBACK_MONITOR_HEIGHT = 768;
+
 // Assumes the correct ImGuiContext is current
 void UpdateImGuiForScaling(float new_scaling) {
     ImGuiStyle& style = ImGui::GetStyle();
@@ -824,8 +827,8 @@ void Window::OnResize() {
     io.DisplayFramebufferScale.y = 1.0f;
 
     if (impl_->wants_auto_size_ || impl_->wants_auto_center_) {
-        int screen_width = 1024;  // defaults in case monitor == nullptr
-        int screen_height = 768;
+        int screen_width = FALLBACK_MONITOR_WIDTH;
+        int screen_height = FALLBACK_MONITOR_HEIGHT;
         auto* monitor = glfwGetWindowMonitor(impl_->window_);
         if (!monitor) {
             monitor = glfwGetPrimaryMonitor();

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -1045,11 +1045,8 @@ struct GuiVisualizer::Impl {
     }
 };
 
-GuiVisualizer::GuiVisualizer(const std::string &title,
-                             int width,
-                             int height)
-    : gui::Window(title, width, height),
-      impl_(new GuiVisualizer::Impl()) {
+GuiVisualizer::GuiVisualizer(const std::string &title, int width, int height)
+    : gui::Window(title, width, height), impl_(new GuiVisualizer::Impl()) {
     Init();
 }
 
@@ -1557,7 +1554,8 @@ void GuiVisualizer::SetTitle(const std::string &title) {
     Super::SetTitle(title.c_str());
 }
 
-void GuiVisualizer::AddItemsToAppMenu(const std::vector<std::pair<std::string, gui::Menu::ItemId>>& items) {
+void GuiVisualizer::AddItemsToAppMenu(
+        const std::vector<std::pair<std::string, gui::Menu::ItemId>> &items) {
 #if !defined(__APPLE__)
     return;  // application menu only exists on macOS
 #endif
@@ -1567,7 +1565,8 @@ void GuiVisualizer::AddItemsToAppMenu(const std::vector<std::pair<std::string, g
             impl_->app_menu_->InsertItem(impl_->app_menu_custom_items_index_++,
                                          it.first.c_str(), it.second);
         }
-        impl_->app_menu_->InsertSeparator(impl_->app_menu_custom_items_index_++);
+        impl_->app_menu_->InsertSeparator(
+                impl_->app_menu_custom_items_index_++);
     }
 }
 

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -627,6 +627,9 @@ struct GuiVisualizer::Impl {
         }
     } settings_;
 
+    int app_menu_custom_items_index_ = -1;
+    std::shared_ptr<gui::Menu> app_menu_;
+
     void SetMaterialsToDefault(rendering::Renderer &renderer) {
         settings_.loaded_materials_.clear();
         if (settings_.wgt_prefab_material) {
@@ -1042,6 +1045,14 @@ struct GuiVisualizer::Impl {
     }
 };
 
+GuiVisualizer::GuiVisualizer(const std::string &title,
+                             int width,
+                             int height)
+    : gui::Window(title, width, height),
+      impl_(new GuiVisualizer::Impl()) {
+    Init();
+}
+
 GuiVisualizer::GuiVisualizer(
         const std::vector<std::shared_ptr<const geometry::Geometry>>
                 &geometries,
@@ -1052,33 +1063,51 @@ GuiVisualizer::GuiVisualizer(
         int top)
     : gui::Window(title, left, top, width, height),
       impl_(new GuiVisualizer::Impl()) {
+    Init();
+    SetGeometry(geometries);  // also updates the camera
+}
+
+void GuiVisualizer::Init() {
     auto &app = gui::Application::GetInstance();
     auto &theme = GetTheme();
 
     // Create menu
     if (!gui::Application::GetInstance().GetMenubar()) {
+        auto menu = std::make_shared<gui::Menu>();
+#if defined(__APPLE__)
+        // The first menu item to be added on macOS becomes the application
+        // menu (no matter its name)
+        auto app_menu = std::make_shared<gui::Menu>();
+        app_menu->AddItem("About", HELP_ABOUT);
+        app_menu->AddSeparator();
+        impl_->app_menu_custom_items_index_ = app_menu->GetNumberOfItems();
+        app_menu->AddItem("Quit", FILE_QUIT, gui::KEY_Q);
+        menu->AddMenu("Open3D", app_menu);
+        impl_->app_menu_ = app_menu;
+#endif  // __APPLE__
         auto file_menu = std::make_shared<gui::Menu>();
         file_menu->AddItem("Open...", FILE_OPEN, gui::KEY_O);
         file_menu->AddItem("Export Current Image...", FILE_EXPORT_RGB);
         file_menu->AddSeparator();
 #if WIN32
         file_menu->AddItem("Exit", FILE_QUIT);
-#else
+#elif !defined(__APPLE__)  // quit goes in app menu on macOS
         file_menu->AddItem("Quit", FILE_QUIT, gui::KEY_Q);
 #endif
+        menu->AddMenu("File", file_menu);
+
+        auto settings_menu = std::make_shared<gui::Menu>();
+        settings_menu->AddItem("Lighting & Materials",
+                               SETTINGS_LIGHT_AND_MATERIALS);
+        settings_menu->SetChecked(SETTINGS_LIGHT_AND_MATERIALS, true);
+        menu->AddMenu("Settings", settings_menu);
+
         auto help_menu = std::make_shared<gui::Menu>();
         help_menu->AddItem("Show Controls", HELP_KEYS);
         help_menu->AddItem("Show Camera Info", HELP_CAMERA);
         help_menu->AddSeparator();
         help_menu->AddItem("About", HELP_ABOUT);
         help_menu->AddItem("Contact", HELP_CONTACT);
-        auto settings_menu = std::make_shared<gui::Menu>();
-        settings_menu->AddItem("Lighting & Materials",
-                               SETTINGS_LIGHT_AND_MATERIALS);
-        settings_menu->SetChecked(SETTINGS_LIGHT_AND_MATERIALS, true);
-        auto menu = std::make_shared<gui::Menu>();
-        menu->AddMenu("File", file_menu);
-        menu->AddMenu("Settings", settings_menu);
 #if defined(__APPLE__) && GUI_USE_NATIVE_MENUS
         // macOS adds a special search item to menus named "Help",
         // so add a space to avoid that.
@@ -1086,6 +1115,7 @@ GuiVisualizer::GuiVisualizer(
 #else
         menu->AddMenu("Help", help_menu);
 #endif
+
         gui::Application::GetInstance().SetMenubar(menu);
     }
 
@@ -1519,15 +1549,26 @@ GuiVisualizer::GuiVisualizer(
     impl_->help_camera_ = CreateCameraDisplay(this);
     impl_->help_camera_->SetVisible(false);
     AddChild(impl_->help_camera_);
-
-    // Set the actual geometries
-    SetGeometry(geometries);  // also updates the camera
 }
 
 GuiVisualizer::~GuiVisualizer() {}
 
 void GuiVisualizer::SetTitle(const std::string &title) {
     Super::SetTitle(title.c_str());
+}
+
+void GuiVisualizer::AddItemsToAppMenu(const std::vector<std::pair<std::string, gui::Menu::ItemId>>& items) {
+#if !defined(__APPLE__)
+    return;  // application menu only exists on macOS
+#endif
+
+    if (impl_->app_menu_ && impl_->app_menu_custom_items_index_ >= 0) {
+        for (auto &it : items) {
+            impl_->app_menu_->InsertItem(impl_->app_menu_custom_items_index_++,
+                                         it.first.c_str(), it.second);
+        }
+        impl_->app_menu_->InsertSeparator(impl_->app_menu_custom_items_index_++);
+    }
 }
 
 void GuiVisualizer::SetGeometry(

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.h
@@ -47,6 +47,7 @@ class GuiVisualizer : public gui::Window {
     using Super = gui::Window;
 
 public:
+    GuiVisualizer(const std::string& title, int width, int height);
     GuiVisualizer(const std::vector<std::shared_ptr<const geometry::Geometry>>&
                           geometries,
                   const std::string& title,
@@ -71,12 +72,17 @@ public:
     void Layout(const gui::Theme& theme) override;
 
 protected:
+    // Add custom items to the application menu (only relevant on macOS)
+    void AddItemsToAppMenu(const std::vector<std::pair<std::string, gui::Menu::ItemId>>& items);
+    
     void OnMenuItemSelected(gui::Menu::ItemId item_id) override;
     void OnDragDropped(const char* path) override;
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
+
+    void Init();
 };
 
 }  // namespace visualization

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.h
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.h
@@ -73,8 +73,10 @@ public:
 
 protected:
     // Add custom items to the application menu (only relevant on macOS)
-    void AddItemsToAppMenu(const std::vector<std::pair<std::string, gui::Menu::ItemId>>& items);
-    
+    void AddItemsToAppMenu(
+            const std::vector<std::pair<std::string, gui::Menu::ItemId>>&
+                    items);
+
     void OnMenuItemSelected(gui::Menu::ItemId item_id) override;
     void OnDragDropped(const char* path) override;
 


### PR DESCRIPTION
Also makes macOS menu more Mac-like, and fixes problems with auto-centering windows. Menu option only exists on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2031)
<!-- Reviewable:end -->
