### PR TITLE
TensorList refactoring and comparison tensor ops

### DIFF
--- a/cpp/open3d/core/ShapeUtil.h
+++ b/cpp/open3d/core/ShapeUtil.h
@@ -82,15 +82,26 @@ SizeVector ReductionShape(const SizeVector& src_shape,
 /// \brief Wrap around negative \p dim.
 ///
 /// E.g. If max_dim == 5, dim -1 will be converted to 4.
-int64_t WrapDim(int64_t dim, int64_t max_dim);
+///
+/// \param dim Dimension index
+/// \param max_dim Maximum dimension index
+/// \param inclusive Set to true to allow dim == max_dim. E.g. for slice
+///        T[start:end], we allow end == max_dim.
+int64_t WrapDim(int64_t dim, int64_t max_dim, bool inclusive = false);
 
-// Infers the size of a dim with size -1, if it exists. Also checks that new
-// shape is compatible with the number of elements.
-//
-// E.g. Shape({2, -1, 4}) with num_elemnts 24, will be inferred as {2, 3, 4}.
-//
-// Ref: PyTorch's aten/src/ATen/InferSize.h
+/// Infers the size of a dim with size -1, if it exists. Also checks that new
+/// shape is compatible with the number of elements.
+///
+/// E.g. Shape({2, -1, 4}) with num_elemnts 24, will be inferred as {2, 3, 4}.
+///
+/// Ref: PyTorch's aten/src/ATen/InferSize.h
 SizeVector InferShape(SizeVector shape, int64_t num_elements);
+
+/// Concatenate two shapes.
+SizeVector Concat(const SizeVector& l_shape, const SizeVector& r_shape);
+
+/// Returns a SizeVector of {0, 1, ..., n - 1}, similar to std::iota.
+SizeVector Iota(int64_t n);
 
 }  // namespace shape_util
 }  // namespace core

--- a/cpp/open3d/core/SizeVector.h
+++ b/cpp/open3d/core/SizeVector.h
@@ -71,95 +71,20 @@ public:
         if (this->size() == 0) {
             return 1;
         }
-        return std::accumulate(this->begin(), this->end(), 1LL,
-                               std::multiplies<int64_t>());
+        return std::accumulate(
+                this->begin(), this->end(), 1LL,
+                [this](const int64_t& lhs, const int64_t& rhs) -> int64_t {
+                    if (lhs < 0 || rhs < 0) {
+                        utility::LogError(
+                                "Shape {} cannot contain negative dimensions.",
+                                this->ToString());
+                    }
+                    return std::multiplies<int64_t>()(lhs, rhs);
+                });
     }
 
     std::string ToString() const { return fmt::format("{}", *this); }
 };
-
-/// \brief Wrap around negative \p dim.
-///
-/// E.g. If max_dim == 5, dim -1 will be converted to 4.
-///
-/// \param dim Dimension index
-/// \param max_dim Maximum dimension index
-/// \param inclusive Set to true to allow dim == max_dim. E.g. for slice
-///        T[start:end], we allow end == max_dim.
-static inline int64_t WrapDim(int64_t dim,
-                              int64_t max_dim,
-                              bool inclusive = false) {
-    if (max_dim <= 0) {
-        utility::LogError("max_dim {} must be >= 0");
-    }
-    int64_t min = -max_dim;
-    int64_t max = inclusive ? max_dim : max_dim - 1;
-
-    if (dim < min || dim > max) {
-        utility::LogError(
-                "Index out-of-range: dim == {}, but it must satisfy {} <= dim "
-                "<= {}",
-                dim, min, max);
-    }
-    if (dim < 0) {
-        dim += max_dim;
-    }
-    return dim;
-}
-
-// Infers the size of a dim with size -1, if it exists. Also checks that new
-// shape is compatible with the number of elements.
-//
-// E.g. Shape({2, -1, 4}) with num_elemnts 24, will be inferred as {2, 3, 4}.
-//
-// Ref: PyTorch's aten/src/ATen/InferSize.h
-inline SizeVector InferShape(SizeVector shape, int64_t num_elements) {
-    SizeVector inferred_shape = shape;
-    int64_t new_size = 1;
-    bool has_inferred_dim = false;
-    int64_t inferred_dim;
-    for (int64_t dim = 0, ndim = shape.size(); dim != ndim; dim++) {
-        if (shape[dim] == -1) {
-            if (has_inferred_dim) {
-                utility::LogError(
-                        "Proposed shape {}, but at most one dimension can be "
-                        "-1 (inferred).",
-                        shape.ToString());
-            }
-            inferred_dim = dim;
-        } else if (shape[dim] >= 0) {
-            new_size *= shape[dim];
-        } else {
-            utility::LogError("Invalid shape dimension {}", shape[dim]);
-        }
-    }
-
-    if (num_elements == new_size ||
-        (has_inferred_dim && new_size > 0 && num_elements % new_size == 0)) {
-        if (has_inferred_dim) {
-            // We have a degree of freedom here to select the dimension size;
-            // follow NumPy semantics and just bail.  However, a nice error
-            // message is needed because users often use `view` as a way to
-            // flatten & unflatten dimensions and will otherwise be confused why
-            //   empty_tensor.view( 0, 0)
-            // works yet
-            //   empty_tensor.view(-1, 0)
-            // doesn't.
-            if (new_size == 0) {
-                utility::LogError(
-                        "Cannot reshape tensor of 0 elements into shape {}, "
-                        "because the unspecified dimension size -1 can be any "
-                        "value and is ambiguous.",
-                        shape.ToString());
-            }
-            inferred_shape[inferred_dim] = num_elements / new_size;
-        }
-        return inferred_shape;
-    }
-
-    utility::LogError("Shape {} is invalid for {} number of elements.", shape,
-                      num_elements);
-}
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -136,26 +136,6 @@ public:
     }
 };
 
