### PR TITLE
Enable CI on Ubuntu 20.04 (focal) with CUDA on GCE

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build
+tags
+.git

--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -37,6 +37,13 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [skip-check]
     if: needs.skip-check.outputs.skip == 'no'
+    strategy:
+      fail-fast: false
+      matrix:
+        UBUNTU_VERSION: ['bionic', 'focal']  # These configs have bionic and focal versions
+
+    env:
+      UBUNTU_VERSION: ${{ matrix.UBUNTU_VERSION }}
 
     steps:
       - name: Checkout code
@@ -108,7 +115,14 @@ jobs:
     name: Clean-up container image
     runs-on: ubuntu-18.04
     needs: [skip-check, build-push-docker-image, build-install-test]
-    if: needs.skip-check.outputs.skip == 'no' && needs.build-push-docker-image.result == 'success' || needs.build-install-test.result == 'failure'
+    if: needs.skip-check.outputs.skip == 'no' || needs.build-install-test.result == 'failure'
+    strategy:
+      fail-fast: false
+      matrix:
+        UBUNTU_VERSION: ['bionic', 'focal']  # These configs have bionic and focal versions
+    env:
+      UBUNTU_VERSION: ${{ matrix.UBUNTU_VERSION }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -115,7 +115,7 @@ jobs:
     name: Clean-up container image
     runs-on: ubuntu-18.04
     needs: [skip-check, build-push-docker-image, build-install-test]
-    if: needs.skip-check.outputs.skip == 'no' || needs.build-install-test.result == 'failure'
+    if: always() && needs.skip-check.outputs.skip == 'no'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       max-parallel: 4     # Limit parallel runs to max GPU quota (4)
       matrix:
-        CI_CONFIG_ID: [2, 3, 4]   # See gce-ubuntu-docker-run.sh for details. These need GPU.
+        CI_CONFIG_ID: [2, 3, 4, 5]   # See gce-ubuntu-docker-run.sh for details. These need GPU.
 
     env:
       CI_CONFIG_ID: ${{ matrix.CI_CONFIG_ID }}
@@ -108,8 +108,7 @@ jobs:
     name: Clean-up container image
     runs-on: ubuntu-18.04
     needs: [skip-check, build-push-docker-image, build-install-test]
-    if: needs.skip-check.outputs.skip == 'no' && needs.build-push-docker-image.result == 'success'
-
+    if: needs.skip-check.outputs.skip == 'no' && needs.build-push-docker-image.result == 'success' || needs.build-install-test.result == 'failure'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -17,7 +17,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]] && [ "$BUILD_CUDA_MODULE" == OFF ] ; then
 fi
 BUILD_RPC_INTERFACE=${BUILD_RPC_INTERFACE:-ON}
 LOW_MEM_USAGE=${LOW_MEM_USAGE:-OFF}
-BUILD_WHEEL_ONLY=${BUILD_WHEEL_ONLY:=OFF}
+BUILD_WHEEL_ONLY=${BUILD_WHEEL_ONLY:-OFF}
 
 # Dependency versions
 CUDA_VERSION=("10-1" "10.1")
