### PR TITLE
Slice out-of-range

### DIFF
--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -641,21 +641,38 @@ Tensor Tensor::Slice(int64_t dim,
                      int64_t stop,
                      int64_t step) const {
     if (shape_.size() == 0) {
-        utility::LogError("Slice cannot be applied to 0-dim Tensor");
+        utility::LogError("Slice cannot be applied to 0-dim Tensor.");
     }
     dim = shape_util::WrapDim(dim, NumDims());
     if (dim < 0 || dim >= static_cast<int64_t>(shape_.size())) {
-        utility::LogError("Dim {} is out of bound for SizeVector of length {}",
+        utility::LogError("Dim {} is out of bound for SizeVector of length {}.",
                           dim, shape_.size());
     }
-    // TODO: support negative step sizes
     if (step == 0) {
-        utility::LogError("Step size cannot be 0");
+        utility::LogError("Step size cannot be 0.");
+    } else if (step < 0) {
+        // TODO: support negative step sizes
+        utility::LogError("Step size cannot be 0.");
     }
-    start = shape_util::WrapDim(start, shape_[dim]);
-    stop = shape_util::WrapDim(stop, shape_[dim], /*inclusive=*/true);
+
+    // Wrap start. Out-of-range slice is valid and produces empty Tensor.
+    if (start < 0) {
+        start += shape_[dim];
+    }
+    if (start < 0) {
+        start = 0;
+    } else if (start >= shape_[dim]) {
+        start = shape_[dim];
+    }
+
+    // Wrap stop. Out-of-range slice is valid and produces empty Tensor.
+    if (stop < 0) {
+        stop += shape_[dim];
+    }
     if (stop < start) {
         stop = start;
+    } else if (stop >= shape_[dim]) {
+        stop = shape_[dim];
     }
 
     void* new_data_ptr = static_cast<char*>(data_ptr_) +

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -318,6 +318,16 @@ def test_getitem(device):
                                                                      0:-1:2])
     np.testing.assert_equal(o3_t[0, 1, :].cpu().numpy(), np_t[0, 1, :])
 
+    # Slice out-of-range
+    np.testing.assert_equal(o3_t[1:6].cpu().numpy(), np_t[1:6])
+    np.testing.assert_equal(o3_t[2:5, -10:20].cpu().numpy(), np_t[2:5, -10:20])
+    np.testing.assert_equal(o3_t[2:2, 3:3, 4:4].cpu().numpy(), np_t[2:2, 3:3,
+                                                                    4:4])
+    np.testing.assert_equal(o3_t[2:20, 3:30, 4:40].cpu().numpy(),
+                            np_t[2:20, 3:30, 4:40])
+    np.testing.assert_equal(o3_t[-2:20, -3:30, -4:40].cpu().numpy(),
+                            np_t[-2:20, -3:30, -4:40])
+
     # Slice the slice
     np.testing.assert_equal(o3_t[0:2, 1:3, 0:4][0:1, 0:2, 2:3].cpu().numpy(),
                             np_t[0:2, 1:3, 0:4][0:1, 0:2, 2:3])


### PR DESCRIPTION
Consistent with python's slicing semantics:
```python
a = o3c.Tensor([0, 1, 2])
print(a[10:20])  # valid, result = [0]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2317)
<!-- Reviewable:end -->
