### PR TITLE
set cmake minimum to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.12.0)
-# CMake 3.12+ is required to allow linking with OBJECT libraries
-# and to prevent erroneous -gencode option deduplication with CUDA.
+cmake_minimum_required(VERSION 3.15.0)
+# CMake 3.15+ is required to allow linking with OBJECT libraries,
+# to prevent erroneous -gencode option deduplication with CUDA,
+# and to simplify generator expressions for selecting compile flags.
 # If you're using Ubuntu 18.04 or older, we suggest you install
 # a backported CMake from https://apt.kitware.com/
 


### PR DESCRIPTION
The generator expressions CXX_COMPILER_ID in cpp/CMakeLists.txt:13 do not support multiple ids before 3.15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2392)
<!-- Reviewable:end -->
