### PR TITLE
speed up 3rd-party package download

### DIFF
--- a/3rdparty/filament/filament_download.cmake
+++ b/3rdparty/filament/filament_download.cmake
@@ -23,21 +23,19 @@ else()
         MESSAGE(FATAL_ERROR "Downloadable version of Filament supports vulkan only on Linux and Apple")
     endif()
 
-    FetchContent_Declare(
-        fetch_filament
+    # ExternalProject_Add happends at build time.
+    ExternalProject_Add(
+        ext_filament
+        PREFIX filament
         URL ${DOWNLOAD_URL_PRIMARY} ${DOWNLOAD_URL_FALLBACK}
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE ON
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
     )
-
-    # FetchContent happends at config time.
-    FetchContent_GetProperties(fetch_filament)
-    if(NOT fetch_filament_POPULATED)
-        message(STATUS "Downloading Filament...")
-        FetchContent_Populate(fetch_filament)
-        # We use the default download and unpack directories for FetchContent.
-        message(STATUS "Filament has been downloaded to ${fetch_filament_DOWNLOADED_FILE}.")
-        message(STATUS "Filament has been extracted to ${fetch_filament_SOURCE_DIR}.")
-        set(FILAMENT_ROOT "${fetch_filament_SOURCE_DIR}")
-    endif()
+    ExternalProject_Get_Property(ext_filament SOURCE_DIR)
+    set(FILAMENT_ROOT ${SOURCE_DIR})
 endif()
 
 message(STATUS "Filament is located at ${FILAMENT_ROOT}")

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -251,6 +251,37 @@ function(import_3rdparty_library name)
     add_library(${PROJECT_NAME}::${name} ALIAS ${name})
 endfunction()
 
+#
+# set_local_or_remote_url(url ...)
+#
+# If LOCAL_URL exists, set URL to LOCAL_URL, otherwise set URL to REMOTE_URLS.
+# This function is needed since CMake does not allow specifying remote URL(s) if
+# a local URL is specified.
+#
+# Valid options:
+#    LOCAL_URL
+#        local url to a file. Optional parameter. If the file does not exist,
+#        LOCAL_URL will be ignored. If the file exists, REMOTE URLS will be
+#        ignored. CMake only allows setting single LOCAL_URL for external
+#        projects.
+#    REMOTE_URLS
+#        remote url(s) to download a file. CMake will try to download the file
+#        in the specified order.
+#
+function(set_local_or_remote_url URL)
+    cmake_parse_arguments(arg "" "LOCAL_URL" "REMOTE_URLS" ${ARGN})
+    if(arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Invalid syntax: set_local_or_remote_url(${name} ${ARGN})")
+    endif()
+    if(arg_LOCAL_URL AND (EXISTS ${arg_LOCAL_URL}))
+        message(STATUS "Using local url: ${arg_LOCAL_URL}")
+        set(${URL} "${arg_LOCAL_URL}" PARENT_SCOPE)
+    else()
+        message(STATUS "Using remote url(s): ${arg_REMOTE_URLS}")
+        set(${URL} "${arg_REMOTE_URLS}" PARENT_SCOPE)
+    endif()
+endfunction()
+
 # Threads
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE) # -pthread instead of -lpthread

--- a/3rdparty/mkl/mkl.cmake
+++ b/3rdparty/mkl/mkl.cmake
@@ -11,14 +11,23 @@
 include(ExternalProject)
 
 if(WIN32)
-    set(MKL_INCLUDE_URL "https://anaconda.org/intel/mkl-include/2020.1/download/win-64/mkl-include-2020.1-intel_216.tar.bz2")
-    set(MKL_URL         "https://anaconda.org/intel/mkl-static/2020.1/download/win-64/mkl-static-2020.1-intel_216.tar.bz2")
+    set(MKL_INCLUDE_URL      "https://anaconda.org/intel/mkl-include/2020.1/download/win-64/mkl-include-2020.1-intel_216.tar.bz2")
+    set(MKL_URL              "https://anaconda.org/intel/mkl-static/2020.1/download/win-64/mkl-static-2020.1-intel_216.tar.bz2")
 elseif(APPLE)
-    set(MKL_INCLUDE_URL   "https://anaconda.org/intel/mkl-include/2020.1/download/osx-64/mkl-include-2020.1-intel_216.tar.bz2")
-    set(MKL_URL           "https://anaconda.org/intel/mkl-static/2020.1/download/osx-64/mkl-static-2020.1-intel_216.tar.bz2")
+    set(MKL_INCLUDE_URL      "https://anaconda.org/intel/mkl-include/2020.1/download/osx-64/mkl-include-2020.1-intel_216.tar.bz2")
+    set(MKL_URL              "https://anaconda.org/intel/mkl-static/2020.1/download/osx-64/mkl-static-2020.1-intel_216.tar.bz2")
 else()
-    set(MKL_INCLUDE_URL   "https://anaconda.org/intel/mkl-include/2020.1/download/linux-64/mkl-include-2020.1-intel_217.tar.bz2")
-    set(MKL_URL           "https://anaconda.org/intel/mkl-static/2020.1/download/linux-64/mkl-static-2020.1-intel_217.tar.bz2")
+    set(MKL_INCLUDE_URL      "https://anaconda.org/intel/mkl-include/2020.1/download/linux-64/mkl-include-2020.1-intel_217.tar.bz2")
+    set_local_or_remote_url(
+        MKL_URL
+        LOCAL_URL   "${THIRD_PARTY_DOWNLOAD_DIR}/mkl-static-2020.1-intel_217.tar.bz2"
+        REMOTE_URLS "https://anaconda.org/intel/mkl-static/2020.1/download/linux-64/mkl-static-2020.1-intel_217.tar.bz2"
+    )
+    set_local_or_remote_url(
+        MKL_MERGED_URL
+        LOCAL_URL   "${THIRD_PARTY_DOWNLOAD_DIR}/linux-merged-mkl-static-2020.1-intel_217.zip"
+        REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.10.0/linux-merged-mkl-static-2020.1-intel_217.zip"
+    )
 endif()
 
 # Where MKL and TBB headers and libs will be installed.
@@ -97,20 +106,6 @@ elseif(APPLE)
     )
     set(STATIC_MKL_LIBRARIES mkl_intel_ilp64 mkl_tbb_thread mkl_core tbb_static)
 else()