@@ -38,16 +38,17 @@ OPEN3D_INSTALL_DIR=~/open3d_install
 
 install_cuda_toolkit() {
 
+    SUDO=${SUDO:-sudo}
     echo "Installing CUDA ${CUDA_VERSION[1]} with apt ..."
-    sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
-    sudo apt-add-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /"
-    sudo apt-get install --yes "cuda-toolkit-${CUDA_VERSION[0]}"
+    $SUDO apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+    $SUDO apt-add-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /"
+    $SUDO apt-get install --yes "cuda-toolkit-${CUDA_VERSION[0]}"
     if [ "${CUDA_VERSION[1]}" == "10.1" ]; then
         echo "CUDA 10.1 needs CUBLAS 10.2. Symlinks ensure this is found by cmake"
         dpkg -L libcublas10 libcublas-dev | while read -r cufile ; do
             if [ -f "$cufile" ] && [ ! -e "${cufile/10.2/10.1}" ] ; then
                 set -x
-                sudo ln -s "$cufile" "${cufile/10.2/10.1}"
+                $SUDO ln -s "$cufile" "${cufile/10.2/10.1}"
                 set +x
             fi
         done
@@ -56,8 +57,8 @@ install_cuda_toolkit() {
     set +u  # Disable "unbound variable is error" since that gives a false alarm error below:
     if [[ "with-cudnn" =~ ^($options)$ ]] ; then
         echo "Installing cuDNN ${CUDNN_VERSION} with apt ..."
-        sudo apt-add-repository "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"
-        sudo apt-get install --yes \
+        $SUDO apt-add-repository "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"
+        $SUDO apt-get install --yes \
             "libcudnn${CUDNN_MAJOR_VERSION}=$CUDNN_VERSION" \
             "libcudnn${CUDNN_MAJOR_VERSION}-dev=$CUDNN_VERSION"
     fi
@@ -67,8 +68,8 @@ install_cuda_toolkit() {
     echo PATH="$PATH"
     echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
     if [[ "purge-cache" =~ ^($options)$ ]] ; then
-        sudo apt-get clean
-        sudo rm -rf /var/lib/apt/lists/*
+        $SUDO apt-get clean
+        $SUDO rm -rf /var/lib/apt/lists/*
     fi
     set -u
 }

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -67,6 +67,13 @@ install_cuda_toolkit() {
     export LD_LIBRARY_PATH="${CUDA_TOOLKIT_DIR}/extras/CUPTI/lib64:$CUDA_TOOLKIT_DIR/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
     echo PATH="$PATH"
     echo LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+    # Ensure g++ < 9 is installed for CUDA 10.1
+    cpp_version=$(c++ --version | grep -o -E '([0-9]+\.)+[0-9]+' | head -1)
+    if dpkg --compare-versions "$cpp_version" ge 9 ; then
+        $SUDO apt-get install --yes --no-install-recommends g++-8 gcc-8
+        update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 70 --slave /usr/bin/gcc gcc /usr/bin/gcc-8
+        update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 70 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+    fi
     if [[ "purge-cache" =~ ^($options)$ ]] ; then
         $SUDO apt-get clean
         $SUDO rm -rf /var/lib/apt/lists/*

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -58,7 +58,7 @@ install_cuda_toolkit() {
     if [[ "with-cudnn" =~ ^($options)$ ]] ; then
         echo "Installing cuDNN ${CUDNN_VERSION} with apt ..."
         $SUDO apt-add-repository "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"
-        $SUDO apt-get install --yes \
+        $SUDO apt-get install --yes --no-install-recommends \
             "libcudnn${CUDNN_MAJOR_VERSION}=$CUDNN_VERSION" \
             "libcudnn${CUDNN_MAJOR_VERSION}-dev=$CUDNN_VERSION"
     fi

--- a/util/docker/open3d-gpu/Dockerfile
+++ b/util/docker/open3d-gpu/Dockerfile
@@ -17,12 +17,13 @@ RUN /root/Open3D/util/docker/open3d-gpu/scripts/env-setup.sh
 COPY ./util/install_deps_ubuntu.sh ./util/ci_utils.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes
 COPY ./util/ci_utils.sh /root/Open3D/util/
-RUN bash -c "source /root/Open3D/util/ci_utils.sh && \
+RUN bash -o errexit -c "source /root/Open3D/util/ci_utils.sh && \
         install_cuda_toolkit with-cudnn purge-cache && \
-        install_python_dependencies with-unit-test with-cuda purge-cache && \
-        echo export PATH=\$PATH >> /root/.bashrc && \
-        echo export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH >> /root/.bashrc"
+        install_python_dependencies with-unit-test with-cuda purge-cache"
+
 # Need to persist PATH for cuda, cudnn
+ENV PATH=/usr/local/cuda/bin:$PATH \
+         LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 COPY . /root/Open3D
 WORKDIR /root/Open3D

--- a/util/docker/open3d-gpu/Dockerfile
+++ b/util/docker/open3d-gpu/Dockerfile
@@ -6,6 +6,8 @@ ARG UBUNTU_VERSION
 ARG NVIDIA_DRIVER_VERSION=440
 LABEL name="open3d-dev/open3d-gpu-ci-${UBUNTU_VERSION}" \
             vendor="open3d.org" \
+            architecture="x86_64" \
+            os="linux" \
             maintainer="sameer.sheorey@intel.com"
 
 ENV DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles SUDO=command
@@ -16,14 +18,18 @@ RUN /root/Open3D/util/docker/open3d-gpu/scripts/env-setup.sh
 # Install dependencies with apt-get and pip
 COPY ./util/install_deps_ubuntu.sh ./util/ci_utils.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes
+
 COPY ./util/ci_utils.sh /root/Open3D/util/
 RUN bash -o errexit -c "source /root/Open3D/util/ci_utils.sh && \
         install_cuda_toolkit with-cudnn purge-cache && \
         install_python_dependencies with-unit-test with-cuda purge-cache"
 
-# Need to persist PATH for cuda, cudnn
+# Persist PATH for cuda, cudnn and set requirements for host and container
 ENV PATH=/usr/local/cuda/bin:$PATH \
-         LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+         LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH \
+         NVIDIA_VISIBLE_DEVICES=all \
+         NVIDIA_DRIVER_CAPABILITIES="compute,utility,graphics" \
+         NVIDIA_REQUIRE_CUDA="cuda>=10.1"
 
 COPY . /root/Open3D
 WORKDIR /root/Open3D

--- a/util/docker/open3d-gpu/Dockerfile
+++ b/util/docker/open3d-gpu/Dockerfile
@@ -1,20 +1,28 @@
 # These defaults can be changed with docker build --build-arg VAR=value
-ARG CONTAINER_BASE_OS=ubuntu18.04
-ARG CUDA_VERSION=10.1
-ARG CUDNN=cudnn7-
-
-# Base container image has NVIDIA drivers, CUDA and (optionally) cuDNN installed
-FROM nvidia/cuda:${CUDA_VERSION}-${CUDNN}devel-${CONTAINER_BASE_OS}
-LABEL maintainer="sameer.sheorey@intel.com"
+ARG UBUNTU_VERSION=bionic
+FROM ubuntu:${UBUNTU_VERSION}
+# Persist ARG for the rest of the build
+ARG UBUNTU_VERSION
+ARG NVIDIA_DRIVER_VERSION=440
+LABEL name="open3d-dev/open3d-gpu-ci-${UBUNTU_VERSION}" \
+            vendor="open3d.org" \
+            maintainer="sameer.sheorey@intel.com"
 
 ENV DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles SUDO=command
 # Install Python 3, cmake>=3.12 and nvidia drivers (only if not installed)
 COPY ./util/docker/open3d-gpu/scripts/env-setup.sh /root/Open3D/util/docker/open3d-gpu/scripts/env-setup.sh
 RUN /root/Open3D/util/docker/open3d-gpu/scripts/env-setup.sh
 
-# Install dependencies with apt-get
-COPY ./util/install_deps_ubuntu.sh /root/Open3D/util/install_deps_ubuntu.sh
+# Install dependencies with apt-get and pip
+COPY ./util/install_deps_ubuntu.sh ./util/ci_utils.sh /root/Open3D/util/
 RUN /root/Open3D/util/install_deps_ubuntu.sh assume-yes
+COPY ./util/ci_utils.sh /root/Open3D/util/
+RUN bash -c "source /root/Open3D/util/ci_utils.sh && \
+        install_cuda_toolkit with-cudnn purge-cache && \
+        install_python_dependencies with-unit-test with-cuda purge-cache && \
+        echo export PATH=\$PATH >> /root/.bashrc && \
+        echo export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH >> /root/.bashrc"
+# Need to persist PATH for cuda, cudnn
 
 COPY . /root/Open3D
 WORKDIR /root/Open3D

--- a/util/docker/open3d-gpu/Dockerfile
+++ b/util/docker/open3d-gpu/Dockerfile
@@ -1,5 +1,5 @@
-# These defaults can be changed with docker build --build-arg VAR=value
-ARG UBUNTU_VERSION=bionic
+# eg: docker build --build-arg UBUNTU_VERSION=focal
+ARG UBUNTU_VERSION
 FROM ubuntu:${UBUNTU_VERSION}
 # Persist ARG for the rest of the build
 ARG UBUNTU_VERSION

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -3,32 +3,34 @@
 # Run this script from the CMakeLists.txt (top-level) directory
 
 # exit when any command fails
-set -e
+set -eo pipefail
 
 # Use SUDO=command to run in docker (user is root, sudo is not installed)
 SUDO=${SUDO:=sudo}
 
 $SUDO apt-get update
-$SUDO apt-get -y install git software-properties-common
+$SUDO apt-get --yes install git software-properties-common
 echo "Installing Python3 and setting as default python"
-$SUDO apt-get --yes install python3 python3-pip
+$SUDO apt-get --yes --no-install-recommends install python3 python3-pip
 if  ! which python || python -V 2>/dev/null | grep -q ' 2.' ; then
-    $SUDO ln -s /usr/bin/python3.6 /usr/local/bin/python
-    $SUDO ln -s /usr/bin/python3.6-config /usr/local/bin/python-config
+    echo 'Making python3 the default python'
+    $SUDO ln -s /usr/bin/python3 /usr/local/bin/python
+    $SUDO ln -s /usr/bin/python3-config /usr/local/bin/python-config
     $SUDO ln -s /usr/bin/pip3 /usr/local/bin/pip
 fi
 
 # cmake not installed or too old
 if ! which cmake || cmake -P CMakeLists.txt 2>&1 | grep -q "or higher is required"  ; then
-    echo 'Installing backported cmake from https://apt.kitware.com/'
+    echo "Installing backported cmake from https://apt.kitware.com/ for Ubuntu $UBUNTU_VERSION"
     $SUDO apt-key adv --fetch-keys https://apt.kitware.com/keys/kitware-archive-latest.asc
-    $SUDO apt-add-repository --yes 'deb https://apt.kitware.com/ubuntu/ bionic main'
-    $SUDO apt-get --yes install cmake
+    $SUDO apt-add-repository --yes \
+        "deb https://apt.kitware.com/ubuntu/ $UBUNTU_VERSION main"
+    $SUDO apt-get --yes --no-install-recommends install cmake
 fi
 
 if [ -n "${NVIDIA_DRIVER_VERSION}" ] ; then
     echo "Installing NVIDIA drivers."
-    $SUDO apt-get --yes "install nvidia-driver-${NVIDIA_DRIVER_VERSION}"
+    $SUDO apt-get --yes --no-install-recommends "install nvidia-driver-${NVIDIA_DRIVER_VERSION}"
 fi
 
 # Cleanup apt cache (for docker)

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -11,7 +11,7 @@ SUDO=${SUDO:=sudo}
 $SUDO apt-get update
 $SUDO apt-get --yes install git software-properties-common
 echo "Installing Python3 and setting as default python"
-$SUDO apt-get --yes --no-install-recommends install python3 python3-pip
+$SUDO apt-get --yes --no-install-recommends install python3 python3-pip python3-setuptools
 if  ! which python || python -V 2>/dev/null | grep -q ' 2.' ; then
     echo 'Making python3 the default python'
     $SUDO ln -s /usr/bin/python3 /usr/local/bin/python
@@ -34,4 +34,5 @@ if [ -n "${NVIDIA_DRIVER_VERSION}" ] ; then
 fi
 
 # Cleanup apt cache (for docker)
+$SUDO apt-get clean
 $SUDO rm -rf /var/lib/apt/lists/*

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -30,7 +30,7 @@ fi
 
 if [ -n "${NVIDIA_DRIVER_VERSION}" ] ; then
     echo "Installing NVIDIA drivers."
-    $SUDO apt-get --yes --no-install-recommends "install nvidia-driver-${NVIDIA_DRIVER_VERSION}"
+    $SUDO apt-get --yes --no-install-recommends install "nvidia-driver-${NVIDIA_DRIVER_VERSION}"
 fi
 
 # Cleanup apt cache (for docker)

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -47,6 +47,7 @@ VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
 # Container configuration
 REGISTRY_HOSTNAME=gcr.io
 DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION:$GITHUB_SHA"
+DC_IMAGE_LATEST_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION:latest"
 
 
 case "$1" in
@@ -59,16 +60,19 @@ case "$1" in
 
       # Build the Docker image
     docker-build )
+        docker pull "$DC_IMAGE_LATEST_TAG" || true        # Pull previous image as cache
         docker build -t "$DC_IMAGE_TAG" \
             -f util/docker/open3d-gpu/Dockerfile \
             --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \
             --build-arg NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION}" \
             .
+        docker tag "$DC_IMAGE_TAG" "$DC_IMAGE_LATEST_TAG"
         ;;
 
       # Push the Docker image to Google Container Registry
     docker-push )
         docker push "$DC_IMAGE_TAG"
+        docker push "$DC_IMAGE_LATEST_TAG"
         ;;
 
 

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -19,7 +19,8 @@ SHARED=( OFF ON OFF ON OFF OFF )
 BUILD_ML_OPS=( OFF ON OFF ON ON ON )
 BUILD_CUDA_MODULE=( OFF OFF ON ON ON ON )
 BUILD_RPC_INTERFACE=( ON ON OFF OFF ON ON )
-UBUNTU_VERSION=( bionic bionic bionic bionic focal )
+UBUNTU_VERSION_LIST=( bionic bionic bionic bionic bionic focal )
+UBUNTU_VERSION=${UBUNTU_VERSION:-${UBUNTU_VERSION_LIST[$CI_CONFIG_ID]}}
 BUILD_TENSORFLOW_OPS=( "${BUILD_ML_OPS[@]}" )
 BUILD_PYTORCH_OPS=( "${BUILD_ML_OPS[@]}" )
 
@@ -45,7 +46,7 @@ VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
 
 # Container configuration
 REGISTRY_HOSTNAME=gcr.io
-DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-${UBUNTU_VERSION[$CI_CONFIG_ID]}:$GITHUB_SHA"
+DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION:$GITHUB_SHA"
 
 
 case "$1" in
@@ -60,7 +61,7 @@ case "$1" in
     docker-build )
         docker build -t "$DC_IMAGE_TAG" \
             -f util/docker/open3d-gpu/Dockerfile \
-            --build-arg UBUNTU_VERSION="${UBUNTU_VERSION[$CI_CONFIG_ID]}" \
+            --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \
             --build-arg NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION}" \
             .
         ;;

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -15,10 +15,11 @@ set -e
 CI_CONFIG_ID=${CI_CONFIG_ID:=0}
 
 # CI configuration specification
-SHARED=( OFF ON OFF ON OFF )
-BUILD_ML_OPS=( OFF ON OFF ON ON )
-BUILD_CUDA_MODULE=( OFF OFF ON ON ON )
-BUILD_RPC_INTERFACE=( ON ON OFF OFF ON )
+SHARED=( OFF ON OFF ON OFF OFF )
+BUILD_ML_OPS=( OFF ON OFF ON ON ON )
+BUILD_CUDA_MODULE=( OFF OFF ON ON ON ON )
+BUILD_RPC_INTERFACE=( ON ON OFF OFF ON ON )
+UBUNTU_VERSION=( bionic bionic bionic bionic focal )
 BUILD_TENSORFLOW_OPS=( "${BUILD_ML_OPS[@]}" )
 BUILD_PYTORCH_OPS=( "${BUILD_ML_OPS[@]}" )
 
@@ -43,11 +44,8 @@ GCE_VM_CUSTOM_IMAGE_FAMILY=ubuntu-os-docker-gpu-2004-lts
 VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
 
 # Container configuration
-CONTAINER_BASE_OS=ubuntu18.04
 REGISTRY_HOSTNAME=gcr.io
-DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-base:$GITHUB_SHA"
-CUDA_VERSION=10.1
-CUDNN="cudnn7-"             # {"", "cudnn7-", "cudnn8-"}
+DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-${UBUNTU_VERSION[$CI_CONFIG_ID]}:$GITHUB_SHA"
 
 
 case "$1" in
@@ -62,9 +60,9 @@ case "$1" in
     docker-build )
         docker build -t "$DC_IMAGE_TAG" \
             -f util/docker/open3d-gpu/Dockerfile \
-            --build-arg CUDA_VERSION="$CUDA_VERSION" \
-            --build-arg CONTAINER_BASE_OS="$CONTAINER_BASE_OS" \
-            --build-arg CUDNN="$CUDNN" .
+            --build-arg UBUNTU_VERSION="${UBUNTU_VERSION[$CI_CONFIG_ID]}" \
+            --build-arg NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION}" \
+            .
         ;;
 
       # Push the Docker image to Google Container Registry

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -47,8 +47,8 @@ VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
 # Container configuration
 REGISTRY_HOSTNAME=gcr.io
 DC_IMAGE="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION"
-DC_IMAGE_TAG="$DC_IMAGE_TAG:$GITHUB_SHA"
-DC_IMAGE_LATEST_TAG="$DC_IMAGE_TAG:latest"
+DC_IMAGE_TAG="$DC_IMAGE:$GITHUB_SHA"
+DC_IMAGE_LATEST_TAG="$DC_IMAGE:latest"
 
 
 case "$1" in

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -61,7 +61,8 @@ case "$1" in
 
       # Build the Docker image
     docker-build )
-        docker pull "$DC_IMAGE_LATEST_TAG" || true        # Pull previous image as cache
+        # Pull previous image as cache: disabled due to disk space
+        # docker pull "$DC_IMAGE_LATEST_TAG" || true
         docker build -t "$DC_IMAGE_TAG" \
             -f util/docker/open3d-gpu/Dockerfile \
             --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -145,11 +145,10 @@ case "$1" in
                 ;;
 
     delete-image )
-        gcloud container images untag "$DC_IMAGE_TAG"
+        gcloud container images untag "$DC_IMAGE_TAG" --quiet
         # Clean up images without tags - keep :latest
         gcloud container images list-tags "$DC_IMAGE" --filter='-tags:*' --format='get(digest)' --limit=unlimited \
             | xargs -I {arg} gcloud container images delete "${DC_IMAGE}@{arg}" --quiet
-        gcloud container images delete "$DC_IMAGE_TAG"
         ;;
 
     delete-vm )

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -46,8 +46,9 @@ VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
 
 # Container configuration
 REGISTRY_HOSTNAME=gcr.io
-DC_IMAGE_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION:$GITHUB_SHA"
-DC_IMAGE_LATEST_TAG="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION:latest"
+DC_IMAGE="$REGISTRY_HOSTNAME/$GCE_PROJECT/open3d-gpu-ci-$UBUNTU_VERSION"
+DC_IMAGE_TAG="$DC_IMAGE_TAG:$GITHUB_SHA"
+DC_IMAGE_LATEST_TAG="$DC_IMAGE_TAG:latest"
 
 
 case "$1" in
@@ -143,6 +144,10 @@ case "$1" in
                 ;;
 
     delete-image )
+        gcloud container images untag "$DC_IMAGE_TAG"
+        # Clean up images without tags - keep :latest
+        gcloud container images list-tags "$DC_IMAGE" --filter='-tags:*' --format='get(digest)' --limit=unlimited \
+            | xargs -I {arg} gcloud container images delete "${DC_IMAGE}@{arg}" --quiet
         gcloud container images delete "$DC_IMAGE_TAG"
         ;;
 


### PR DESCRIPTION
Configuration: 
BUILD_SHARED_LIBS=OFF
BUILD_TORCH_OPS=ON
BUILD_TENSORFLOW_OPS=ON
BUILD_RPC_INTERFACE=ON
BUILD_CUDA_MODULE=ON

CUDA 10.1 on Ubuntu 20.04 needs gcc 8.4 (default is gcc 9.3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2308)
<!-- Reviewable:end -->
