### PR TITLE
fix cpu only builds for torch op library

### DIFF
--- a/cpp/open3d/ml/PyTorch/CMakeLists.txt
+++ b/cpp/open3d/ml/PyTorch/CMakeLists.txt
@@ -25,7 +25,6 @@ else()
     file(GLOB_RECURSE open3d_torch_ops_SOURCES "*.cpp" "../impl/*/*.cc"
          "../impl/*/*.cpp")
 endif()
-message(STATUS ${open3d_torch_ops_SOURCES})
 
 add_library(open3d_torch_ops SHARED ${open3d_torch_ops_SOURCES})
 open3d_set_global_properties(open3d_torch_ops)
@@ -62,7 +61,12 @@ target_include_directories(open3d_torch_ops SYSTEM PRIVATE
 
 target_link_libraries(open3d_torch_ops PRIVATE
     3rdparty_tbb
-    ${TORCH_LIBRARIES}
+    torch_cpu
     ${EIGEN3_TARGET}
     ${FMT_TARGET}
 )
+if( BUILD_CUDA_MODULE )
+    target_link_libraries(open3d_torch_ops PRIVATE
+        ${TORCH_LIBRARIES}
+    )
+endif()


### PR DESCRIPTION
Use torch_cpu target for cpu builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2292)
<!-- Reviewable:end -->