-    # Resolving static library circular dependencies.
-    # - Approach 1: Add `-Wl,--start-group` `-Wl,--end-group` around, but this
-    #               is not friendly with CMake.
-    # - Approach 2: Set LINK_INTERFACE_MULTIPLICITY to 3. However this does not
-    #               work directly with interface library, and requires big
-    #               changes to the build system. See discussions in:
-    #               - https://gitlab.kitware.com/cmake/cmake/-/issues/17964
-    #               - https://gitlab.kitware.com/cmake/cmake/-/issues/18415
-    #               - https://stackoverflow.com/q/50166553/1255535
-    # - Approach 3: Merge libmkl_intel_ilp64.a, libmkl_tbb_thread.a and
-    #               libmkl_core.a into libmkl_merged.a. This is the most simple
-    #               approach to integrate with the build system. However, extra
-    #               time is required to merge the libraries and the merged
-    #               library size can be large. We choose to use approach 3.
     ExternalProject_Add(
         ext_mkl_include
         PREFIX mkl_include
@@ -120,22 +115,51 @@ else()
         BUILD_COMMAND ""
         INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/include ${MKL_INSTALL_PREFIX}/include
     )
-    ExternalProject_Add(
-        ext_mkl
-        PREFIX mkl
-        URL ${MKL_URL}
-        UPDATE_COMMAND ""
-        CONFIGURE_COMMAND ""
-        BUILD_IN_SOURCE ON
-        BUILD_COMMAND echo "Extracting static libs..."
-        COMMAND ar x lib/libmkl_intel_ilp64.a
-        COMMAND ar x lib/libmkl_tbb_thread.a
-        COMMAND ar x lib/libmkl_core.a
-        COMMAND echo "Merging static libs..."
-        COMMAND bash -c "ar -qc lib/libmkl_merged.a *.o"
-        COMMAND echo "Cleaning up *.o files..."
-        COMMAND bash -c "rm *.o"
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E copy lib/libmkl_merged.a ${MKL_INSTALL_PREFIX}/lib/libmkl_merged.a
-    )
+    option(USE_LINUX_MKL_FROM_CONDA_REPO "On linux, use MKL from official conda repo" OFF)
+    if(USE_LINUX_MKL_FROM_CONDA_REPO)
+        # Resolving static library circular dependencies.
+        # - Approach 1: Add `-Wl,--start-group` `-Wl,--end-group` around, but this
+        #               is not friendly with CMake.
+        # - Approach 2: Set LINK_INTERFACE_MULTIPLICITY to 3. However this does not
+        #               work directly with interface library, and requires big
+        #               changes to the build system. See discussions in:
+        #               - https://gitlab.kitware.com/cmake/cmake/-/issues/17964
+        #               - https://gitlab.kitware.com/cmake/cmake/-/issues/18415
+        #               - https://stackoverflow.com/q/50166553/1255535
+        # - Approach 3: Merge libmkl_intel_ilp64.a, libmkl_tbb_thread.a and
+        #               libmkl_core.a into libmkl_merged.a. This is the most simple
+        #               approach to integrate with the build system. However, extra
+        #               time is required to merge the libraries and the merged
+        #               library size can be large. We choose to use approach 3.
+        ExternalProject_Add(
+            ext_mkl
+            PREFIX mkl
+            URL ${MKL_URL}
+            UPDATE_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_IN_SOURCE ON
+            BUILD_COMMAND echo "Extracting static libs..."
+            COMMAND ar x lib/libmkl_intel_ilp64.a
+            COMMAND ar x lib/libmkl_tbb_thread.a
+            COMMAND ar x lib/libmkl_core.a
+            COMMAND echo "Merging static libs..."
+            COMMAND bash -c "ar -qc lib/libmkl_merged.a *.o"
+            COMMAND echo "Cleaning up *.o files..."
+            COMMAND bash -c "rm *.o"
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E copy lib/libmkl_merged.a ${MKL_INSTALL_PREFIX}/lib/libmkl_merged.a
+        )
+    else()
+        # We also provide a direct download for libmkl_merged.a.
+        ExternalProject_Add(
+            ext_mkl
+            PREFIX mkl
+            URL ${MKL_MERGED_URL}
+            UPDATE_COMMAND ""
+            CONFIGURE_COMMAND ""
+            BUILD_IN_SOURCE ON
+            BUILD_COMMAND ""
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E copy lib/libmkl_merged.a ${MKL_INSTALL_PREFIX}/lib/libmkl_merged.a
+        )
+    endif()
     set(STATIC_MKL_LIBRARIES mkl_merged tbb_static)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,17 @@ option(BUILD_AZURE_KINECT         "Build support for Azure Kinect sensor"    OFF
 option(BUILD_TENSORFLOW_OPS       "Build ops for Tensorflow"                 OFF)
 option(BUILD_PYTORCH_OPS          "Build ops for Pytorch"                    OFF)
 
+# In ExternalProject_Add, if THIRD_PARTY_DOWNLOAD_DIR is specified, CMake will
+# first try to look for the required files in THIRD_PARTY_DOWNLOAD_DIR, before
+# downloading it from the internet. The files inside THIRD_PARTY_DOWNLOAD_DIR
+# are prepared manually by the user. This is only supported by limited 3rd party
+# libraries.
+if(THIRD_PARTY_DOWNLOAD_DIR)
+    message(STATUS "THIRD_PARTY_DOWNLOAD_DIR is set to ${THIRD_PARTY_DOWNLOAD_DIR}.")
+else()
+    message(STATUS "THIRD_PARTY_DOWNLOAD_DIR is not specified, will download directly.")
+endif()
+
 set(FILAMENT_PRECOMPILED_ROOT "" CACHE PATH "Path to precompiled Filament library (used if BUILD_FILAMENT_FROM_SOURCE=OFF)")
 set(FILAMENT_SOURCE_ROOT "" CACHE PATH "Path to Filament library sources (used if BUILD_FILAMENT_FROM_SOURCE=ON)")
 


### PR DESCRIPTION
- MKL
    - MKL merged lib is provided for linux
    - Now we upload to github releases, instead of google cloud bucket
- Filament
    - Use external project instead of fetch content to trigger download at build time, instead of config time
- In general
    - Allow user to specify `THIRD_PARTY_DOWNLOAD_DIR`, and prepare the downloaded files **manually**
    - Added function to accommodate local and remote URL.
    - By default, remote URLs is used if `THIRD_PARTY_DOWNLOAD_DIR` is not specified. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2155)
<!-- Reviewable:end -->
