### PR TITLE
Fix left side of checkboxes in a treeview not being clickable

### DIFF
--- a/cpp/open3d/visualization/gui/TreeView.cpp
+++ b/cpp/open3d/visualization/gui/TreeView.cpp
@@ -419,7 +419,8 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
                     colorToImguiRGBA(context.theme.tree_selected_color));
         }
 
-        int flags = ImGuiTreeNodeFlags_DefaultOpen;
+        int flags = ImGuiTreeNodeFlags_DefaultOpen |
+                    ImGuiTreeNodeFlags_AllowItemOverlap;
         if (impl_->can_select_parents_) {
             flags |= ImGuiTreeNodeFlags_OpenOnDoubleClick;
             flags |= ImGuiTreeNodeFlags_OpenOnArrow;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2301)
<!-- Reviewable:end -->
