### PR TITLE
gui::TreeView now supports arbitrary widgets for its cells

### DIFF
--- a/cpp/open3d/visualization/gui/Button.cpp
+++ b/cpp/open3d/visualization/gui/Button.cpp
@@ -121,6 +121,8 @@ Widget::DrawResult Button::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
     auto result = Widget::DrawResult::NONE;
 
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
+
     bool was_on = impl_->is_on_;
     if (was_on) {
         ImGui::PushStyleColor(ImGuiCol_Text,
@@ -140,14 +142,10 @@ Widget::DrawResult Button::Draw(const DrawContext& context) {
         auto params = impl_->image_->CalcDrawParams(context.renderer, frame);
         ImTextureID image_id =
                 reinterpret_cast<ImTextureID>(params.texture.GetId());
-        ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
-                                   params.pos_y - context.uiOffsetY));
         pressed = ImGui::ImageButton(
                 image_id, ImVec2(params.width, params.height),
                 ImVec2(params.u0, params.v0), ImVec2(params.u1, params.v1));
     } else {
-        ImGui::SetCursorPos(ImVec2(frame.x - context.uiOffsetX,
-                                   frame.y - context.uiOffsetY));
         pressed = ImGui::Button(impl_->title_.c_str(),
                                 ImVec2(GetFrame().width, GetFrame().height));
     }

