### PR TITLE
Fix NanoFlannIndex base class memory leak

### DIFF
--- a/cpp/open3d/core/nns/NanoFlannIndex.h
+++ b/cpp/open3d/core/nns/NanoFlannIndex.h
@@ -53,7 +53,9 @@ namespace nns {
 enum Metric { L1, L2, Linf };
 
 /// Base struct for Index holder
-struct NanoFlannIndexHolderBase {};
+struct NanoFlannIndexHolderBase {
+    virtual ~NanoFlannIndexHolderBase() {}
+};
 
 /// NanoFlann Index Holder
 template <int METRIC, class T>


### PR DESCRIPTION
`NanoFlannIndexHolderBase` does not have a virtual destructor, causing the `unique_ptr` to its children classes not being able to destruct property.

Quick test case that causes memory leak:
```cpp
void RunTest() {
    core::Tensor ref = core::Tensor::Ones({100, 3}, core::Dtype::Float64);
    core::nns::NanoFlannIndex index(ref);
}

TEST(NearestNeighborSearch, KnnSearch) {
    while (true) {
        RunTest();
    }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2340)
<!-- Reviewable:end -->
