### PR TITLE
convert noncontiguous tensors instead of throwing an exception.

### DIFF
--- a/cpp/open3d/ml/pytorch/continuous_conv/ContinuousConvOps.cpp
+++ b/cpp/open3d/ml/pytorch/continuous_conv/ContinuousConvOps.cpp
@@ -72,16 +72,16 @@ public:
         CHECK_SAME_DEVICE_TYPE(filters, out_positions, inp_positions,
                                inp_features, inp_importance);
 
-        CHECK_CONTIGUOUS(filters);
-        CHECK_CONTIGUOUS(out_positions);
-        CHECK_CONTIGUOUS(extents);
-        CHECK_CONTIGUOUS(offset);
-        CHECK_CONTIGUOUS(inp_positions);
-        CHECK_CONTIGUOUS(inp_features);
-        CHECK_CONTIGUOUS(inp_importance);
-        CHECK_CONTIGUOUS(neighbors_index);
-        CHECK_CONTIGUOUS(neighbors_importance);
-        CHECK_CONTIGUOUS(neighbors_row_splits);
+        filters = filters.contiguous();
+        out_positions = out_positions.contiguous();
+        extents = extents.contiguous();
+        offset = offset.contiguous();
+        inp_positions = inp_positions.contiguous();
+        inp_features = inp_features.contiguous();
+        inp_importance = inp_importance.contiguous();
+        neighbors_index = neighbors_index.contiguous();
+        neighbors_importance = neighbors_importance.contiguous();
+        neighbors_row_splits = neighbors_row_splits.contiguous();
 
         // check input shapes
         using namespace open3d::ml::op_util;
@@ -198,8 +198,7 @@ public:
         auto device = inp_features.device();
         const auto& real_dtype = filters.dtype();
         const auto& index_dtype = neighbors_index.dtype();
-        auto out_features_gradient = grad_output[0];
-        CHECK_CONTIGUOUS(out_features_gradient);
+        auto out_features_gradient = grad_output[0].contiguous();
         CHECK_SAME_DTYPE(out_features_gradient, inp_features, filters);
         CHECK_SAME_DEVICE_TYPE(out_features_gradient, inp_features, filters);
 

--- a/cpp/open3d/ml/pytorch/continuous_conv/ContinuousConvTransposeOps.cpp
+++ b/cpp/open3d/ml/pytorch/continuous_conv/ContinuousConvTransposeOps.cpp
@@ -78,19 +78,20 @@ public:
         CHECK_SAME_DEVICE_TYPE(filters, out_positions, inp_positions,
                                inp_features, out_importance);
 
-        CHECK_CONTIGUOUS(filters);
-        CHECK_CONTIGUOUS(out_positions);
-        CHECK_CONTIGUOUS(out_importance);
-        CHECK_CONTIGUOUS(extents);
-        CHECK_CONTIGUOUS(offset);
-        CHECK_CONTIGUOUS(inp_positions);
-        CHECK_CONTIGUOUS(inp_features);
-        CHECK_CONTIGUOUS(inp_neighbors_index);
-        CHECK_CONTIGUOUS(inp_neighbors_importance_sum);
-        CHECK_CONTIGUOUS(inp_neighbors_row_splits);
-        CHECK_CONTIGUOUS(neighbors_index);
-        CHECK_CONTIGUOUS(neighbors_importance);
-        CHECK_CONTIGUOUS(neighbors_row_splits);
+        filters = filters.contiguous();
+        out_positions = out_positions.contiguous();
+        out_importance = out_importance.contiguous();
+        extents = extents.contiguous();
+        offset = offset.contiguous();
+        inp_positions = inp_positions.contiguous();
+        inp_features = inp_features.contiguous();
+        inp_neighbors_index = inp_neighbors_index.contiguous();
+        inp_neighbors_importance_sum =
+                inp_neighbors_importance_sum.contiguous();
+        inp_neighbors_row_splits = inp_neighbors_row_splits.contiguous();
+        neighbors_index = neighbors_index.contiguous();
+        neighbors_importance = neighbors_importance.contiguous();
+        neighbors_row_splits = neighbors_row_splits.contiguous();
 
         // check input shapes
         using namespace open3d::ml::op_util;
@@ -218,8 +219,7 @@ public:
         auto device = inp_features.device();
         const auto& real_dtype = filters.dtype();
         const auto& index_dtype = neighbors_index.dtype();
-        auto out_features_gradient = grad_output[0];
-        CHECK_CONTIGUOUS(out_features_gradient);
+        auto out_features_gradient = grad_output[0].contiguous();
         CHECK_SAME_DTYPE(out_features_gradient, inp_features, filters);
         CHECK_SAME_DEVICE_TYPE(out_features_gradient, inp_features, filters);
 

