### PR TITLE
fix unused var error with clang

### DIFF
--- a/cpp/open3d/io/rpc/Connection.cpp
+++ b/cpp/open3d/io/rpc/Connection.cpp
@@ -58,11 +58,11 @@ Connection::Connection(const std::string& address,
       address_(address),
       connect_timeout_(connect_timeout),
       timeout_(timeout) {
-    socket_->setsockopt(ZMQ_LINGER, timeout);
-    socket_->setsockopt(ZMQ_CONNECT_TIMEOUT, connect_timeout);
-    socket_->setsockopt(ZMQ_RCVTIMEO, timeout);
-    socket_->setsockopt(ZMQ_SNDTIMEO, timeout);
-    socket_->connect(address.c_str());
+    socket_->setsockopt(ZMQ_LINGER, timeout_);
+    socket_->setsockopt(ZMQ_CONNECT_TIMEOUT, connect_timeout_);
+    socket_->setsockopt(ZMQ_RCVTIMEO, timeout_);
+    socket_->setsockopt(ZMQ_SNDTIMEO, timeout_);
+    socket_->connect(address_.c_str());
 }
 
 Connection::~Connection() { socket_->close(); }


### PR DESCRIPTION

```
In file included from /home/yixing/repo/Open3D/cpp/open3d/io/rpc/Connection.cpp:27:
/home/yixing/repo/Open3D/cpp/open3d/io/rpc/Connection.h:64:15: error: private field 'connect_timeout_' is not used [-Werror,-Wunused-private-field]
    const int connect_timeout_;
              ^
/home/yixing/repo/Open3D/cpp/open3d/io/rpc/Connection.h:65:15: error: private field 'timeout_' is not used [-Werror,-Wunused-private-field]
    const int timeout_;
              ^
2 errors generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2196)
<!-- Reviewable:end -->
