### PR TITLE
fix utility::LogXX {} escape problem

### DIFF
--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -155,10 +156,7 @@ protected:
 public:
     VerbosityLevel verbosity_level_;
     std::function<void(const std::string &)> print_fcn_ =
-            [](const std::string &msg) {
-                fmt::print(msg);
-                fmt::print("\n");
-            };
+            [](const std::string &msg) { std::cout << msg << std::endl; };
 };
 
 /// Set global verbosity level of Open3D

--- a/cpp/tests/utility/Console.cpp
+++ b/cpp/tests/utility/Console.cpp
@@ -35,6 +35,10 @@ TEST(Logger, LogError) {
                  std::runtime_error);
 }
 
+TEST(Logger, LogInfo) {
+    utility::LogInfo("{}", "Example shape print {1, 2, 3}");
+}
+
 TEST(Console, DISABLED_SetVerbosityLevel) { NotImplemented(); }
 
 TEST(Console, DISABLED_GetVerbosityLevel) { NotImplemented(); }

--- a/cpp/tests/utility/Console.cpp
+++ b/cpp/tests/utility/Console.cpp
@@ -31,12 +31,12 @@ namespace open3d {
 namespace tests {
 
 TEST(Logger, LogError) {
-    EXPECT_THROW(utility::LogError("Example exeption message"),
+    EXPECT_THROW(utility::LogError("Example exception message."),
                  std::runtime_error);
 }
 
 TEST(Logger, LogInfo) {
-    utility::LogInfo("{}", "Example shape print {1, 2, 3}");
+    utility::LogInfo("{}", "Example shape print {1, 2, 3}.");
 }
 
 TEST(Console, DISABLED_SetVerbosityLevel) { NotImplemented(); }


### PR DESCRIPTION
```cpp
utility::LogInfo("{}", "Example shape print {1, 2, 3}");
```
results in
```
C++ exception with description "invalid format string" thrown in the test body.
```
This is related to this fmt library's `{}` escaping issue: https://github.com/fmtlib/fmt/issues/634 . 

Somehow, if we replace the final `fmt::print(msg);` call with `std::cout`, it works properly. Not it can correctly print:
```
[ RUN      ] Logger.LogInfo
[Open3D INFO] Example shape print {1, 2, 3}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2072)
<!-- Reviewable:end -->
