### PR TITLE
Use GitHub actions again for macOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,6 +28,19 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Setup cache
+      uses: actions/cache@v2
+      with:
+        # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
+        path: ~/.ccache
+        # We include the commit sha in the cache key, as new cache entries are
+        # only created if there is no existing entry for the key yet.
+        key: ${{ runner.os }}-ccache-${{ github.sha }}
+        # Restore any ccache cache entry, if none for
+        # ${{ runner.os }}-ccache-${{ github.sha }} exists.
+        # Common prefix will be used so that ccache can be used across commits.
+        restore-keys: |
+          ${{ runner.os }}-ccache
     - name: Set up Python version
       uses: actions/setup-python@v2
       with:
@@ -35,6 +48,10 @@ jobs:
     - name: Install dependencies
       run: |
         ./util/scripts/install-deps-osx.sh
+        brew install ccache
+        ccache -M 500M  # Github's overall cache limit is 5GB
     - name: Config and build
       run: |
+        ccache -s
         ./util/scripts/run-ci.sh
+        ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,7 +47,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        ./util/scripts/install-deps-osx.sh
+        ./util/scripts/install-deps-osx.sh skip-upgrade
         brew install ccache
         ccache -M 500M  # Github's overall cache limit is 5GB
     - name: Config and build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         ./util/scripts/install-deps-osx.sh skip-upgrade
         brew install ccache
-        ccache -M 1G  # GitHub's overall cache limit is 5GB
+        ccache -M 2G  # GitHub's total cache limit is 5GB for all OSes.
     - name: Config and build
       run: |
         PATH=/usr/local/var/homebrew/linked/ccache/libexec:$PATH

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,7 @@ jobs:
         ccache -M 1G  # GitHub's overall cache limit is 5GB
     - name: Config and build
       run: |
+        PATH=/usr/local/var/homebrew/linked/ccache/libexec:$PATH
         ccache -s
         ./util/scripts/run-ci.sh
         ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,4 +37,4 @@ jobs:
         ./util/scripts/install-deps-osx.sh
     - name: Config and build
       run: |
-        ./util/scripts/run-travis.sh
+        ./util/scripts/run-ci.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,40 @@
+
+name: macOS CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    types: [opened, reopened, synchronize] # Rebuild on new pushes to PR
+
+jobs:
+  macos:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        BUILD_ML_OPS: [ON, OFF]
+    env:
+      SHARED: OFF
+      NPROC: 2
+      BUILD_DEPENDENCY_FROM_SOURCE: OFF
+      BUILD_CUDA_MODULE: OFF
+      BUILD_TENSORFLOW_OPS: ${{ matrix.BUILD_ML_OPS }}
+      BUILD_PYTORCH_OPS: ${{ matrix.BUILD_ML_OPS }}
+      LOW_MEM_USAGE: ON
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python version
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        ./util/scripts/install-deps-osx.sh
+    - name: Config and build
+      run: |
+        ./util/scripts/run-travis.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,3 @@
-
 name: macOS CI
 
 on:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         ./util/scripts/install-deps-osx.sh skip-upgrade
         brew install ccache
-        ccache -M 500M  # Github's overall cache limit is 5GB
+        ccache -M 1G  # GitHub's overall cache limit is 5GB
     - name: Config and build
       run: |
         ccache -s

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,6 +54,7 @@ jobs:
         ccache -M 1G  # GitHub's overall cache limit is 5GB
     - name: Config and build
       run: |
+        PATH=/user/lib/ccache:$PATH
         ccache -s
         ./util/scripts/run-ci.sh
         ccache -s

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         ./util/scripts/install-deps-ubuntu.sh assume-yes
         sudo apt-get --yes install ccache
-        ccache -M 1G  # GitHub's overall cache limit is 5GB
+        ccache -M 2G  # GitHub's total cache limit is 5GB for all OSes.
     - name: Config and build
       run: |
         PATH=/usr/lib/ccache:$PATH

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,7 +54,7 @@ jobs:
         ccache -M 1G  # GitHub's overall cache limit is 5GB
     - name: Config and build
       run: |