-/// Tensor assignment lvalue = lvalue, e.g. `tensor_a = tensor_b`
-Tensor& Tensor::operator=(const Tensor& other) & {
-    shape_ = other.shape_;
-    strides_ = other.strides_;
-    dtype_ = other.dtype_;
-    blob_ = other.blob_;
-    data_ptr_ = other.data_ptr_;
-    return *this;
-}
-
-/// Tensor assignment lvalue = rvalue, e.g. `tensor_a = tensor_b[0]`
-Tensor& Tensor::operator=(Tensor&& other) & {
-    shape_ = other.shape_;
-    strides_ = other.strides_;
-    dtype_ = other.dtype_;
-    blob_ = other.blob_;
-    data_ptr_ = other.data_ptr_;
-    return *this;
-}
-
 /// Tensor assignment rvalue = lvalue, e.g. `tensor_a[0] = tensor_b`
 Tensor& Tensor::operator=(const Tensor& other) && {
     kernel::Copy(other, *this);
@@ -597,8 +577,8 @@ Tensor Tensor::IndexExtract(int64_t dim, int64_t idx) const {
     if (shape_.size() == 0) {
         utility::LogError("Tensor has shape (), cannot be indexed.");
     }
-    dim = WrapDim(dim, NumDims());
-    idx = WrapDim(idx, shape_[dim]);
+    dim = shape_util::WrapDim(dim, NumDims());
+    idx = shape_util::WrapDim(idx, shape_[dim]);
 
     SizeVector new_shape(shape_);
     new_shape.erase(new_shape.begin() + dim);
@@ -616,7 +596,7 @@ Tensor Tensor::Slice(int64_t dim,
     if (shape_.size() == 0) {
         utility::LogError("Slice cannot be applied to 0-dim Tensor");
     }
-    dim = WrapDim(dim, NumDims());
+    dim = shape_util::WrapDim(dim, NumDims());
     if (dim < 0 || dim >= static_cast<int64_t>(shape_.size())) {
         utility::LogError("Dim {} is out of bound for SizeVector of length {}",
                           dim, shape_.size());
@@ -625,8 +605,8 @@ Tensor Tensor::Slice(int64_t dim,
     if (step == 0) {
         utility::LogError("Step size cannot be 0");
     }
-    start = WrapDim(start, shape_[dim]);
-    stop = WrapDim(stop, shape_[dim], /*inclusive=*/true);
+    start = shape_util::WrapDim(start, shape_[dim]);
+    stop = shape_util::WrapDim(stop, shape_[dim], /*inclusive=*/true);
     if (stop < start) {
         stop = start;
     }
@@ -1035,6 +1015,20 @@ std::vector<Tensor> Tensor::NonZeroNumpy() const {
 
 Tensor Tensor::NonZero() const { return kernel::NonZero(*this); }
 
+bool Tensor::All() const {
+    Tensor dst({}, dtype_, GetDevice());
+    kernel::Reduction(*this, dst, shape_util::Iota(NumDims()), false,
+                      kernel::ReductionOpCode::All);
+    return dst.Item<bool>();
+}
+
+bool Tensor::Any() const {
+    Tensor dst({}, dtype_, GetDevice());
+    kernel::Reduction(*this, dst, shape_util::Iota(NumDims()), false,
+                      kernel::ReductionOpCode::Any);
+    return dst.Item<bool>();
+}
+
 DLManagedTensor* Tensor::ToDLPack() const {
     return Open3DDLManagedTensor::Create(*this);
 }
@@ -1126,6 +1120,38 @@ Tensor Tensor::FromDLPack(const DLManagedTensor* src) {
                   reinterpret_cast<char*>(blob->GetDataPtr()) +
                           src->dl_tensor.byte_offset,
                   dtype, blob);
+}
+
+bool Tensor::AllClose(const Tensor& other, double rtol, double atol) const {
+    // TODO: support nan;
+    return IsClose(other, rtol, atol).All();
+}
+
+Tensor Tensor::IsClose(const Tensor& other, double rtol, double atol) const {
+    if (GetDevice() != other.GetDevice()) {
+        utility::LogError("Device mismatch {} != {}.", GetDevice().ToString(),
+                          other.GetDevice().ToString());
+    }
+    if (dtype_ != other.dtype_) {
+        utility::LogError("Dtype mismatch {} != {}.",
+                          DtypeUtil::ToString(dtype_),
+                          DtypeUtil::ToString(other.dtype_));
+    }
+    if (shape_ != other.shape_) {
+        utility::LogError("Shape mismatch {} != {}.", shape_, other.shape_);
+    }
+
+    Tensor lhs = this->To(Dtype::Float64);
+    Tensor rhs = other.To(Dtype::Float64);
+    Tensor actual_error = (lhs - rhs).Abs();
+    Tensor max_error = atol + rtol * rhs.Abs();
+    return actual_error <= max_error;
+}
+
+bool Tensor::IsSame(const Tensor& other) const {
+    return blob_ == other.blob_ && shape_ == other.shape_ &&
+           strides_ == other.strides_ && data_ptr_ == other.data_ptr_ &&
+           dtype_ == other.dtype_;
 }
 
 }  // namespace core

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -136,6 +136,30 @@ public:
     }
 };
 
+// Equivalent to `Tensor& operator=(const Tensor& other) & = default;`.
+// Manual implentaiton is need to avoid MSVC bug (error C2580:  multiple
+// versions of a defaulted special member functions are not allowed.)
+Tensor& Tensor::operator=(const Tensor& other) & {
+    shape_ = other.shape_;
+    strides_ = other.strides_;
+    dtype_ = other.dtype_;
+    blob_ = other.blob_;
+    data_ptr_ = other.data_ptr_;
+    return *this;
+}
+
+// Equivalent to `Tensor& operator=(Tensor&& other) & = default;`.
+// Manual implentaiton is need to avoid MSVC bug (error C2580:  multiple
+// versions of a defaulted special member functions are not allowed.)
+Tensor& Tensor::operator=(Tensor&& other) & {
+    shape_ = other.shape_;
+    strides_ = other.strides_;
+    dtype_ = other.dtype_;
+    blob_ = other.blob_;
+    data_ptr_ = other.data_ptr_;
+    return *this;
+}
+
 /// Tensor assignment rvalue = lvalue, e.g. `tensor_a[0] = tensor_b`
 Tensor& Tensor::operator=(const Tensor& other) && {
     kernel::Copy(other, *this);

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -105,11 +105,11 @@ public:
 
     /// Tensor assignment lvalue = lvalue, e.g. `tensor_a = tensor_b`.
     /// This results in a "shallow" copy.
-    Tensor& operator=(const Tensor& other) & = default;
+    Tensor& operator=(const Tensor& other) &;
 
     /// Tensor assignment lvalue = rvalue, e.g. `tensor_a = tensor_b[0]`.
     /// This results in a "shallow" copy.
-    Tensor& operator=(Tensor&& other) & = default;
+    Tensor& operator=(Tensor&& other) &;
 
     /// Tensor assignment rvalue = lvalue, e.g. `tensor_a[0] = tensor_b`.
     /// An actual copy of the data will be performed.

--- a/cpp/open3d/core/TensorList.h
+++ b/cpp/open3d/core/TensorList.h
@@ -40,133 +40,213 @@
 namespace open3d {
 namespace core {
 
-/// A TensorList is an extendable tensor at the 0-th dimension.
-/// It is similar to std::vector<Tensor>, but uses Open3D's tensor memory
-/// management system.
+/// A tensorlist is a list of Tensors of the same shape, similar to
+/// std::vector<Tensor>. Internally, a tensorlist stores the Tensors in one
+/// bigger internal tensor, where the begin dimension of the internal tensor is
+/// extendable.
 ///
-/// Typical use cases:
-/// - Pointcloud: (N, 3)
-/// - Sparse Voxel Grid: (N, 8, 8, 8)
+/// Examples:
+/// - A 3D point cloud with N points:
+///   - element_shape        : (3,)
+///   - reserved_size        : M, where M >= N
+///   - internal_tensor.shape: (M, 3)
+/// - Sparse voxel grid of N voxels:
+///   - element_shape        : (8, 8, 8)
+///   - reserved_size        : M, where M >= N
+///   - internal_tensor.shape: (M, 8, 8, 8)
 class TensorList {
 public:
-    /// Constructor for creating an (empty by default) tensor list.
+    TensorList() = delete;
+
+    /// Constructs an empty tensorlist.
     ///
-    /// \param shape Shape for the contained tensors. e.g.
-    /// (3) for a list points,
-    /// (8, 8, 8) for a list of voxel blocks.
-    /// \param dtype Type for the contained tensors. e.g. Dtype::Int64.
-    /// \param device Device to store the contained tensors. e.g. "CPU:0".
-    /// \param size Size of 0-th dimension.
-    TensorList(const SizeVector& shape,
+    /// \param element_shape Shape of the contained tensors, e.g. {3,}. 0-sized
+    /// and scalar element_shape are allowed.
+    /// \param dtype Data type of the contained tensors. e.g. Dtype::Float32.
+    /// \param device Device of the contained tensors. e.g. Device("CPU:0").
+    TensorList(const SizeVector& element_shape,
                Dtype dtype,
-               const Device& device = Device("CPU:0"),
-               const int64_t& size = 0);
-
-    /// Constructor from a vector with broadcastable tensors.
-    ///
-    /// \param tensors A vector of tensors. The tensors must be broadcastable to
-    /// a common shape, which will be set as the shape of the TensorList. The
-    /// tensors must be on the same device and have the same dtype.
-    /// \param device Device to store the contained tensors. e.g. "CPU:0".
-    TensorList(const std::vector<Tensor>& tensors,
-               const Device& device = Device("CPU:0"));
-
-    /// Constructor from a list of broadcastable tensors.
-    ///
-    /// \param tensors A list of tensors. The tensors must be broadcastable to
-    /// a common shape, which will be set as the shape of the TensorList.
-    /// \param device Ddevice to store the contained tensors. e.g. "CPU:0".
-    TensorList(const std::initializer_list<Tensor>& tensors,
-               const Device& device = Device("CPU:0"));
-
-    /// Constructor from iterators, an abstract wrapper for std vectors
-    /// and initializer lists.
-    template <class InputIterator>
-    TensorList(InputIterator first,
-               InputIterator last,
                const Device& device = Device("CPU:0"))
-        : device_(device) {
-        ConstructFromIterators(first, last);
+        : element_shape_(element_shape),
+          size_(0),
+          reserved_size_(ComputeReserveSize(0)),
+          internal_tensor_(shape_util::Concat({reserved_size_}, element_shape_),
+                           dtype,
+                           device) {}
+
+    /// Constructs a tensorlist from a vector of Tensors. The tensors must have
+    /// the same shape, dtype and device. Values will be copied.
+    ///
+    /// \param tensors A vector of tensors. The tensors must have common shape,
+    /// dtype and device.
+    TensorList(const std::vector<Tensor>& tensors)
+        : TensorList(tensors.begin(), tensors.end()) {}
+
+    /// Constructs a tensorlist from a list of Tensors. The tensors must have
+    /// the same shape, dtype and device. Values will be copied.
+    ///
+    /// \param tensors A list of tensors. The tensors must have common shape,
+    /// dtype and device.
+    TensorList(const std::initializer_list<Tensor>& tensors)
+        : TensorList(tensors.begin(), tensors.end()) {}
+
+    /// Constructs a tensorlist from Tensor iterator. The tensors must have
+    /// the same shape, dtype and device. Values will be copied.
+    ///
+    /// \param begin Begin iterator.
+    /// \param end End iterator.
+    template <class InputIterator>
+    TensorList(InputIterator begin, InputIterator end) {
+        int64_t size = std::distance(begin, end);
+        if (size == 0) {
+            utility::LogError(
+                    "Empty input tensors cannot initialize a tensorlist.");
+        }
+
+        // Set size_ and reserved_size_.
+        size_ = size;
+        reserved_size_ = ComputeReserveSize(size_);
+
+        // Check shape consistency and set element_shape_.
+        element_shape_ = begin->GetShape();
+        std::for_each(begin, end, [&](const Tensor& tensor) -> void {
+            if (tensor.GetShape() != element_shape_) {
+                utility::LogError(
+                        "Tensors must have the same shape {}, but got {}.",
+                        element_shape_, tensor.GetShape());
+            }
+        });
+
+        // Check dtype consistency.
+        Dtype dtype = begin->GetDtype();
+        std::for_each(begin, end, [&](const Tensor& tensor) -> void {
+            if (tensor.GetDtype() != dtype) {
+                utility::LogError(
+                        "Tensors must have the same dtype {}, but got {}.",
+                        DtypeUtil::ToString(dtype),
+                        DtypeUtil::ToString(tensor.GetDtype()));
+            }
+        });
+
+        // Check device consistency.
+        Device device = begin->GetDevice();
+        std::for_each(begin, end, [&](const Tensor& tensor) -> void {
+            if (tensor.GetDevice() != device) {
+                utility::LogError(
+                        "Tensors must have the same device {}, but got {}.",
+                        device.ToString(), tensor.GetDevice().ToString());
+            }
+        });
+
+        // Construct internal tensor.
+        internal_tensor_ =
+                Tensor(shape_util::Concat({reserved_size_}, element_shape_),
+                       dtype, device);
+        size_t i = 0;
+        for (auto iter = begin; iter != end; ++iter, ++i) {
+            internal_tensor_[i] = *iter;
+        }
     }
 
-    /// Constructor from a raw internal tensor.
-    /// The inverse of AsTensor().
+    /// Factory function to create tensorlist from a Tensor.
     ///
-    /// \param internal_tensor raw tensor
-    /// \param inplace:
-    /// - If true (default), reuse the raw internal tensor. The input tensor
-    /// must be contiguous.
-    /// - If false, create a new contiguous internal tensor with precomputed
-    /// reserved size.
-    TensorList(const Tensor& internal_tensor, bool inplace = true);
-
-    /// Factory constructor from a raw tensor
+    /// \param tensor The input tensor. The tensor must have at least one
+    /// dimension (tensor.NumDims() >= 1). The first dimension of the tensor
+    /// will be used as the "size" dimension of the tensorlist, while the
+    /// remaining dimensions will be used as the element shape of the tensor
+    /// list. For example, if the input tensor has shape (2, 3, 4), the
+    /// resulting tensorlist will have size 2 and element shape (3, 4).
+    ///
+    /// \param inplace If `inplace == true`, the tensorlist shares the same
+    /// memory with the input tensor. The input tensor must be contiguous. The
+    /// resulting tensorlist cannot be extended. If `inplace == false`, the
+    /// tensor values will be copied when creating the tensorlist.
     static TensorList FromTensor(const Tensor& tensor, bool inplace = false);
 
-    /// Copy constructor from a tensor list.
-    /// Create a new tensor list with copy of data.
-    TensorList(const TensorList& other);
+    /// Copy constructor for tensorlist. The internal tensor will share the same
+    /// memory as the input. Also see: the copy constructor for Tensor.
+    TensorList(const TensorList& other) = default;
 
-    /// Deep copy
+    /// Move constructor for tensorlist. The internal tensor will share the same
+    /// memory as the input. Also see: the move constructor for Tensor.
+    TensorList(TensorList&& other) = default;
+
+    /// Copy assignment operator. The internal tensor will share the same memory
+    /// as the input.
+    TensorList& operator=(const TensorList& other) & = default;
+
+    /// Move assignment operator. The internal tensor will share the same memory
+    /// as the input.
+    TensorList& operator=(TensorList&& other) & = default;
+
+    /// Performs actual copy from another tensorlist. The internal tensor will
+    /// be explicitly copied. All attributes will be copied and replaced. The
+    /// returned tensor will always be resizable.
     void CopyFrom(const TensorList& other);
 
-    /// TensorList assignment lvalue = lvalue, e.g.
-    /// `tensorlist_a = tensorlist_b`,
-    /// resulting in a shallow copy.
-    /// We don't redirect Slice operation to tensors, so right value assignment
-    /// is not explicitly supported.
-    TensorList& operator=(const TensorList& other) &;
-
-    /// Shallow copy
+    /// Performs "shallow" copy from another tensorlist. The internal tensor
+    /// memory will be shared.
     void ShallowCopyFrom(const TensorList& other);
+
+    /// Duplicate the current tensorlist. Values will be copied. The returned
+    /// tensor will always be resizable.
+    TensorList Copy() const;
 
     /// Return the reference of the contained valid tensors with shared memory.
     Tensor AsTensor() const;
 
-    /// Resize an existing tensor list.
-    /// If the size increases, the increased part will be assigned 0.
-    /// If the size decreases, the decreased part's value will be undefined.
-    void Resize(int64_t n);
+    /// Resize tensorlist.
+    /// If the size increases, the increased part will be initialized with 0.
+    /// If the size decreases, the reserved_size_ remain unchanged. This
+    /// operation is only valid for resizable tensorlist.
+    void Resize(int64_t new_size);
 
-    /// Push back the copy of a tensor to the list.
-    /// The tensor must broadcastable to the TensorList's shape.
-    /// The tensor must be on the same device and have the same dtype.
+    /// Push back a tensor to the tensorlist. The values will be copied. This
+    /// operation is only valid for resizable tensorlist.
+    ///
+    /// \param tensor The tensor to to be copied to the end of the tensorlist.
+    /// The tensor must be of the same shape, dtype and device as the tensot
+    /// list.
     void PushBack(const Tensor& tensor);
 
-    /// Concatenate two TensorLists.
-    /// Return a new TensorList with data copied.
-    /// Two TensorLists must have the same shape, type, and device.
+    /// Extend the current tensorlist with another tensorlist appended to the
+    /// end. The data is copied. The two tensorlists must have the same
+    /// element_shape, dtype, and device. This operation is only valid for
+    /// resizable tensorlist.
+    void Extend(const TensorList& other);
+
+    /// Concatenate two tensorlists.
+    /// Return a new tensorlists with data copied.
+    /// Two tensorlists must have the same element_shape, type, and device.
     static TensorList Concatenate(const TensorList& a, const TensorList& b);
 
-    /// Concatenate two TensorLists.
+    /// Concatenate two tensorlists.
     TensorList operator+(const TensorList& other) const {
         return Concatenate(*this, other);
     }
 
-    /// Extend the current TensorList with another TensorList appended to the
-    /// end. The data is copied. The two TensorLists must have the same shape,
-    /// dtype, and device.
-    void Extend(const TensorList& other);
-
+    /// Inplace concatenate with another tensorlist. This operation is only
+    /// valid for resizable tensorlist.
     TensorList& operator+=(const TensorList& other) {
         Extend(other);
         return *this;
     }
 
-    /// Extract the i-th Tensor along the first axis, returning a new view.
+    /// Extract the i-th Tensor along the begin axis, returning a new view.
     /// For advanced indexing like Slice, use tensorlist.AsTensor().Slice().
     Tensor operator[](int64_t index) const;
 
-    /// Clear the tensor list by discarding all data and creating a empty one.
+    /// Clear the tensorlist by disgarding the internal tensor and resetting the
+    /// size to 0. This operation is only valid for resizable tensorlist.
     void Clear();
 
     std::string ToString() const;
 
-    SizeVector GetShape() const { return shape_; }
+    SizeVector GetElementShape() const { return element_shape_; }
 
-    Device GetDevice() const { return device_; }
+    Device GetDevice() const { return internal_tensor_.GetDevice(); }
 
-    Dtype GetDtype() const { return dtype_; }
+    Dtype GetDtype() const { return internal_tensor_.GetDtype(); }
 
     int64_t GetSize() const { return size_; }
 
@@ -174,86 +254,62 @@ public:
 
     const Tensor& GetInternalTensor() const { return internal_tensor_; }
 
+    bool IsResizable() const { return is_resizable_; }
+
 protected:
-    // The shared internal constructor for iterators.
-    template <class InputIterator>
-    void ConstructFromIterators(InputIterator first, InputIterator last) {
-        int64_t size = std::distance(first, last);
-        if (size == 0) {
-            utility::LogError(
-                    "Empty input tensors cannot initialize a TensorList.");
-        }
+    /// Fully specified constructor.
+    TensorList(const SizeVector element_shape,
+               int64_t size,
+               int64_t reserved_size,
+               const Tensor& internal_tensor,
+               bool is_resizable)
+        : element_shape_(element_shape),
+          size_(size),
+          reserved_size_(reserved_size),
+          internal_tensor_(internal_tensor),
+          is_resizable_(is_resizable) {}
 
-        // Infer size and reserved_size
-        size_ = size;
-        reserved_size_ = ReserveSize(size_);
-
-        // Infer shape
-        shape_ = std::accumulate(
-                std::next(first), last, first->GetShape(),
-                [](const SizeVector shape, const Tensor& tensor) {
-                    return shape_util::BroadcastedShape(std::move(shape),
-                                                        tensor.GetShape());
-                });
-
-        // Infer dtype
-        dtype_ = first->GetDtype();
-        bool dtype_consistent = std::accumulate(
-                std::next(first), last, true,
-                [&](bool same_type, const Tensor& tensor) {
-                    return same_type && (dtype_ == tensor.GetDtype());
-                });
-        if (!dtype_consistent) {
-            utility::LogError(
-                    "Inconsistent tensor dtypes in tensors are not supported "
-                    "in TensorList.");
-        }
-
-        // Construct internal tensor
-        SizeVector expanded_shape = ExpandFrontDim(shape_, reserved_size_);
-        internal_tensor_ = Tensor(expanded_shape, dtype_, device_);
-
-        // Assign tensors
-        size_t i = 0;
-        for (auto iter = first; iter != last; ++iter, ++i) {
-            internal_tensor_[i] = *iter;
-        }
-    }
-
-    /// Expand the size of the internal tensor.
-    void ExpandTensor(int64_t new_reserved_size);
-
-    /// Expand the shape in the first indexing dimension.
-    /// e.g. (8, 8, 8) -> (1, 8, 8, 8)
-    static SizeVector ExpandFrontDim(const SizeVector& shape,
-                                     int64_t new_dim_size = 1);
+    /// Expand internal tensor to be larger or equal to the requested size. If
+    /// the current reserved size is smaller than the requested size, the
+    /// reserved size will be increased, a new internal tensor will be allocated
+    /// and the original data will be copied. If the current reserved size is
+    /// larger than or equal to the requested size, no operation will be
+    /// performed.
+    ///
+    /// \param new_size The requested size.
+    void ResizeWithExpand(int64_t new_size);
 
     /// Compute the reserved size for the desired number of tensors
     /// with reserved_size_ = (1 << (ceil(log2(size_)) + 1)).
-    int64_t ReserveSize(int64_t n);
+    static int64_t ComputeReserveSize(int64_t size);
 
 protected:
-    /// The shape_ represents the shape for each element in the TensorList.
-    /// The internal_tensor_'s shape is (reserved_size_, *shape_).
-    SizeVector shape_;
+    /// The shape for each element tensor in the tensorlist.
+    SizeVector element_shape_;
 
-    Dtype dtype_;
-    Device device_;
-
-    /// Number of active (valid) elements in TensorList.
+    /// Number of active (valid) elements in tensorlist.
     /// The internal_tensor_ has shape (reserved_size_, *shape_), but only the
     /// front (size_, *shape_) is active.
     int64_t size_ = 0;
 
-    /// Maximum number of elements in TensorList.
-    /// The internal_tensor_'s shape is (reserved_size_, *shape_).
-    /// In general, reserved_size_ >= (1 << (ceil(log2(size_)) + 1))
-    /// as conventionally done in std::vector.
-    /// Examples: (size_, reserved_size_) = (3, 8), (4, 8), (5, 16).
+    /// Maximum number of elements in tensorlist.
+    ///
+    /// The internal_tensor_'s shape is (reserved_size_, *element_shape_). In
+    /// general, reserved_size_ >= (1 << (ceil(log2(size_)) + 1)) as
+    /// conventionally done in std::vector.
+    ///
+    /// Examples: size_ = 3, reserved_size_ = 8
+    ///           size_ = 4, reserved_size_ = 8
+    ///           size_ = 5, reserved_size_ = 16
     int64_t reserved_size_ = 0;
 
     /// The internal tensor for data storage.
     Tensor internal_tensor_;
+
+    /// Whether the tensorlist is resizable. Typically, if the tensorlist is
+    /// created with pre-allocated shared buffer, the tensorlist is not
+    /// resizable.
+    bool is_resizable_ = true;
 };
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/kernel/Reduction.cpp
+++ b/cpp/open3d/core/kernel/Reduction.cpp
@@ -38,7 +38,7 @@ void Reduction(const Tensor& src,
                ReductionOpCode op_code) {
     // For ArgMin and ArgMax, keepdim == false, and dims can only contain one or
     // all dimensions.
-    if (arg_reduce_ops.find(op_code) != arg_reduce_ops.end()) {
+    if (s_arg_reduce_ops.find(op_code) != s_arg_reduce_ops.end()) {
         if (keepdim) {
             utility::LogError("Arg-reduction keepdim must be false");
         }

--- a/cpp/open3d/core/kernel/Reduction.h
+++ b/cpp/open3d/core/kernel/Reduction.h
@@ -37,13 +37,34 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-enum class ReductionOpCode { Sum, Prod, Min, Max, ArgMin, ArgMax };
+enum class ReductionOpCode {
+    Sum,
+    Prod,
+    Min,
+    Max,
+    ArgMin,
+    ArgMax,
+    All,
+    Any,
+};
 
 static const std::unordered_set<ReductionOpCode, utility::hash_enum_class>
-        regular_reduce_ops = {ReductionOpCode::Sum, ReductionOpCode::Prod,
-                              ReductionOpCode::Min, ReductionOpCode::Max};
+        s_regular_reduce_ops = {
+                ReductionOpCode::Sum,
+                ReductionOpCode::Prod,
+                ReductionOpCode::Min,
+                ReductionOpCode::Max,
+};
 static const std::unordered_set<ReductionOpCode, utility::hash_enum_class>
-        arg_reduce_ops = {ReductionOpCode::ArgMin, ReductionOpCode::ArgMax};
+        s_arg_reduce_ops = {
+                ReductionOpCode::ArgMin,
+                ReductionOpCode::ArgMax,
+};
+static const std::unordered_set<ReductionOpCode, utility::hash_enum_class>
+        s_boolean_reduce_ops = {
+                ReductionOpCode::All,
+                ReductionOpCode::Any,
+};
 
 void Reduction(const Tensor& src,
                Tensor& dst,

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -387,9 +387,11 @@ void pybind_core_tensor(py::module& m) {
     tensor.def("logical_not", &core::Tensor::LogicalNot);
     tensor.def("logical_not_", &core::Tensor::LogicalNot_);
 
-    // Boolean find
+    // Boolean
     tensor.def("_non_zero", &core::Tensor::NonZero);
     tensor.def("_non_zero_numpy", &core::Tensor::NonZeroNumpy);
+    tensor.def("all", &core::Tensor::All);
+    tensor.def("any", &core::Tensor::Any);
 
     // Reduction ops
     tensor.def("sum", &core::Tensor::Sum);
@@ -400,6 +402,14 @@ void pybind_core_tensor(py::module& m) {
     tensor.def("argmin_", &core::Tensor::ArgMin);
     tensor.def("argmax_", &core::Tensor::ArgMax);
 
+    // Comparison
+    tensor.def("allclose", &core::Tensor::AllClose, "other"_a, "rtol"_a = 1e-5,
+               "atol"_a = 1e-8);
+    tensor.def("isclose", &core::Tensor::IsClose, "other"_a, "rtol"_a = 1e-5,
+               "atol"_a = 1e-8);
+    tensor.def("issame", &core::Tensor::IsSame);
+
+    // Print tensor
     tensor.def("__repr__",
                [](const core::Tensor& tensor) { return tensor.ToString(); });
     tensor.def("__str__",

--- a/cpp/pybind/core/tensorlist.cpp
+++ b/cpp/pybind/core/tensorlist.cpp
@@ -47,59 +47,61 @@ void pybind_core_tensorlist(py::module& m) {
             m, "TensorList",
             "A TensorList is an extendable tensor at the 0-th dimension.");
 
-    tensorlist
-            .def(py::init(
-                    [](const core::SizeVector& shape, const core::Dtype& dtype,
-                       const core::Device& device, const int64_t& size = 0) {
-                        core::TensorList tl =
-                                core::TensorList(shape, dtype, device, size);
-                        return tl;
-                    }))
-            .def("shallow_copy_from", &core::TensorList::ShallowCopyFrom)
-            .def("copy_from", &core::TensorList::CopyFrom)
-            // Construct from existing tensors with compatible shapes
-            .def("from_tensors",
-                 [](const std::vector<core::Tensor>& tensors,
-                    const core::Device& device) {
-                     core::TensorList tl = core::TensorList(tensors, device);
-                     return tl;
-                 })
-            // Construct from existing internal tensor with at least one valid
-            // dimension
-            .def_static("from_tensor", &core::TensorList::FromTensor)
-            .def("tensor",
-                 [](const core::TensorList& tl) { return tl.AsTensor(); })
-            .def("push_back",
-                 [](core::TensorList& tl, const core::Tensor& tensor) {
-                     return tl.PushBack(tensor);
-                 })
-            .def("resize",
-                 [](core::TensorList& tl, int64_t n) { return tl.Resize(n); })
-            .def("extend",
-                 [](core::TensorList& tl_a, const core::TensorList& tl_b) {
-                     return tl_a.Extend(tl_b);
-                 })
-            .def("size",
-                 [](const core::TensorList& tl) { return tl.GetSize(); })
+    // Constructors.
+    tensorlist.def(
+            py::init([](const core::SizeVector& element_shape,
+                        const core::Dtype& dtype, const core::Device& device) {
+                return new core::TensorList(element_shape, dtype, device);
+            }),
+            "element_shape"_a, "dtype"_a, "device"_a);
+    tensorlist.def(py::init([](const std::vector<core::Tensor>& tensors) {
+                       return new core::TensorList(tensors);
+                   }),
+                   "tensors"_a);
+    tensorlist.def(py::init([](const core::TensorList& other) {
+                       return new core::TensorList(other);
+                   }),
+                   "other"_a);
 
-            .def("_getitem",
-                 [](core::TensorList& tl, int64_t index) { return tl[index]; })
-            .def("_setitem",
-                 [](core::TensorList& tl, int64_t index,
-                    const core::Tensor& value) { tl[index].SetItem(value); })
+    // Factory function.
+    tensorlist.def_static("from_tensor", &core::TensorList::FromTensor,
+                          "tensor"_a, "inplace"_a = false);
 
-            .def(py::self + py::self)
-            .def(py::self += py::self)
-            .def("__repr__",
-                 [](const core::TensorList& tl) { return tl.ToString(); })
-            .def_static("concat", [](const core::TensorList& tl_a,
-                                     const core::TensorList& tl_b) {
-                return core::TensorList::Concatenate(tl_a, tl_b);
-            });
+    // Copiers.
+    tensorlist.def("shallow_copy_from", &core::TensorList::ShallowCopyFrom);
+    tensorlist.def("copy_from", &core::TensorList::CopyFrom);
+    tensorlist.def("copy", &core::TensorList::Copy);
 
-    tensorlist.def_property_readonly("shape", &core::TensorList::GetShape);
+    // Accessors.
+    tensorlist.def("__getitem__", [](core::TensorList& tl, int64_t index) {
+        return tl[index];
+    });
+    tensorlist.def("__setitem__",
+                   [](core::TensorList& tl, int64_t index,
+                      const core::Tensor& value) { tl[index] = value; });
+    tensorlist.def("as_tensor",
+                   [](const core::TensorList& tl) { return tl.AsTensor(); });
+    tensorlist.def("__repr__",
+                   [](const core::TensorList& tl) { return tl.ToString(); });
+    tensorlist.def("__str__",
+                   [](const core::TensorList& tl) { return tl.ToString(); });
+
+    // Manipulations.
+    tensorlist.def("push_back", &core::TensorList::PushBack);
+    tensorlist.def("resize", &core::TensorList::Resize);
+    tensorlist.def("extend", &core::TensorList::Extend);
+    tensorlist.def("__iadd__", &core::TensorList::operator+=);
+    tensorlist.def("__add__", &core::TensorList::operator+);
+    tensorlist.def_static("concat", &core::TensorList::Concatenate);
+
+    // Properties.
+    tensorlist.def_property_readonly("size", &core::TensorList::GetSize);
+    tensorlist.def_property_readonly("element_shape",
+                                     &core::TensorList::GetElementShape);
     tensorlist.def_property_readonly("dtype", &core::TensorList::GetDtype);
     tensorlist.def_property_readonly("device", &core::TensorList::GetDevice);
+    tensorlist.def_property_readonly("is_resizable",
+                                     &core::TensorList::IsResizable);
 }
 
 }  // namespace open3d

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -65,13 +65,19 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(TensorPermuteDevices, Constructor) {
     core::Device device = GetParam();
-
-    core::SizeVector shape{2, 3};
     core::Dtype dtype = core::Dtype::Float32;
-    core::Tensor t(shape, dtype, device);
 
-    EXPECT_EQ(t.GetShape(), shape);
-    EXPECT_EQ(t.GetBlob()->GetDevice(), device);
+    for (const core::SizeVector &shape : std::vector<core::SizeVector>{
+                 {}, {0}, {0, 0}, {0, 1}, {1, 0}, {2, 3}}) {
+        core::Tensor t(shape, dtype, device);
+        EXPECT_EQ(t.GetShape(), shape);
+        EXPECT_EQ(t.GetDtype(), dtype);
+        EXPECT_EQ(t.GetDevice(), device);
+    }
+
+    EXPECT_ANY_THROW(core::Tensor({-1}, dtype, device));
+    EXPECT_ANY_THROW(core::Tensor({0, -2}, dtype, device));
+    EXPECT_ANY_THROW(core::Tensor({-1, -1}, dtype, device));
 }
 
 TEST_P(TensorPermuteDevices, ConstructorBool) {
@@ -363,6 +369,21 @@ TEST_P(TensorPermuteDevices, Item) {
     core::Tensor t_1_2_3 = t[1][2][3];
     EXPECT_THROW(t_1_2_3.Item<int32_t>(), std::runtime_error);
     EXPECT_EQ(t_1_2_3.Item<float>(), 23.f);
+}
+
+TEST_P(TensorPermuteDevices, ItemBool) {
+    core::Device device = GetParam();
+
+    std::vector<bool> vals{true, true, false};
+    core::Tensor t(vals, {3}, core::Dtype::Bool, device);
+
+    core::Tensor t_0 = t[0];
+    EXPECT_THROW(t_0.Item<float>(), std::runtime_error);
+    EXPECT_THROW(t_0.Item<uint8_t>(), std::runtime_error);
+
+    EXPECT_EQ(t[0].Item<bool>(), true);
+    EXPECT_EQ(t[1].Item<bool>(), true);
+    EXPECT_EQ(t[2].Item<bool>(), false);
 }
 
 TEST_P(TensorPermuteDevices, ItemAssign) {
@@ -2474,6 +2495,50 @@ TEST_P(TensorPermuteDevices, ToDLPackFromDLPack) {
                       core::DtypeUtil::ByteSize(core::Dtype::Float32) * 3 * 4);
     EXPECT_EQ(dst_t.ToFlatVector<float>(),
               std::vector<float>({12, 14, 20, 22}));
+}
+
+TEST_P(TensorPermuteDevices, IsSame) {
+    core::Device device = GetParam();
+
+    // "Shallow" copy.
+    core::Tensor t0 = core::Tensor::Ones({6, 8}, core::Dtype::Float32, device);
+    core::Tensor t1 = t0;  // "Shallow" copy
+    EXPECT_TRUE(t0.IsSame(t1));
+    EXPECT_TRUE(t1.IsSame(t0));
+
+    // Copy constructor copies view.
+    core::Tensor t0_copy_construct(t0);
+    EXPECT_TRUE(t0.IsSame(t0_copy_construct));
+    EXPECT_TRUE(t0_copy_construct.IsSame(t0));
+
+    // New tensor of the same value.
+    core::Tensor t2 = core::Tensor::Ones({6, 8}, core::Dtype::Float32, device);
+    EXPECT_FALSE(t0.IsSame(t2));
+    EXPECT_FALSE(t2.IsSame(t0));
+
+    // Tensor::Contiguous() does not copy if already contiguous.
+    core::Tensor t0_contiguous = t0.Contiguous();
+    EXPECT_TRUE(t0.IsSame(t0_contiguous));
+    EXPECT_TRUE(t0_contiguous.IsSame(t0));
+
+    // Slices are views.
+    core::Tensor t0_slice =
+            t0.GetItem({core::TensorKey::Slice(0, 5, 2)})[0];  // t0[0:5:2][0]
+    core::Tensor t1_slice = t1[0];
+    EXPECT_TRUE(t0_slice.IsSame(t1_slice));
+    EXPECT_TRUE(t1_slice.IsSame(t0_slice));
+
+    // Explicit copy to the same device.
+    core::Tensor t0_copy = t0.Copy(device);
+    EXPECT_FALSE(t0.IsSame(t0_copy));
+    EXPECT_FALSE(t0_copy.IsSame(t0));
+
+    // std::vector<Tensor> initializer list and push_back() are views.
+    std::vector<core::Tensor> vec{t0};
+    vec.push_back(t1);
+    EXPECT_TRUE(t0.IsSame(vec[0]));
+    EXPECT_TRUE(t1.IsSame(vec[1]));
+    EXPECT_TRUE(vec[0].IsSame(vec[1]));
 }
 
 }  // namespace tests

--- a/cpp/tests/core/TensorList.cpp
+++ b/cpp/tests/core/TensorList.cpp
@@ -39,336 +39,431 @@ INSTANTIATE_TEST_SUITE_P(TensorList,
                          TensorListPermuteDevices,
                          testing::ValuesIn(PermuteDevices::TestCases()));
 
-TEST_P(TensorListPermuteDevices, ConstructFromIterators) {
+TEST_P(TensorListPermuteDevices, EmptyConstructor) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    // TensorList allows 0-sized and scalar {} element_shape.
+    for (const core::SizeVector& element_shape : std::vector<core::SizeVector>{
+                 {},   // Scalar {} element_shape is fine.
+                 {0},  // 0-sized element_shape is fine.
+                 {1},  // This is different from {}.
+                 {0, 0},
+                 {0, 1},
+                 {1, 0},
+                 {2, 3},
+         }) {
+        core::TensorList tl(element_shape, dtype, device);
+        EXPECT_EQ(tl.GetElementShape(), element_shape);
+        EXPECT_EQ(tl.GetDtype(), dtype);
+        EXPECT_EQ(tl.GetDevice(), device);
+    }
 
-    std::vector<core::Tensor> tensors = {t0, t1, t2};
-    core::TensorList tensor_list(tensors.begin(), tensors.end(), device);
-
-    core::SizeVector shape({3, 2, 3});
-    EXPECT_EQ(tensor_list.AsTensor().GetShape(), shape);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
+    // TensorList does not allow negative element_shape.
+    EXPECT_ANY_THROW(core::TensorList({0, -1}, dtype, device));
+    EXPECT_ANY_THROW(core::TensorList({-1, -1}, dtype, device));
 }
 
-TEST_P(TensorListPermuteDevices, ConstructFromVector) {
+TEST_P(TensorListPermuteDevices, ConstructFromTensorVector) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    core::Tensor t0 = core::Tensor::Ones({2, 3}, dtype, device) * 0.;
+    core::Tensor t1 = core::Tensor::Ones({2, 3}, dtype, device) * 1.;
+    core::Tensor t2 = core::Tensor::Ones({2, 3}, dtype, device) * 2.;
+    core::TensorList tl(std::vector<core::Tensor>({t0, t1, t2}));
 
-    std::vector<core::Tensor> tensors = {t0, t1, t2};
-    core::TensorList tensor_list(tensors, device);
+    // Check tensor list.
+    core::SizeVector full_shape({3, 2, 3});
+    EXPECT_EQ(tl.AsTensor().GetShape(), full_shape);
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_EQ(tl.GetReservedSize(), 8);
 
-    core::SizeVector shape({3, 2, 3});
-    EXPECT_EQ(tensor_list.AsTensor().GetShape(), shape);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
+    // Values should be copied. IsClose also ensures the same dtype and device.
+    EXPECT_TRUE(tl[0].AllClose(t0));
+    EXPECT_TRUE(tl[1].AllClose(t1));
+    EXPECT_TRUE(tl[2].AllClose(t2));
+    EXPECT_FALSE(tl[0].IsSame(t0));
+    EXPECT_FALSE(tl[1].IsSame(t1));
+    EXPECT_FALSE(tl[2].IsSame(t2));
+
+    // Device mismatch.
+    core::Tensor t3 = core::Tensor::Ones({2, 3}, dtype, core::Device("CPU:0"));
+    core::Tensor t4 = core::Tensor::Ones({2, 3}, dtype, device);
+    if (t3.GetDevice() != t4.GetDevice()) {
+        // This tests only fires when CUDA is available.
+        EXPECT_ANY_THROW(core::TensorList(std::vector<core::Tensor>({t3, t4})));
+    }
+
+    // Shape mismatch.
+    core::Tensor t5 = core::Tensor::Ones({2, 3}, core::Dtype::Float32, device);
+    core::Tensor t6 = core::Tensor::Ones({2, 3}, core::Dtype::Float64, device);
+    EXPECT_ANY_THROW(core::TensorList(std::vector<core::Tensor>({t5, t6})));
 }
 
-TEST_P(TensorListPermuteDevices, ConstructFromInitList) {
+TEST_P(TensorListPermuteDevices, ConstructFromTensors) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    core::Tensor t0 = core::Tensor::Ones({2, 3}, dtype, device) * 0.;
+    core::Tensor t1 = core::Tensor::Ones({2, 3}, dtype, device) * 1.;
+    core::Tensor t2 = core::Tensor::Ones({2, 3}, dtype, device) * 2.;
+    std::vector<core::Tensor> tensors({t0, t1, t2});
 
-    core::TensorList tensor_list({t0, t1, t2}, device);
+    for (const core::TensorList& tl : std::vector<core::TensorList>({
+                 core::TensorList(tensors),
+                 core::TensorList(tensors.begin(), tensors.end()),
+                 core::TensorList({t0, t1, t2}),
+         })) {
+        core::SizeVector full_shape({3, 2, 3});
+        EXPECT_EQ(tl.AsTensor().GetShape(), full_shape);
+        EXPECT_EQ(tl.GetSize(), 3);
+        EXPECT_EQ(tl.GetReservedSize(), 8);
+        // Values are the same.
+        EXPECT_TRUE(tl[0].AllClose(t0));
+        EXPECT_TRUE(tl[1].AllClose(t1));
+        EXPECT_TRUE(tl[2].AllClose(t2));
+        // Tensors are copied.
+        EXPECT_FALSE(tl[0].IsSame(t0));
+        EXPECT_FALSE(tl[1].IsSame(t1));
+        EXPECT_FALSE(tl[2].IsSame(t2));
+    }
 
-    core::SizeVector shape({3, 2, 3});
-    EXPECT_EQ(tensor_list.AsTensor().GetShape(), shape);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
+    // Device mismatch.
+    core::Tensor t3 = core::Tensor::Ones({2, 3}, dtype, core::Device("CPU:0"));
+    core::Tensor t4 = core::Tensor::Ones({2, 3}, dtype, device);
+    if (t3.GetDevice() != t4.GetDevice()) {
+        // This tests only fires when CUDA is available.
+        EXPECT_ANY_THROW(core::TensorList(std::vector<core::Tensor>({t3, t4})));
+    }
+
+    // Shape mismatch.
+    core::Tensor t5 = core::Tensor::Ones({2, 3}, core::Dtype::Float32, device);
+    core::Tensor t6 = core::Tensor::Ones({2, 3}, core::Dtype::Float64, device);
+    EXPECT_ANY_THROW(core::TensorList(std::vector<core::Tensor>({t5, t6})));
 }
 
-TEST_P(TensorListPermuteDevices, TensorConstructFromTensor) {
+TEST_P(TensorListPermuteDevices, FromTensor) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t = core::Tensor::Ones({3, 4, 5}, dtype, device);
 
-    core::Tensor t(std::vector<float>(3 * 2 * 3, 1), {3, 2, 3},
-                   core::Dtype::Float32, device);
+    // Copyied tensor.
+    core::TensorList tl = core::TensorList::FromTensor(t);
+    EXPECT_EQ(tl.GetElementShape(), core::SizeVector({4, 5}));
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_EQ(tl.GetReservedSize(), 8);
+    EXPECT_TRUE(tl.AsTensor().AllClose(t));
+    EXPECT_FALSE(tl.AsTensor().IsSame(t));
 
-    core::TensorList tensor_list(t);
-    core::SizeVector shape({2, 3});
-    EXPECT_EQ(tensor_list.GetShape(), shape);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>(3 * 2 * 3, 1));
+    // Inplace tensor.
+    core::TensorList tl_inplace = core::TensorList::FromTensor(t, true);
+    EXPECT_EQ(tl_inplace.GetElementShape(), core::SizeVector({4, 5}));
+    EXPECT_EQ(tl_inplace.GetSize(), 3);
+    EXPECT_EQ(tl_inplace.GetReservedSize(), 3);
+    EXPECT_TRUE(tl_inplace.AsTensor().AllClose(t));
+    EXPECT_TRUE(tl_inplace.AsTensor().IsSame(t));
 }
 
-TEST_P(TensorListPermuteDevices, CopyConstruct) {
+TEST_P(TensorListPermuteDevices, CopyConstructor) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t = core::Tensor::Ones({3, 4, 5}, dtype, device);
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-
-    std::vector<core::Tensor> tensors = {t0, t1, t2};
-    core::TensorList tensor_list(tensors, device);
-    core::TensorList tensor_list_new(tensor_list);
-
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              tensor_list_new.AsTensor().ToFlatVector<float>());
-
-    /// Change of the copy should NOT affect the origin
-    tensor_list.AsTensor()[0][0][0] = 1;
-    EXPECT_NE(tensor_list.AsTensor().ToFlatVector<float>(),
-              tensor_list_new.AsTensor().ToFlatVector<float>());
+    core::TensorList tl = core::TensorList::FromTensor(t, false);
+    core::TensorList tl_copy(tl);
+    EXPECT_TRUE(tl.AsTensor().IsSame(tl_copy.AsTensor()));
 }
 
-TEST_P(TensorListPermuteDevices, AssignOperator) {
+TEST_P(TensorListPermuteDevices, MoveConstructor) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t = core::Tensor::Ones({3, 4, 5}, dtype, device);
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    auto create_tl = [&t]() {
+        return core::TensorList::FromTensor(t, /*inplace=*/true);
+    };
+    core::TensorList tl(create_tl());
+    EXPECT_TRUE(tl.AsTensor().IsSame(t));
+}
 
-    /// Right value assignment
-    core::TensorList tensor_list_gt = {t0, t1, t2};
-    core::TensorList tensor_list_a = {t2, t2, t2};
-    core::TensorList tensor_list_b = {t0, t1};
+TEST_P(TensorListPermuteDevices, CopyAssignmentOperator) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t = core::Tensor::Ones({3, 4, 5}, dtype, device);
 
-    tensor_list_a.AsTensor().Slice(0, 0, 2) = tensor_list_b.AsTensor();
-    EXPECT_EQ(tensor_list_a.AsTensor().ToFlatVector<float>(),
-              tensor_list_gt.AsTensor().ToFlatVector<float>());
+    // Initially tl_a and tl_b does not share the same underlying memory.
+    core::TensorList tl_a = core::TensorList::FromTensor(t);
+    core::TensorList tl_b = core::TensorList::FromTensor(t);
+    EXPECT_TRUE(tl_a.AsTensor().AllClose(tl_b.AsTensor()));
+    EXPECT_FALSE(tl_a.AsTensor().IsSame(tl_b.AsTensor()));
+
+    // After copy assignment, the underlying memory are the same.
+    tl_a = tl_b;
+    EXPECT_TRUE(tl_a.AsTensor().AllClose(tl_b.AsTensor()));
+    EXPECT_TRUE(tl_a.AsTensor().IsSame(tl_b.AsTensor()));
+
+    // The is_resizable_ property will be overwritten.
+    core::TensorList tl_a_inplace = core::TensorList::FromTensor(t, true);
+    EXPECT_FALSE(tl_a_inplace.IsResizable());
+    tl_a_inplace = tl_b;
+    EXPECT_TRUE(tl_a_inplace.IsResizable());
+}
+
+TEST_P(TensorListPermuteDevices, MoveAssignmentOperator) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t_a = core::Tensor::Ones({3, 4, 5}, dtype, device);
+    core::Tensor t_b = core::Tensor::Ones({3, 4, 5}, dtype, device);
+
+    core::TensorList tl_a = core::TensorList::FromTensor(t_a, /*inplace=*/true);
+    auto create_tl_b = [&t_b]() {
+        return core::TensorList::FromTensor(t_b, /*inplace=*/true);
+    };
+    EXPECT_FALSE(tl_a.AsTensor().IsSame(t_b));
+    tl_a = create_tl_b();
+    EXPECT_TRUE(tl_a.AsTensor().IsSame(t_b));
+}
+
+TEST_P(TensorListPermuteDevices, CopyFrom) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t_a = core::Tensor::Ones({10, 4, 5}, dtype, device);
+    core::Tensor t_b = core::Tensor::Ones({0, 2, 3}, dtype, device);
+
+    core::TensorList tl_a = core::TensorList::FromTensor(t_a);
+    core::TensorList tl_b = core::TensorList::FromTensor(t_b);
+    EXPECT_NE(tl_a.GetElementShape(), tl_b.GetElementShape());
+    EXPECT_NE(tl_a.GetSize(), tl_b.GetSize());
+    EXPECT_NE(tl_a.GetReservedSize(), tl_b.GetReservedSize());
+
+    tl_b.CopyFrom(tl_a);
+    EXPECT_EQ(tl_a.GetElementShape(), tl_b.GetElementShape());
+    EXPECT_EQ(tl_a.GetSize(), tl_b.GetSize());
+    EXPECT_EQ(tl_a.GetReservedSize(), tl_b.GetReservedSize());
+    EXPECT_TRUE(tl_b.AsTensor().AllClose(tl_a.AsTensor()));
+    EXPECT_FALSE(tl_b.AsTensor().IsSame(tl_a.AsTensor()));
+
+    // The is_resizable_ property will be overwritten.
+    core::TensorList tl_a_inplace = core::TensorList::FromTensor(t_a, true);
+    EXPECT_FALSE(tl_a_inplace.IsResizable());
+    tl_a_inplace.CopyFrom(tl_b);
+    EXPECT_TRUE(tl_a_inplace.IsResizable());
+}
+
+TEST_P(TensorListPermuteDevices, ShallowCopyFrom) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t_a = core::Tensor::Ones({10, 4, 5}, dtype, device);
+    core::Tensor t_b = core::Tensor::Ones({0, 2, 3}, dtype, device);
+
+    core::TensorList tl_a = core::TensorList::FromTensor(t_a);
+    core::TensorList tl_b = core::TensorList::FromTensor(t_b);
+    EXPECT_NE(tl_a.GetElementShape(), tl_b.GetElementShape());
+    EXPECT_NE(tl_a.GetSize(), tl_b.GetSize());
+    EXPECT_NE(tl_a.GetReservedSize(), tl_b.GetReservedSize());
+
+    tl_b.ShallowCopyFrom(tl_a);
+    EXPECT_EQ(tl_a.GetElementShape(), tl_b.GetElementShape());
+    EXPECT_EQ(tl_a.GetSize(), tl_b.GetSize());
+    EXPECT_EQ(tl_a.GetReservedSize(), tl_b.GetReservedSize());
+    EXPECT_TRUE(tl_b.AsTensor().AllClose(tl_a.AsTensor()));
+    EXPECT_TRUE(tl_b.AsTensor().IsSame(tl_a.AsTensor()));
+
+    // The is_resizable_ property will be overwritten.
+    core::TensorList tl_a_inplace = core::TensorList::FromTensor(t_a, true);
+    EXPECT_FALSE(tl_a_inplace.IsResizable());
+    tl_a_inplace.ShallowCopyFrom(tl_b);
+    EXPECT_TRUE(tl_a_inplace.IsResizable());
+}
+
+TEST_P(TensorListPermuteDevices, CopyBecomesResizable) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t_a = core::Tensor::Ones({10, 4, 5}, dtype, device);
+    core::Tensor t_b = core::Tensor::Ones({0, 2, 3}, dtype, device);
+    core::Tensor t = core::Tensor::Ones({4, 5}, dtype, device);
+
+    core::TensorList tl_a = core::TensorList::FromTensor(t_a, true);
+    core::TensorList tl_b = core::TensorList::FromTensor(t_b, true);
+    core::TensorList tl_b_backup = tl_b;
+    EXPECT_FALSE(tl_a.IsResizable());
+    EXPECT_FALSE(tl_b.IsResizable());
+    EXPECT_FALSE(tl_b_backup.IsResizable());
+
+    tl_b.CopyFrom(tl_a);
+    tl_b.PushBack(t);
+    EXPECT_TRUE(tl_b.IsResizable());
+    EXPECT_FALSE(tl_b_backup.IsResizable());  // tl_b_backup is not affected.
+    EXPECT_EQ(tl_b_backup.GetSize(), 0);
 }
 
 TEST_P(TensorListPermuteDevices, Resize) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+    core::Tensor t = core::Tensor::Ones({3, 4, 5}, dtype, device);
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    core::TensorList tl = core::TensorList::FromTensor(t);
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_EQ(tl.GetReservedSize(), 8);
+    EXPECT_TRUE(tl.AsTensor().AllClose(t));
 
-    std::vector<core::Tensor> tensors = {t0, t1, t2};
-    core::TensorList tensor_list(tensors, device);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>(
-                      {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}));
+    tl.Resize(5);
+    EXPECT_EQ(tl.GetSize(), 5);
+    EXPECT_EQ(tl.GetReservedSize(), 16);
+    EXPECT_TRUE(tl.AsTensor().Slice(0, 0, 3).AllClose(t));
+    EXPECT_TRUE(tl.AsTensor().Slice(0, 3, 5).AllClose(
+            core::Tensor::Zeros({2, 4, 5}, dtype, device)));
 
-    tensor_list.Resize(5);
-    EXPECT_EQ(tensor_list.GetSize(), 5);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 16);
-    EXPECT_EQ(
-            tensor_list.AsTensor().ToFlatVector<float>(),
-            std::vector<float>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2,
-                                2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+    tl.Resize(2);
+    EXPECT_EQ(tl.GetSize(), 2);
+    EXPECT_EQ(tl.GetReservedSize(), 16);
+    EXPECT_TRUE(tl.AsTensor().AllClose(
+            core::Tensor::Ones({2, 4, 5}, dtype, device)));
 
-    tensor_list.Resize(2);
-    EXPECT_EQ(tensor_list.GetSize(), 2);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 16);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1}));
+    tl = core::TensorList::FromTensor(t, /*inplace=*/true);
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_EQ(tl.GetReservedSize(), 3);
+    EXPECT_ANY_THROW(tl.Resize(5));
+
+    // Inplace TensorList does not suport resize.
+    core::TensorList tl_inplace = core::TensorList::FromTensor(t, true);
+    EXPECT_ANY_THROW(tl_inplace.Resize(2));
 }
 
 TEST_P(TensorListPermuteDevices, PushBack) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
