### PR TITLE
disable CMP0104 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,10 @@ if (BUILD_CUDA_MODULE)
         find_package(CUDA REQUIRED) # required for cuda_select_nvcc_arch_flags
         message(STATUS "Building CUDA enabled")
         enable_language(CUDA)
+        # TODO: when CMake minimum version is 3.18+, switch to the NEW behavior
+        # of CMP0104 and replease CUDA_GENCODES with CUDA_ARCHITECTURES target
+        # properties. See https://cmake.org/cmake/help/v3.18/policy/CMP0104.html.
+        cmake_policy(SET CMP0104 OLD)
         # Get gencode flags
         if("${CUDA_ARCH}" STREQUAL "User")
             cuda_select_nvcc_arch_flags(CUDA_GENCODES "${CUDA_ARCH_USER}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,9 @@ if (BUILD_CUDA_MODULE)
         # TODO: when CMake minimum version is 3.18+, switch to the NEW behavior
         # of CMP0104 and replease CUDA_GENCODES with CUDA_ARCHITECTURES target
         # properties. See https://cmake.org/cmake/help/v3.18/policy/CMP0104.html.
-        cmake_policy(SET CMP0104 OLD)
+        if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+            cmake_policy(SET CMP0104 OLD)
+        endif()
         # Get gencode flags
         if("${CUDA_ARCH}" STREQUAL "User")
             cuda_select_nvcc_arch_flags(CUDA_GENCODES "${CUDA_ARCH_USER}")


### PR DESCRIPTION
disables the `CUDA_ARCHITECTURES is empty for target "Open3D"` warning on cmake 3.18+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2175)
<!-- Reviewable:end -->
