### PR TITLE
Fix screen rendering in offscreen mode

### DIFF
--- a/cpp/open3d/visualization/visualizer/Visualizer.h
+++ b/cpp/open3d/visualization/visualizer/Visualizer.h
@@ -240,7 +240,7 @@ protected:
     /// Function to do the main rendering
     /// The function first sets view point, then draw geometry (pointclouds and
     /// meshes individually).
-    virtual void Render();
+    virtual void Render(bool render_screen = false);
 
     void CopyViewStatusToClipboard();
 
@@ -277,6 +277,12 @@ protected:
     bool is_redraw_required_ = true;
     bool is_initialized_ = false;
     GLuint vao_id_;
+
+    // render targets for "capture_screen_float_buffer" and
+    // "capture_screen_image" in offscreen render mode
+    unsigned int render_fbo_;
+    unsigned int render_rgb_tex_;
+    unsigned int render_depth_stencil_rbo_;
 
     // view control
     std::unique_ptr<ViewControl> view_control_ptr_;


### PR DESCRIPTION
This PR fixes #1367 (although the issue has been closed, it is still not fixed). 

In the current version of Open3D (0.10.1.0), the methods `capture_screen_image()` and `capture_screen_float_buffer()` **do not work in offscreen mode**. An image of the desktop is shown instead of the rendered scene. 

You can easily verify this by executing the following script:
```
import numpy as np
import matplotlib.pyplot as plt
import open3d as o3d

print('o3d.__version__', o3d.__version__)

ofp = 'some/path/to/file.png'

mesh = o3d.geometry.TriangleMesh.create_coordinate_frame()
vis = o3d.visualization.Visualizer()
vis.create_window(visible=False)
vis.add_geometry(mesh)
vis.poll_events()
vis.update_renderer()

vis.capture_screen_image(ofp, True)
color = vis.capture_screen_float_buffer(True)
depth = vis.capture_depth_float_buffer(True)

vis.destroy_window()
color = np.asarray(color)
depth = np.asarray(depth)
plt.imshow(color)
plt.show()
plt.imshow(depth)
plt.show()
```

The provided solution relies heavily on the [post](https://github.com/intel-isl/Open3D/issues/1367#issuecomment-602248382) of heiwang1997.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2257)
<!-- Reviewable:end -->
