### PR TITLE
Python camera message fix

### DIFF
--- a/cpp/pybind/camera/camera.cpp
+++ b/cpp/pybind/camera/camera.cpp
@@ -157,7 +157,7 @@ void pybind_camera_classes(py::module &m) {
                            "List of PinholeCameraParameters objects.")
             .def("__repr__", [](const PinholeCameraTrajectory &c) {
                 return std::string("PinholeCameraTrajectory class.\n") +
-                       std::string("Access its data via camera_parameters.");
+                       std::string("Access its data via camera.parameters.");
             });
 }
 


### PR DESCRIPTION
This version is clearer, in python `camera.camera_parameters` gives an AttributeError.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2312)
<!-- Reviewable:end -->