-        PATH=/user/lib/ccache:$PATH
+        PATH=/usr/lib/ccache:$PATH
         ccache -s
         ./util/scripts/run-ci.sh
         ccache -s

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -29,6 +29,19 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Setup cache
+      uses: actions/cache@v2
+      with:
+        # Ref: https://github.com/apache/incubator-mxnet/pull/18459/files
+        path: ~/.ccache
+        # We include the commit sha in the cache key, as new cache entries are
+        # only created if there is no existing entry for the key yet.
+        key: ${{ runner.os }}-ccache-${{ github.sha }}
+        # Restore any ccache cache entry, if none for
+        # ${{ runner.os }}-ccache-${{ github.sha }} exists.
+        # Common prefix will be used so that ccache can be used across commits.
+        restore-keys: |
+          ${{ runner.os }}-ccache
     - name: Set up Python version
       uses: actions/setup-python@v2
       with:
@@ -36,7 +49,11 @@ jobs:
     # Pre-installed 18.04 packages: https://git.io/JfHmW
     - name: Install dependencies
       run: |
-        ./util/scripts/setup-linux.sh
+        ./util/scripts/install-deps-ubuntu.sh assume-yes
+        sudo apt-get --yes install ccache
+        ccache -M 1G  # GitHub's overall cache limit is 5GB
     - name: Config and build
       run: |
+        ccache -s
         ./util/scripts/run-ci.sh
+        ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,38 +97,6 @@ matrix:
         - ./util/scripts/make-documentation.sh
         - ./.travis/deploy_docs.sh
 
-<<<<<<< Updated upstream
-    - os: osx
-      osx_image: xcode11.5
-      env: BUILD_TENSORFLOW_OPS=ON BUILD_PYTORCH_OPS=ON LOW_MEM_USAGE=ON
-      install:
-        - echo "Travis processors:"
-        - nproc
-        - brew update
-        - brew upgrade python || true
-          #python@3 on Travis is 3.7
-        - /usr/local/opt/python@3/bin/pip3 install virtualenv
-        - /usr/local/opt/python@3/bin/python3 -m venv ~/py3env
-        - source ~/py3env/bin/activate
-        - ./util/scripts/install-deps-osx.sh
-      script: ./util/scripts/run-ci.sh
-
-    - os: osx
-      osx_image: xcode11.5
-      env: BUILD_TENSORFLOW_OPS=OFF BUILD_PYTORCH_OPS=OFF LOW_MEM_USAGE=ON
-      install:
-        - echo "Travis processors:"
-        - nproc
-        - brew update
-        - brew upgrade python || true
-        - /usr/local/opt/python@3.8/bin/pip3 install virtualenv
-        - /usr/local/opt/python@3.8/bin/python3 -m venv ~/py3env
-        - source ~/py3env/bin/activate
-        - ./util/scripts/install-deps-osx.sh
-      script: ./util/scripts/run-ci.sh
-
-=======
->>>>>>> Stashed changes
     # - env: DOCKER=YES UBUNTU=16.04 BUNDLE=deps ENV=py3 LINK=STATIC
     #   script: ./util/docker/open3d-test/tools/test.sh $UBUNTU $BUNDLE $ENV $LINK
     #   install: sudo apt-get update && sudo apt-get install -y realpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,9 @@ matrix:
         - ./util/scripts/make-documentation.sh
         - ./.travis/deploy_docs.sh
 
+<<<<<<< Updated upstream
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode11.5
       env: BUILD_TENSORFLOW_OPS=ON BUILD_PYTORCH_OPS=ON LOW_MEM_USAGE=ON
       install:
         - echo "Travis processors:"
@@ -126,6 +127,8 @@ matrix:
         - ./util/scripts/install-deps-osx.sh
       script: ./util/scripts/run-ci.sh
 
+=======
+>>>>>>> Stashed changes
     # - env: DOCKER=YES UBUNTU=16.04 BUNDLE=deps ENV=py3 LINK=STATIC
     #   script: ./util/docker/open3d-test/tools/test.sh $UBUNTU $BUNDLE $ENV $LINK
     #   install: sudo apt-get update && sudo apt-get install -y realpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ matrix:
             - cmake
             - clang-7
             - clang-format-5.0
