### PR TITLE
Fix window showing buffer from last resize when a window is moved on macOS

### DIFF
--- a/cpp/apps/Open3DViewer/Open3DViewer_mac.mm
+++ b/cpp/apps/Open3DViewer/Open3DViewer_mac.mm
@@ -132,6 +132,8 @@ protected:
     }
 };
 
+constexpr Menu::ItemId Open3DVisualizer::MAC_MAKE_DEFAULT_APP;  // for Xcode
+
 // ----------------------------------------------------------------------------
 static void LoadAndCreateWindow(const char *path) {
     auto vis = std::make_shared<Open3DVisualizer>();

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -226,6 +226,7 @@ Window::Window(const std::string& title,
 
     glfwSetWindowUserPointer(impl_->window_, this);
     glfwSetWindowSizeCallback(impl_->window_, ResizeCallback);
+    glfwSetWindowPosCallback(impl_->window_, WindowMovedCallback);
     glfwSetWindowRefreshCallback(impl_->window_, DrawCallback);
     glfwSetCursorPosCallback(impl_->window_, MouseMoveCallback);
     glfwSetMouseButtonCallback(impl_->window_, MouseButtonCallback);
@@ -1068,6 +1069,16 @@ void Window::ResizeCallback(GLFWwindow* window, int os_width, int os_height) {
     Window* w = static_cast<Window*>(glfwGetWindowUserPointer(window));
     w->OnResize();
     UpdateAfterEvent(w);
+}
+
+void Window::WindowMovedCallback(GLFWwindow* window, int os_x, int os_y) {
+#ifdef __APPLE__
+    // On macOS we need to recreate the swap chain if the window changes
+    // size OR MOVES!
+    Window* w = static_cast<Window*>(glfwGetWindowUserPointer(window));
+    w->OnResize();
+    UpdateAfterEvent(w);
+#endif
 }
 
 void Window::RescaleCallback(GLFWwindow* window, float xscale, float yscale) {

--- a/cpp/open3d/visualization/gui/Window.h
+++ b/cpp/open3d/visualization/gui/Window.h
@@ -172,6 +172,7 @@ private:
 
     static void DrawCallback(GLFWwindow* window);
     static void ResizeCallback(GLFWwindow* window, int os_width, int os_height);
+    static void WindowMovedCallback(GLFWwindow* window, int os_x, int os_y);
     static void RescaleCallback(GLFWwindow* window, float xscale, float yscale);
     static void MouseMoveCallback(GLFWwindow* window, double x, double y);
     static void MouseButtonCallback(GLFWwindow* window,


### PR DESCRIPTION
To reproduce (prior to this fix): on macOS, launch the viewer app but don't load a model. Now resize the window. Load a model, then move the window. You should see the pre-resized image squeezed (or pulled) into the window. (The fact that we didn't have any model loaded when we resized should be make the problem especially noticeable.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2076)
<!-- Reviewable:end -->