+    core::Tensor t0 = core::Tensor::Ones({2, 3}, dtype, device) * 0;
+    core::Tensor t1 = core::Tensor::Ones({2, 3}, dtype, device) * 1;
+    core::Tensor t2 = core::Tensor::Ones({2, 3}, dtype, device) * 2;
 
-    core::TensorList tensor_list({2, 3}, core::Dtype::Float32, device);
-    EXPECT_EQ(tensor_list.GetSize(), 0);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 1);
+    // Start from emtpy tensor list
+    core::TensorList tl({2, 3}, core::Dtype::Float32, device);
+    EXPECT_EQ(tl.GetSize(), 0);
+    EXPECT_EQ(tl.GetReservedSize(), 1);
 
-    tensor_list.PushBack(t0);
-    EXPECT_EQ(tensor_list.GetSize(), 1);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 2);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0}));
+    tl.PushBack(t0);
+    EXPECT_EQ(tl.GetSize(), 1);
+    EXPECT_EQ(tl.GetReservedSize(), 2);
+    EXPECT_TRUE(tl[0].AllClose(t0));
+    EXPECT_FALSE(tl[0].IsSame(t0));  // Values should be copied
 
-    tensor_list.PushBack(t1);
-    EXPECT_EQ(tensor_list.GetSize(), 2);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 4);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1}));
+    tl.PushBack(t1);
+    EXPECT_EQ(tl.GetSize(), 2);
+    EXPECT_EQ(tl.GetReservedSize(), 4);
+    EXPECT_TRUE(tl[1].AllClose(t1));
+    EXPECT_FALSE(tl[1].IsSame(t1));
 