--- a/cpp/open3d/ml/pytorch/misc/BuildSpatialHashTableOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/BuildSpatialHashTableOps.cpp
@@ -48,15 +48,15 @@ void BuildSpatialHashTableCUDA(const torch::Tensor& points,
 #endif
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> BuildSpatialHashTable(
-        const torch::Tensor& points,
+        torch::Tensor points,
         double radius,
         torch::Tensor points_row_splits,
         double hash_table_size_factor,
         int64_t max_hash_table_size) {
     // ensure that these tensors are on the cpu
     points_row_splits = points_row_splits.to(torch::kCPU);
-    CHECK_CONTIGUOUS(points);
-    CHECK_CONTIGUOUS(points_row_splits);
+    points = points.contiguous();
+    points_row_splits = points_row_splits.contiguous();
     CHECK_TYPE(points_row_splits, kInt64);
 
     // check input shapes

--- a/cpp/open3d/ml/pytorch/misc/FixedRadiusSearchOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/FixedRadiusSearchOps.cpp
@@ -67,14 +67,14 @@ void FixedRadiusSearchCUDA(const torch::Tensor& points,
 #endif
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FixedRadiusSearch(
-        const torch::Tensor& points,
-        const torch::Tensor& queries,
+        torch::Tensor points,
+        torch::Tensor queries,
         double radius,
         torch::Tensor points_row_splits,
         torch::Tensor queries_row_splits,
         torch::Tensor hash_table_splits,
-        const torch::Tensor& hash_table_index,
-        const torch::Tensor& hash_table_cell_splits,
+        torch::Tensor hash_table_index,
+        torch::Tensor hash_table_cell_splits,
         const std::string& metric_str,
         const bool ignore_query_point,
         const bool return_distances) {
@@ -100,13 +100,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> FixedRadiusSearch(
     points_row_splits = points_row_splits.to(torch::kCPU);
     queries_row_splits = queries_row_splits.to(torch::kCPU);
     hash_table_splits = hash_table_splits.to(torch::kCPU);
-    CHECK_CONTIGUOUS(points);
-    CHECK_CONTIGUOUS(queries);
-    CHECK_CONTIGUOUS(points_row_splits);
-    CHECK_CONTIGUOUS(queries_row_splits);
-    CHECK_CONTIGUOUS(hash_table_splits);
-    CHECK_CONTIGUOUS(hash_table_index);
-    CHECK_CONTIGUOUS(hash_table_cell_splits);
+    points = points.contiguous();
+    queries = queries.contiguous();
+    points_row_splits = points_row_splits.contiguous();
+    queries_row_splits = queries_row_splits.contiguous();
+    hash_table_splits = hash_table_splits.contiguous();
+    hash_table_index = hash_table_index.contiguous();
+    hash_table_cell_splits = hash_table_cell_splits.contiguous();
 
     // check input shapes
     using namespace open3d::ml::op_util;

--- a/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.cpp
@@ -35,12 +35,12 @@
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsList(
         int64_t num_points,
-        const torch::Tensor& inp_neighbors_index,
-        const torch::Tensor& inp_neighbors_row_splits,
-        const torch::Tensor& inp_neighbors_attributes) {
-    CHECK_CONTIGUOUS(inp_neighbors_index);
-    CHECK_CONTIGUOUS(inp_neighbors_row_splits);
-    CHECK_CONTIGUOUS(inp_neighbors_attributes);
+        torch::Tensor inp_neighbors_index,
+        torch::Tensor inp_neighbors_row_splits,
+        torch::Tensor inp_neighbors_attributes) {
+    inp_neighbors_index = inp_neighbors_index.contiguous();
+    inp_neighbors_row_splits = inp_neighbors_row_splits.contiguous();
+    inp_neighbors_attributes = inp_neighbors_attributes.contiguous();
     CHECK_TYPE(inp_neighbors_row_splits, kInt64);
 
     // check input shapes

--- a/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.h
+++ b/cpp/open3d/ml/pytorch/misc/InvertNeighborsListOps.h
@@ -30,6 +30,6 @@
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> InvertNeighborsList(
         int64_t num_points,
-        const torch::Tensor& inp_neighbors_index,
-        const torch::Tensor& inp_neighbors_row_splits,
-        const torch::Tensor& inp_neighbors_attributes);
+        torch::Tensor inp_neighbors_index,
+        torch::Tensor inp_neighbors_row_splits,
+        torch::Tensor inp_neighbors_attributes);

--- a/cpp/open3d/ml/pytorch/misc/KnnSearchOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/KnnSearchOps.cpp
@@ -47,8 +47,8 @@ void KnnSearchCPU(const torch::Tensor& points,
                   torch::Tensor& neighbors_distance);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> KnnSearch(
-        const torch::Tensor& points,
-        const torch::Tensor& queries,
+        torch::Tensor points,
+        torch::Tensor queries,
         const int64_t k,
         torch::Tensor points_row_splits,
         torch::Tensor queries_row_splits,
@@ -72,10 +72,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> KnnSearch(
     // ensure that these are on the cpu
     points_row_splits = points_row_splits.to(torch::kCPU);
     queries_row_splits = queries_row_splits.to(torch::kCPU);
-    CHECK_CONTIGUOUS(points);
-    CHECK_CONTIGUOUS(queries);
-    CHECK_CONTIGUOUS(points_row_splits);
-    CHECK_CONTIGUOUS(queries_row_splits);
+    points = points.contiguous();
+    queries = queries.contiguous();
+    points_row_splits = points_row_splits.contiguous();
+    queries_row_splits = queries_row_splits.contiguous();
 
     // check input shapes
     using namespace open3d::ml::op_util;

--- a/cpp/open3d/ml/pytorch/misc/RadiusSearchOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/RadiusSearchOps.cpp
@@ -48,9 +48,9 @@ void RadiusSearchCPU(const torch::Tensor& points,
                      torch::Tensor& neighbors_distance);
 
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> MultiRadiusSearch(
-        const torch::Tensor& points,
-        const torch::Tensor& queries,
-        const torch::Tensor& radii,
+        torch::Tensor points,
+        torch::Tensor queries,
+        torch::Tensor radii,
         torch::Tensor points_row_splits,
         torch::Tensor queries_row_splits,
         const std::string& metric_str,
@@ -73,11 +73,11 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> MultiRadiusSearch(
     // ensure that these are on the cpu
     points_row_splits = points_row_splits.to(torch::kCPU);
     queries_row_splits = queries_row_splits.to(torch::kCPU);
-    CHECK_CONTIGUOUS(points);
-    CHECK_CONTIGUOUS(queries);
-    CHECK_CONTIGUOUS(radii);
-    CHECK_CONTIGUOUS(points_row_splits);
-    CHECK_CONTIGUOUS(queries_row_splits);
+    points = points.contiguous();
+    queries = queries.contiguous();
+    radii = radii.contiguous();
+    points_row_splits = points_row_splits.contiguous();
+    queries_row_splits = queries_row_splits.contiguous();
 
     // check input shapes
     using namespace open3d::ml::op_util;

--- a/cpp/open3d/ml/pytorch/misc/ReduceSubarraysSumOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/ReduceSubarraysSumOps.cpp
@@ -33,10 +33,10 @@
 #include "open3d/ml/pytorch/misc/ReduceSubarraysSumOpKernel.h"
 #include "torch/script.h"
 
-torch::Tensor ReduceSubarraysSum(const torch::Tensor& values,
-                                 const torch::Tensor& row_splits) {
-    CHECK_CONTIGUOUS(values);
-    CHECK_CONTIGUOUS(row_splits);
+torch::Tensor ReduceSubarraysSum(torch::Tensor values,
+                                 torch::Tensor row_splits) {
+    values = values.contiguous();
+    row_splits = row_splits.contiguous();
     CHECK_TYPE(row_splits, kInt64);
 
     const auto& attr_type = values.dtype();

--- a/cpp/open3d/ml/pytorch/misc/ReduceSubarraysSumOps.h
+++ b/cpp/open3d/ml/pytorch/misc/ReduceSubarraysSumOps.h
@@ -28,5 +28,5 @@
 
 #include "torch/script.h"
 
-torch::Tensor ReduceSubarraysSum(const torch::Tensor& values,
-                                 const torch::Tensor& row_splits);
+torch::Tensor ReduceSubarraysSum(torch::Tensor values,
+                                 torch::Tensor row_splits);

--- a/cpp/open3d/ml/pytorch/misc/VoxelPoolingOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/VoxelPoolingOps.cpp
@@ -91,8 +91,8 @@ public:
                         "'nearest_neighbor', 'max') but got " +
                                 feature_fn_str);
         }
-        CHECK_CONTIGUOUS(positions);
-        CHECK_CONTIGUOUS(features);
+        positions = positions.contiguous();
+        features = features.contiguous();
 
         // check input shapes
         {
@@ -182,9 +182,10 @@ public:
         auto positions = saved_vars[0];
         auto features = saved_vars[1];
         auto pooled_positions = saved_vars[2];
-        auto pooled_features_gradient = grad_output[1];
-        CHECK_CONTIGUOUS(positions);
-        CHECK_CONTIGUOUS(features);
+        auto pooled_features_gradient = grad_output[1].contiguous();
+        positions = positions.contiguous();
+        features = features.contiguous();
+        pooled_positions = pooled_positions.contiguous();
 
         torch::Tensor features_backprop =
                 torch::empty(features.sizes(), features.dtype());


### PR DESCRIPTION
This also fixes problems with noncontiguous tensors in the backward pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2354)
<!-- Reviewable:end -->