-      install: ./util/scripts/setup-linux.sh
+      install:
+        - ./util/scripts/install-deps-ubuntu.sh assume-yes
       script:
         - mkdir build
         - cd build
@@ -57,7 +58,7 @@ matrix:
             - libosmesa6-dev
       install:
         # Install ubuntu dependencies
-        - ./util/scripts/setup-linux.sh
+        - ./util/scripts/install-deps-ubuntu.sh assume-yes
         # Install Kinect k4a package
         - curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         - sudo apt-add-repository --yes https://packages.microsoft.com/ubuntu/18.04/prod

--- a/util/scripts/install-deps-osx.sh
+++ b/util/scripts/install-deps-osx.sh
@@ -12,16 +12,27 @@ if [[ $? != 0 ]]; then
 else
     echo "Homebrew Detected."
     echo "Performing update ..."
-    brew update
+    if [ "$1" == "skip-upgrade" ]; then
+        echo "brew update skipped."
+    else
+        # `brew update` upgrades brew itself.
+        brew update
+    fi
 fi
 
 for pkg in libusb glew glfw3 libjpeg libpng pkg-config eigen tbb; do
     if brew list -1 | grep -q "^${pkg}\$"; then
-        echo "Package '$pkg' has already been installed and is being upgraded ..."
-        brew upgrade $pkg || true # Upgrade might cause error when already installed
+        if [ "$1" == "skip-upgrade" ]; then
+            echo "Package '$pkg' has already been installed."
+        else
+            echo "Package '$pkg' has already been installed and is being upgraded ..."
+            # Using HOMEBREW_NO_AUTO_UPDATE=1 since `brew update` has already
+            # been performed if needed. Upgrade might cause error when already
+            # installed and thus `|| true` is used.
+            HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade $pkg || true
+        fi
     else
         echo "Package '$pkg' is being installed ..."
-        brew install $pkg
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install $pkg
     fi
 done
-

--- a/util/scripts/install-deps-ubuntu.sh
+++ b/util/scripts/install-deps-ubuntu.sh
@@ -18,7 +18,7 @@ if [ "$1" == "assume-yes" ]; then
     sudo apt-get --yes install libc++-7-dev || true
     sudo apt-get --yes install libc++abi-7-dev || true
     sudo apt-get --yes install ninja-build || true
-    sudo apt-get --yes install libxi-dev
+    sudo apt-get --yes install libxi-dev || true
 else
     sudo apt-get install xorg-dev libglu1-mesa-dev libgl1-mesa-glx || true
     sudo apt-get install libglew-dev || true
@@ -34,5 +34,5 @@ else
     sudo apt-get install libc++-7-dev || true
     sudo apt-get install libc++abi-7-dev || true
     sudo apt-get install ninja-build || true
-    sudo apt-get install libxi-dev
+    sudo apt-get install libxi-dev || true
 fi

--- a/util/scripts/run-ci.sh
+++ b/util/scripts/run-ci.sh
@@ -2,11 +2,12 @@
 #
 # The following environment variables are required:
 # - SHARED
-# - BUILD_TENSORFLOW_OPS
-# - BUILD_PYTORCH_OPS
+# - NPROC
 # - BUILD_DEPENDENCY_FROM_SOURCE
 # - BUILD_CUDA_MODULE
-# - NPROC
+# - BUILD_TENSORFLOW_OPS
+# - BUILD_PYTORCH_OPS
+# - LOW_MEM_USAGE
 
 set -euo pipefail
 

--- a/util/scripts/setup-linux.sh
+++ b/util/scripts/setup-linux.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# This script is used by CI only
-
-./util/scripts/install-deps-ubuntu.sh assume-yes


### PR DESCRIPTION
- Enable GitHub actions for macOS CI, disable Travis.
- Skip `brew update` for macOS on CI.
- Use `ccache` for Ubuntu and macOS builds
  - Prints `ccache` status before and each run. It shows that `cache` is indeed activated. e.g. https://github.com/intel-isl/Open3D/runs/843543441#step:6:24 and https://github.com/intel-isl/Open3D/runs/843543441#step:6:6213


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2045)
<!-- Reviewable:end -->