-    tensor_list.PushBack(t2);
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>(
-                      {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}));
-}
+    tl.PushBack(t2);
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_EQ(tl.GetReservedSize(), 8);
+    EXPECT_TRUE(tl[2].AllClose(t2));
+    EXPECT_FALSE(tl[2].IsSame(t2));
 
-TEST_P(TensorListPermuteDevices, AccessOperator) {
-    core::Device device = GetParam();
-
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-
-    std::vector<core::Tensor> tensors = {t0, t1, t2};
-    core::TensorList tensor_list(tensors, device);
-
-    EXPECT_EQ(tensor_list.GetSize(), 3);
-    EXPECT_EQ(tensor_list[0].ToFlatVector<float>(), t0.ToFlatVector<float>());
-    EXPECT_EQ(tensor_list[1].ToFlatVector<float>(), t1.ToFlatVector<float>());
-    EXPECT_EQ(tensor_list[2].ToFlatVector<float>(), t2.ToFlatVector<float>());
-
-    tensor_list[0] = t2;
-    tensor_list[1] = t1;
-    tensor_list[2] = t0;
-
-    EXPECT_EQ(tensor_list.AsTensor().ToFlatVector<float>(),
-              std::vector<float>(
-                      {2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0}));
-}
-
-TEST_P(TensorListPermuteDevices, Slice) {
-    core::Device device = GetParam();
-
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t3(std::vector<float>(2 * 3, 3), {2, 3}, core::Dtype::Float32,
-                    device);
-
-    std::vector<core::Tensor> tensors = {t0, t1, t2, t3};
-    core::TensorList tensor_list(tensors, device);
-
-    core::Tensor tensor = tensor_list.AsTensor().Slice(0, 0, 3, 2);
-    EXPECT_EQ(tensor.ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2}));
-}
-
-TEST_P(TensorListPermuteDevices, IndexGet) {
-    core::Device device = GetParam();
-
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t3(std::vector<float>(2 * 3, 3), {2, 3}, core::Dtype::Float32,
-                    device);
-
-    std::vector<core::Tensor> tensors = {t0, t1, t2, t3};
-    core::TensorList tensor_list(tensors, device);
-
-    std::vector<core::Tensor> indices = {core::Tensor(
-            std::vector<int64_t>({0, -1, 2}), {3}, core::Dtype::Int64, device)};
-    core::Tensor tensor = tensor_list.AsTensor().IndexGet(indices);
-    EXPECT_EQ(tensor.ToFlatVector<float>(),
-              std::vector<float>(
-                      {0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2}));
-}
-
-TEST_P(TensorListPermuteDevices, Concatenate) {
-    core::Device device = GetParam();
-
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    std::vector<core::Tensor> tensors0 = {t0};
-
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t3(std::vector<float>(2 * 3, 3), {2, 3}, core::Dtype::Float32,
-                    device);
-    std::vector<core::Tensor> tensors1 = {t1, t2, t3};
-
-    core::TensorList tensor_list0(tensors0, device);
-    core::TensorList tensor_list1(tensors1, device);
-
-    core::TensorList tensor_list2 = tensor_list0 + tensor_list1;
-    EXPECT_EQ(tensor_list2.GetSize(), 4);
-    EXPECT_EQ(tensor_list2.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list2.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-                                  2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3}));
-
-    core::TensorList tensor_list3 =
-            core::TensorList::Concatenate(tensor_list1, tensor_list0);
-    EXPECT_EQ(tensor_list3.GetSize(), 4);
-    EXPECT_EQ(tensor_list3.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list3.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
-                                  3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0}));
+    // Inplace TensorList does not suport push back.
+    core::TensorList tl_inplace = core::TensorList::FromTensor(
+            core::Tensor::Ones({3, 2, 3}, dtype, device), true);
+    EXPECT_ANY_THROW(tl_inplace.PushBack(t0));
 }
 
 TEST_P(TensorListPermuteDevices, Extend) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    std::vector<core::Tensor> tensors0 = {t0};
