### PR TITLE
Revert #1936

### DIFF
--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -121,7 +121,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_image",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 geometry::Image image;
                 io::ReadImage(filename, image);
                 return image;
@@ -134,7 +133,6 @@ void pybind_class_io(py::module &m_io) {
             "write_image",
             [](const std::string &filename, const geometry::Image &image,
                int quality) {
-                py::gil_scoped_release release;
                 return io::WriteImage(filename, image, quality);
             },
             "Function to write Image to file", "filename"_a, "image"_a,
@@ -147,7 +145,6 @@ void pybind_class_io(py::module &m_io) {
             "read_line_set",
             [](const std::string &filename, const std::string &format,
                bool print_progress) {
-                py::gil_scoped_release release;
                 geometry::LineSet line_set;
                 io::ReadLineSet(filename, line_set, format, print_progress);
                 return line_set;
@@ -161,7 +158,6 @@ void pybind_class_io(py::module &m_io) {
             "write_line_set",
             [](const std::string &filename, const geometry::LineSet &line_set,
                bool write_ascii, bool compressed, bool print_progress) {
-                py::gil_scoped_release release;
                 return io::WriteLineSet(filename, line_set, write_ascii,
                                         compressed, print_progress);
             },
@@ -177,7 +173,6 @@ void pybind_class_io(py::module &m_io) {
             [](const std::string &filename, const std::string &format,
                bool remove_nan_points, bool remove_infinite_points,
                bool print_progress) {
-                py::gil_scoped_release release;
                 geometry::PointCloud pcd;
                 io::ReadPointCloud(filename, pcd,
                                    {format, remove_nan_points,
@@ -195,7 +190,6 @@ void pybind_class_io(py::module &m_io) {
             [](const std::string &filename,
                const geometry::PointCloud &pointcloud, bool write_ascii,
                bool compressed, bool print_progress) {
-                py::gil_scoped_release release;
                 return io::WritePointCloud(
                         filename, pointcloud,
                         {write_ascii, compressed, print_progress});
@@ -210,7 +204,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_triangle_mesh",
             [](const std::string &filename, bool print_progress) {
-                py::gil_scoped_release release;
                 geometry::TriangleMesh mesh;
                 io::ReadTriangleMesh(filename, mesh, print_progress);
                 return mesh;
@@ -226,7 +219,6 @@ void pybind_class_io(py::module &m_io) {
                bool write_ascii, bool compressed, bool write_vertex_normals,
                bool write_vertex_colors, bool write_triangle_uvs,
                bool print_progress) {
-                py::gil_scoped_release release;
                 return io::WriteTriangleMesh(
                         filename, mesh, write_ascii, compressed,
                         write_vertex_normals, write_vertex_colors,
@@ -244,7 +236,6 @@ void pybind_class_io(py::module &m_io) {
             "read_voxel_grid",
             [](const std::string &filename, const std::string &format,
                bool print_progress) {
-                py::gil_scoped_release release;
                 geometry::VoxelGrid voxel_grid;
                 io::ReadVoxelGrid(filename, voxel_grid, format);
                 return voxel_grid;
@@ -259,7 +250,6 @@ void pybind_class_io(py::module &m_io) {
             [](const std::string &filename,
                const geometry::VoxelGrid &voxel_grid, bool write_ascii,
                bool compressed, bool print_progress) {
-                py::gil_scoped_release release;
                 return io::WriteVoxelGrid(filename, voxel_grid, write_ascii,
                                           compressed, print_progress);
             },
@@ -273,7 +263,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_pinhole_camera_intrinsic",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 camera::PinholeCameraIntrinsic intrinsic;
                 io::ReadIJsonConvertible(filename, intrinsic);
                 return intrinsic;
@@ -286,7 +275,6 @@ void pybind_class_io(py::module &m_io) {
             "write_pinhole_camera_intrinsic",
             [](const std::string &filename,
                const camera::PinholeCameraIntrinsic &intrinsic) {
-                py::gil_scoped_release release;
                 return io::WriteIJsonConvertible(filename, intrinsic);
             },
             "Function to write PinholeCameraIntrinsic to file", "filename"_a,
@@ -297,7 +285,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_pinhole_camera_parameters",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 camera::PinholeCameraParameters parameters;
                 io::ReadIJsonConvertible(filename, parameters);
                 return parameters;
@@ -310,7 +297,6 @@ void pybind_class_io(py::module &m_io) {
             "write_pinhole_camera_parameters",
             [](const std::string &filename,
                const camera::PinholeCameraParameters &parameters) {
-                py::gil_scoped_release release;
                 return io::WriteIJsonConvertible(filename, parameters);
             },
             "Function to write PinholeCameraParameters to file", "filename"_a,
@@ -321,7 +307,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_pinhole_camera_trajectory",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 camera::PinholeCameraTrajectory trajectory;
                 io::ReadPinholeCameraTrajectory(filename, trajectory);
                 return trajectory;
@@ -334,7 +319,6 @@ void pybind_class_io(py::module &m_io) {
             "write_pinhole_camera_trajectory",
             [](const std::string &filename,
                const camera::PinholeCameraTrajectory &trajectory) {
-                py::gil_scoped_release release;
                 return io::WritePinholeCameraTrajectory(filename, trajectory);
             },
             "Function to write PinholeCameraTrajectory to file", "filename"_a,
@@ -346,7 +330,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_feature",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 pipelines::registration::Feature feature;
                 io::ReadFeature(filename, feature);
                 return feature;
@@ -359,7 +342,6 @@ void pybind_class_io(py::module &m_io) {
             "write_feature",
             [](const std::string &filename,
                const pipelines::registration::Feature &feature) {
-                py::gil_scoped_release release;
                 return io::WriteFeature(filename, feature);
             },
             "Function to write Feature to file", "filename"_a, "feature"_a);
@@ -369,7 +351,6 @@ void pybind_class_io(py::module &m_io) {
     m_io.def(
             "read_pose_graph",
             [](const std::string &filename) {
-                py::gil_scoped_release release;
                 pipelines::registration::PoseGraph pose_graph;
                 io::ReadPoseGraph(filename, pose_graph);
                 return pose_graph;
@@ -382,7 +363,6 @@ void pybind_class_io(py::module &m_io) {
             "write_pose_graph",
             [](const std::string &filename,
                const pipelines::registration::PoseGraph pose_graph) {
-                py::gil_scoped_release release;
                 io::WritePoseGraph(filename, pose_graph);
             },
             "Function to write PoseGraph to file", "filename"_a,


### PR DESCRIPTION
Revert #1936 to remove bugs causing instability in IO, detailed in #2148.

May revisit if the feature is supported without bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2225)
<!-- Reviewable:end -->
