### PR TITLE
Fix for abort on disabled CUDA devices

### DIFF
--- a/cpp/open3d/core/linalg/LinalgUtils.cpp
+++ b/cpp/open3d/core/linalg/LinalgUtils.cpp
@@ -47,8 +47,7 @@ CuSolverContext::~CuSolverContext() {
     }
 }
 
-std::shared_ptr<CuSolverContext> CuSolverContext::instance_ =
-        CuSolverContext::GetInstance();
+std::shared_ptr<CuSolverContext> CuSolverContext::instance_ = nullptr;
 
 std::shared_ptr<CuBLASContext> CuBLASContext::GetInstance() {
     if (instance_ == nullptr) {
@@ -64,8 +63,7 @@ CuBLASContext::CuBLASContext() {
 }
 CuBLASContext::~CuBLASContext() { cublasDestroy(handle_); }
 
-std::shared_ptr<CuBLASContext> CuBLASContext::instance_ =
-        CuBLASContext::GetInstance();
+std::shared_ptr<CuBLASContext> CuBLASContext::instance_ = nullptr;
 
 }  // namespace core
 }  // namespace open3d

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -64,6 +64,8 @@ if _build_config["BUILD_CUDA_MODULE"]:
             __DEVICE_API__ = 'cuda'
     except ImportError:
         pass
+    except RuntimeError:  # no CUDA-capable device is detected
+        pass
 
 if 'pybind' not in locals():
     from open3d.cpu.pybind import (camera, geometry, io, pipelines, utility,


### PR DESCRIPTION
Delay cuSOLVER and cuBLAS init so exceptions are transferred to Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2319)
<!-- Reviewable:end -->