+    core::Tensor t0 = core::Tensor::Zeros({1, 2, 3}, dtype, device);
+    core::Tensor t1 = core::Tensor::Ones({3, 2, 3}, dtype, device);
+    core::TensorList tl0 = core::TensorList::FromTensor(t0);
+    core::TensorList tl1 = core::TensorList::FromTensor(t1);
 
-    core::Tensor t1(std::vector<float>(2 * 3, 1), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t2(std::vector<float>(2 * 3, 2), {2, 3}, core::Dtype::Float32,
-                    device);
-    core::Tensor t3(std::vector<float>(2 * 3, 3), {2, 3}, core::Dtype::Float32,
-                    device);
-    std::vector<core::Tensor> tensors1 = {t1, t2, t3};
+    tl1.Extend(tl1);
+    EXPECT_EQ(tl1.GetSize(), 6);
+    EXPECT_TRUE(tl1.AsTensor().AllClose(
+            core::Tensor::Ones({6, 2, 3}, dtype, device)));
+    tl1.Extend(tl0);
+    EXPECT_EQ(tl1.GetSize(), 7);
+    EXPECT_TRUE(tl1[6].AllClose(core::Tensor::Zeros({2, 3}, dtype, device)));
 
-    core::TensorList tensor_list0(tensors0, device);
-    core::TensorList tensor_list1(tensors1, device);
+    // Inplace TensorList cannot be extended.
+    core::TensorList tl0_inplace = core::TensorList::FromTensor(t0, true);
+    EXPECT_ANY_THROW(tl0_inplace.Extend(tl0));
 
-    tensor_list0.Extend(tensor_list1);
-    EXPECT_EQ(tensor_list0.GetSize(), 4);
-    EXPECT_EQ(tensor_list0.GetReservedSize(), 8);
-    EXPECT_EQ(tensor_list0.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-                                  2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3}));
+    // Inplace TensorList can be the extension part.
+    tl1.Extend(tl0_inplace);
+    EXPECT_TRUE(tl1[7].AllClose(core::Tensor::Zeros({2, 3}, dtype, device)));
+}
 
