### PR TITLE
simplify filament build-from-source

### DIFF
--- a/3rdparty/filament/filament_build.cmake
+++ b/3rdparty/filament/filament_build.cmake
@@ -1,45 +1,40 @@
 include(ExternalProject)
-if(FILAMENT_SOURCE_ROOT)
-    if(EXISTS "${FILAMENT_SOURCE_ROOT}")
-        set(FILAMENT_ROOT "${FILAMENT_SOURCE_ROOT}")
-    else()
-        message(FATAL_ERROR "Filament sources not found in ${FILAMENT_SOURCE_ROOT}")
-    endif()
-else()
-    set(FILAMENT_SOURCE_ROOT ${CMAKE_BINARY_DIR}/downloads/filament-1.8.1)
-    if (NOT EXISTS ${FILAMENT_SOURCE_ROOT}/README.md)
-        set(DOWNLOAD_PATH ${CMAKE_BINARY_DIR}/downloads)
-        file(MAKE_DIRECTORY ${DOWNLOAD_PATH})
-        set(TAR_PWD ${DOWNLOAD_PATH})
-        file(MAKE_DIRECTORY ${TAR_PWD})
-        if (NOT EXISTS ${ARCHIVE_FILE})
-            set(ARCHIVE_FILE ${CMAKE_BINARY_DIR}/downloads/filament_source.tgz)
-
-            set(DOWNLOAD_URL "https://github.com/google/filament/archive/v1.8.1.tar.gz")
-
-            file(DOWNLOAD ${DOWNLOAD_URL} ${ARCHIVE_FILE} SHOW_PROGRESS STATUS DOWNLOAD_RESULT)
-        endif()
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf ${ARCHIVE_FILE} WORKING_DIRECTORY ${TAR_PWD})
-    endif()
-endif()
 
 set(FILAMENT_ROOT "${CMAKE_BINARY_DIR}/filament-binaries")
-
-# TODO: don't build samples
 
 ExternalProject_Add(
     ext_filament
     PREFIX filament
-    SOURCE_DIR ${FILAMENT_SOURCE_ROOT}
+    GIT_REPOSITORY https://github.com/google/filament.git
+    GIT_TAG v1.8.1
     UPDATE_COMMAND ""
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=Release
+        -DCCACHE_PROGRAM=OFF  # enables ccache, "launch-cxx" is not working.
+        -DFILAMENT_ENABLE_JAVA=OFF
         -DCMAKE_C_COMPILER=${FILAMENT_C_COMPILER}
         -DCMAKE_CXX_COMPILER=${FILAMENT_CXX_COMPILER}
         -DCMAKE_INSTALL_PREFIX=${FILAMENT_ROOT}
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DUSE_STATIC_CRT=${STATIC_WINDOWS_RUNTIME}
         -DUSE_STATIC_LIBCXX=ON
+        -DFILAMENT_SUPPORTS_VULKAN=OFF
+        -DFILAMENT_SKIP_SAMPLES=ON
 )
 
-set(filament_LIBRARIES filameshio filament filamat_lite filamat filaflat filabridge geometry backend bluegl ibl image meshoptimizer smol-v utils)
+set(filament_LIBRARIES
+    filameshio
+    filament
+    filamat_lite
+    filamat
+    filaflat
+    filabridge
+    geometry
+    backend
+    bluegl
+    ibl
+    image
+    meshoptimizer
+    smol-v
+    utils
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ else()
 endif()
 
 set(FILAMENT_PRECOMPILED_ROOT "" CACHE PATH "Path to precompiled Filament library (used if BUILD_FILAMENT_FROM_SOURCE=OFF)")
-set(FILAMENT_SOURCE_ROOT "" CACHE PATH "Path to Filament library sources (used if BUILD_FILAMENT_FROM_SOURCE=ON)")
 
 if (PREFER_OSX_HOMEBREW)
     set(CMAKE_FIND_FRAMEWORK LAST)


### PR DESCRIPTION
Simplifies filament build-from-source scripts. Added some additional flags.
- `CCACHE_PROGRAM=OFF`: this actually enables ccache for ubuntu
- `FILAMENT_ENABLE_JAVA=OFF`
- `FILAMENT_SUPPORTS_VULKAN=OFF`, the pre-compiled Filament has Vulkan support, but since we're compiling it, we don't need it
- `FILAMENT_SKIP_SAMPLES=ON`

(This was part of the efforts to port Open3D to ARM64, where filament will be compiled from source. However, `bluegl` is not yet supporting ARM: https://github.com/google/filament/issues/1135  and `bluegl` cannot be disabled for Filament.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2303)
<!-- Reviewable:end -->
