### PR TITLE
ml-contrib subsample library

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -365,6 +365,11 @@ endif()
 set(FLANN_TARGET "3rdparty_flann")
 list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${FLANN_TARGET}")
 
+# Nanoflann
+build_3rdparty_library(3rdparty_nanoflann DIRECTORY nanoflann INCLUDE_DIRS include/ INCLUDE_ALL)
+set(NANOFLANN_TARGET "3rdparty_nanoflann")
+list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${NANOFLANN_TARGET}")
+
 # GLEW
 if(USE_SYSTEM_GLEW)
     find_package(GLEW)

--- a/cpp/open3d/CMakeLists.txt
+++ b/cpp/open3d/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(${CMAKE_PROJECT_NAME}
     $<TARGET_OBJECTS:geometry>
     $<TARGET_OBJECTS:tgeometry>
     $<TARGET_OBJECTS:io>
+    $<TARGET_OBJECTS:ml_contrib>
     $<TARGET_OBJECTS:pipelines>
     $<TARGET_OBJECTS:utility>
     $<TARGET_OBJECTS:visualization>

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -104,7 +104,9 @@ public:
                                       shape_.NumElements() * dtype.ByteSize());
     }
 
-    /// The fully specified constructor
+    /// The fully specified constructor. Since you're responsible for creating
+    /// the Blob, take care of Blob's deleter if the memory is allocated
+    /// elsewhere. See Blob.h for more details.
     Tensor(const SizeVector& shape,
            const SizeVector& strides,
            void* data_ptr,

--- a/cpp/open3d/ml/CMakeLists.txt
+++ b/cpp/open3d/ml/CMakeLists.txt
@@ -2,6 +2,7 @@ if (BUILD_TENSORFLOW_OPS AND WIN32)
     message( FATAL_ERROR "Building Tensorflow ops on Windows is currently not supported." )
     # see https://github.com/tensorflow/custom-op/issues/24
 endif ()
+
 if (BUILD_TENSORFLOW_OPS)
     add_subdirectory(TensorFlow)
 endif ()
@@ -10,3 +11,4 @@ if (BUILD_PYTORCH_OPS)
     add_subdirectory(PyTorch)
 endif ()
 
+add_subdirectory(contrib)

--- a/cpp/open3d/ml/contrib/CMakeLists.txt
+++ b/cpp/open3d/ml/contrib/CMakeLists.txt
@@ -1,0 +1,10 @@
+set (SRC
+    Cloud.cpp
+    GridSubsampling.cpp
+)
+
+add_library(ml_contrib OBJECT ${SRC})
+open3d_set_global_properties(ml_contrib)
+open3d_link_3rdparty_libraries(ml_contrib)
+open3d_set_open3d_lib_properties(ml_contrib)
+open3d_show_and_abort_on_warning(ml_contrib)

--- a/cpp/open3d/ml/contrib/Cloud.cpp
+++ b/cpp/open3d/ml/contrib/Cloud.cpp
@@ -1,0 +1,87 @@
+// Source code from: https://github.com/HuguesTHOMAS/KPConv.
+//
+// MIT License
+//
+// Copyright (c) 2019 HuguesTHOMAS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//
+//
+//		0==========================0
+//		|    Local feature test    |
+//		0==========================0
+//
+//		version 1.0 :
+//			>
+//
+//---------------------------------------------------
+//
+//		Cloud source :
+//		Define usefull Functions/Methods
+//
+//----------------------------------------------------
+//
+//		Hugues THOMAS - 10/02/2017
+//
+
+#include "open3d/ml/contrib/Cloud.h"
+
+namespace open3d {
+namespace ml {
+namespace contrib {
+
+// Getters
+// *******
+
+PointXYZ max_point(std::vector<PointXYZ> points) {
+    // Initialize limits
+    PointXYZ maxP(points[0]);
+
+    // Loop over all points
+    for (auto p : points) {
+        if (p.x > maxP.x) maxP.x = p.x;
+
+        if (p.y > maxP.y) maxP.y = p.y;
+
+        if (p.z > maxP.z) maxP.z = p.z;
+    }
+
+    return maxP;
+}
+
+PointXYZ min_point(std::vector<PointXYZ> points) {
+    // Initialize limits
+    PointXYZ minP(points[0]);
+
+    // Loop over all points
+    for (auto p : points) {
+        if (p.x < minP.x) minP.x = p.x;
+
+        if (p.y < minP.y) minP.y = p.y;
+
+        if (p.z < minP.z) minP.z = p.z;
+    }
+
+    return minP;
+}
+
+}  // namespace contrib
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/contrib/Cloud.h
+++ b/cpp/open3d/ml/contrib/Cloud.h
@@ -1,0 +1,193 @@
+// Source code from: https://github.com/HuguesTHOMAS/KPConv.
+//
+// MIT License
+//
+// Copyright (c) 2019 HuguesTHOMAS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//
+//
+//		0==========================0
+//		|    Local feature test    |
+//		0==========================0
+//
+//		version 1.0 :
+//			>
+//
+//---------------------------------------------------
+//
+//		Cloud header
+//
+//----------------------------------------------------
+//
+//		Hugues THOMAS - 10/02/2017
+//
+
+#pragma once
+
+#include <time.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <unordered_map>
+#include <vector>
+
+namespace open3d {
+namespace ml {
+namespace contrib {
+
+// Point class
+// ***********
+
+class PointXYZ {
+public:
+    // Elements
+    // ********
+
+    float x, y, z;
+
+    // Methods
+    // *******
+
+    // Constructor
+    PointXYZ() {
+        x = 0;
+        y = 0;
+        z = 0;
+    }
+    PointXYZ(float x0, float y0, float z0) {
+        x = x0;
+        y = y0;
+        z = z0;
+    }
+
+    // array type accessor
+    float operator[](int i) const {
+        if (i == 0)
+            return x;
+        else if (i == 1)
+            return y;
+        else
+            return z;
+    }
+
+    // opperations
+    float dot(const PointXYZ P) const { return x * P.x + y * P.y + z * P.z; }
+
+    float sq_norm() { return x * x + y * y + z * z; }
+
+    PointXYZ cross(const PointXYZ P) const {
+        return PointXYZ(y * P.z - z * P.y, z * P.x - x * P.z,
+                        x * P.y - y * P.x);
+    }
+
+    PointXYZ& operator+=(const PointXYZ& P) {
+        x += P.x;
+        y += P.y;
+        z += P.z;
+        return *this;
+    }
+
+    PointXYZ& operator-=(const PointXYZ& P) {
+        x -= P.x;
+        y -= P.y;
+        z -= P.z;
+        return *this;
+    }
+
+    PointXYZ& operator*=(const float& a) {
+        x *= a;
+        y *= a;
+        z *= a;
+        return *this;
+    }
+
+    static PointXYZ floor(const PointXYZ P) {
+        return PointXYZ(std::floor(P.x), std::floor(P.y), std::floor(P.z));
+    }
+};
+
+// Point Opperations
+// *****************
+
+inline PointXYZ operator+(const PointXYZ A, const PointXYZ B) {
+    return PointXYZ(A.x + B.x, A.y + B.y, A.z + B.z);
+}
+
+inline PointXYZ operator-(const PointXYZ A, const PointXYZ B) {
+    return PointXYZ(A.x - B.x, A.y - B.y, A.z - B.z);
+}
+
+inline PointXYZ operator*(const PointXYZ P, const float a) {
+    return PointXYZ(P.x * a, P.y * a, P.z * a);
+}
+
+inline PointXYZ operator*(const float a, const PointXYZ P) {
+    return PointXYZ(P.x * a, P.y * a, P.z * a);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const PointXYZ P) {
+    return os << "[" << P.x << ", " << P.y << ", " << P.z << "]";
+}
+
+inline bool operator==(const PointXYZ A, const PointXYZ B) {
+    return A.x == B.x && A.y == B.y && A.z == B.z;
+}
+
+PointXYZ max_point(std::vector<PointXYZ> points);
+PointXYZ min_point(std::vector<PointXYZ> points);
+
+struct PointCloud {
+    std::vector<PointXYZ> pts;
+
+    // Must return the number of data points
+    inline size_t kdtree_get_point_count() const { return pts.size(); }
+
+    // Returns the dim'th component of the idx'th point in the class:
+    // Since this is inlined and the "dim" argument is typically an immediate
+    // value, the
+    //  "if/else's" are actually solved at compile time.
+    inline float kdtree_get_pt(const size_t idx, const size_t dim) const {
+        if (dim == 0)
+            return pts[idx].x;
+        else if (dim == 1)
+            return pts[idx].y;
+        else
+            return pts[idx].z;
+    }
+
+    // Optional bounding-box computation: return false to default to a standard
+    // bbox computation loop.
+    //   Return true if the BBOX was already computed by the class and returned
+    //   in "bb" so it can be avoided to redo it again. Look at bb.size() to
+    //   find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX& /* bb */) const {
+        return false;
+    }
+};
+
+}  // namespace contrib
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/contrib/GridSubsampling.cpp
+++ b/cpp/open3d/ml/contrib/GridSubsampling.cpp
@@ -69,7 +69,7 @@ void grid_subsampling(std::vector<PointXYZ>& original_points,
 
     // Verbose parameters
     int i = 0;
-    int nDisp = N / 100;
+    int nDisp = static_cast<int>(N / 100);
 
     // Initialize variables
     size_t iX, iY, iZ, mapIdx;
@@ -109,7 +109,7 @@ void grid_subsampling(std::vector<PointXYZ>& original_points,
     if (use_feature) subsampled_features.reserve(data.size() * fdim);
     if (use_classes) subsampled_classes.reserve(data.size() * ldim);
     for (auto& v : data) {
-        subsampled_points.push_back(v.second.point * (1.0 / v.second.count));
+        subsampled_points.push_back(v.second.point * (1.0f / v.second.count));
         if (use_feature) {
             float count = (float)v.second.count;
             transform(v.second.features.begin(), v.second.features.end(),
@@ -159,7 +159,7 @@ void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
     size_t ldim = original_classes.size() / N;
 
     // Handle max_p = 0
-    if (max_p < 1) max_p = N;
+    if (max_p < 1) max_p = static_cast<int>(N);
 
     // Loop over batches
     // *****************
@@ -213,7 +213,7 @@ void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
                                           b_s_classes.begin(),
                                           b_s_classes.end());
 
-            subsampled_batches.push_back(b_s_points.size());
+            subsampled_batches.push_back(static_cast<int>(b_s_points.size()));
         } else {
             subsampled_points.insert(subsampled_points.end(),
                                      b_s_points.begin(),

--- a/cpp/open3d/ml/contrib/GridSubsampling.cpp
+++ b/cpp/open3d/ml/contrib/GridSubsampling.cpp
@@ -72,10 +72,11 @@ void grid_subsampling(std::vector<PointXYZ>& original_points,
     int nDisp = static_cast<int>(N / 100);
 
     // Initialize variables
-    size_t iX, iY, iZ, mapIdx;
     std::unordered_map<size_t, SampledData> data;
 
     for (auto& p : original_points) {
+        size_t iX, iY, iZ, mapIdx;
+
         // Position of point in sample map
         iX = (size_t)std::floor((p.x - originCorner.x) / sampleDl);
         iY = (size_t)std::floor((p.y - originCorner.y) / sampleDl);

--- a/cpp/open3d/ml/contrib/GridSubsampling.cpp
+++ b/cpp/open3d/ml/contrib/GridSubsampling.cpp
@@ -1,0 +1,244 @@
+// Source code from: https://github.com/HuguesTHOMAS/KPConv.
+//
+// MIT License
+//
+// Copyright (c) 2019 HuguesTHOMAS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "open3d/ml/contrib/GridSubsampling.h"
+
+namespace open3d {
+namespace ml {
+namespace contrib {
+
+void grid_subsampling(std::vector<PointXYZ>& original_points,
+                      std::vector<PointXYZ>& subsampled_points,
+                      std::vector<float>& original_features,
+                      std::vector<float>& subsampled_features,
+                      std::vector<int>& original_classes,
+                      std::vector<int>& subsampled_classes,
+                      float sampleDl,
+                      int verbose) {
+    // Initialize variables
+    // ******************
+
+    // Number of points in the cloud
+    size_t N = original_points.size();
+
+    // Dimension of the features
+    size_t fdim = original_features.size() / N;
+    size_t ldim = original_classes.size() / N;
+
+    // Limits of the cloud
+    PointXYZ minCorner = min_point(original_points);
+    PointXYZ maxCorner = max_point(original_points);
+    PointXYZ originCorner =
+            PointXYZ::floor(minCorner * (1 / sampleDl)) * sampleDl;
+
+    // Dimensions of the grid
+    size_t sampleNX =
+            (size_t)floor((maxCorner.x - originCorner.x) / sampleDl) + 1;
+    size_t sampleNY =
+            (size_t)floor((maxCorner.y - originCorner.y) / sampleDl) + 1;
+    // size_t sampleNZ = (size_t)floor((maxCorner.z - originCorner.z) /
+    // sampleDl) + 1;
+
+    // Check if features and classes need to be processed
+    bool use_feature = original_features.size() > 0;
+    bool use_classes = original_classes.size() > 0;
+
+    // Create the sampled map
+    // **********************
+
+    // Verbose parameters
+    int i = 0;
+    int nDisp = N / 100;
+
+    // Initialize variables
+    size_t iX, iY, iZ, mapIdx;
+    std::unordered_map<size_t, SampledData> data;
+
+    for (auto& p : original_points) {
+        // Position of point in sample map
+        iX = (size_t)std::floor((p.x - originCorner.x) / sampleDl);
+        iY = (size_t)std::floor((p.y - originCorner.y) / sampleDl);
+        iZ = (size_t)std::floor((p.z - originCorner.z) / sampleDl);
+        mapIdx = iX + sampleNX * iY + sampleNX * sampleNY * iZ;
+
+        // If not already created, create key
+        if (data.count(mapIdx) < 1)
+            data.emplace(mapIdx, SampledData(fdim, ldim));
+
+        // Fill the sample map
+        if (use_feature && use_classes)
+            data[mapIdx].update_all(p, original_features.begin() + i * fdim,
+                                    original_classes.begin() + i * ldim);
+        else if (use_feature)
+            data[mapIdx].update_features(p,
+                                         original_features.begin() + i * fdim);
+        else if (use_classes)
+            data[mapIdx].update_classes(p, original_classes.begin() + i * ldim);
+        else
+            data[mapIdx].update_points(p);
+
+        // Display
+        i++;
+        if (verbose > 1 && i % nDisp == 0)
+            std::cout << "\rSampled Map : " << std::setw(3) << i / nDisp << "%";
+    }
+
+    // Divide for barycentre and transfer to a vector
+    subsampled_points.reserve(data.size());
+    if (use_feature) subsampled_features.reserve(data.size() * fdim);
+    if (use_classes) subsampled_classes.reserve(data.size() * ldim);
+    for (auto& v : data) {
+        subsampled_points.push_back(v.second.point * (1.0 / v.second.count));
+        if (use_feature) {
+            float count = (float)v.second.count;
+            transform(v.second.features.begin(), v.second.features.end(),
+                      v.second.features.begin(),
+                      [count](float f) { return f / count; });
+            subsampled_features.insert(subsampled_features.end(),
+                                       v.second.features.begin(),
+                                       v.second.features.end());
+        }
+        if (use_classes) {
+            for (int i = 0; i < ldim; i++)
+                subsampled_classes.push_back(
+                        max_element(v.second.labels[i].begin(),
+                                    v.second.labels[i].end(),
+                                    [](const std::pair<int, int>& a,
+                                       const std::pair<int, int>& b) {
+                                        return a.second < b.second;
+                                    })
+                                ->first);
+        }
+    }
+
+    return;
+}
+
+void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
+                            std::vector<PointXYZ>& subsampled_points,
+                            std::vector<float>& original_features,
+                            std::vector<float>& subsampled_features,
+                            std::vector<int>& original_classes,
+                            std::vector<int>& subsampled_classes,
+                            std::vector<int>& original_batches,
+                            std::vector<int>& subsampled_batches,
+                            float sampleDl,
+                            int max_p) {
+    // Initialize variables
+    // ******************
+
+    int b = 0;
+    int sum_b = 0;
+
+    // Number of points in the cloud
+    size_t N = original_points.size();
+
+    // Dimension of the features
+    size_t fdim = original_features.size() / N;
+    size_t ldim = original_classes.size() / N;
+
+    // Handle max_p = 0
+    if (max_p < 1) max_p = N;
+
+    // Loop over batches
+    // *****************
+
+    for (b = 0; b < original_batches.size(); b++) {
+        // Extract batch points features and labels
+        std::vector<PointXYZ> b_o_points = std::vector<PointXYZ>(
+                original_points.begin() + sum_b,
+                original_points.begin() + sum_b + original_batches[b]);
+
+        std::vector<float> b_o_features;
+        if (original_features.size() > 0) {
+            b_o_features = std::vector<float>(
+                    original_features.begin() + sum_b * fdim,
+                    original_features.begin() +
+                            (sum_b + original_batches[b]) * fdim);
+        }
+
+        std::vector<int> b_o_classes;
+        if (original_classes.size() > 0) {
+            b_o_classes =
+                    std::vector<int>(original_classes.begin() + sum_b * ldim,
+                                     original_classes.begin() + sum_b +
+                                             original_batches[b] * ldim);
+        }
+
+        // Create result containers
+        std::vector<PointXYZ> b_s_points;
+        std::vector<float> b_s_features;
+        std::vector<int> b_s_classes;
+
+        // Compute subsampling on current batch
+        grid_subsampling(b_o_points, b_s_points, b_o_features, b_s_features,
+                         b_o_classes, b_s_classes, sampleDl, 0);
+
+        // Stack batches points features and labels
+        // ****************************************
+
+        // If too many points remove some
+        if (b_s_points.size() <= max_p) {
+            subsampled_points.insert(subsampled_points.end(),
+                                     b_s_points.begin(), b_s_points.end());
+
+            if (original_features.size() > 0)
+                subsampled_features.insert(subsampled_features.end(),
+                                           b_s_features.begin(),
+                                           b_s_features.end());
+
+            if (original_classes.size() > 0)
+                subsampled_classes.insert(subsampled_classes.end(),
+                                          b_s_classes.begin(),
+                                          b_s_classes.end());
+
+            subsampled_batches.push_back(b_s_points.size());
+        } else {
+            subsampled_points.insert(subsampled_points.end(),
+                                     b_s_points.begin(),
+                                     b_s_points.begin() + max_p);
+
+            if (original_features.size() > 0)
+                subsampled_features.insert(subsampled_features.end(),
+                                           b_s_features.begin(),
+                                           b_s_features.begin() + max_p * fdim);
+
+            if (original_classes.size() > 0)
+                subsampled_classes.insert(subsampled_classes.end(),
+                                          b_s_classes.begin(),
+                                          b_s_classes.begin() + max_p * ldim);
+
+            subsampled_batches.push_back(max_p);
+        }
+
+        // Stack new batch lengths
+        sum_b += original_batches[b];
+    }
+
+    return;
+}
+
+}  // namespace contrib
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/contrib/GridSubsampling.cpp
+++ b/cpp/open3d/ml/contrib/GridSubsampling.cpp
@@ -120,7 +120,7 @@ void grid_subsampling(std::vector<PointXYZ>& original_points,
                                        v.second.features.end());
         }
         if (use_classes) {
-            for (int i = 0; i < ldim; i++)
+            for (int i = 0; i < static_cast<int>(ldim); i++)
                 subsampled_classes.push_back(
                         max_element(v.second.labels[i].begin(),
                                     v.second.labels[i].end(),
@@ -164,7 +164,7 @@ void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
     // Loop over batches
     // *****************
 
-    for (b = 0; b < original_batches.size(); b++) {
+    for (b = 0; b < static_cast<int>(original_batches.size()); b++) {
         // Extract batch points features and labels
         std::vector<PointXYZ> b_o_points = std::vector<PointXYZ>(
                 original_points.begin() + sum_b,
@@ -199,7 +199,7 @@ void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
         // ****************************************
 
         // If too many points remove some
-        if (b_s_points.size() <= max_p) {
+        if (static_cast<int>(b_s_points.size()) <= max_p) {
             subsampled_points.insert(subsampled_points.end(),
                                      b_s_points.begin(), b_s_points.end());
 

--- a/cpp/open3d/ml/contrib/GridSubsampling.h
+++ b/cpp/open3d/ml/contrib/GridSubsampling.h
@@ -1,0 +1,127 @@
+// Source code from: https://github.com/HuguesTHOMAS/KPConv.
+//
+// MIT License
+//
+// Copyright (c) 2019 HuguesTHOMAS
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <cstdint>
+#include <set>
+
+#include "open3d/ml/contrib/Cloud.h"
+
+namespace open3d {
+namespace ml {
+namespace contrib {
+
+class SampledData {
+public:
+    // Elements
+    // ********
+
+    int count;
+    PointXYZ point;
+    std::vector<float> features;
+    std::vector<std::unordered_map<int, int>> labels;
+
+    // Methods
+    // *******
+
+    // Constructor
+    SampledData() {
+        count = 0;
+        point = PointXYZ();
+    }
+
+    SampledData(const size_t fdim, const size_t ldim) {
+        count = 0;
+        point = PointXYZ();
+        features = std::vector<float>(fdim);
+        labels = std::vector<std::unordered_map<int, int>>(ldim);
+    }
+
+    // Method Update
+    void update_all(const PointXYZ p,
+                    std::vector<float>::iterator f_begin,
+                    std::vector<int>::iterator l_begin) {
+        count += 1;
+        point += p;
+        transform(features.begin(), features.end(), f_begin, features.begin(),
+                  std::plus<float>());
+        int i = 0;
+        for (std::vector<int>::iterator it = l_begin;
+             it != l_begin + labels.size(); ++it) {
+            labels[i][*it] += 1;
+            i++;
+        }
+        return;
+    }
+
+    void update_features(const PointXYZ p,
+                         std::vector<float>::iterator f_begin) {
+        count += 1;
+        point += p;
+        transform(features.begin(), features.end(), f_begin, features.begin(),
+                  std::plus<float>());
+        return;
+    }
+
+    void update_classes(const PointXYZ p, std::vector<int>::iterator l_begin) {
+        count += 1;
+        point += p;
+        int i = 0;
+        for (std::vector<int>::iterator it = l_begin;
+             it != l_begin + labels.size(); ++it) {
+            labels[i][*it] += 1;
+            i++;
+        }
+        return;
+    }
+
+    void update_points(const PointXYZ p) {
+        count += 1;
+        point += p;
+        return;
+    }
+};
+
+void grid_subsampling(std::vector<PointXYZ>& original_points,
+                      std::vector<PointXYZ>& subsampled_points,
+                      std::vector<float>& original_features,
+                      std::vector<float>& subsampled_features,
+                      std::vector<int>& original_classes,
+                      std::vector<int>& subsampled_classes,
+                      float sampleDl,
+                      int verbose);
+
+void batch_grid_subsampling(std::vector<PointXYZ>& original_points,
+                            std::vector<PointXYZ>& subsampled_points,
+                            std::vector<float>& original_features,
+                            std::vector<float>& subsampled_features,
+                            std::vector<int>& original_classes,
+                            std::vector<int>& subsampled_classes,
+                            std::vector<int>& original_batches,
+                            std::vector<int>& subsampled_batches,
+                            float sampleDl,
+                            int max_p);
+
+}  // namespace contrib
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/utility/Optional.h
+++ b/cpp/open3d/utility/Optional.h
@@ -1,0 +1,946 @@
+// Copyright (C) 2011 - 2012 Andrzej Krzemienski.
+//
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// The idea and interface is based on Boost.Optional library
+// authored by Fernando Luis Cacciola Carballal
+//
+// From https://github.com/akrzemi1/Optional
+//
+// C10
+// - Move to `c10` namespace.
+// - Remove macro use in line 478 because the nvcc device compiler cannot handle
+// it.
+// - revise constructor logic so that it is consistent with c++ 17 standard
+// documented here in (8):
+// https://en.cppreference.com/w/cpp/utility/optional/optional, and could be
+// able to support initialization of optionals from convertible type U, also
+// remove two old constructors optional(const T&) and optional(T&&) as it could
+// be handled by the template<U=T> case with default template argument.
+// - `constexpr struct in_place_t {} in_place{}` is moved to
+// `c10/util/in_place.h`, so that it can also be used in `c10/util/variant.h`.
+// - Remove special cases for pre-c++14 compilers to make code simpler
+//
+//
+// Open3D
+// - Namespace change: open3d::utility::optional
+
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#define TR2_OPTIONAL_REQUIRES(...) \
+    typename std::enable_if<__VA_ARGS__::value, bool>::type = false
+
+namespace open3d {
+namespace utility {
+
+struct in_place_t {
+    explicit in_place_t() = default;
+};
+
+template <std::size_t I>
+struct in_place_index_t {
+    explicit in_place_index_t() = default;
+};
+
+template <typename T>
+struct in_place_type_t {
+    explicit in_place_type_t() = default;
+};
+
+constexpr in_place_t in_place{};
+
+// 20.5.4, optional for object types
+template <class T>
+class optional;
+
+// 20.5.5, optional for lvalue reference types
+template <class T>
+class optional<T&>;
+
+// workaround: std utility functions aren't constexpr yet
+template <class T>
+inline constexpr T&& constexpr_forward(
+        typename std::remove_reference<T>::type& t) noexcept {
+    return static_cast<T&&>(t);
+}
+
+template <class T>
+inline constexpr T&& constexpr_forward(
+        typename std::remove_reference<T>::type&& t) noexcept {
+    static_assert(!std::is_lvalue_reference<T>::value, "!!");
+    return static_cast<T&&>(t);
+}
+
+template <class T>
+inline constexpr typename std::remove_reference<T>::type&& constexpr_move(
+        T&& t) noexcept {
+    return static_cast<typename std::remove_reference<T>::type&&>(t);
+}
+
+#if defined NDEBUG
+#define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
+#else
+#define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) \
+    ((CHECK) ? (EXPR) : ([] { assert(!#CHECK); }(), (EXPR)))
+#endif
+
+#if defined(__CUDA_ARCH__)
+#define TR2_OPTIONAL_HOST_CONSTEXPR
+#else
+#define TR2_OPTIONAL_HOST_CONSTEXPR constexpr
+#endif
+
+namespace detail_ {
+
+// VS doesn't handle constexpr well, so we need to skip these stuff.
+#if (defined _MSC_VER)
+template <typename T>
+T* static_addressof(T& ref) {
+    return std::addressof(ref);
+}
+#else
+// static_addressof: a constexpr version of addressof
+template <typename T>
+struct has_overloaded_addressof {
+    template <class X>
+    constexpr static bool has_overload(...) {
+        return false;
+    }
+
+    template <class X, size_t S = sizeof(std::declval<X&>().operator&())>
+    constexpr static bool has_overload(bool) {
+        return true;
+    }
+
+    constexpr static bool value = has_overload<T>(true);
+};
+
+template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
+constexpr T* static_addressof(T& ref) {
+    return &ref;
+}
+
+template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
+T* static_addressof(T& ref) {
+    return std::addressof(ref);
+}
+#endif
+
+// the call to convert<A>(b) has return type A and converts b to type A iff b
+// decltype(b) is implicitly convertible to A
+template <class U>
+constexpr U convert(U v) {
+    return v;
+}
+
+}  // namespace detail_
+
+constexpr struct trivial_init_t {
+} trivial_init{};
+
+// 20.5.7, Disengaged state indicator
+struct nullopt_t {
+    struct init {};
+    constexpr explicit nullopt_t(init) {}
+};
+constexpr nullopt_t nullopt{nullopt_t::init()};
+
+// 20.5.8, class bad_optional_access
+class bad_optional_access : public std::logic_error {
+public:
+    explicit bad_optional_access(const std::string& what_arg)
+        : logic_error{what_arg} {}
+    explicit bad_optional_access(const char* what_arg)
+        : logic_error{what_arg} {}
+};
+
+template <class T>
+union storage_t {
+    unsigned char dummy_;
+    T value_;
+
+    constexpr storage_t(trivial_init_t) noexcept : dummy_(){};
+
+    template <class... Args>
+    constexpr storage_t(Args&&... args)
+        : value_(constexpr_forward<Args>(args)...) {}
+
+    ~storage_t() {}
+};
+
+template <class T>
+union constexpr_storage_t {
+    unsigned char dummy_;
+    T value_;
+
+    constexpr constexpr_storage_t(trivial_init_t) noexcept : dummy_(){};
+
+    template <class... Args>
+    constexpr constexpr_storage_t(Args&&... args)
+        : value_(constexpr_forward<Args>(args)...) {}
+
+    ~constexpr_storage_t() = default;
+};
+
+template <class T>
+struct optional_base {
+    bool init_;
+    storage_t<T> storage_;
+
+    constexpr optional_base() noexcept : init_(false), storage_(trivial_init){};
+
+    explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
+
+    explicit constexpr optional_base(T&& v)
+        : init_(true), storage_(constexpr_move(v)) {}
+
+    template <class... Args>
+    explicit optional_base(in_place_t, Args&&... args)
+        : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+    template <class U,
+              class... Args,
+              TR2_OPTIONAL_REQUIRES(
+                      std::is_constructible<T, std::initializer_list<U>>)>
+    explicit optional_base(in_place_t,
+                           std::initializer_list<U> il,
+                           Args&&... args)
+        : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+    ~optional_base() {
+        if (init_) storage_.value_.T::~T();
+    }
+};
+
+template <class T>
+struct constexpr_optional_base {
+    bool init_;
+    constexpr_storage_t<T> storage_;
+
+    constexpr constexpr_optional_base() noexcept
+        : init_(false), storage_(trivial_init){};
+
+    explicit constexpr constexpr_optional_base(const T& v)
+        : init_(true), storage_(v) {}
+
+    explicit constexpr constexpr_optional_base(T&& v)
+        : init_(true), storage_(constexpr_move(v)) {}
+
+    template <class... Args>
+    explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
+        : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+    template <class U,
+              class... Args,
+              TR2_OPTIONAL_REQUIRES(
+                      std::is_constructible<T, std::initializer_list<U>>)>
+    constexpr explicit constexpr_optional_base(in_place_t,
+                                               std::initializer_list<U> il,
+                                               Args&&... args)
+        : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+    ~constexpr_optional_base() = default;
+};
+
+template <class T>
+using OptionalBase = typename std::conditional<
+        std::is_trivially_destructible<T>::value,  // if possible
+        constexpr_optional_base<typename std::remove_const<
+                T>::type>,  // use base with trivial destructor
+        optional_base<typename std::remove_const<T>::type>>::type;
+
+template <class T>
+class optional : private OptionalBase<T> {
+    template <class U>  // re-declaration for nvcc on Windows.
+    using OptionalBase = typename std::conditional<
+            std::is_trivially_destructible<U>::value,  // if possible
+            constexpr_optional_base<typename std::remove_const<
+                    U>::type>,  // use base with trivial destructor
+            optional_base<typename std::remove_const<U>::type>>::type;
+
+    static_assert(!std::is_same<typename std::decay<T>::type, nullopt_t>::value,
+                  "bad T");
+    static_assert(
+            !std::is_same<typename std::decay<T>::type, in_place_t>::value,
+            "bad T");
+
+    constexpr bool initialized() const noexcept {
+        return OptionalBase<T>::init_;
+    }
+    typename std::remove_const<T>::type* dataptr() {
+        return std::addressof(OptionalBase<T>::storage_.value_);
+    }
+    constexpr const T* dataptr() const {
+        return detail_::static_addressof(OptionalBase<T>::storage_.value_);
+    }
+
+    constexpr const T& contained_val() const& {
+        return OptionalBase<T>::storage_.value_;
+    }
+    constexpr T&& contained_val() && {
+        return std::move(OptionalBase<T>::storage_.value_);
+    }
+    constexpr T& contained_val() & { return OptionalBase<T>::storage_.value_; }
+
+    void clear() noexcept {
+        if (initialized()) dataptr()->~T();
+        OptionalBase<T>::init_ = false;
+    }
+
+    template <class... Args>
+    void initialize(Args&&... args) noexcept(
+            noexcept(T(std::forward<Args>(args)...))) {
+        assert(!OptionalBase<T>::init_);
+        ::new (static_cast<void*>(dataptr())) T(std::forward<Args>(args)...);
+        OptionalBase<T>::init_ = true;
+    }
+
+    template <class U, class... Args>
+    void initialize(std::initializer_list<U> il, Args&&... args) noexcept(
+            noexcept(T(il, std::forward<Args>(args)...))) {
+        assert(!OptionalBase<T>::init_);
+        ::new (static_cast<void*>(dataptr()))
+                T(il, std::forward<Args>(args)...);
+        OptionalBase<T>::init_ = true;
+    }
+
+public:
+    typedef T value_type;
+
+    // 20.5.5.1, constructors
+    constexpr optional() noexcept : OptionalBase<T>(){};
+    constexpr optional(nullopt_t) noexcept : OptionalBase<T>(){};
+
+    optional(const optional& rhs) : OptionalBase<T>() {
+        if (rhs.initialized()) {
+            ::new (static_cast<void*>(dataptr())) T(*rhs);
+            OptionalBase<T>::init_ = true;
+        }
+    }
+
+    optional(optional&& rhs) noexcept(
+            std::is_nothrow_move_constructible<T>::value)
+        : OptionalBase<T>() {
+        if (rhs.initialized()) {
+            ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+            OptionalBase<T>::init_ = true;
+        }
+    }
+
+    // see https://github.com/akrzemi1/Optional/issues/16
+    // and https://en.cppreference.com/w/cpp/utility/optional/optional,
+    // in constructor 8, the std::optional spec can allow initialization
+    // of optionals from convertible type U
+    //
+    // 8 - implicit move construct from value
+    template <typename U = T,
+              TR2_OPTIONAL_REQUIRES(std::is_constructible<T, U&&>::value &&
+                                    !std::is_same<typename std::decay<U>::type,
+                                                  in_place_t>::value &&
+                                    !std::is_same<typename std::decay<U>::type,
+                                                  optional<T>>::value &&
+                                    std::is_convertible<U&&, T>)>
+    constexpr optional(U&& u) : OptionalBase<T>(std::forward<U>(u)) {}
+
+    // 8 - explicit move construct from value
+    template <typename U = T,
+              TR2_OPTIONAL_REQUIRES(std::is_constructible<T, U&&>::value &&
+                                    !std::is_same<typename std::decay<U>::type,
+                                                  in_place_t>::value &&
+                                    !std::is_same<typename std::decay<U>::type,
+                                                  optional<T>>::value &&
+                                    !std::is_convertible<U&&, T>)>
+    explicit constexpr optional(U&& u) : OptionalBase<T>(std::forward<U>(u)) {}
+
+    template <class... Args>
+    explicit constexpr optional(in_place_t, Args&&... args)
+        : OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+
+    template <class U,
+              class... Args,
+              TR2_OPTIONAL_REQUIRES(
+                      std::is_constructible<T, std::initializer_list<U>>)>
+    constexpr explicit optional(in_place_t,
+                                std::initializer_list<U> il,
+                                Args&&... args)
+        : OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+
+    // 20.5.4.2, Destructor
+    ~optional() = default;
+
+    // 20.5.4.3, assignment
+    optional& operator=(nullopt_t) noexcept {
+        clear();
+        return *this;
+    }
+
+    optional& operator=(const optional& rhs) {
+        if (initialized() == true && rhs.initialized() == false)
+            clear();
+        else if (initialized() == false && rhs.initialized() == true)
+            initialize(*rhs);
+        else if (initialized() == true && rhs.initialized() == true)
+            contained_val() = *rhs;
+        return *this;
+    }
+
+    optional& operator=(optional&& rhs) noexcept(
+            std::is_nothrow_move_assignable<T>::value&&
+                    std::is_nothrow_move_constructible<T>::value) {
+        if (initialized() == true && rhs.initialized() == false)
+            clear();
+        else if (initialized() == false && rhs.initialized() == true)
+            initialize(std::move(*rhs));
+        else if (initialized() == true && rhs.initialized() == true)
+            contained_val() = std::move(*rhs);
+        return *this;
+    }
+
+    template <class U = T>
+    auto operator=(U&& v) -> typename std::enable_if<
+            std::is_constructible<T, U>::value &&
+                    !std::is_same<typename std::decay<U>::type,
+                                  optional<T>>::value &&
+                    (std::is_scalar<T>::value ||
+                     std::is_same<typename std::decay<U>::type, T>::value) &&
+                    std::is_assignable<T&, U>::value,
+            optional&>::type {
+        if (initialized()) {
+            contained_val() = std::forward<U>(v);
+        } else {
+            initialize(std::forward<U>(v));
+        }
+        return *this;
+    }
+
+    template <class... Args>
+    void emplace(Args&&... args) {
+        clear();
+        initialize(std::forward<Args>(args)...);
+    }
+
+    template <class U, class... Args>
+    void emplace(std::initializer_list<U> il, Args&&... args) {
+        clear();
+        initialize<U, Args...>(il, std::forward<Args>(args)...);
+    }
+
+    // 20.5.4.4, Swap
+    void swap(optional<T>& rhs) noexcept(
+            std::is_nothrow_move_constructible<T>::value&& noexcept(
+                    std::swap(std::declval<T&>(), std::declval<T&>()))) {
+        if (initialized() == true && rhs.initialized() == false) {
+            rhs.initialize(std::move(**this));
+            clear();
+        } else if (initialized() == false && rhs.initialized() == true) {
+            initialize(std::move(*rhs));
+            rhs.clear();
+        } else if (initialized() == true && rhs.initialized() == true) {
+            using std::swap;
+            swap(**this, *rhs);
+        }
+    }
+
+    // 20.5.4.5, Observers
+
+    explicit constexpr operator bool() const noexcept { return initialized(); }
+    constexpr bool has_value() const noexcept { return initialized(); }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T const* operator->() const {
+        return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T* operator->() {
+        assert(initialized());
+        return dataptr();
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T const& operator*() const& {
+        return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T& operator*() & {
+        assert(initialized());
+        return contained_val();
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T&& operator*() && {
+        assert(initialized());
+        return constexpr_move(contained_val());
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T const& value() const& {
+        return initialized()
+                       ? contained_val()
+                       : (throw bad_optional_access("bad optional access"),
+                          contained_val());
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T& value() & {
+        return initialized()
+                       ? contained_val()
+                       : (throw bad_optional_access("bad optional access"),
+                          contained_val());
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T&& value() && {
+        if (!initialized()) throw bad_optional_access("bad optional access");
+        return std::move(contained_val());
+    }
+
+    template <class V>
+    constexpr T value_or(V&& v) const& {
+        return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+    }
+
+    template <class V>
+    constexpr T value_or(V&& v) && {
+        return *this ? constexpr_move(
+                               const_cast<optional<T>&>(*this).contained_val())
+                     : detail_::convert<T>(constexpr_forward<V>(v));
+    }
+
+    // 20.6.3.6, modifiers
+    void reset() noexcept { clear(); }
+};
+
+// XXX: please refrain from using optional<T&>, since it is being against with
+// the optional standard in c++ 17, see the debate and the details here:
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3406#rationale.refs
+// if you need it, consider using optional<std::reference_wrapper<T>> or *
+// pointer
+//
+// we leave the implementation here in case we want to reconsider using it in
+// the future if it becomes a definitely necessary case.
+template <class T>
+class optional<T&> {
+    // add this assert to prevent user from using optional reference as
+    // indicated above
+    static_assert(sizeof(T) == 0,
+                  "optional references is ill-formed, \
+    consider use optional of a std::reference_wrapper of type T to \
+    hold a reference if you really need to");
+
+    static_assert(!std::is_same<T, nullopt_t>::value, "bad T");
+    static_assert(!std::is_same<T, in_place_t>::value, "bad T");
+    T* ref;
+
+public:
+    // 20.5.5.1, construction/destruction
+    constexpr optional() noexcept : ref(nullptr) {}
+
+    constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
+
+    template <typename U = T>
+    constexpr optional(U& u) noexcept : ref(detail_::static_addressof(u)) {}
+
+    template <typename U = T>
+    optional(U&&) = delete;
+
+    constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
+
+    explicit constexpr optional(in_place_t, T& v) noexcept
+        : ref(detail_::static_addressof(v)) {}
+
+    explicit optional(in_place_t, T&&) = delete;
+
+    ~optional() = default;
+
+    // 20.5.5.2, mutation
+    optional& operator=(nullopt_t) noexcept {
+        ref = nullptr;
+        return *this;
+    }
+
+    // optional& operator=(const optional& rhs) noexcept {
+    // ref = rhs.ref;
+    // return *this;
+    // }
+
+    // optional& operator=(optional&& rhs) noexcept {
+    // ref = rhs.ref;
+    // return *this;
+    // }
+
+    template <typename U>
+    auto operator=(U&& rhs) noexcept -> typename std::enable_if<
+            std::is_same<typename std::decay<U>::type, optional<T&>>::value,
+            optional&>::type {
+        ref = rhs.ref;
+        return *this;
+    }
+
+    template <typename U>
+    auto operator=(U&& rhs) noexcept -> typename std::enable_if<
+            !std::is_same<typename std::decay<U>::type, optional<T&>>::value,
+            optional&>::type = delete;
+
+    void emplace(T& v) noexcept { ref = detail_::static_addressof(v); }
+
+    void emplace(T&&) = delete;
+
+    void swap(optional<T&>& rhs) noexcept { std::swap(ref, rhs.ref); }
+
+    // 20.5.5.3, observers
+    TR2_OPTIONAL_HOST_CONSTEXPR T* operator->() const {
+        return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, ref);
+    }
+
+    TR2_OPTIONAL_HOST_CONSTEXPR T& operator*() const {
+        return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, *ref);
+    }
+
+    constexpr T& value() const {
+        return ref ? *ref
+                   : (throw bad_optional_access("bad optional access"), *ref);
+    }
+
+    explicit constexpr operator bool() const noexcept { return ref != nullptr; }
+
+    constexpr bool has_value() const noexcept { return ref != nullptr; }
+
+    template <class V>
+    constexpr typename std::decay<T>::type value_or(V&& v) const {
+        return *this ? **this
+                     : detail_::convert<typename std::decay<T>::type>(
+                               constexpr_forward<V>(v));
+    }
+
+    // x.x.x.x, modifiers
+    void reset() noexcept { ref = nullptr; }
+};
+
+template <class T>
+class optional<T&&> {
+    static_assert(sizeof(T) == 0, "optional rvalue references disallowed");
+};
+
+// 20.5.8, Relational operators
+template <class T>
+constexpr bool operator==(const optional<T>& x, const optional<T>& y) {
+    return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, const optional<T>& y) {
+    return !(x == y);
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>& x, const optional<T>& y) {
+    return (!y) ? false : (!x) ? true : *x < *y;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, const optional<T>& y) {
+    return (y < x);
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, const optional<T>& y) {
+    return !(y < x);
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>& x, const optional<T>& y) {
+    return !(x < y);
+}
+
+// 20.5.9, Comparison with nullopt
+template <class T>
+constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept {
+    return (!x);
+}
+
+template <class T>
+constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept {
+    return (!x);
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept {
+    return bool(x);
+}
+
+template <class T>
+constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept {
+    return bool(x);
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>&, nullopt_t) noexcept {
+    return false;
+}
+
+template <class T>
+constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept {
+    return bool(x);
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept {
+    return (!x);
+}
+
+template <class T>
+constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept {
+    return true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept {
+    return bool(x);
+}
+
+template <class T>
+constexpr bool operator>(nullopt_t, const optional<T>&) noexcept {
+    return false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept {
+    return true;
+}
+
+template <class T>
+constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept {
+    return (!x);
+}
+
+// 20.5.10, Comparison with T
+template <class T>
+constexpr bool operator==(const optional<T>& x, const T& v) {
+    return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<T>& x) {
+    return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, const T& v) {
+    return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<T>& x) {
+    return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>& x, const T& v) {
+    return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<T>& x) {
+    return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, const T& v) {
+    return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<T>& x) {
+    return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>& x, const T& v) {
+    return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<T>& x) {
+    return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, const T& v) {
+    return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<T>& x) {
+    return bool(x) ? v >= *x : true;
+}
+
+// Comparison of optional<T&> with T
+template <class T>
+constexpr bool operator==(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<T&>& x) {
+    return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<T&>& x) {
+    return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<T&>& x) {
+    return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<T&>& x) {
+    return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<T&>& x) {
+    return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T&>& x, const T& v) {
+    return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<T&>& x) {
+    return bool(x) ? v >= *x : true;
+}
+
+// Comparison of optional<T const&> with T
+template <class T>
+constexpr bool operator==(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<const T&>& x, const T& v) {
+    return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<const T&>& x) {
+    return bool(x) ? v >= *x : true;
+}
+
+// 20.5.12, Specialized algorithms
+template <class T>
+void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y))) {
+    x.swap(y);
+}
+
+template <class T>
+constexpr optional<typename std::decay<T>::type> make_optional(T&& v) {
+    return optional<typename std::decay<T>::type>(constexpr_forward<T>(v));
+}
+
+template <class X>
+constexpr optional<X&> make_optional(std::reference_wrapper<X> v) {
+    return optional<X&>(v.get());
+}
+
+}  // namespace utility
+}  // namespace open3d
+
+namespace std {
+template <typename T>
+struct hash<open3d::utility::optional<T>> {
+    typedef typename hash<T>::result_type result_type;
+    typedef open3d::utility::optional<T> argument_type;
+
+    constexpr result_type operator()(argument_type const& arg) const {
+        return arg ? std::hash<T>{}(*arg) : result_type{};
+    }
+};
+
+template <typename T>
+struct hash<open3d::utility::optional<T&>> {
+    typedef typename hash<T>::result_type result_type;
+    typedef open3d::utility::optional<T&> argument_type;
+
+    constexpr result_type operator()(argument_type const& arg) const {
+        return arg ? std::hash<T>{}(*arg) : result_type{};
+    }
+};
+}  // namespace std
+
+#undef TR2_OPTIONAL_REQUIRES
+#undef TR2_OPTIONAL_ASSERTED_EXPRESSION
+#undef TR2_OPTIONAL_HOST_CONSTEXPR

--- a/cpp/pybind/core/core.cpp
+++ b/cpp/pybind/core/core.cpp
@@ -26,12 +26,100 @@
 
 #include "pybind/core/core.h"
 
+#include "open3d/core/Tensor.h"
+#include "open3d/utility/Console.h"
 #include "pybind/open3d_pybind.h"
+#include "pybind/pybind_utils.h"
 
 namespace open3d {
 namespace core {
 
-void pybind_core(py::module &m) {
+/// Convert Tensor class to py::array (Numpy array).
+py::array TensorToPyArray(const Tensor& tensor) {
+    if (tensor.GetDevice().GetType() != Device::DeviceType::CPU) {
+        utility::LogError(
+                "Can only convert CPU Tensor to numpy. Copy Tensor to CPU "
+                "before converting to numpy.");
+    }
+    py::dtype py_dtype =
+            py::dtype(pybind_utils::DtypeToArrayFormat(tensor.GetDtype()));
+    py::array::ShapeContainer py_shape(tensor.GetShape());
+    SizeVector strides = tensor.GetStrides();
+    int64_t element_byte_size = tensor.GetDtype().ByteSize();
+    for (auto& s : strides) {
+        s *= element_byte_size;
+    }
+    py::array::StridesContainer py_strides(strides);
+
+    // `base_tensor` is a shallow copy of `tensor`. `base_tensor`
+    // is on the heap and is owned by py::capsule
+    // `base_tensor_capsule`. The capsule is referenced as the
+    // "base" of the numpy tensor returned by o3d.Tensor.numpy().
+    // When the "base" goes out-of-scope (e.g. when all numpy
+    // tensors referencing the base have gone out-of-scope), the
+    // deleter is called to free the `base_tensor`.
+    //
+    // This behavior is important when the origianl `tensor` goes
+    // out-of-scope while we still want to keep the data alive.
+    // e.g.
+    //
+    // ```python
+    // def get_np_tensor():
+    //     o3d_t = o3d.Tensor(...)
+    //     return o3d_t.numpy()
+    //
+    // # Now, `o3d_t` is out-of-scope, but `np_t` still
+    // # references the base tensor which references the
+    // # underlying data of `o3d_t`. Thus np_t is still valid.
+    // # When np_t goes out-of-scope, the underlying data will be
+    // # finally freed.
+    // np_t = get_np_tensor()
+    // ```
+    //
+    // See:
+    // https://stackoverflow.com/questions/44659924/returning-numpy-arrays-via-pybind11
+    Tensor* base_tensor = new Tensor(tensor);
+
+    // See PyTorch's torch/csrc/Module.cpp
+    auto capsule_destructor = [](PyObject* data) {
+        Tensor* base_tensor = reinterpret_cast<Tensor*>(
+                PyCapsule_GetPointer(data, "open3d::Tensor"));
+        if (base_tensor) {
+            delete base_tensor;
+        } else {
+            PyErr_Clear();
+        }
+    };
+
+    py::capsule base_tensor_capsule(base_tensor, "open3d::Tensor",
+                                    capsule_destructor);
+    return py::array(py_dtype, py_shape, py_strides, tensor.GetDataPtr(),
+                     base_tensor_capsule);
+}
+
+Tensor PyArrayToTensor(py::array array, bool inplace) {
+    py::buffer_info info = array.request();
+
+    SizeVector shape(info.shape.begin(), info.shape.end());
+    SizeVector strides(info.strides.begin(), info.strides.end());
+    for (size_t i = 0; i < strides.size(); ++i) {
+        strides[i] /= info.itemsize;
+    }
+    Dtype dtype = pybind_utils::ArrayFormatToDtype(info.format);
+    Device device("CPU:0");
+
+    std::function<void(void*)> deleter = [](void*) -> void {};
+    auto blob = std::make_shared<Blob>(device, info.ptr, deleter);
+    Tensor t_inplace(shape, strides, info.ptr, dtype, blob);
+
+    if (inplace) {
+        return t_inplace;
+    } else {
+        return t_inplace.Copy();
+    }
+}
+
+void pybind_core(py::module& m) {
     py::module m_core = m.def_submodule("core");
     pybind_cuda_utils(m_core);
     pybind_core_blob(m_core);

--- a/cpp/pybind/core/core.h
+++ b/cpp/pybind/core/core.h
@@ -26,13 +26,44 @@
 
 #pragma once
 
+#include "open3d/core/Tensor.h"
 #include "pybind/open3d_pybind.h"
 
 namespace open3d {
 namespace core {
 
-void pybind_core(py::module& m);
+/// Converts Tensor to py::array (Numpy array). The python object holds a
+/// reference to the Tensor, and when it goes out of scope, the Tensor's
+/// reference counter will be decremented by 1.
+///
+/// You may use this helper function for exporting data to Numpy.
+///
+/// To expose a C++ buffer to python, we need to carefully manage the buffer
+/// ownership. You firest need to allocate the memory in the heap (e.g. with
+/// `new`, `malloc`, avoid using containers that frees up memory when the C++
+/// variable goes out of scope), then in pybind11, define a deleter function for
+/// py::array_t that deallocates the buffer. This deleater function will be
+/// called once the python reference count decreases to 0. See
+/// https://stackoverflow.com/a/44682603/1255535 for details. This approach is
+/// efficient since no memory copy is required.
+///
+/// Alternatively, you can create a Tensor with a **copy** of your data (so that
+/// your original buffer can be freed), and let TensorToPyArray generate a
+/// py::array that manages the buffer lifetime automatically. This is more
+/// convienent, but will require an extra copy.
+py::array TensorToPyArray(const Tensor& tensor);
 
+/// Converts py::array (Numpy array) to Tensor.
+///
+/// You may use this helper function for importing data from Numpy.
+///
+/// \param inplace If True, Tensor will directly use the underlying Numpy
+/// buffer. However, The data will become invalid once the Numpy variable is
+/// deallocated, the Tensor's data becomes invalid without notice. If False, the
+/// python buffer will be copied.
+Tensor PyArrayToTensor(py::array array, bool inplace);
+
+void pybind_core(py::module& m);
 void pybind_cuda_utils(py::module& m);
 void pybind_core_blob(py::module& m);
 void pybind_core_dtype(py::module& m);

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -125,87 +125,10 @@ void pybind_core_tensor(py::module& m) {
     });
 
     // Buffer I/O for Numpy and DLPack(PyTorch)
-    tensor.def("numpy", [](const Tensor& tensor) {
-        if (tensor.GetDevice().GetType() != Device::DeviceType::CPU) {
-            utility::LogError(
-                    "Can only convert CPU Tensor to numpy. Copy "
-                    "Tensor to CPU before converting to numpy.");
-        }
-        py::dtype py_dtype =
-                py::dtype(pybind_utils::DtypeToArrayFormat(tensor.GetDtype()));
-        py::array::ShapeContainer py_shape(tensor.GetShape());
-        SizeVector strides = tensor.GetStrides();
-        int64_t element_byte_size = tensor.GetDtype().ByteSize();
-        for (auto& s : strides) {
-            s *= element_byte_size;
-        }
-        py::array::StridesContainer py_strides(strides);
-
-        // `base_tensor` is a shallow copy of `tensor`. `base_tensor`
-        // is on the heap and is owned by py::capsule
-        // `base_tensor_capsule`. The capsule is referenced as the
-        // "base" of the numpy tensor returned by o3d.Tensor.numpy().
-        // When the "base" goes out-of-scope (e.g. when all numpy
-        // tensors referencing the base have gone out-of-scope), the
-        // deleter is called to free the `base_tensor`.
-        //
-        // This behavior is important when the origianl `tensor` goes
-        // out-of-scope while we still want to keep the data alive.
-        // e.g.
-        //
-        // ```python
-        // def get_np_tensor():
-        //     o3d_t = o3d.Tensor(...)
-        //     return o3d_t.numpy()
-        //
-        // # Now, `o3d_t` is out-of-scope, but `np_t` still
-        // # references the base tensor which references the
-        // # underlying data of `o3d_t`. Thus np_t is still valid.
-        // # When np_t goes out-of-scope, the underlying data will be
-        // # finally freed.
-        // np_t = get_np_tensor()
-        // ```
-        //
-        // See:
-        // https://stackoverflow.com/questions/44659924/returning-numpy-arrays-via-pybind11
-        Tensor* base_tensor = new Tensor(tensor);
-
-        // See PyTorch's torch/csrc/Module.cpp
-        auto capsule_destructor = [](PyObject* data) {
-            Tensor* base_tensor = reinterpret_cast<Tensor*>(
-                    PyCapsule_GetPointer(data, "open3d::Tensor"));
-            if (base_tensor) {
-                delete base_tensor;
-            } else {
-                PyErr_Clear();
-            }
-        };
-
-        py::capsule base_tensor_capsule(base_tensor, "open3d::Tensor",
-                                        capsule_destructor);
-
-        return py::array(py_dtype, py_shape, py_strides, tensor.GetDataPtr(),
-                         base_tensor_capsule);
-    });
+    tensor.def("numpy", &core::TensorToPyArray);
 
     tensor.def_static("from_numpy", [](py::array np_array) {
-        py::buffer_info info = np_array.request();
-
-        SizeVector shape(info.shape.begin(), info.shape.end());
-        SizeVector strides(info.strides.begin(), info.strides.end());
-        for (size_t i = 0; i < strides.size(); ++i) {
-            strides[i] /= info.itemsize;
-        }
-        Dtype dtype = pybind_utils::ArrayFormatToDtype(info.format);
-        Device device("CPU:0");
-
-        // Blob expects an std::function<void(void*)> deleter, a
-        // dummy deleter is used here, since the memory is
-        // managed by numpy.
-        std::function<void(void*)> deleter = [](void*) -> void {};
-        auto blob = std::make_shared<Blob>(device, info.ptr, deleter);
-
-        return Tensor(shape, strides, info.ptr, dtype, blob);
+        return core::PyArrayToTensor(np_array, true);
     });
 
     tensor.def("to_dlpack", [](const Tensor& tensor) {

--- a/cpp/pybind/ml/contrib.cpp
+++ b/cpp/pybind/ml/contrib.cpp
@@ -360,7 +360,7 @@ const py::tuple Subsample(py::array points,
         return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
                               core::TensorToPyArray(subsampled_classes_t));
     } else {
-        return py::make_tuple(core::TensorToPyArray(subsampled_points_t));
+        return core::TensorToPyArray(subsampled_points_t);
     }
 }
 

--- a/cpp/pybind/ml/contrib.cpp
+++ b/cpp/pybind/ml/contrib.cpp
@@ -81,6 +81,10 @@ const py::tuple SubsampleBatch(py::array points,
                           batches_t.Sum({0}).Item<int32_t>(), num_points);
     }
     original_batches = batches_t.ToFlatVector<int32_t>();
+    if (verbose) {
+        utility::LogInfo("Got {} batches with a total of {} points as inputs.",
+                         num_batches, num_points);
+    }
 
     // Fill original_features.
     int64_t feature_dim = -1;
@@ -154,6 +158,10 @@ const py::tuple SubsampleBatch(py::array points,
                 "{} points.",
                 subsampled_batches_t.Sum({0}).Item<int32_t>(),
                 num_subsampled_points);
+    }
+    if (verbose) {
+        utility::LogInfo("Subsampled to {} batches with a total of {} points.",
+                         num_subsampled_batches, num_subsampled_points);
     }
 
     // Wrap result subsampled_features. Data will be copied.
@@ -238,6 +246,9 @@ const py::tuple Subsample(py::array points,
             reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()),
             reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()) +
                     num_points);
+    if (verbose) {
+        utility::LogInfo("Got {} points as inputs.", num_points);
+    }
 
     // Fill original_features.
     int64_t feature_dim = -1;
@@ -297,6 +308,9 @@ const py::tuple Subsample(py::array points,
     core::Tensor subsampled_points_t(
             reinterpret_cast<float*>(subsampled_points.data()),
             {num_subsampled_points, 3}, core::Dtype::Float32);
+    if (verbose) {
+        utility::LogInfo("Subsampled to {} points.", num_subsampled_points);
+    }
 
     // Wrap result subsampled_features. Data will be copied.
     core::Tensor subsampled_features_t;

--- a/cpp/pybind/ml/contrib.cpp
+++ b/cpp/pybind/ml/contrib.cpp
@@ -1,0 +1,367 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/ml/contrib/GridSubsampling.h"
+#include "pybind/core/core.h"
+#include "pybind/docstring.h"
+#include "pybind/open3d_pybind.h"
+#include "pybind/pybind_utils.h"
+
+namespace open3d {
+namespace ml {
+
+const py::tuple SubsampleBatch(py::array points,
+                               py::array batches,
+                               utility::optional<py::array> features,
+                               utility::optional<py::array> classes,
+                               float sampleDl,
+                               const std::string& method,
+                               int max_p,
+                               int verbose) {
+    std::vector<contrib::PointXYZ> original_points;
+    std::vector<contrib::PointXYZ> subsampled_points;
+    std::vector<int> original_batches;
+    std::vector<int> subsampled_batches;
+    std::vector<float> original_features;
+    std::vector<float> subsampled_features;
+    std::vector<int> original_classes;
+    std::vector<int> subsampled_classes;
+
+    // Fill original_points.
+    core::Tensor points_t = core::PyArrayToTensor(points, true).Contiguous();
+    if (points_t.GetDtype() != core::Dtype::Float32) {
+        utility::LogError("points must be np.float32.");
+    }
+    if (points_t.NumDims() != 2 || points_t.GetShape()[1] != 3) {
+        utility::LogError("points must have shape (N, 3), but got {}.",
+                          points_t.GetShape().ToString());
+    }
+    int64_t num_points = points_t.NumElements() / 3;
+    original_points = std::vector<contrib::PointXYZ>(
+            reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()),
+            reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()) +
+                    num_points);
+
+    // Fill original batches.
+    core::Tensor batches_t = core::PyArrayToTensor(batches, true).Contiguous();
+    if (batches_t.GetDtype() != core::Dtype::Int32) {
+        utility::LogError("batches must be np.int32.");
+    }
+    if (batches_t.NumDims() != 1) {
+        utility::LogError("batches must have shape (NB,), but got {}.",
+                          batches_t.GetShape().ToString());
+    }
+    int64_t num_batches = batches_t.GetShape()[0];
+    if (static_cast<int64_t>(batches_t.Sum({0}).Item<int32_t>()) !=
+        num_points) {
+        utility::LogError("batches got {} points, but points got {} points.",
+                          batches_t.Sum({0}).Item<int32_t>(), num_points);
+    }
+    original_batches = batches_t.ToFlatVector<int32_t>();
+
+    // Fill original_features.
+    int64_t feature_dim = -1;
+    if (features.has_value()) {
+        core::Tensor features_t =
+                core::PyArrayToTensor(features.value(), true).Contiguous();
+        if (features_t.GetDtype() != core::Dtype::Float32) {
+            utility::LogError("features must be np.float32.");
+        }
+        if (features_t.NumDims() != 2) {
+            utility::LogError("features must have shape (N, d), but got {}.",
+                              features_t.GetShape().ToString());
+        }
+        if (features_t.GetShape()[0] != num_points) {
+            utility::LogError(
+                    "features's shape {} is not compatible with "
+                    "points's shape {}, their first dimension must "
+                    "be equal.",
+                    features_t.GetShape().ToString(),
+                    points_t.GetShape().ToString());
+        }
+        feature_dim = features_t.GetShape()[1];
+        original_features = features_t.ToFlatVector<float>();
+    }
+
+    // Fill original_classes.
+    if (classes.has_value()) {
+        core::Tensor classes_t =
+                core::PyArrayToTensor(classes.value(), true).Contiguous();
+        if (classes_t.GetDtype() != core::Dtype::Int32) {
+            utility::LogError("classes must be np.int32.");
+        }
+        if (classes_t.NumDims() != 1) {
+            utility::LogError("classes must have shape (N,), but got {}.",
+                              classes_t.GetShape().ToString());
+        }
+        if (classes_t.GetShape()[0] != num_points) {
+            utility::LogError(
+                    "classes's shape {} is not compatible with "
+                    "points's shape {}, their first dimension must "
+                    "be equal.",
+                    classes_t.GetShape().ToString(),
+                    points_t.GetShape().ToString());
+        }
+        original_classes = classes_t.ToFlatVector<int32_t>();
+    }
+
+    // Call function.
+    batch_grid_subsampling(
+            original_points, subsampled_points, original_features,
+            subsampled_features, original_classes, subsampled_classes,
+            original_batches, subsampled_batches, sampleDl, max_p);
+
+    // Wrap result subsampled_points. Data will be copied.
+    assert(std::is_pod<contrib::PointXYZ>());
+    int64_t num_subsampled_points =
+            static_cast<int64_t>(subsampled_points.size());
+    core::Tensor subsampled_points_t(
+            reinterpret_cast<float*>(subsampled_points.data()),
+            {num_subsampled_points, 3}, core::Dtype::Float32);
+
+    // Wrap result subsampled_batches. Data will be copied.
+    int64_t num_subsampled_batches =
+            static_cast<int64_t>(subsampled_batches.size());
+    core::Tensor subsampled_batches_t = core::Tensor(
+            subsampled_batches, {num_subsampled_batches}, core::Dtype::Int32);
+    if (static_cast<int64_t>(subsampled_batches_t.Sum({0}).Item<int32_t>()) !=
+        num_subsampled_points) {
+        utility::LogError(
+                "subsampled_batches got {} points, but subsampled_points got "
+                "{} points.",
+                subsampled_batches_t.Sum({0}).Item<int32_t>(),
+                num_subsampled_points);
+    }
+
+    // Wrap result subsampled_features. Data will be copied.
+    core::Tensor subsampled_features_t;
+    if (features.has_value()) {
+        if (subsampled_features.size() % num_subsampled_points != 0) {
+            utility::LogError(
+                    "Error: subsampled_points.size() {} is not a "
+                    "multiple of num_subsampled_points {}.",
+                    subsampled_points.size(), num_subsampled_points);
+        }
+        int64_t subsampled_feature_dim =
+                static_cast<int64_t>(subsampled_features.size()) /
+                num_subsampled_points;
+        if (feature_dim != subsampled_feature_dim) {
+            utility::LogError(
+                    "Error: input feature dim {} does not match "
+                    "the subsampled feature dim {}.",
+                    feature_dim, subsampled_feature_dim);
+        }
+        subsampled_features_t = core::Tensor(
+                subsampled_features, {num_subsampled_points, feature_dim},
+                core::Dtype::Float32);
+    }
+
+    // Wrap result subsampled_classes. Data will be copied.
+    core::Tensor subsampled_classes_t;
+    if (classes.has_value()) {
+        if (subsampled_classes.size() != num_subsampled_points) {
+            utility::LogError(
+                    "Error: subsampled_classes.size() {} != "
+                    "num_subsampled_points {}.",
+                    subsampled_classes.size(), num_subsampled_points);
+        }
+        subsampled_classes_t =
+                core::Tensor(subsampled_classes, {num_subsampled_points},
+                             core::Dtype::Int32);
+    }
+
+    if (features.has_value() && classes.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_batches_t),
+                              core::TensorToPyArray(subsampled_features_t),
+                              core::TensorToPyArray(subsampled_classes_t));
+    } else if (features.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_batches_t),
+                              core::TensorToPyArray(subsampled_features_t));
+    } else if (classes.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_batches_t),
+                              core::TensorToPyArray(subsampled_classes_t));
+    } else {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_batches_t));
+    }
+}
+
+const py::tuple Subsample(py::array points,
+                          utility::optional<py::array> features,
+                          utility::optional<py::array> classes,
+                          float sampleDl,
+                          int verbose) {
+    std::vector<contrib::PointXYZ> original_points;
+    std::vector<contrib::PointXYZ> subsampled_points;
+    std::vector<float> original_features;
+    std::vector<float> subsampled_features;
+    std::vector<int> original_classes;
+    std::vector<int> subsampled_classes;
+
+    // Fill original_points.
+    core::Tensor points_t = core::PyArrayToTensor(points, true).Contiguous();
+    if (points_t.GetDtype() != core::Dtype::Float32) {
+        utility::LogError("points must be np.float32.");
+    }
+    if (points_t.NumDims() != 2 || points_t.GetShape()[1] != 3) {
+        utility::LogError("points must have shape (N, 3), but got {}.",
+                          points_t.GetShape().ToString());
+    }
+    int64_t num_points = points_t.NumElements() / 3;
+    original_points = std::vector<contrib::PointXYZ>(
+            reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()),
+            reinterpret_cast<contrib::PointXYZ*>(points_t.GetDataPtr()) +
+                    num_points);
+
+    // Fill original_features.
+    int64_t feature_dim = -1;
+    if (features.has_value()) {
+        core::Tensor features_t =
+                core::PyArrayToTensor(features.value(), true).Contiguous();
+        if (features_t.GetDtype() != core::Dtype::Float32) {
+            utility::LogError("features must be np.float32.");
+        }
+        if (features_t.NumDims() != 2) {
+            utility::LogError("features must have shape (N, d), but got {}.",
+                              features_t.GetShape().ToString());
+        }
+        if (features_t.GetShape()[0] != num_points) {
+            utility::LogError(
+                    "features's shape {} is not compatible with "
+                    "points's shape {}, their first dimension must "
+                    "be equal.",
+                    features_t.GetShape().ToString(),
+                    points_t.GetShape().ToString());
+        }
+        feature_dim = features_t.GetShape()[1];
+        original_features = features_t.ToFlatVector<float>();
+    }
+
+    // Fill original_classes.
+    if (classes.has_value()) {
+        core::Tensor classes_t =
+                core::PyArrayToTensor(classes.value(), true).Contiguous();
+        if (classes_t.GetDtype() != core::Dtype::Int32) {
+            utility::LogError("classes must be np.int32.");
+        }
+        if (classes_t.NumDims() != 1) {
+            utility::LogError("classes must have shape (N,), but got {}.",
+                              classes_t.GetShape().ToString());
+        }
+        if (classes_t.GetShape()[0] != num_points) {
+            utility::LogError(
+                    "classes's shape {} is not compatible with "
+                    "points's shape {}, their first dimension must "
+                    "be equal.",
+                    classes_t.GetShape().ToString(),
+                    points_t.GetShape().ToString());
+        }
+        original_classes = classes_t.ToFlatVector<int32_t>();
+    }
+
+    // Call function.
+    grid_subsampling(original_points, subsampled_points, original_features,
+                     subsampled_features, original_classes, subsampled_classes,
+                     sampleDl, verbose);
+
+    // Wrap result subsampled_points. Data will be copied.
+    assert(std::is_pod<contrib::PointXYZ>());
+    int64_t num_subsampled_points =
+            static_cast<int64_t>(subsampled_points.size());
+    core::Tensor subsampled_points_t(
+            reinterpret_cast<float*>(subsampled_points.data()),
+            {num_subsampled_points, 3}, core::Dtype::Float32);
+
+    // Wrap result subsampled_features. Data will be copied.
+    core::Tensor subsampled_features_t;
+    if (features.has_value()) {
+        if (subsampled_features.size() % num_subsampled_points != 0) {
+            utility::LogError(
+                    "Error: subsampled_points.size() {} is not a "
+                    "multiple of num_subsampled_points {}.",
+                    subsampled_points.size(), num_subsampled_points);
+        }
+        int64_t subsampled_feature_dim =
+                static_cast<int64_t>(subsampled_features.size()) /
+                num_subsampled_points;
+        if (feature_dim != subsampled_feature_dim) {
+            utility::LogError(
+                    "Error: input feature dim {} does not match "
+                    "the subsampled feature dim {}.",
+                    feature_dim, subsampled_feature_dim);
+        }
+        subsampled_features_t = core::Tensor(
+                subsampled_features, {num_subsampled_points, feature_dim},
+                core::Dtype::Float32);
+    }
+
+    // Wrap result subsampled_classes. Data will be copied.
+    core::Tensor subsampled_classes_t;
+    if (classes.has_value()) {
+        if (subsampled_classes.size() != num_subsampled_points) {
+            utility::LogError(
+                    "Error: subsampled_classes.size() {} != "
+                    "num_subsampled_points {}.",
+                    subsampled_classes.size(), num_subsampled_points);
+        }
+        subsampled_classes_t =
+                core::Tensor(subsampled_classes, {num_subsampled_points},
+                             core::Dtype::Int32);
+    }
+
+    if (features.has_value() && classes.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_features_t),
+                              core::TensorToPyArray(subsampled_classes_t));
+    } else if (features.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_features_t));
+    } else if (classes.has_value()) {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t),
+                              core::TensorToPyArray(subsampled_classes_t));
+    } else {
+        return py::make_tuple(core::TensorToPyArray(subsampled_points_t));
+    }
+}
+
+void pybind_contrib(py::module& m) {
+    py::module m_contrib = m.def_submodule("contrib");
+
+    m_contrib.def("subsample", &Subsample, "points"_a,
+                  "features"_a = py::none(), "classes"_a = py::none(),
+                  "sampleDl"_a = 0.1, "verbose"_a = 0);
+
+    m_contrib.def("subsample_batch", &SubsampleBatch, "points"_a, "batches"_a,
+                  "features"_a = py::none(), "classes"_a = py::none(),
+                  "sampleDl"_a = 0.1, "method"_a = "barycenters", "max_p"_a = 0,
+                  "verbose"_a = 0);
+}
+
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/pybind/ml/ml.cpp
+++ b/cpp/pybind/ml/ml.cpp
@@ -24,46 +24,17 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "pybind/ml/ml.h"
+
 #include "pybind/open3d_pybind.h"
 
-#include "open3d/utility/Console.h"
-#include "pybind/camera/camera.h"
-#include "pybind/core/core.h"
-#include "pybind/geometry/geometry.h"
-#include "pybind/io/io.h"
-#include "pybind/ml/ml.h"
-#include "pybind/pipelines/pipelines.h"
-#include "pybind/tgeometry/geometry.h"
-#include "pybind/utility/utility.h"
-#include "pybind/visualization/visualization.h"
-
 namespace open3d {
+namespace ml {
 
-PYBIND11_MODULE(pybind, m) {
-    open3d::utility::Logger::i().print_fcn_ = [](const std::string& msg) {
-        py::print(msg);
-    };
-
-    m.doc() = "Python binding of Open3D";
-
-    // Check Open3D CXX11_ABI with
-    // import open3d as o3d; print(o3d.open3d_pybind._GLIBCXX_USE_CXX11_ABI)
-    m.add_object("_GLIBCXX_USE_CXX11_ABI",
-                 _GLIBCXX_USE_CXX11_ABI ? Py_True : Py_False);
-
-    // The binding order matters: if a class haven't been binded, binding the
-    // user of this class will result in "could not convert default argument
-    // into a Python object" error.
-    utility::pybind_utility(m);
-
-    camera::pybind_camera(m);
-    core::pybind_core(m);
-    geometry::pybind_geometry(m);
-    tgeometry::pybind_geometry(m);
-    ml::pybind_ml(m);
-    io::pybind_io(m);
-    pipelines::pybind_pipelines(m);
-    visualization::pybind_visualization(m);
+void pybind_ml(py::module &m) {
+    py::module m_ml = m.def_submodule("ml");
+    pybind_contrib(m_ml);
 }
 
+}  // namespace ml
 }  // namespace open3d

--- a/cpp/pybind/ml/ml.h
+++ b/cpp/pybind/ml/ml.h
@@ -24,46 +24,15 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#pragma once
+
 #include "pybind/open3d_pybind.h"
 
-#include "open3d/utility/Console.h"
-#include "pybind/camera/camera.h"
-#include "pybind/core/core.h"
-#include "pybind/geometry/geometry.h"
-#include "pybind/io/io.h"
-#include "pybind/ml/ml.h"
-#include "pybind/pipelines/pipelines.h"
-#include "pybind/tgeometry/geometry.h"
-#include "pybind/utility/utility.h"
-#include "pybind/visualization/visualization.h"
-
 namespace open3d {
+namespace ml {
 
-PYBIND11_MODULE(pybind, m) {
-    open3d::utility::Logger::i().print_fcn_ = [](const std::string& msg) {
-        py::print(msg);
-    };
+void pybind_ml(py::module& m);
+void pybind_contrib(py::module& m);
 
-    m.doc() = "Python binding of Open3D";
-
-    // Check Open3D CXX11_ABI with
-    // import open3d as o3d; print(o3d.open3d_pybind._GLIBCXX_USE_CXX11_ABI)
-    m.add_object("_GLIBCXX_USE_CXX11_ABI",
-                 _GLIBCXX_USE_CXX11_ABI ? Py_True : Py_False);
-
-    // The binding order matters: if a class haven't been binded, binding the
-    // user of this class will result in "could not convert default argument
-    // into a Python object" error.
-    utility::pybind_utility(m);
-
-    camera::pybind_camera(m);
-    core::pybind_core(m);
-    geometry::pybind_geometry(m);
-    tgeometry::pybind_geometry(m);
-    ml::pybind_ml(m);
-    io::pybind_io(m);
-    pipelines::pybind_pipelines(m);
-    visualization::pybind_visualization(m);
-}
-
+}  // namespace ml
 }  // namespace open3d

--- a/cpp/pybind/open3d_pybind.h
+++ b/cpp/pybind/open3d_pybind.h
@@ -101,7 +101,7 @@ void bind_copy_functions(Class_ &cl) {
 ///         if (!b.has_value()) {
 ///             return a;
 ///         } else {
-///             return a + b;
+///             return a + b.value();
 ///         }
 ///     },
 ///     py::arg("a"), py::arg("b") = py::none()

--- a/cpp/pybind/open3d_pybind.h
+++ b/cpp/pybind/open3d_pybind.h
@@ -37,6 +37,7 @@
 
 #include "open3d/pipelines/registration/PoseGraph.h"
 #include "open3d/utility/Eigen.h"
+#include "open3d/utility/Optional.h"
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -62,7 +63,6 @@ PYBIND11_MAKE_OPAQUE(
 PYBIND11_MAKE_OPAQUE(
         std::vector<open3d::pipelines::registration::PoseGraphNode>);
 
-// some helper functions
 namespace pybind11 {
 namespace detail {
 
@@ -77,6 +77,83 @@ void bind_copy_functions(Class_ &cl) {
     cl.def("__copy__", [](T &v) { return T(v); });
     cl.def("__deepcopy__", [](T &v, py::dict &memo) { return T(v); });
 }
+
+/// Custom pybind11 type caster for open3d::utility::optional, which backports
+/// C++17's `std::optional`. We need compiler supporting C++14 or newer.
+/// Typically, this can be used to handle "None" parameters from Python.
+///
+/// Example python function:
+///
+/// ```python
+/// def add(a, b=None):
+///     # Assuming a, b are int.
+///     if b is None:
+///         return a
+///     else:
+///         return a + b
+/// ```
+///
+/// Here's the equivalent C++ implementation:
+///
+/// ```cpp
+/// m.def("add",
+///     [](int a, open3d::utility::optional<int> b) {
+///         if (!b.has_value()) {
+///             return a;
+///         } else {
+///             return a + b;
+///         }
+///     },
+///     py::arg("a"), py::arg("b") = py::none()
+/// );
+/// ```
+///
+/// Then this function can be called with:
+///
+/// ```python
+/// add(1)
+/// add(1, 2)
+/// add(1, b=2)
+/// add(1, b=None)
+/// ```
+///
+template <typename T>
+struct open3d_optional_caster {
+    using value_conv = make_caster<typename T::value_type>;
+
+    template <typename T_>
+    static handle cast(T_ &&src, return_value_policy policy, handle parent) {
+        if (!src) return none().inc_ref();
+        if (!std::is_lvalue_reference<T>::value) {
+            policy = return_value_policy_override<T>::policy(policy);
+        }
+        return value_conv::cast(*std::forward<T_>(src), policy, parent);
+    }
+
+    bool load(handle src, bool convert) {
+        if (!src) {
+            return false;
+        } else if (src.is_none()) {
+            return true;  // default-constructed value is already empty
+        }
+        value_conv inner_caster;
+        if (!inner_caster.load(src, convert)) return false;
+
+        value.emplace(
+                cast_op<typename T::value_type &&>(std::move(inner_caster)));
+        return true;
+    }
+
+    PYBIND11_TYPE_CASTER(T, _("Optional[") + value_conv::name + _("]"));
+};
+
+template <typename T>
+struct type_caster<open3d::utility::optional<T>>
+    : public open3d_optional_caster<open3d::utility::optional<T>> {};
+
+template <>
+struct type_caster<open3d::utility::nullopt_t>
+    : public void_caster<open3d::utility::nullopt_t> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/python/test/ml/test_contrib.py
+++ b/python/test/ml/test_contrib.py
@@ -1,17 +1,72 @@
 import numpy as np
+import pytest
 from open3d.pybind.ml.contrib import subsample, subsample_batch
 
 
 def test_subsample():
-    points = np.ones((10, 3), dtype=np.float32)
-    features = np.ones((10, 5), dtype=np.float32)
-    classes = np.ones((10,), dtype=np.int32)
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0 ,1], [1, 1, 1], [5, 0, 0], [5, 1, 0]], dtype=np.float32)
+    features = np.array(range(21), dtype=np.float32).reshape(-1, 3)
+    labels = np.array(range(7), dtype = np.int32)
 
-    # Test handling of None
-    p = subsample(points)
-    p, f, c = subsample(points, features, classes)
-    p, c = subsample(points, classes=classes)
+    # Passing only points.
+    sub_points_ref = np.array([[5, 0.5, 0], [0.4, 0.4, 0.4]], dtype=np.float32)
+    sub_points = subsample(points, sampleDl=1.1)
 
+    np.testing.assert_equal(sub_points, sub_points_ref)
+
+    #Passing points and features.
+    sub_features_ref = np.array([[16.5, 17.5, 18.5], [6, 7, 8]], dtype=np.float32)
+    sub_points_feat = subsample(points, features=features, sampleDl=1.1)
+
+    assert len(sub_points_feat) == 2
+
+    sub_points, sub_features = sub_points_feat
+
+    np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
+    np.testing.assert_equal(sub_features, sub_features_ref)
+
+    #Passing points, features and labels.
+    sub_labels_ref = np.array([6, 4], dtype=np.int32)
+    sub_points_feat_lab = subsample(points, features=features, classes=labels, sampleDl=1.1)
+
+    assert len(sub_points_feat_lab) == 3
+
+    sub_points, sub_features, sub_labels = sub_points_feat_lab
+
+    np.testing.assert_equal(sub_labels, sub_labels_ref)
+    np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
+
+    # Test wrong dtype.
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(np.array(points, dtype=np.int32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(np.array(points, dtype=np.float64), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points, features=np.array(features, dtype=np.int32), sampleDl=1.1)
+    
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points, features=features, classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points, features=np.array(features, np.int32), classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+
+    # Test shape mismatch
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points[0], sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(np.ones((10, 4), dtype=np.float32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points, features=features[0], sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points[0], sampleDl=1.1)
+
+    with pytest.raises(TypeError):
+        sub_points = subsample(None, sampleDl=1.1)
 
 def test_subsample_batch():
     points = np.ones((10, 3), dtype=np.float32)
@@ -23,3 +78,5 @@ def test_subsample_batch():
     p, b = subsample_batch(points, batches)
     p, b, f, c = subsample_batch(points, batches, features, classes)
     p, b, c = subsample_batch(points, batches, classes=classes)
+
+# test_subsample()

--- a/python/test/ml/test_contrib.py
+++ b/python/test/ml/test_contrib.py
@@ -16,7 +16,7 @@ def test_subsample():
 
     np.testing.assert_equal(sub_points, sub_points_ref)
 
-    #Passing points and features.
+    # Passing points and features.
     sub_features_ref = np.array([[16.5, 17.5, 18.5], [6, 7, 8]],
                                 dtype=np.float32)
     sub_points_feat = subsample(points, features=features, sampleDl=1.1)
@@ -29,7 +29,7 @@ def test_subsample():
     np.testing.assert_equal(sub_features, sub_features_ref)
     np.testing.assert_equal(sub_points, sub_points_ref)
 
-    #Passing points, features and labels.
+    # Passing points, features and labels.
     sub_labels_ref = np.array([6, 4], dtype=np.int32)
     sub_points_feat_lab = subsample(points,
                                     features=features,
@@ -93,7 +93,7 @@ def test_subsample_batch():
     labels = np.array(range(7), dtype=np.int32)
     batches = np.array([3, 2, 2], dtype=np.int32)
 
-    #Passing only points.
+    # Passing only points.
     sub_points_ref = np.array(
         [[0.3333333, 0.3333333, 0], [0.5, 0.5, 1], [5, 0.5, 0]],
         dtype=np.float32)
@@ -104,7 +104,7 @@ def test_subsample_batch():
     np.testing.assert_almost_equal(sub_points, sub_points_ref)
     np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
 
-    #Passing points and features.
+    # Passing points and features.
     sub_features_ref = np.array(
         [[4, 5, 6, 7], [14, 15, 16, 17], [22, 23, 24, 25]], dtype=np.float32)
     sub_points_feat = subsample_batch(points,
@@ -121,7 +121,7 @@ def test_subsample_batch():
     np.testing.assert_almost_equal(sub_points, sub_points_ref)
     np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
 
-    #Passing points, features and labels.
+    # Passing points, features and labels.
     sub_labels_ref = np.array([2, 4, 6], dtype=np.int32)
     sub_points_feat_lab = subsample_batch(points,
                                           batches,

--- a/python/test/ml/test_contrib.py
+++ b/python/test/ml/test_contrib.py
@@ -24,6 +24,7 @@ def test_subsample():
 
     np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
     np.testing.assert_equal(sub_features, sub_features_ref)
+    np.testing.assert_equal(sub_points, sub_points_ref)
 
     #Passing points, features and labels.
     sub_labels_ref = np.array([6, 4], dtype=np.int32)
@@ -35,6 +36,7 @@ def test_subsample():
 
     np.testing.assert_equal(sub_labels, sub_labels_ref)
     np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
+    np.testing.assert_equal(sub_points, sub_points_ref)
 
     # Test wrong dtype.
     with pytest.raises(RuntimeError):
@@ -69,14 +71,87 @@ def test_subsample():
         sub_points = subsample(None, sampleDl=1.1)
 
 def test_subsample_batch():
-    points = np.ones((10, 3), dtype=np.float32)
-    batches = np.array([2, 1, 3, 4], dtype=np.int32)
-    features = np.ones((10, 5), dtype=np.float32)
-    classes = np.ones((10,), dtype=np.int32)
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0 ,1], [1, 1, 1], [5, 0, 0], [5, 1, 0]], dtype=np.float32)
+    features = np.array(range(28), dtype=np.float32).reshape(-1, 4)
+    labels = np.array(range(7), dtype = np.int32)
+    batches = np.array([3, 2, 2], dtype=np.int32)
 
-    # Test handling of None
-    p, b = subsample_batch(points, batches)
-    p, b, f, c = subsample_batch(points, batches, features, classes)
-    p, b, c = subsample_batch(points, batches, classes=classes)
+    #Passing only points.
+    sub_points_ref = np.array([[0.3333333, 0.3333333, 0], [0.5, 0.5, 1], [5, 0.5, 0]], dtype=np.float32)
+    sub_batch_ref = np.array([1, 1, 1], dtype=np.int32)
 
-# test_subsample()
+    (sub_points, sub_batch) = subsample_batch(points, batches, sampleDl=1.1)
+
+    np.testing.assert_almost_equal(sub_points, sub_points_ref)
+    np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
+
+    #Passing points and features.
+    sub_features_ref = np.array([[4, 5, 6, 7], [14, 15, 16, 17], [22, 23, 24, 25]], dtype=np.float32)
+    sub_points_feat = subsample_batch(points, batches, features=features, sampleDl=1.1)
+
+    assert len(sub_points_feat) == 3
+
+    sub_points, sub_batch, sub_features = sub_points_feat
+
+    np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
+    np.testing.assert_almost_equal(sub_features, sub_features_ref)
+    np.testing.assert_almost_equal(sub_points, sub_points_ref)
+    np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
+
+    #Passing points, features and labels.
+    sub_labels_ref = np.array([2, 4, 6], dtype=np.int32)
+    sub_points_feat_lab = subsample_batch(points, batches, features=features, classes=labels, sampleDl=1.1)
+
+    assert len(sub_points_feat_lab) == 4
+
+    sub_points, sub_batch, sub_features, sub_labels = sub_points_feat_lab
+
+    np.testing.assert_equal(sub_labels, sub_labels_ref)
+    np.testing.assert_equal(sub_features.shape, sub_features_ref.shape)
+    np.testing.assert_almost_equal(sub_points, sub_points_ref)
+    np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
+
+    # Test wrong dtype.
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(np.array(points, dtype=np.int32), batches, sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, np.array(batches, dtype=np.float32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(np.array(points, dtype=np.float64), batches, sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, batches, features=np.array(features, dtype=np.int32), sampleDl=1.1)
+    
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, batches, features=features, classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, batches, features=np.array(features, np.int32), classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+
+    # Test shape mismatch
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points[0], batches, sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(np.ones((10, 4), dtype=np.float32), batches, sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, batches, features=features[0], sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points[0], batches, sampleDl=1.1)
+
+    with pytest.raises(TypeError):
+        sub_points = subsample_batch(None, None, sampleDl=1.1)
+
+    # Test sum(batch) != num_points
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, np.array([3, 3, 2], dtype=np.int32), sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, np.array([3, 3, 2], dtype=np.int32), features=features, classes=labels, sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points, np.array([1], dtype=np.int32), sampleDl=1.1)

--- a/python/test/ml/test_contrib.py
+++ b/python/test/ml/test_contrib.py
@@ -4,9 +4,11 @@ from open3d.pybind.ml.contrib import subsample, subsample_batch
 
 
 def test_subsample():
-    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0 ,1], [1, 1, 1], [5, 0, 0], [5, 1, 0]], dtype=np.float32)
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1],
+                       [5, 0, 0], [5, 1, 0]],
+                      dtype=np.float32)
     features = np.array(range(21), dtype=np.float32).reshape(-1, 3)
-    labels = np.array(range(7), dtype = np.int32)
+    labels = np.array(range(7), dtype=np.int32)
 
     # Passing only points.
     sub_points_ref = np.array([[5, 0.5, 0], [0.4, 0.4, 0.4]], dtype=np.float32)
@@ -15,7 +17,8 @@ def test_subsample():
     np.testing.assert_equal(sub_points, sub_points_ref)
 
     #Passing points and features.
-    sub_features_ref = np.array([[16.5, 17.5, 18.5], [6, 7, 8]], dtype=np.float32)
+    sub_features_ref = np.array([[16.5, 17.5, 18.5], [6, 7, 8]],
+                                dtype=np.float32)
     sub_points_feat = subsample(points, features=features, sampleDl=1.1)
 
     assert len(sub_points_feat) == 2
@@ -28,7 +31,10 @@ def test_subsample():
 
     #Passing points, features and labels.
     sub_labels_ref = np.array([6, 4], dtype=np.int32)
-    sub_points_feat_lab = subsample(points, features=features, classes=labels, sampleDl=1.1)
+    sub_points_feat_lab = subsample(points,
+                                    features=features,
+                                    classes=labels,
+                                    sampleDl=1.1)
 
     assert len(sub_points_feat_lab) == 3
 
@@ -46,13 +52,21 @@ def test_subsample():
         sub_points = subsample(np.array(points, dtype=np.float64), sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample(points, features=np.array(features, dtype=np.int32), sampleDl=1.1)
-    
-    with pytest.raises(RuntimeError):
-        sub_points = subsample(points, features=features, classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+        sub_points = subsample(points,
+                               features=np.array(features, dtype=np.int32),
+                               sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample(points, features=np.array(features, np.int32), classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+        sub_points = subsample(points,
+                               features=features,
+                               classes=np.array(labels, dtype=np.float32),
+                               sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample(points,
+                               features=np.array(features, np.int32),
+                               classes=np.array(labels, dtype=np.float32),
+                               sampleDl=1.1)
 
     # Test shape mismatch
     with pytest.raises(RuntimeError):
@@ -70,14 +84,19 @@ def test_subsample():
     with pytest.raises(TypeError):
         sub_points = subsample(None, sampleDl=1.1)
 
+
 def test_subsample_batch():
-    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0 ,1], [1, 1, 1], [5, 0, 0], [5, 1, 0]], dtype=np.float32)
+    points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1],
+                       [5, 0, 0], [5, 1, 0]],
+                      dtype=np.float32)
     features = np.array(range(28), dtype=np.float32).reshape(-1, 4)
-    labels = np.array(range(7), dtype = np.int32)
+    labels = np.array(range(7), dtype=np.int32)
     batches = np.array([3, 2, 2], dtype=np.int32)
 
     #Passing only points.
-    sub_points_ref = np.array([[0.3333333, 0.3333333, 0], [0.5, 0.5, 1], [5, 0.5, 0]], dtype=np.float32)
+    sub_points_ref = np.array(
+        [[0.3333333, 0.3333333, 0], [0.5, 0.5, 1], [5, 0.5, 0]],
+        dtype=np.float32)
     sub_batch_ref = np.array([1, 1, 1], dtype=np.int32)
 
     (sub_points, sub_batch) = subsample_batch(points, batches, sampleDl=1.1)
@@ -86,8 +105,12 @@ def test_subsample_batch():
     np.testing.assert_almost_equal(sub_batch, sub_batch_ref)
 
     #Passing points and features.
-    sub_features_ref = np.array([[4, 5, 6, 7], [14, 15, 16, 17], [22, 23, 24, 25]], dtype=np.float32)
-    sub_points_feat = subsample_batch(points, batches, features=features, sampleDl=1.1)
+    sub_features_ref = np.array(
+        [[4, 5, 6, 7], [14, 15, 16, 17], [22, 23, 24, 25]], dtype=np.float32)
+    sub_points_feat = subsample_batch(points,
+                                      batches,
+                                      features=features,
+                                      sampleDl=1.1)
 
     assert len(sub_points_feat) == 3
 
@@ -100,7 +123,11 @@ def test_subsample_batch():
 
     #Passing points, features and labels.
     sub_labels_ref = np.array([2, 4, 6], dtype=np.int32)
-    sub_points_feat_lab = subsample_batch(points, batches, features=features, classes=labels, sampleDl=1.1)
+    sub_points_feat_lab = subsample_batch(points,
+                                          batches,
+                                          features=features,
+                                          classes=labels,
+                                          sampleDl=1.1)
 
     assert len(sub_points_feat_lab) == 4
 
@@ -113,32 +140,55 @@ def test_subsample_batch():
 
     # Test wrong dtype.
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(np.array(points, dtype=np.int32), batches, sampleDl=1.1)
+        sub_points = subsample_batch(np.array(points, dtype=np.int32),
+                                     batches,
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, np.array(batches, dtype=np.float32), sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     np.array(batches, dtype=np.float32),
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(np.array(points, dtype=np.float64), batches, sampleDl=1.1)
+        sub_points = subsample_batch(np.array(points, dtype=np.float64),
+                                     batches,
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, batches, features=np.array(features, dtype=np.int32), sampleDl=1.1)
-    
-    with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, batches, features=features, classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     batches,
+                                     features=np.array(features,
+                                                       dtype=np.int32),
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, batches, features=np.array(features, np.int32), classes=np.array(labels, dtype=np.float32), sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     batches,
+                                     features=features,
+                                     classes=np.array(labels, dtype=np.float32),
+                                     sampleDl=1.1)
+
+    with pytest.raises(RuntimeError):
+        sub_points = subsample_batch(points,
+                                     batches,
+                                     features=np.array(features, np.int32),
+                                     classes=np.array(labels, dtype=np.float32),
+                                     sampleDl=1.1)
 
     # Test shape mismatch
     with pytest.raises(RuntimeError):
         sub_points = subsample_batch(points[0], batches, sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(np.ones((10, 4), dtype=np.float32), batches, sampleDl=1.1)
+        sub_points = subsample_batch(np.ones((10, 4), dtype=np.float32),
+                                     batches,
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, batches, features=features[0], sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     batches,
+                                     features=features[0],
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
         sub_points = subsample_batch(points[0], batches, sampleDl=1.1)
@@ -148,10 +198,18 @@ def test_subsample_batch():
 
     # Test sum(batch) != num_points
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, np.array([3, 3, 2], dtype=np.int32), sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     np.array([3, 3, 2], dtype=np.int32),
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, np.array([3, 3, 2], dtype=np.int32), features=features, classes=labels, sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     np.array([3, 3, 2], dtype=np.int32),
+                                     features=features,
+                                     classes=labels,
+                                     sampleDl=1.1)
 
     with pytest.raises(RuntimeError):
-        sub_points = subsample_batch(points, np.array([1], dtype=np.int32), sampleDl=1.1)
+        sub_points = subsample_batch(points,
+                                     np.array([1], dtype=np.int32),
+                                     sampleDl=1.1)

--- a/python/test/ml/test_contrib.py
+++ b/python/test/ml/test_contrib.py
@@ -1,0 +1,25 @@
+import numpy as np
+from open3d.pybind.ml.contrib import subsample, subsample_batch
+
+
+def test_subsample():
+    points = np.ones((10, 3), dtype=np.float32)
+    features = np.ones((10, 5), dtype=np.float32)
+    classes = np.ones((10,), dtype=np.int32)
+
+    # Test handling of None
+    p = subsample(points)
+    p, f, c = subsample(points, features, classes)
+    p, c = subsample(points, classes=classes)
+
+
+def test_subsample_batch():
+    points = np.ones((10, 3), dtype=np.float32)
+    batches = np.array([2, 1, 3, 4], dtype=np.int32)
+    features = np.ones((10, 5), dtype=np.float32)
+    classes = np.ones((10,), dtype=np.int32)
+
+    # Test handling of None
+    p, b = subsample_batch(points, batches)
+    p, b, f, c = subsample_batch(points, batches, features, classes)
+    p, b, c = subsample_batch(points, batches, classes=classes)


### PR DESCRIPTION
### ML-Contrib library for subsampling

#### Use case
These are meant for temporary use to support with 3D-ML repo. They should be replaced by Open3D's own PointCloud subsampling methods in the future.

#### Review helper
- `cpp/open3d/ml/contrib/*`: 3rdparty code. Need to review CMake and directory structure. In particular, is this a good place to put the 3rdparty ML code?
- `cpp/pybind/ml/contrib.cpp`: main change. Includes our own python wrapper and input sanity checks.
- Related to `optional`: this PR introduces a back-ported C++17 `std::optional` as `open3d::utility::optional` to handle `None` parameter in pybind11.
- Unit tests: unit tests are dummy. @sanskar107 could you provide some unit tests in this PR or a separate PR?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2254)
<!-- Reviewable:end -->
