### PR TITLE
Fast compression mode for png writing (issue #846)

### DIFF
--- a/cpp/open3d/io/ImageIO.cpp
+++ b/cpp/open3d/io/ImageIO.cpp
@@ -85,7 +85,7 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
 
 bool WriteImage(const std::string &filename,
                 const geometry::Image &image,
-                int quality /* = 90*/) {
+                int quality /* = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY*/) {
     std::string filename_ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {

--- a/cpp/open3d/io/ImageIO.cpp
+++ b/cpp/open3d/io/ImageIO.cpp
@@ -85,7 +85,7 @@ bool ReadImage(const std::string &filename, geometry::Image &image) {
 
 bool WriteImage(const std::string &filename,
                 const geometry::Image &image,
-                int quality /* = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY*/) {
+                int quality /* = kOpen3DImageIODefaultQuality*/) {
     std::string filename_ext =
             utility::filesystem::GetFileExtensionInLowerCase(filename);
     if (filename_ext.empty()) {

--- a/cpp/open3d/io/ImageIO.h
+++ b/cpp/open3d/io/ImageIO.h
@@ -43,7 +43,7 @@ std::shared_ptr<geometry::Image> CreateImageFromFile(
 /// \return return true if the read function is successful, false otherwise.
 bool ReadImage(const std::string &filename, geometry::Image &image);
 
-#define OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY -1
+constexpr int kOpen3DImageIODefaultQuality = -1;
 
 /// The general entrance for writing an Image to a file
 /// The function calls write functions based on the extension name of filename.
@@ -57,19 +57,19 @@ bool ReadImage(const std::string &filename, geometry::Image &image);
 /// \return return true if the write function is successful, false otherwise.
 bool WriteImage(const std::string &filename,
                 const geometry::Image &image,
-                int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
+                int quality = kOpen3DImageIODefaultQuality);
 
 bool ReadImageFromPNG(const std::string &filename, geometry::Image &image);
 
 bool WriteImageToPNG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
+                     int quality = kOpen3DImageIODefaultQuality);
 
 bool ReadImageFromJPG(const std::string &filename, geometry::Image &image);
 
 bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
+                     int quality = kOpen3DImageIODefaultQuality);
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/ImageIO.h
+++ b/cpp/open3d/io/ImageIO.h
@@ -43,26 +43,31 @@ std::shared_ptr<geometry::Image> CreateImageFromFile(
 /// \return return true if the read function is successful, false otherwise.
 bool ReadImage(const std::string &filename, geometry::Image &image);
 
+#define OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY -1
+
 /// The general entrance for writing an Image to a file
 /// The function calls write functions based on the extension name of filename.
 /// If the write function supports quality, the parameter will be used.
 /// Otherwise it will be ignored.
+/// \param quality: PNG: [0-9] <=2 fast write for storing intermediate data
+///                            >=3 (default) normal write for balanced speed and file size
+///                 JPEG: [0-100] Typically in [70,95]. 90 is default (good quality).
 /// \return return true if the write function is successful, false otherwise.
 bool WriteImage(const std::string &filename,
                 const geometry::Image &image,
-                int quality = 90);
+                int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
 
 bool ReadImageFromPNG(const std::string &filename, geometry::Image &image);
 
 bool WriteImageToPNG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality);
+                     int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
 
 bool ReadImageFromJPG(const std::string &filename, geometry::Image &image);
 
 bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality = 90);
+                     int quality = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/ImageIO.h
+++ b/cpp/open3d/io/ImageIO.h
@@ -50,8 +50,10 @@ bool ReadImage(const std::string &filename, geometry::Image &image);
 /// If the write function supports quality, the parameter will be used.
 /// Otherwise it will be ignored.
 /// \param quality: PNG: [0-9] <=2 fast write for storing intermediate data
-///                            >=3 (default) normal write for balanced speed and file size
-///                 JPEG: [0-100] Typically in [70,95]. 90 is default (good quality).
+///                            >=3 (default) normal write for balanced speed and
+///                            file size
+///                 JPEG: [0-100] Typically in [70,95]. 90 is default (good
+///                 quality).
 /// \return return true if the write function is successful, false otherwise.
 bool WriteImage(const std::string &filename,
                 const geometry::Image &image,

--- a/cpp/open3d/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/io/file_format/FileJPG.cpp
@@ -107,10 +107,12 @@ bool WriteImageToJPG(const std::string &filename,
         utility::LogWarning("Write JPG failed: unsupported image data.");
         return false;
     }
-    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)       // Set default quality
+    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)  // Set default quality
         quality = 90;
     if (quality < 0 || quality > 100) {
-        utility::LogWarning("Write JPG failed: image quality should be in the range [0,100].");
+        utility::LogWarning(
+                "Write JPG failed: image quality should be in the range "
+                "[0,100].");
         return false;
     }
 

--- a/cpp/open3d/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/io/file_format/FileJPG.cpp
@@ -97,7 +97,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
 
 bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality /* = 90*/) {
+                     int quality /* = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY*/) {
     if (!image.HasData()) {
         utility::LogWarning("Write JPG failed: image has no data.");
         return false;
@@ -107,6 +107,13 @@ bool WriteImageToJPG(const std::string &filename,
         utility::LogWarning("Write JPG failed: unsupported image data.");
         return false;
     }
+    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)       // Set default quality
+        quality = 90;
+    if (quality < 0 || quality > 100) {
+        utility::LogWarning("Write JPG failed: image quality should be in the range [0,100].");
+        return false;
+    }
+
     struct jpeg_compress_struct cinfo;
     struct jpeg_error_mgr jerr;
     FILE *file_out;

--- a/cpp/open3d/io/file_format/FileJPG.cpp
+++ b/cpp/open3d/io/file_format/FileJPG.cpp
@@ -97,7 +97,7 @@ bool ReadImageFromJPG(const std::string &filename, geometry::Image &image) {
 
 bool WriteImageToJPG(const std::string &filename,
                      const geometry::Image &image,
-                     int quality /* = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY*/) {
+                     int quality /* = kOpen3DImageIODefaultQuality*/) {
     if (!image.HasData()) {
         utility::LogWarning("Write JPG failed: image has no data.");
         return false;
@@ -107,7 +107,7 @@ bool WriteImageToJPG(const std::string &filename,
         utility::LogWarning("Write JPG failed: unsupported image data.");
         return false;
     }
-    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)  // Set default quality
+    if (quality == kOpen3DImageIODefaultQuality)  // Set default quality
         quality = 90;
     if (quality < 0 || quality > 100) {
         utility::LogWarning(

--- a/cpp/open3d/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/io/file_format/FilePNG.cpp
@@ -34,7 +34,9 @@ namespace open3d {
 namespace {
 using namespace io;
 
-void SetPNGImageFromImage(const geometry::Image &image, int quality, png_image &pngimage) {
+void SetPNGImageFromImage(const geometry::Image &image,
+                          int quality,
+                          png_image &pngimage) {
     pngimage.width = image.width_;
     pngimage.height = image.height_;
     pngimage.format = pngimage.flags = 0;
@@ -90,10 +92,11 @@ bool WriteImageToPNG(const std::string &filename,
         utility::LogWarning("Write PNG failed: image has no data.");
         return false;
     }
-    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)       // Set default quality
+    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)  // Set default quality
         quality = 6;
-    if (quality<0 || quality>9) {
-        utility::LogWarning("Write PNG failed: quality ({}) must be in the range [0,9]",
+    if (quality < 0 || quality > 9) {
+        utility::LogWarning(
+                "Write PNG failed: quality ({}) must be in the range [0,9]",
                 quality);
         return false;
     }

--- a/cpp/open3d/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/io/file_format/FilePNG.cpp
@@ -34,15 +34,19 @@ namespace open3d {
 namespace {
 using namespace io;
 
-void SetPNGImageFromImage(const geometry::Image &image, png_image &pngimage) {
+void SetPNGImageFromImage(const geometry::Image &image, int quality, png_image &pngimage) {
     pngimage.width = image.width_;
     pngimage.height = image.height_;
-    pngimage.format = 0;
+    pngimage.format = pngimage.flags = 0;
+
     if (image.bytes_per_channel_ == 2) {
         pngimage.format |= PNG_FORMAT_FLAG_LINEAR;
     }
     if (image.num_of_channels_ == 3) {
         pngimage.format |= PNG_FORMAT_FLAG_COLOR;
+    }
+    if (quality <= 2) {
+        pngimage.flags |= PNG_IMAGE_FLAG_FAST;
     }
 }
 
@@ -86,10 +90,17 @@ bool WriteImageToPNG(const std::string &filename,
         utility::LogWarning("Write PNG failed: image has no data.");
         return false;
     }
+    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)       // Set default quality
+        quality = 6;
+    if (quality<0 || quality>9) {
+        utility::LogWarning("Write PNG failed: quality ({}) must be in the range [0,9]",
+                quality);
+        return false;
+    }
     png_image pngimage;
     memset(&pngimage, 0, sizeof(pngimage));
     pngimage.version = PNG_IMAGE_VERSION;
-    SetPNGImageFromImage(image, pngimage);
+    SetPNGImageFromImage(image, quality, pngimage);
     if (png_image_write_to_file(&pngimage, filename.c_str(), 0,
                                 image.data_.data(), 0, NULL) == 0) {
         utility::LogWarning("Write PNG failed: unable to write file: {}",

--- a/cpp/open3d/io/file_format/FilePNG.cpp
+++ b/cpp/open3d/io/file_format/FilePNG.cpp
@@ -95,7 +95,7 @@ bool WriteImageToPNG(const std::string &filename,
         utility::LogWarning("Write PNG failed: image has no data.");
         return false;
     }
-    if (quality == OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY)  // Set default quality
+    if (quality == kOpen3DImageIODefaultQuality)  // Set default quality
         quality = 6;
     if (quality < 0 || quality > 9) {
         utility::LogWarning(

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -138,7 +138,7 @@ void pybind_class_io(py::module &m_io) {
                 return WriteImage(filename, image, quality);
             },
             "Function to write Image to file", "filename"_a, "image"_a,
-            "quality"_a = 90);
+            "quality"_a = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
     docstring::FunctionDocInject(m_io, "write_image",
                                  map_shared_argument_docstrings);
 

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -138,7 +138,7 @@ void pybind_class_io(py::module &m_io) {
                 return WriteImage(filename, image, quality);
             },
             "Function to write Image to file", "filename"_a, "image"_a,
-            "quality"_a = OPEN3D_IO_IMAGEIO_DEFAULT_QUALITY);
+            "quality"_a = kOpen3DImageIODefaultQuality);
     docstring::FunctionDocInject(m_io, "write_image",
                                  map_shared_argument_docstrings);
 

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -17,7 +17,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]] && [ "$BUILD_CUDA_MODULE" == OFF ] ; then
 fi
 BUILD_RPC_INTERFACE=${BUILD_RPC_INTERFACE:-ON}
 LOW_MEM_USAGE=${LOW_MEM_USAGE:-OFF}
-BUILD_WHEEL_ONLY=${BUILD_WHEEL_ONLY:-OFF}
 
 # Dependency versions
 CUDA_VERSION=("10-1" "10.1")


### PR DESCRIPTION
Enable PNG_IMAGE_FLAG_FAST with quality<=2
Write time: 86ms->19ms
File size: 374KB->596KB
for lena_color (512x512)

Issue #846

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2325)
<!-- Reviewable:end -->