-    tensor_list1 += tensor_list1;
-    EXPECT_EQ(tensor_list1.GetSize(), 6);
-    EXPECT_EQ(tensor_list1.GetReservedSize(), 16);
-    EXPECT_EQ(tensor_list1.AsTensor().ToFlatVector<float>(),
-              std::vector<float>({1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
-                                  3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1,
-                                  2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3}));
+TEST_P(TensorListPermuteDevices, Concatenate) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+
+    core::Tensor t0 = core::Tensor::Zeros({1, 2, 3}, dtype, device);
+    core::Tensor t1 = core::Tensor::Ones({3, 2, 3}, dtype, device);
+    core::TensorList tl0 = core::TensorList::FromTensor(t0);
+    core::TensorList tl1 = core::TensorList::FromTensor(t1);
+
+    core::TensorList tl2 = tl0 + tl1;
+    EXPECT_EQ(tl2.GetSize(), 4);
+    EXPECT_EQ(tl2.GetReservedSize(), 8);
+    EXPECT_TRUE(tl2.AsTensor().Slice(0, 0, 1).AllClose(t0));
+    EXPECT_TRUE(tl2.AsTensor().Slice(0, 1, 4).AllClose(t1));
+
+    core::TensorList tl3 = tl1 + tl0;
+    EXPECT_EQ(tl3.GetSize(), 4);
+    EXPECT_EQ(tl1.GetReservedSize(), 8);
+    EXPECT_EQ(tl3.GetReservedSize(), 8);
+    EXPECT_TRUE(tl3.AsTensor().Slice(0, 0, 3).AllClose(tl1.AsTensor()));
+    EXPECT_FALSE(tl3.AsTensor().Slice(0, 0, 3).IsSame(tl1.AsTensor()));  // Copy
+    EXPECT_TRUE(tl3.AsTensor().Slice(0, 3, 4).AllClose(tl0.AsTensor()));
+    EXPECT_FALSE(tl3.AsTensor().Slice(0, 3, 4).IsSame(tl0.AsTensor()));  // Copy
+}
+
+TEST_P(TensorListPermuteDevices, SquareBracketsOperator) {
+    core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
+
+    core::Tensor t0 = core::Tensor::Ones({2, 3}, dtype, device) * 0;
+    core::Tensor t1 = core::Tensor::Ones({2, 3}, dtype, device) * 1;
+    core::Tensor t2 = core::Tensor::Ones({2, 3}, dtype, device) * 2;
+    core::TensorList tl({t0, t1, t2});
+
+    EXPECT_EQ(tl.GetSize(), 3);
+    EXPECT_TRUE(tl[0].AllClose(t0));
+    EXPECT_TRUE(tl[1].AllClose(t1));
+    EXPECT_TRUE(tl[2].AllClose(t2));
+    EXPECT_TRUE(tl[-1].AllClose(t2));
+    EXPECT_TRUE(tl[-2].AllClose(t1));
+    EXPECT_TRUE(tl[-3].AllClose(t0));
+    EXPECT_FALSE(tl[0].IsSame(t0));
+    EXPECT_FALSE(tl[1].IsSame(t1));
+    EXPECT_FALSE(tl[2].IsSame(t2));
+    EXPECT_ANY_THROW(tl[3]);
+    EXPECT_ANY_THROW(tl[-4]);
+
+    tl[0] = t1;
+    tl[1] = t2;
+    tl[-1] = t0;
+    EXPECT_TRUE(tl[0].AllClose(t1));
+    EXPECT_TRUE(tl[1].AllClose(t2));
+    EXPECT_TRUE(tl[2].AllClose(t0));
+    EXPECT_FALSE(tl[0].IsSame(t1));  // Deep copy when assigned to a slice.
+    EXPECT_FALSE(tl[1].IsSame(t2));
+    EXPECT_FALSE(tl[2].IsSame(t0));
 }
 
 TEST_P(TensorListPermuteDevices, Clear) {
     core::Device device = GetParam();
+    core::Dtype dtype = core::Dtype::Float32;
 
-    core::Tensor t0(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,
-                    device);
-    std::vector<core::Tensor> tensors = {t0};
+    core::Tensor t = core::Tensor::Ones({10, 4, 5}, dtype, device);
+    core::TensorList tl = core::TensorList::FromTensor(t);
+    tl.Clear();
+    EXPECT_EQ(tl.GetSize(), 0);
+    EXPECT_EQ(tl.GetReservedSize(), 1);
 
-    core::TensorList tensor_list(tensors, device);
-    tensor_list.Clear();
-    EXPECT_EQ(tensor_list.GetSize(), 0);
-    EXPECT_EQ(tensor_list.GetReservedSize(), 1);
+    core::TensorList tl_inplace = core::TensorList::FromTensor(t, true);
+    EXPECT_ANY_THROW(tl_inplace.Clear());
 }
 
 }  // namespace tests