--- a/cpp/open3d/visualization/gui/Checkbox.cpp
+++ b/cpp/open3d/visualization/gui/Checkbox.cpp
@@ -70,8 +70,7 @@ Size Checkbox::CalcPreferredSize(const Theme& theme) const {
 
 Widget::DrawResult Checkbox::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
     auto result = Widget::DrawResult::NONE;
 
     // ImGUI doesn't offer styling specific to checkboxes other than the

--- a/cpp/open3d/visualization/gui/ColorEdit.cpp
+++ b/cpp/open3d/visualization/gui/ColorEdit.cpp
@@ -76,8 +76,7 @@ Size ColorEdit::CalcPreferredSize(const Theme& theme) const {
 
 ColorEdit::DrawResult ColorEdit::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     auto new_value = impl_->value_;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/Combobox.cpp
+++ b/cpp/open3d/visualization/gui/Combobox.cpp
@@ -164,8 +164,7 @@ Combobox::DrawResult Combobox::Draw(const DrawContext& context) {
     bool did_open = false;
 
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     ImGui::PushStyleColor(
             ImGuiCol_Button,

--- a/cpp/open3d/visualization/gui/ImageLabel.cpp
+++ b/cpp/open3d/visualization/gui/ImageLabel.cpp
@@ -84,8 +84,7 @@ Widget::DrawResult ImageLabel::Draw(const DrawContext& context) {
     if (params.texture != visualization::rendering::TextureHandle::kBad) {
         ImTextureID image_id =
                 reinterpret_cast<ImTextureID>(params.texture.GetId());
-        ImGui::SetCursorPos(ImVec2(params.pos_x - context.uiOffsetX,
-                                   params.pos_y - context.uiOffsetY));
+        ImGui::SetCursorScreenPos(ImVec2(params.pos_x, params.pos_y));
         ImGui::Image(image_id, ImVec2(params.width, params.height),
                      ImVec2(params.u0, params.v0),
                      ImVec2(params.u1, params.v1));
@@ -113,8 +112,7 @@ Widget::DrawResult ImageLabel::Draw(const DrawContext& context) {
         float x = (float(frame.width) - text_size.x) / 2.0f;
         float y = (float(frame.height) - text_size.y) / 2.0f;
 
-        ImGui::SetCursorPos(ImVec2(x + frame.x - context.uiOffsetX,
-                                   y + frame.y - context.uiOffsetY));
+        ImGui::SetCursorScreenPos(ImVec2(x + frame.x, y + frame.y));
         ImGui::PushTextWrapPos(wrapX);
         ImGui::TextWrapped("%s", error_text);
         ImGui::PopTextWrapPos();

--- a/cpp/open3d/visualization/gui/Label.cpp
+++ b/cpp/open3d/visualization/gui/Label.cpp
@@ -115,8 +115,7 @@ Size Label::CalcPreferredSize(const Theme& theme) const {
 
 Widget::DrawResult Label::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
     ImGui::PushItemWidth(frame.width);
     bool is_default_color = (impl_->color_ == DEFAULT_COLOR);
     if (!is_default_color) {

--- a/cpp/open3d/visualization/gui/ListView.cpp
+++ b/cpp/open3d/visualization/gui/ListView.cpp
@@ -99,8 +99,7 @@ Size ListView::CalcPreferredSize(const Theme &theme) const {
 
 Widget::DrawResult ListView::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
     ImGui::PushItemWidth(frame.width);
 
     ImGui::PushStyleColor(ImGuiCol_FrameBg,

--- a/cpp/open3d/visualization/gui/NumberEdit.cpp
+++ b/cpp/open3d/visualization/gui/NumberEdit.cpp
@@ -124,8 +124,7 @@ Size NumberEdit::CalcPreferredSize(const Theme &theme) const {
 
 Widget::DrawResult NumberEdit::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text edit borders

--- a/cpp/open3d/visualization/gui/Slider.cpp
+++ b/cpp/open3d/visualization/gui/Slider.cpp
@@ -101,8 +101,7 @@ Size Slider::CalcPreferredSize(const Theme& theme) const {
 
 Widget::DrawResult Slider::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     float new_value = impl_->value_;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/TabControl.cpp
+++ b/cpp/open3d/visualization/gui/TabControl.cpp
@@ -90,8 +90,7 @@ void TabControl::Layout(const Theme& theme) {
 
 TabControl::DrawResult TabControl::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     auto result = Widget::DrawResult::NONE;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/TextEdit.cpp
+++ b/cpp/open3d/visualization/gui/TextEdit.cpp
@@ -102,8 +102,7 @@ Size TextEdit::CalcPreferredSize(const Theme &theme) const {
 
 Widget::DrawResult TextEdit::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text editing

--- a/cpp/open3d/visualization/gui/TreeView.cpp
+++ b/cpp/open3d/visualization/gui/TreeView.cpp
@@ -31,6 +31,9 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "open3d/visualization/gui/Checkbox.h"
+#include "open3d/visualization/gui/ColorEdit.h"
+#include "open3d/visualization/gui/Label.h"
 #include "open3d/visualization/gui/Theme.h"
 #include "open3d/visualization/gui/Util.h"
 
@@ -38,6 +41,105 @@ namespace open3d {
 namespace visualization {
 namespace gui {
 
+struct CheckableTextTreeCell::Impl {
+    std::shared_ptr<Checkbox> checkbox_;
+    std::shared_ptr<Label> label_;
+};
+
+CheckableTextTreeCell::CheckableTextTreeCell(const char *text,
+                                             bool is_checked,
+                                             std::function<void(bool)> on_toggled)
+: impl_(new CheckableTextTreeCell::Impl()){
+    // We don't want any text in the checkbox, but passing "" seems to make it
+    // not toggle, so we need to pass in something. This way it will just be
+    // extra spacing.
+    impl_->checkbox_ = std::make_shared<Checkbox>(" ");
+    impl_->checkbox_->SetChecked(is_checked);
+    impl_->checkbox_->SetOnChecked(on_toggled);
+    impl_->label_ = std::make_shared<Label>(text);
+    AddChild(impl_->checkbox_);
+    AddChild(impl_->label_);
+}
+
+CheckableTextTreeCell::~CheckableTextTreeCell() {}
+
+Size CheckableTextTreeCell::CalcPreferredSize(const Theme& theme) const {
+    auto check_pref = impl_->checkbox_->CalcPreferredSize(theme);
+    auto label_pref = impl_->label_->CalcPreferredSize(theme);
+    return Size(check_pref.width + label_pref.width,
+                std::max(check_pref.height, label_pref.height));
+}
+
+void CheckableTextTreeCell::Layout(const Theme& theme) {
+    auto &frame = GetFrame();
+    auto check_width = impl_->checkbox_->CalcPreferredSize(theme).width;
+    impl_->checkbox_->SetFrame(Rect(frame.x, frame.y,
+                                    check_width, frame.height));
+    auto x = impl_->checkbox_->GetFrame().GetRight();
+    impl_->label_->SetFrame(Rect(x, frame.y,
+                                 frame.GetRight() - x, frame.height));
+}
+
+// ----------------------------------------------------------------------------
+struct LUTTreeCell::Impl {
+    std::shared_ptr<Checkbox> checkbox_;
+    std::shared_ptr<Label> label_;
+    std::shared_ptr<ColorEdit> color_;
+    float color_width_percent = 0.2f;
+};
+
+LUTTreeCell::LUTTreeCell(const char *text,
+                         bool is_checked,
+                         const Color& color,
+                         std::function<void(bool)> on_enabled,
+                         std::function<void(const Color&)> on_color_changed)
+: impl_(new LUTTreeCell::Impl()){
+    // We don't want any text in the checkbox, but passing "" seems to make it
+    // not toggle, so we need to pass in something. This way it will just be
+    // extra spacing.
+    impl_->checkbox_ = std::make_shared<Checkbox>(" ");
+    impl_->checkbox_->SetChecked(is_checked);
+    impl_->checkbox_->SetOnChecked(on_enabled);
+    impl_->label_ = std::make_shared<Label>(text);
+    impl_->color_ = std::make_shared<ColorEdit>();
+    impl_->color_->SetValue(color);
+    impl_->color_->SetOnValueChanged(on_color_changed);
+    AddChild(impl_->checkbox_);
+    AddChild(impl_->label_);
+    AddChild(impl_->color_);
+}
+
+LUTTreeCell::~LUTTreeCell() {}
+
+Size LUTTreeCell::CalcPreferredSize(const Theme& theme) const {
+    auto check_pref = impl_->checkbox_->CalcPreferredSize(theme);
+    auto label_pref = impl_->label_->CalcPreferredSize(theme);
+    auto color_pref = impl_->color_->CalcPreferredSize(theme);
+    return Size(check_pref.width + label_pref.width + color_pref.width,
+                std::max(check_pref.height,
+                         std::max(label_pref.height, color_pref.height)));
+}
+
+void LUTTreeCell::Layout(const Theme& theme) {
+    auto em = theme.font_size;
+    auto &frame = GetFrame();
+    auto check_width = impl_->checkbox_->CalcPreferredSize(theme).width;
+    auto color_width = int(std::ceil(impl_->color_width_percent * float(frame.width)));
+    auto min_color_width = 8 * theme.font_size;
+    color_width = std::max(min_color_width, color_width);
+    if (frame.width - (color_width + check_width) < 8 * em) {
+        color_width = frame.width - check_width - 8 * em;
+    }
+    impl_->checkbox_->SetFrame(Rect(frame.x, frame.y,
+                                    check_width, frame.height));
+    impl_->color_->SetFrame(Rect(frame.GetRight() - color_width, frame.y,
+                                 color_width, frame.height));
+    auto x = impl_->checkbox_->GetFrame().GetRight();
+    impl_->label_->SetFrame(Rect(x, frame.y,
+                                 impl_->color_->GetFrame().x - x, frame.height));
+}
+
+// ----------------------------------------------------------------------------
 namespace {
 static int g_treeview_id = 1;
 }
@@ -51,16 +153,16 @@ struct TreeView::Impl {
     struct Item {
         TreeView::ItemId id = -1;
         std::string id_string;
-        std::string text;
+        std::shared_ptr<Widget> cell;
         Item *parent = nullptr;
         std::list<Item> children;
     };
     int id_;
     Item root_;
-    std::unordered_map<TreeView::ItemId, Item *> id2item_;
+    std::unordered_map<TreeView::ItemId, Item*> id2item_;
     TreeView::ItemId selected_id_ = -1;
     bool can_select_parents_ = false;
-    std::function<void(const char *, TreeView::ItemId)> on_selection_changed_;
+    std::function<void(TreeView::ItemId)> on_selection_changed_;
 };
 
 TreeView::ItemId TreeView::Impl::g_next_id = 0;
@@ -75,14 +177,14 @@ TreeView::~TreeView() {}
 
 TreeView::ItemId TreeView::GetRootItem() const { return impl_->root_.id; }
 
-TreeView::ItemId TreeView::AddItem(ItemId parent_id, const char *text) {
+TreeView::ItemId TreeView::AddItem(ItemId parent_id, std::shared_ptr<Widget> w) {
     Impl::Item item;
     item.id = Impl::g_next_id++;
     // ImGUI uses the text to identify the item, create a ID string
     std::stringstream s;
     s << "treeview" << impl_->id_ << "item" << item.id;
     item.id_string = s.str();
-    item.text = text;
+    item.cell = w;
 
     Impl::Item *parent = &impl_->root_;
     auto parent_it = impl_->id2item_.find(parent_id);
@@ -96,10 +198,15 @@ TreeView::ItemId TreeView::AddItem(ItemId parent_id, const char *text) {
     return item.id;
 }
 
+TreeView::ItemId TreeView::AddTextItem(ItemId parent_id, const char *text) {
+    std::shared_ptr<Widget> w = std::make_shared<Label>(text);
+    return AddItem(parent_id, w);
+}
+
 void TreeView::RemoveItem(ItemId item_id) {
     auto item_it = impl_->id2item_.find(item_id);
     if (item_it != impl_->id2item_.end()) {
-        auto *item = item_it->second;
+        auto item = item_it->second;
         // Erase the item here, because RemoveItem(child) will also erase,
         // which will invalidate our iterator.
         impl_->id2item_.erase(item_it);
@@ -127,19 +234,18 @@ void TreeView::RemoveItem(ItemId item_id) {
     }
 }
 
-const char *TreeView::GetItemText(ItemId item_id) const {
-    auto item_it = impl_->id2item_.find(item_id);
-    if (item_it != impl_->id2item_.end()) {
-        return item_it->second->text.c_str();
-    }
-    return nullptr;
+void TreeView::Clear() {
+    impl_->selected_id_ = -1;
+    impl_->id2item_.clear();
+    impl_->root_.children.clear();
 }
 
-void TreeView::SetItemText(ItemId item_id, const char *text) {
+std::shared_ptr<Widget> TreeView::GetItem(ItemId item_id) const {
     auto item_it = impl_->id2item_.find(item_id);
     if (item_it != impl_->id2item_.end()) {
-        item_it->second->text = text;
+        return item_it->second->cell;
     }
+    return nullptr;
 }
 
 std::vector<TreeView::ItemId> TreeView::GetItemChildren(
@@ -179,7 +285,7 @@ void TreeView::SetSelectedItemId(ItemId item_id) {
 }
 
 void TreeView::SetOnSelectionChanged(
-        std::function<void(const char *, ItemId)> on_selection_changed) {
+        std::function<void(ItemId)> on_selection_changed) {
     impl_->on_selection_changed_ = on_selection_changed;
 }
 
@@ -187,12 +293,17 @@ Size TreeView::CalcPreferredSize(const Theme &theme) const {
     return Size(Widget::DIM_GROW, Widget::DIM_GROW);
 }
 
+void TreeView::Layout(const Theme& theme) {
+    // Nothing to do here. We don't know the x position because of the
+    // indentations, which also means we don't know the size. So we need
+    // to defer layout to Draw().
+}
+
 Widget::DrawResult TreeView::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
 
     DrawImGuiPushEnabledState();
-    ImGui::SetCursorPosX(frame.x - context.uiOffsetX);
-    ImGui::SetCursorPosY(frame.y - context.uiOffsetY);
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     // ImGUI's tree wants to highlight the row as the user moves over it.
     // There are several problems here. First, there seems to be a bug in
@@ -220,17 +331,18 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
     std::function<void(Impl::Item &)> DrawItem;
     DrawItem = [&DrawItem, this, &frame, &context,
                 &new_selection](Impl::Item &item) {
+        int height = item.cell->CalcPreferredSize(context.theme).height;
+
         // ImGUI's tree doesn't seem to support selected items,
         // so we have to draw our own selection.
         if (item.id == impl_->selected_id_) {
-            auto h = ImGui::GetTextLineHeightWithSpacing();
             // Since we are in a child, the cursor is relative to the upper left
             // of the tree's frame. To draw directly to the window list we
             // need to the absolute coordinates (relative the OS window's
             // upper left)
             auto y = frame.y + ImGui::GetCursorPosY() - ImGui::GetScrollY();
             ImGui::GetWindowDrawList()->AddRectFilled(
-                    ImVec2(frame.x, y), ImVec2(frame.GetRight(), y + h),
+                    ImVec2(frame.x, y), ImVec2(frame.GetRight(), y + height),
                     colorToImguiRGBA(context.theme.tree_selected_color));
         }
 
@@ -244,21 +356,40 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
         }
         bool is_selectable =
                 (item.children.empty() || impl_->can_select_parents_);
-        if (ImGui::TreeNodeEx(item.id_string.c_str(), flags, "%s",
-                              item.text.c_str())) {
+        auto DrawThis = [this, &tree_frame=frame, &context, &new_selection](TreeView::Impl::Item& item, int height, bool is_selectable) {
+            ImGui::SameLine(0, 0);
+            auto x = ImGui::GetCursorScreenPos().x;
+            auto y = ImGui::GetCursorScreenPos().y;
+            auto scroll_width = ImGui::GetStyle().ScrollbarSize;
+            auto indent = ImGui::GetCursorScreenPos().x - tree_frame.x;
+            item.cell->SetFrame(Rect(x, y,
+                                     tree_frame.width - indent - scroll_width,
+                                     height));
+            // Now that we know the frame we can finally layout. It would be
+            // nice to not relayout until something changed, which would
+            // usually work, unless the cell changes shape in response to
+            // something, which would be a problem. So do it every time.
+            item.cell->Layout(context.theme);
+
+            ImGui::BeginGroup();
+            item.cell->Draw(context);
+            ImGui::EndGroup();
+
             if (ImGui::IsItemClicked() && is_selectable) {
                 impl_->selected_id_ = item.id;
                 new_selection = &item;
             }
+        };
+
+        if (ImGui::TreeNodeEx(item.id_string.c_str(), flags, "")) {
+            DrawThis(item, height, is_selectable);
+
             for (auto &child : item.children) {
                 DrawItem(child);
             }
             ImGui::TreePop();
         } else {
-            if (ImGui::IsItemClicked() && is_selectable) {
-                impl_->selected_id_ = item.id;
-                new_selection = &item;
-            }
+            DrawThis(item, height, is_selectable);
         }
     };
     for (auto &top : impl_->root_.children) {
@@ -277,8 +408,7 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
     auto result = Widget::DrawResult::NONE;
     if (new_selection) {
         if (impl_->on_selection_changed_) {
-            impl_->on_selection_changed_(new_selection->text.c_str(),
-                                         new_selection->id);
+            impl_->on_selection_changed_(new_selection->id);
         }
         result = Widget::DrawResult::REDRAW;
     }

--- a/cpp/open3d/visualization/gui/TreeView.cpp
+++ b/cpp/open3d/visualization/gui/TreeView.cpp
@@ -46,10 +46,9 @@ struct CheckableTextTreeCell::Impl {
     std::shared_ptr<Label> label_;
 };
 
-CheckableTextTreeCell::CheckableTextTreeCell(const char *text,
-                                             bool is_checked,
-                                             std::function<void(bool)> on_toggled)
-: impl_(new CheckableTextTreeCell::Impl()){
+CheckableTextTreeCell::CheckableTextTreeCell(
+        const char *text, bool is_checked, std::function<void(bool)> on_toggled)
+    : impl_(new CheckableTextTreeCell::Impl()) {
     // We don't want any text in the checkbox, but passing "" seems to make it
     // not toggle, so we need to pass in something. This way it will just be
     // extra spacing.
@@ -63,21 +62,21 @@ CheckableTextTreeCell::CheckableTextTreeCell(const char *text,
 
 CheckableTextTreeCell::~CheckableTextTreeCell() {}
 
-Size CheckableTextTreeCell::CalcPreferredSize(const Theme& theme) const {
+Size CheckableTextTreeCell::CalcPreferredSize(const Theme &theme) const {
     auto check_pref = impl_->checkbox_->CalcPreferredSize(theme);
     auto label_pref = impl_->label_->CalcPreferredSize(theme);
     return Size(check_pref.width + label_pref.width,
                 std::max(check_pref.height, label_pref.height));
 }
 
-void CheckableTextTreeCell::Layout(const Theme& theme) {
+void CheckableTextTreeCell::Layout(const Theme &theme) {
     auto &frame = GetFrame();
     auto check_width = impl_->checkbox_->CalcPreferredSize(theme).width;
-    impl_->checkbox_->SetFrame(Rect(frame.x, frame.y,
-                                    check_width, frame.height));
+    impl_->checkbox_->SetFrame(
+            Rect(frame.x, frame.y, check_width, frame.height));
     auto x = impl_->checkbox_->GetFrame().GetRight();
-    impl_->label_->SetFrame(Rect(x, frame.y,
-                                 frame.GetRight() - x, frame.height));
+    impl_->label_->SetFrame(
+            Rect(x, frame.y, frame.GetRight() - x, frame.height));
 }
 
 // ----------------------------------------------------------------------------
@@ -90,10 +89,10 @@ struct LUTTreeCell::Impl {
 
 LUTTreeCell::LUTTreeCell(const char *text,
                          bool is_checked,
-                         const Color& color,
+                         const Color &color,
                          std::function<void(bool)> on_enabled,
-                         std::function<void(const Color&)> on_color_changed)
-: impl_(new LUTTreeCell::Impl()){
+                         std::function<void(const Color &)> on_color_changed)
+    : impl_(new LUTTreeCell::Impl()) {
     // We don't want any text in the checkbox, but passing "" seems to make it
     // not toggle, so we need to pass in something. This way it will just be
     // extra spacing.
@@ -111,7 +110,7 @@ LUTTreeCell::LUTTreeCell(const char *text,
 
 LUTTreeCell::~LUTTreeCell() {}
 
-Size LUTTreeCell::CalcPreferredSize(const Theme& theme) const {
+Size LUTTreeCell::CalcPreferredSize(const Theme &theme) const {
     auto check_pref = impl_->checkbox_->CalcPreferredSize(theme);
     auto label_pref = impl_->label_->CalcPreferredSize(theme);
     auto color_pref = impl_->color_->CalcPreferredSize(theme);
@@ -120,23 +119,24 @@ Size LUTTreeCell::CalcPreferredSize(const Theme& theme) const {
                          std::max(label_pref.height, color_pref.height)));
 }
 
-void LUTTreeCell::Layout(const Theme& theme) {
+void LUTTreeCell::Layout(const Theme &theme) {
     auto em = theme.font_size;
     auto &frame = GetFrame();
     auto check_width = impl_->checkbox_->CalcPreferredSize(theme).width;
-    auto color_width = int(std::ceil(impl_->color_width_percent * float(frame.width)));
+    auto color_width =
+            int(std::ceil(impl_->color_width_percent * float(frame.width)));
     auto min_color_width = 8 * theme.font_size;
     color_width = std::max(min_color_width, color_width);
     if (frame.width - (color_width + check_width) < 8 * em) {
         color_width = frame.width - check_width - 8 * em;
     }
-    impl_->checkbox_->SetFrame(Rect(frame.x, frame.y,
-                                    check_width, frame.height));
+    impl_->checkbox_->SetFrame(
+            Rect(frame.x, frame.y, check_width, frame.height));
     impl_->color_->SetFrame(Rect(frame.GetRight() - color_width, frame.y,
                                  color_width, frame.height));
     auto x = impl_->checkbox_->GetFrame().GetRight();
-    impl_->label_->SetFrame(Rect(x, frame.y,
-                                 impl_->color_->GetFrame().x - x, frame.height));
+    impl_->label_->SetFrame(
+            Rect(x, frame.y, impl_->color_->GetFrame().x - x, frame.height));
 }
 
 // ----------------------------------------------------------------------------
@@ -159,7 +159,7 @@ struct TreeView::Impl {
     };
     int id_;
     Item root_;
-    std::unordered_map<TreeView::ItemId, Item*> id2item_;
+    std::unordered_map<TreeView::ItemId, Item *> id2item_;
     TreeView::ItemId selected_id_ = -1;
     bool can_select_parents_ = false;
     std::function<void(TreeView::ItemId)> on_selection_changed_;
@@ -177,7 +177,8 @@ TreeView::~TreeView() {}
 
 TreeView::ItemId TreeView::GetRootItem() const { return impl_->root_.id; }
 
-TreeView::ItemId TreeView::AddItem(ItemId parent_id, std::shared_ptr<Widget> w) {
+TreeView::ItemId TreeView::AddItem(ItemId parent_id,
+                                   std::shared_ptr<Widget> w) {
     Impl::Item item;
     item.id = Impl::g_next_id++;
     // ImGUI uses the text to identify the item, create a ID string
@@ -293,7 +294,7 @@ Size TreeView::CalcPreferredSize(const Theme &theme) const {
     return Size(Widget::DIM_GROW, Widget::DIM_GROW);
 }
 
-void TreeView::Layout(const Theme& theme) {
+void TreeView::Layout(const Theme &theme) {
     // Nothing to do here. We don't know the x position because of the
     // indentations, which also means we don't know the size. So we need
     // to defer layout to Draw().
@@ -356,15 +357,15 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
         }
         bool is_selectable =
                 (item.children.empty() || impl_->can_select_parents_);
-        auto DrawThis = [this, &tree_frame=frame, &context, &new_selection](TreeView::Impl::Item& item, int height, bool is_selectable) {
+        auto DrawThis = [ this, &tree_frame = frame, &context, &new_selection ](
+                TreeView::Impl::Item & item, int height, bool is_selectable) {
             ImGui::SameLine(0, 0);
             auto x = ImGui::GetCursorScreenPos().x;
             auto y = ImGui::GetCursorScreenPos().y;
             auto scroll_width = ImGui::GetStyle().ScrollbarSize;
             auto indent = ImGui::GetCursorScreenPos().x - tree_frame.x;
-            item.cell->SetFrame(Rect(x, y,
-                                     tree_frame.width - indent - scroll_width,
-                                     height));
+            item.cell->SetFrame(Rect(
+                    x, y, tree_frame.width - indent - scroll_width, height));
             // Now that we know the frame we can finally layout. It would be
             // nice to not relayout until something changed, which would
             // usually work, unless the cell changes shape in response to

--- a/cpp/open3d/visualization/gui/TreeView.cpp
+++ b/cpp/open3d/visualization/gui/TreeView.cpp
@@ -27,6 +27,7 @@
 #include "open3d/visualization/gui/TreeView.h"
 
 #include <imgui.h>
+#include <cmath>
 #include <list>
 #include <sstream>
 #include <unordered_map>
@@ -382,7 +383,7 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
             }
         };
 
-        if (ImGui::TreeNodeEx(item.id_string.c_str(), flags, "")) {
+        if (ImGui::TreeNodeEx(item.id_string.c_str(), flags, "%s", "")) {
             DrawThis(item, height, is_selectable);
 
             for (auto &child : item.children) {

--- a/cpp/open3d/visualization/gui/TreeView.h
+++ b/cpp/open3d/visualization/gui/TreeView.h
@@ -41,7 +41,7 @@ namespace gui {
 /// (if any, and if CanSelectItemsWithChildren is false).
 class CheckableTextTreeCell : public Widget {
 public:
-    CheckableTextTreeCell(const char *text,
+    CheckableTextTreeCell(const char* text,
                           bool is_checked,
                           std::function<void(bool)> on_toggled);
     ~CheckableTextTreeCell();
@@ -56,7 +56,7 @@ private:
 
 class LUTTreeCell : public Widget {
 public:
-    LUTTreeCell(const char *text,
+    LUTTreeCell(const char* text,
                 bool is_checked,
                 const Color& color,
                 std::function<void(bool)> on_enabled,
@@ -86,7 +86,7 @@ public:
     /// Adds an item to the tree.
     ItemId AddItem(ItemId parent_id, std::shared_ptr<Widget> item);
     /// Adds a text item to the tree
-    ItemId AddTextItem(ItemId parent_id, const char *text);
+    ItemId AddTextItem(ItemId parent_id, const char* text);
     /// Removes an item an all its children (if any) from the tree
     void RemoveItem(ItemId item_id);
     /// Clears all the items

--- a/cpp/open3d/visualization/gui/TreeView.h
+++ b/cpp/open3d/visualization/gui/TreeView.h
@@ -34,6 +34,43 @@ namespace open3d {
 namespace visualization {
 namespace gui {
 
+/// The only difference between just putting in a Checkbox with
+/// TreeView::AddItem() is that with a Checkbox, clicking on the
+/// text will toggle on/off, whereas with this you must click on
+/// the checkbox; clicking on the text will open/close the children
+/// (if any, and if CanSelectItemsWithChildren is false).
+class CheckableTextTreeCell : public Widget {
+public:
+    CheckableTextTreeCell(const char *text,
+                          bool is_checked,
+                          std::function<void(bool)> on_toggled);
+    ~CheckableTextTreeCell();
+
+    Size CalcPreferredSize(const Theme& theme) const override;
+    void Layout(const Theme& theme) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+class LUTTreeCell : public Widget {
+public:
+    LUTTreeCell(const char *text,
+                bool is_checked,
+                const Color& color,
+                std::function<void(bool)> on_enabled,
+                std::function<void(const Color&)> on_color_changed);
+    ~LUTTreeCell();
+
+    Size CalcPreferredSize(const Theme& theme) const override;
+    void Layout(const Theme& theme) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
 class TreeView : public Widget {
     using Super = Widget;
 
@@ -44,15 +81,18 @@ public:
     ~TreeView();
 
     /// Returns the ID of the root item, that is,
-    /// AddItem(GetRootItem(), "...") will be a top-level item.
+    /// AddItem(GetRootItem(), ...) will be a top-level item.
     ItemId GetRootItem() const;
     /// Adds an item to the tree.
-    ItemId AddItem(ItemId parent_id, const char* text);
+    ItemId AddItem(ItemId parent_id, std::shared_ptr<Widget> item);
+    /// Adds a text item to the tree
+    ItemId AddTextItem(ItemId parent_id, const char *text);
     /// Removes an item an all its children (if any) from the tree
     void RemoveItem(ItemId item_id);
-    /// Returns the text of the item, or nullptr if item_id cannot be found.
-    const char* GetItemText(ItemId item_id) const;
-    void SetItemText(ItemId item_id, const char* text);
+    /// Clears all the items
+    void Clear();
+    /// Returns item, or nullptr if item_id cannot be found.
+    std::shared_ptr<Widget> GetItem(ItemId item_id) const;
     std::vector<ItemId> GetItemChildren(ItemId parent_id) const;
 
     bool GetCanSelectItemsWithChildren() const;
@@ -68,12 +108,14 @@ public:
 
     Size CalcPreferredSize(const Theme& theme) const override;
 
+    void Layout(const Theme& theme) override;
+
     DrawResult Draw(const DrawContext& context) override;
 
     /// Calls onSelectionChanged(const char *sel_text, ItemId sel_item_id)
     /// when the list selection changes because of user action.
     void SetOnSelectionChanged(
-            std::function<void(const char*, ItemId)> on_selection_changed);
+            std::function<void(ItemId)> on_selection_changed);
 
 private:
     struct Impl;

--- a/cpp/open3d/visualization/gui/VectorEdit.cpp
+++ b/cpp/open3d/visualization/gui/VectorEdit.cpp
@@ -77,8 +77,7 @@ Size VectorEdit::CalcPreferredSize(const Theme& theme) const {
 
 Widget::DrawResult VectorEdit::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorPos(
-            ImVec2(frame.x - context.uiOffsetX, frame.y - context.uiOffsetY));
+    ImGui::SetCursorScreenPos(ImVec2(frame.x, frame.y));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text editing

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -1822,7 +1822,7 @@ void GuiVisualizer::Layout(const gui::Theme &theme) {
             impl_->settings_.wgt_base->CalcPreferredSize(theme);
     gui::Rect lightSettingsRect(r.width - LIGHT_SETTINGS_WIDTH, r.y,
                                 LIGHT_SETTINGS_WIDTH,
-                                light_settings_size.height);
+                                std::min(r.height, light_settings_size.height));
     impl_->settings_.wgt_base->SetFrame(lightSettingsRect);
 
     Super::Layout(theme);

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -741,13 +741,12 @@ void pybind_gui_classes(py::module &m) {
                  "are "
                  "the top-level items")
             .def("add_item", &TreeView::AddItem,
+                 "Adds a child item to the parent. add_item(parent, widget)")
+            .def("add_text_item", &TreeView::AddTextItem,
                  "Adds a child item to the parent. add_item(parent, text)")
             .def("remove_item", &TreeView::RemoveItem,
                  "Removes an item and all its children (if any)")
-            .def("get_item_text", &TreeView::GetItemText,
-                 "Returns the text of the item")
-            .def("set_item_text", &TreeView::SetItemText,
-                 "Sets the text of an item")
+            .def("clear", &TreeView::Clear, "Removes all items")
             .def_property(
                     "can_select_items_with_children",
                     &TreeView::GetCanSelectItemsWithChildren,
@@ -761,9 +760,22 @@ void pybind_gui_classes(py::module &m) {
                           &TreeView::SetSelectedItemId,
                           "The currently selected item")
             .def("set_on_selection_changed", &TreeView::SetOnSelectionChanged,
-                 "Sets f(new_item_text, new_item_id) which is called when the "
-                 "user "
+                 "Sets f(new_item_id) which is called when the user "
                  "changes the selection.");
+
+    // ---- TreeView cells ----
+    py::class_<CheckableTextTreeCell, std::shared_ptr<CheckableTextTreeCell>, Widget> checkable_cell(m, "CheckableTextTreeCell", "TreeView cell with a checkbox and text");
+    checkable_cell.def(py::init<>([](const char *text, bool checked,
+                                     std::function<void(bool)> on_toggled) {
+        return std::make_shared<CheckableTextTreeCell>(text, checked, on_toggled);
+    }));
+
+    py::class_<LUTTreeCell, std::shared_ptr<LUTTreeCell>, Widget> lut_cell(m, "LUTTreeCell", "TreeView cell with checkbox, text, and color edit");
+    lut_cell.def(py::init<>([](const char *text, bool checked, const Color& color,
+                               std::function<void(bool)> on_enabled,
+                               std::function<void(const Color&)> on_color){
+        return std::make_shared<LUTTreeCell>(text, checked, color, on_enabled, on_color);
+    }));
 
     // ---- VectorEdit ----
     py::class_<VectorEdit, std::shared_ptr<VectorEdit>, Widget> vectoredit(

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -764,18 +764,26 @@ void pybind_gui_classes(py::module &m) {
                  "changes the selection.");
 
     // ---- TreeView cells ----
-    py::class_<CheckableTextTreeCell, std::shared_ptr<CheckableTextTreeCell>, Widget> checkable_cell(m, "CheckableTextTreeCell", "TreeView cell with a checkbox and text");
+    py::class_<CheckableTextTreeCell, std::shared_ptr<CheckableTextTreeCell>,
+               Widget>
+            checkable_cell(m, "CheckableTextTreeCell",
+                           "TreeView cell with a checkbox and text");
     checkable_cell.def(py::init<>([](const char *text, bool checked,
                                      std::function<void(bool)> on_toggled) {
-        return std::make_shared<CheckableTextTreeCell>(text, checked, on_toggled);
+        return std::make_shared<CheckableTextTreeCell>(text, checked,
+                                                       on_toggled);
     }));
 
-    py::class_<LUTTreeCell, std::shared_ptr<LUTTreeCell>, Widget> lut_cell(m, "LUTTreeCell", "TreeView cell with checkbox, text, and color edit");
-    lut_cell.def(py::init<>([](const char *text, bool checked, const Color& color,
-                               std::function<void(bool)> on_enabled,
-                               std::function<void(const Color&)> on_color){
-        return std::make_shared<LUTTreeCell>(text, checked, color, on_enabled, on_color);
-    }));
+    py::class_<LUTTreeCell, std::shared_ptr<LUTTreeCell>, Widget> lut_cell(
+            m, "LUTTreeCell",
+            "TreeView cell with checkbox, text, and color edit");
+    lut_cell.def(
+            py::init<>([](const char *text, bool checked, const Color &color,
+                          std::function<void(bool)> on_enabled,
+                          std::function<void(const Color &)> on_color) {
+                return std::make_shared<LUTTreeCell>(text, checked, color,
+                                                     on_enabled, on_color);
+            }));
 
     // ---- VectorEdit ----
     py::class_<VectorEdit, std::shared_ptr<VectorEdit>, Widget> vectoredit(

--- a/examples/python/GUI/all-widgets.py
+++ b/examples/python/GUI/all-widgets.py
@@ -307,8 +307,8 @@ class ExampleWindow:
     def _on_list(self, new_val, is_dbl_click):
         print(new_val)
 
-    def _on_tree(self, new_text, new_item):
-        print(new_text)
+    def _on_tree(self, new_item_id):
+        print(new_item_id)
 
     def _on_slider(self, new_val):
         self._progress.value = new_val / 20.0

--- a/examples/python/GUI/all-widgets.py
+++ b/examples/python/GUI/all-widgets.py
@@ -125,13 +125,13 @@ class ExampleWindow:
 
         # Add a tree view
         tree = gui.TreeView()
-        tree.add_item(tree.get_root_item(), "Camera")
-        geo_id = tree.add_item(tree.get_root_item(), "Geometries")
-        mesh_id = tree.add_item(geo_id, "Mesh")
-        tree.add_item(mesh_id, "Triangles")
-        tree.add_item(mesh_id, "Albedo texture")
-        tree.add_item(mesh_id, "Normal map")
-        points_id = tree.add_item(geo_id, "Points")
+        tree.add_text_item(tree.get_root_item(), "Camera")
+        geo_id = tree.add_text_item(tree.get_root_item(), "Geometries")
+        mesh_id = tree.add_text_item(geo_id, "Mesh")
+        tree.add_text_item(mesh_id, "Triangles")
+        tree.add_text_item(mesh_id, "Albedo texture")
+        tree.add_text_item(mesh_id, "Normal map")
+        points_id = tree.add_text_item(geo_id, "Points")
         tree.can_select_items_with_children = True
         tree.set_on_selection_changed(self._on_tree)
         # does not call on_selection_changed: user did not change selection


### PR DESCRIPTION

A Python script testing this is attached below (note that you will need to rename it to .py, as GitHub won't accept a .py file)

[ml-vis.txt](https://github.com/intel-isl/Open3D/files/4974546/ml-vis.txt) (change line 288 to `dataset.visualize(0)` if using the small version of SemanticKITTI linked below
[microkitti.tar.gz](https://github.com/intel-isl/Open3D/files/4983757/microkitti.tar.gz) (very small version of SemanticKITTI)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2105)
<!-- Reviewable:end -->
