### PR TITLE
Fix for "symbol already registered"

### DIFF
--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -42,7 +42,7 @@ int DeviceCount() {
     try {
         std::shared_ptr<CUDAState> cuda_state = CUDAState::GetInstance();
         return cuda_state->GetNumDevices();
-    } catch (const std::runtime_error & e) {    // GetInstance can throw
+    } catch (const std::runtime_error& e) {  // GetInstance can throw
         return 0;
     }
 #else

--- a/cpp/open3d/core/CUDAUtils.cpp
+++ b/cpp/open3d/core/CUDAUtils.cpp
@@ -39,8 +39,12 @@ namespace cuda {
 
 int DeviceCount() {
 #ifdef BUILD_CUDA_MODULE
-    std::shared_ptr<CUDAState> cuda_state = CUDAState::GetInstance();
-    return cuda_state->GetNumDevices();
+    try {
+        std::shared_ptr<CUDAState> cuda_state = CUDAState::GetInstance();
+        return cuda_state->GetNumDevices();
+    } catch (const std::runtime_error & e) {    // GetInstance can throw
+        return 0;
+    }
 #else
     return 0;
 #endif
@@ -66,3 +70,8 @@ void ReleaseCache() {
 }  // namespace cuda
 }  // namespace core
 }  // namespace open3d
+
+// C interface to provide un-mangled function to Python ctypes
+extern "C" int open3d_core_cuda_device_count() {
+    return open3d::core::cuda::DeviceCount();
+}

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -47,20 +47,27 @@ os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 __DEVICE_API__ = 'cpu'
 from open3d._build_config import _build_config
 if _build_config["BUILD_CUDA_MODULE"]:
-    # Check CUDA availability without importing CUDA pybind symbols into Python
-    # to prevent "symbol already registered" errors if first import fails.
+    # Load CPU pybind dll gracefully without introducing new python variable.
+    # Do this before loading the CUDA pybind dll to correctly resolve symbols
     from ctypes import CDLL as _CDLL
     from pathlib import Path as _Path
+    try:  # StopIteration if cpu version not available
+        _CDLL(next((_Path(__file__).parent / 'cpu').glob('pybind*')))
+    except StopIteration:
+        pass
     try:
-        _pybind_cuda = _CDLL(next((_Path(__file__).parent / 'cuda').glob('pybind*')))
+        # Check CUDA availability without importing CUDA pybind symbols to
+        # prevent "symbol already registered" errors if first import fails.
+        _pybind_cuda = _CDLL(
+            next((_Path(__file__).parent / 'cuda').glob('pybind*')))
         if _pybind_cuda.open3d_core_cuda_device_count() > 0:
             from open3d.cuda.pybind import (camera, geometry, io, pipelines,
                                             utility, tgeometry)
             from open3d.cuda import pybind
             __DEVICE_API__ = 'cuda'
-    except OSError:       # CUDA not installed
+    except OSError:  # CUDA not installed
         pass
-    except StopIteration: # pybind cuda library not available
+    except StopIteration:  # pybind cuda library not available
         pass
 
 if __DEVICE_API__ == 'cpu':


### PR DESCRIPTION
Loading  cuda pybind, checking cuda availability and then loading cpu pybind causes "symbol already registered"  error. This re-appeared in specific combinations after the CUDA_VISIBLE_DEVICES fix. This uses ctypes to prevent symbol registration.
New `open3d_core_cuda_device_count() `C interface can be called through ctypes. Directly calling C++ interface is not portable due to name mangling.

Tested with these combinations:
GPU + CUDA : ISL workstation
GPU + CUDA + CUDA_VISIBLE_DEVICES=none : ISL workstation
No GPU + no CUDA : docker
GPU + no CUDA : docker
No GPU + CUDA : docker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2324)
<!-- Reviewable:end -->