--- a/python/open3d/core.py
+++ b/python/open3d/core.py
@@ -6,6 +6,7 @@ from open3d.pybind.core import Device
 from open3d.pybind.core import DtypeUtil
 from open3d.pybind.core import cuda
 from open3d.pybind.core import NoneType
+from open3d.pybind.core import TensorList
 
 none = NoneType()
 
@@ -628,7 +629,7 @@ class Tensor(o3d.pybind.core.Tensor):
         elif isinstance(dim, int):
             dim = self._reduction_dim_to_size_vector([dim])
         else:
-            raise TypeError("dim must be int or None, but got {}".format(dim))
+            raise TypeError("dim must be int or None, but got {}.".format(dim))
         return super(Tensor, self).argmin_(dim)
 
     @cast_to_py_tensor
@@ -646,8 +647,20 @@ class Tensor(o3d.pybind.core.Tensor):
         elif isinstance(dim, int):
             dim = self._reduction_dim_to_size_vector([dim])
         else:
-            raise TypeError("dim must be int or None, but got {}".format(dim))
+            raise TypeError("dim must be int or None, but got {}.".format(dim))
         return super(Tensor, self).argmax_(dim)
+
+    @cast_to_py_tensor
+    def isclose(self, other, rtol=1e-5, atol=1e-8):
+        """
+        Element-wise test if the tensor value is close to other.
+        - If the device is not the same: throws exception.
+        - If the dtype is not the same: throws exception.
+        - If the shape is not the same: throws exception.
+        - For each element in the returned tensor:
+          abs(self - other) <= (atol + rtol * abs(other)).
+        """
+        return super(Tensor, self).isclose(other, rtol, atol)
 
     def __lt__(self, value):
         return self.lt(value)
@@ -666,127 +679,3 @@ class Tensor(o3d.pybind.core.Tensor):
 
     def __ge__(self, value):
         return self.ge(value)
