### PR TITLE
lower case "open3d/3rdparty" intall dir

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -88,7 +88,7 @@ function(build_3rdparty_library name)
             )
         endforeach()
         target_include_directories(${name} PUBLIC
-            $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty>
+            $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty>
         )
         open3d_set_global_properties(${name})
         set_target_properties(${name} PROPERTIES
@@ -110,7 +110,7 @@ function(build_3rdparty_library name)
             )
         endforeach()
         target_include_directories(${name} INTERFACE
-            $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty>
+            $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty>
         )
     endif()
     if(NOT BUILD_SHARED_LIBS OR arg_PUBLIC)
@@ -124,11 +124,11 @@ function(build_3rdparty_library name)
         foreach(incl IN LISTS include_dirs)
             if(arg_INCLUDE_ALL)
                 install(DIRECTORY ${incl}
-                    DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty
+                    DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty
                 )
             else()
                 install(DIRECTORY ${incl}
-                    DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty
+                    DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty
                     FILES_MATCHING
                         PATTERN "*.h"
                         PATTERN "*.hpp"
@@ -210,10 +210,10 @@ function(import_3rdparty_library name)
         endif()
         target_include_directories(${name} SYSTEM INTERFACE $<BUILD_INTERFACE:${incl_path}>)
         if(arg_PUBLIC OR arg_HEADER)
-            install(DIRECTORY ${arg_INCLUDE_DIR} DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty
+            install(DIRECTORY ${arg_INCLUDE_DIR} DESTINATION ${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty
                 FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
             )
-            target_include_directories(${name} INTERFACE $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/3rdparty>)
+            target_include_directories(${name} INTERFACE $<INSTALL_INTERFACE:${Open3D_INSTALL_INCLUDE_DIR}/open3d/3rdparty>)
         endif()
     endif()
     if(arg_LIBRARIES)


### PR DESCRIPTION
Install 3rdparty header in `open3d/3rdparty/...` rather than `Open3D/3rdparty/...`.

**Before**
```
(open3d3) ➜  ~ tree -L 3 open3d_install
open3d_install
├── include
│   ├── open3d                  <=== open3d
│   │   ├── 3rdparty
│   │   ├── camera
│   │   ├── core
│   │   ├── geometry
│   │   ├── io
│   │   ├── Macro.h
│   │   ├── ml
│   │   ├── Open3DConfig.h
│   │   ├── Open3D.h
│   │   ├── pipelines
│   │   ├── utility
│   │   └── visualization
│   └── Open3D                  <=== Open3D
│       └── 3rdparty
└── lib
    ├── cmake
    │   └── Open3D
    └── libOpen3D.so
```

**After**
```
(open3d3) ➜  ~ tree -L 3 open3d_install
open3d_install
├── include
│   └── open3d
│       ├── 3rdparty
│       ├── camera
│       ├── core
│       ├── geometry
│       ├── io
│       ├── Macro.h
│       ├── ml
│       ├── Open3DConfig.h
│       ├── Open3D.h
│       ├── pipelines
│       ├── utility
│       └── visualization
└── lib
    ├── cmake
    │   └── Open3D
    └── libOpen3D.so
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2083)
<!-- Reviewable:end -->
