### PR TITLE
bugfixes for torch ContinuousConv layer

### DIFF
--- a/python/open3d/ml/tf/python/layers/convolutions.py
+++ b/python/open3d/ml/tf/python/layers/convolutions.py
@@ -130,6 +130,14 @@ class ContinuousConv(tf.keras.layers.Layer):
           input and output point sets are the same and
           'radius_search_ignore_query_points' has been set to True.
 
+        dense_kernel_initializer: Initializer for the kernel weights of the
+          linear layer used for the center if 'use_dense_layer_for_center'
+          is True.
+
+        dense_kernel_regularizer: Regularizer for the kernel weights of the
+          linear layer used for the center if 'use_dense_layer_for_center'
+          is True.
+
         in_channels: This keyword argument is for compatibility with Pytorch.
           It is not used and in_channels will be inferred at the first execution
           of the layer.
@@ -153,6 +161,8 @@ class ContinuousConv(tf.keras.layers.Layer):
                  offset=None,
                  window_function=None,
                  use_dense_layer_for_center=False,
+                 dense_kernel_initializer='glorot_uniform',
+                 dense_kernel_regularizer=None,
                  in_channels=None,
                  **kwargs):
 
@@ -171,6 +181,10 @@ class ContinuousConv(tf.keras.layers.Layer):
         self.normalize = normalize
         self.radius_search_ignore_query_points = radius_search_ignore_query_points
         self.radius_search_metric = radius_search_metric
+        self.dense_kernel_initializer = initializers.get(
+            dense_kernel_initializer)
+        self.dense_kernel_regularizer = regularizers.get(
+            dense_kernel_regularizer)
 
         if offset is None:
             self.offset = tf.zeros(shape=(3,))
@@ -192,7 +206,11 @@ class ContinuousConv(tf.keras.layers.Layer):
 
         self.use_dense_layer_for_center = use_dense_layer_for_center
         if self.use_dense_layer_for_center:
-            self.dense = tf.keras.layers.Dense(self.filters, use_bias=False)
+            self.dense = tf.keras.layers.Dense(
+                self.filters,
+                kernel_initializer=dense_kernel_initializer,
+                kernel_regularizer=dense_kernel_regularizer,
+                use_bias=False)
 
         super().__init__(**kwargs)
 

--- a/python/open3d/ml/torch/python/layers/convolutions.py
+++ b/python/open3d/ml/torch/python/layers/convolutions.py
@@ -128,6 +128,10 @@ class ContinuousConv(torch.nn.Module):
           useful when using even kernel sizes that have no center element and
           input and output point sets are the same and
           'radius_search_ignore_query_points' has been set to True.
+
+        dense_kernel_initializer: Initializer for the kernel weights of the
+          linear layer used for the center if 'use_dense_layer_for_center'
+          is True.
     """
 
     def __init__(
@@ -148,6 +152,7 @@ class ContinuousConv(torch.nn.Module):
             offset=None,
             window_function=None,
             use_dense_layer_for_center=False,
+            dense_kernel_initializer=torch.nn.init.xavier_uniform_,
             **kwargs):
         super().__init__()
 
@@ -164,6 +169,7 @@ class ContinuousConv(torch.nn.Module):
         self.normalize = normalize
         self.radius_search_ignore_query_points = radius_search_ignore_query_points
         self.radius_search_metric = radius_search_metric
+        self.dense_kernel_initializer = dense_kernel_initializer
 
         if offset is None:
             offset = torch.zeros(size=(3,), dtype=torch.float32)
@@ -187,6 +193,7 @@ class ContinuousConv(torch.nn.Module):
             self.dense = torch.nn.Linear(self.in_channels,
                                          self.filters,
                                          bias=False)
+            self.dense_kernel_initializer(self.dense.weight)
 
         kernel_shape = (*self.kernel_size, self.in_channels, self.filters)
         self.kernel = torch.nn.Parameter(data=torch.Tensor(*kernel_shape),
@@ -255,6 +262,9 @@ class ContinuousConv(torch.nn.Module):
 
         offset = self.offset
 
+        if isinstance(extents, float):
+            extents = torch.tensor(extents)
+
         if inp_importance is None:
             inp_importance = torch.empty((0,),
                                          dtype=torch.float32,
@@ -275,8 +285,6 @@ class ContinuousConv(torch.nn.Module):
             neighbors_row_splits = user_neighbors_row_splits
 
         else:
-            if isinstance(extents, float):
-                extents = torch.tensor(extents)
             if len(extents.shape) == 0:
                 radius = 0.5 * extents
                 self.nns = self.fixed_radius_search(


### PR DESCRIPTION
-bugfix for float extents for torch cconv layer
-fixed discrepancy between dense layer initialization between tf and torch
-added parameters for the dense weight initializer to the cconv layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2361)
<!-- Reviewable:end -->
