### PR TITLE
PointToPlane and ColoedICP should only require target PointCloud to have pre-computed Normals

### DIFF
--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -157,11 +157,11 @@ RegistrationResult RegistrationICP(
                  TransformationEstimationType::PointToPlane ||
          estimation.GetTransformationEstimationType() ==
                  TransformationEstimationType::ColoredICP) &&
-        (!source.HasNormals() || !target.HasNormals())) {
+        (!target.HasNormals())) {
         utility::LogError(
                 "TransformationEstimationPointToPlane and "
                 "TransformationEstimationColoredICP "
-                "require pre-computed normal vectors.");
+                "require pre-computed normal vectors for target PointCloud.");
     }
 
     Eigen::Matrix4d transformation = init;


### PR DESCRIPTION
This PR fixes #2075 

https://github.com/intel-isl/Open3D/blob/ae38f286302f1d650e6acd1048178ca28c86af00/cpp/open3d/pipelines/registration/Registration.cpp#L160

![image](https://user-images.githubusercontent.com/21349875/87456459-5a33a600-c5dd-11ea-9461-227c7e0e971a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2118)
<!-- Reviewable:end -->