-
-
-def cast_to_py_tensorlist(func):
-    """
-    Args:
-        func: function returning a `o3d.pybind.core.Tensor`.
-
-    Return:
-        A function which returns a python object `Tensor`.
-    """
-
-    def wrapped_func(self, *args, **kwargs):
-        result = func(self, *args, **kwargs)
-        wrapped_result = TensorList([0])
-        wrapped_result.shallow_copy_from(result)
-        return wrapped_result
-
-    return wrapped_func
-
-
-class TensorList(o3d.pybind.core.TensorList):
-    """
-    Open3D TensorList class. A TensorList is an extendable tensor at the 0-th dimension.
-    It is similar to python list, but uses Open3D's tensor memory management system.
-    """
-
-    def __init__(self, shape, dtype=None, device=None, size=None):
-        if isinstance(shape, list) or isinstance(shape, tuple):
-            shape = SizeVector(shape)
-        elif isinstance(shape, SizeVector):
-            pass
-        else:
-            raise ValueError('shape must be a list, tuple, or SizeVector')
-
-        if dtype is None:
-            dtype = Dtype.Float32
-        if device is None:
-            device = Device("CPU:0")
-        if size is None:
-            size = 0
-
-        super(TensorList, self).__init__(shape, dtype, device, size)
-
-    @cast_to_py_tensor
-    def __getitem__(self, index):
-        '''
-        \index can be a
-        \slice, or \list or \tuple of int: return a TensorList
-        \int: return a Tensor
-        '''
-        if isinstance(index, int):
-            return self._getitem(index)
-        else:
-            raise ValueError('Unsupported index type, only int is supported.')
-
-    def __setitem__(self, index, value):
-        '''
-        If \index is a single int, \value is a Tensor;
-        If \index is a list of ints, \value is correspondingly a TensorList.
-        '''
-        if isinstance(index, int) and isinstance(value, Tensor):
-            self._setitem(index, value)
-
-        else:
-            raise ValueError(
-                'Unsupported index type.'
-                'Use tensorlist.tensor() to assign value with slices or advanced indexing'
-            )
-
-    @cast_to_py_tensorlist
-    def __iadd__(self, other):
-        return super(TensorList, self).__iadd__(other)
-
-    @cast_to_py_tensorlist
-    def __add__(self, other):
-        return super(TensorList, self).__add__(other)
-
-    @cast_to_py_tensor
-    def tensor(self):
-        return super(TensorList, self).tensor()
-
-    @staticmethod
-    @cast_to_py_tensorlist
-    def concat(tl_a, tl_b):
-        return super(TensorList, TensorList).concat(tl_a, tl_b)
-
-    @staticmethod
-    @cast_to_py_tensorlist
-    def from_tensor(tensor, inplace=False):
-        """
-        Returns a TensorList from an existing tensor.
-        Args:
-            tensor: The internal Tensor to construct from, whose 0-th dimension
-                    corresponds to the size of the tensorlist.
-            inplace: Reuse tensor memory in place if True, else make a copy.
-        """
-
-        if not isinstance(tensor, Tensor):
-            raise ValueError('tensor must be a Tensor')
-
-        return super(TensorList, TensorList).from_tensor(tensor, inplace)
-
-    @staticmethod
-    @cast_to_py_tensorlist
-    def from_tensors(tensors, device=None):
-        """
-        Returns a TensorList from a list of existing tensors.
-        Args:
-            tensors: The list of Tensor to construct from.
-                     The tensors' shapes should be compatible.
-            device: The device where the tensorlist is targeted.
-        """
-
-        if not isinstance(tensors, list) and not isinstance(tensors, tuple):
-            raise ValueError('tensors must be a list or tuple')
-
-        for tensor in tensors:
-            if not isinstance(tensor, Tensor):
-                raise ValueError(
-                    'every element of the input list must be a valid tensor')
-        if device is None:
-            device = Device("CPU:0")
-
-        return super(TensorList, TensorList).from_tensors(tensors, device)

--- a/python/test/core/core_test_utils.py
+++ b/python/test/core/core_test_utils.py
@@ -1,0 +1,65 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import numpy as np
+import pytest
+
+import open3d as o3d
+import numpy as np
+import pytest
+
+
+def torch_available():
+    try:
+        import torch
+        import torch.utils.dlpack
+    except ImportError:
+        return False
+    return True
+
+
+def list_devices():
+    """
+    If Open3D is built with CUDA support:
+    - If cuda device is available, returns [Device("CPU:0"), Device("CUDA:0")].
+    - If cuda device is not available, returns [Device("CPU:0")].
+
+    If Open3D is built without CUDA support:
+    - returns [Device("CPU:0")].
+    """
+    devices = [o3d.core.Device("CPU:" + str(0))]
+    if torch_available() and o3d._build_config['BUILD_CUDA_MODULE']:
+        import torch
+        import torch.utils.dlpack
+        if (o3d.core.cuda.device_count() != torch.cuda.device_count()):
+            raise RuntimeError(
+                "o3d.core.cuda.device_count() != torch.cuda.device_count(), "
+                "{} != {}".format(o3d.core.cuda.device_count(),
+                                  torch.cuda.device_count()))
+    if o3d.core.cuda.device_count() > 0:
+        devices.append(o3d.core.Device("CUDA:0"))
+    return devices

--- a/python/test/core/test_tensorlist.py
+++ b/python/test/core/test_tensorlist.py
@@ -1,0 +1,153 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import open3d.core as o3c
+import numpy as np
+import pytest
+import core_test_utils
+
+
+@pytest.mark.parametrize("device", core_test_utils.list_devices())
+def test_tensorlist_create(device):
+    dtype = o3c.Dtype.Float32
+
+    # Construct uninitialized tensorlist.
+    tl = o3c.TensorList(o3c.SizeVector([3, 4]), dtype, device)
+    assert tl.size == 0
+    assert tl.element_shape == o3c.SizeVector([3, 4])
+
+    tl = o3c.TensorList(o3c.SizeVector([3, 4]), dtype, device=device)
+    assert tl.size == 0
+    assert tl.element_shape == o3c.SizeVector([3, 4])
+
+    tl = o3c.TensorList(o3c.SizeVector([3, 4]), dtype=dtype, device=device)
+    assert tl.size == 0
+    assert tl.element_shape == o3c.SizeVector([3, 4])
+
+    tl = o3c.TensorList(element_shape=o3c.SizeVector([3, 4]),
+                        dtype=dtype,
+                        device=device)
+    assert tl.size == 0
+    assert tl.element_shape == o3c.SizeVector([3, 4])
+
+    # Construct from a list of tensors.
+    t0 = o3c.Tensor.ones((2, 3), dtype, device) * 0
+    t1 = o3c.Tensor.ones((2, 3), dtype, device) * 1
+    t2 = o3c.Tensor.ones((2, 3), dtype, device) * 2
+    tl = o3c.TensorList([t0, t1, t2])
+    assert tl[0].allclose(t0)
+    assert tl[1].allclose(t1)
+    assert tl[2].allclose(t2)
+    assert tl[-1].allclose(t2)
+    assert not tl[0].issame(t0)
+    assert not tl[1].issame(t1)
+    assert not tl[2].issame(t2)
+    assert not tl[-1].issame(t2)
+
+    # Create from a internal tensor.
+    t = o3c.Tensor.ones((4, 2, 3), dtype, device)
+    tl = o3c.TensorList.from_tensor(o3c.Tensor.ones((4, 2, 3), dtype, device))
+    assert tl.element_shape == o3c.SizeVector([2, 3])
+    assert tl.size == 4
+    assert tl.dtype == dtype
+    assert tl.device == device
+    assert tl.is_resizable
+    assert not tl.as_tensor().issame(t)
+
+    # Create from a internal tensor, in-place.
+    t = o3c.Tensor.ones((4, 2, 3), dtype, device)
+    tl = o3c.TensorList.from_tensor(t, inplace=True)
+    assert tl.element_shape == o3c.SizeVector([2, 3])
+    assert tl.size == 4
+    assert tl.dtype == dtype
+    assert tl.device == device
+    assert not tl.is_resizable
+    assert tl.as_tensor().issame(t)
+
+
+@pytest.mark.parametrize("device", core_test_utils.list_devices())
+def test_tensorlist_operation(device):
+    dtype = o3c.Dtype.Float32
+    t0 = o3c.Tensor.ones((2, 3), dtype, device) * 0
+    t1 = o3c.Tensor.ones((2, 3), dtype, device) * 1
+    t2 = o3c.Tensor.ones((2, 3), dtype, device) * 2
+
+    # push_back
+    tl = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    assert tl.size == 0
+    tl.push_back(t0)
+    assert tl.size == 1
+
+    # resize
+    tl.resize(10)
+    assert tl.size == 10
+    tl.resize(1)
+    assert tl.size == 1
+
+    # extend
+    tl = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl.push_back(t0)
+    tl_other = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl_other.push_back(t1)
+    tl_other.push_back(t2)
+    tl.extend(tl_other)
+    assert tl.size == 3
+    assert tl[0].allclose(t0)
+    assert tl[1].allclose(t1)
+    assert tl[2].allclose(t2)
+
+    # +=
+    tl = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl.push_back(t0)
+    tl_other = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl_other.push_back(t1)
+    tl_other.push_back(t2)
+    tl += tl_other
+    assert tl.size == 3
+    assert tl[0].allclose(t0)
+    assert tl[1].allclose(t1)
+    assert tl[2].allclose(t2)
+
+    # concat
+    tl = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl.push_back(t0)
+    tl_other = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl_other.push_back(t1)
+    tl_combined = o3c.TensorList.concat(tl, tl_other)
+    assert tl_combined.size == 2
+    assert tl_combined[0].allclose(t0)
+    assert tl_combined[1].allclose(t1)
+
+    # +
+    tl = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl.push_back(t0)
+    tl_other = o3c.TensorList(o3c.SizeVector([2, 3]), dtype, device)
+    tl_other.push_back(t1)
+    tl_combined = tl + tl_other
+    assert tl_combined.size == 2
+    assert tl_combined[0].allclose(t0)
+    assert tl_combined[1].allclose(t1)


### PR DESCRIPTION
- Refactor `TensorList`
  - In-place created tensor list cannot be resized (i.e. cannot do push_back, extend, ...).
  - Refined copy behavior: copy constructor, move constructor, copy assignment and move assignment.
    - Now unless explicitly copy, everything else is "shallow" copy
  - Get device and dtype info from tensor directly
  - Do not allow auto broadcasting
  - Removed second-layer python wrapper (`core.py`) for TensorList -- it's not needed
  - Simplified internal implementations
- `Tensor`
  - New op: `Tensor::AllClose`
  - New op: `Tensor::IsClose`
  - New op: `Tensor::Any`
  - New op: `Tensor::All`
  - New op: `Tensor::IsSame`: useful to test if teh tensor shares the same memory
- Pybind
- C++ and python tests, also moved some test files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2066)
<!-- Reviewable:end -->
