### PR TITLE
Refector some image tests failing on arm simulator

### DIFF
--- a/cpp/tests/geometry/Image.cpp
+++ b/cpp/tests/geometry/Image.cpp
@@ -35,9 +35,6 @@ namespace tests {
 using ConversionType = geometry::Image::ColorToIntensityConversionType;
 using FilterType = geometry::Image::FilterType;
 
-// ----------------------------------------------------------------------------
-// test the default constructor scenario
-// ----------------------------------------------------------------------------
 TEST(Image, DefaultConstructor) {
     geometry::Image image;
 
@@ -63,9 +60,6 @@ TEST(Image, DefaultConstructor) {
     EXPECT_EQ(0, image.BytesPerLine());
 }
 
-// ----------------------------------------------------------------------------
-// test Prepare aka image creation
-// ----------------------------------------------------------------------------
 TEST(Image, CreateImage) {
     int width = 1920;
     int height = 1080;
@@ -96,9 +90,6 @@ TEST(Image, CreateImage) {
               image.BytesPerLine());
 }
 
-// ----------------------------------------------------------------------------
-// test Clear
-// ----------------------------------------------------------------------------
 TEST(Image, Clear) {
     int width = 1920;
     int height = 1080;
@@ -129,9 +120,6 @@ TEST(Image, Clear) {
     EXPECT_EQ(0, image.BytesPerLine());
 }
 
-// ----------------------------------------------------------------------------
-// test FloatValueAt, bilinear(?) interpolation
-// ----------------------------------------------------------------------------
 TEST(Image, FloatValueAt) {
     geometry::Image image;
 
@@ -159,9 +147,6 @@ TEST(Image, FloatValueAt) {
     EXPECT_NEAR(1.0f, image.FloatValueAt(1.5, 1.5).second, THRESHOLD_1E_6);
 }
 
-// ----------------------------------------------------------------------------
-// member data is not private and as such can lead to errors
-// ----------------------------------------------------------------------------
 TEST(Image, DISABLED_MemberData) {
     int width = 1920;
     int height = 1080;
@@ -223,12 +208,6 @@ TEST(Image, CreateDepthToCameraDistanceMultiplierFloatImage) {
     EXPECT_EQ(bytes_per_channel, image->bytes_per_channel_);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configurations
-// channels: bytes per channel
-// 1: 1/2/4
-// 3: 1/2/4 with either Equal or Weighted type
-// ----------------------------------------------------------------------------
 void TEST_CreateFloatImage(
         const int& num_of_channels,
         const int& bytes_per_channel,
@@ -255,189 +234,306 @@ void TEST_CreateFloatImage(
     ExpectEQ(ref, float_image->data_);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 1
-// bytes per channel: 1
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_1_1) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            215, 214, 86,  63,  201, 200, 200, 62,  200, 199, 71,  63,  204,
-            203, 75,  63,  233, 232, 104, 63,  201, 200, 72,  62,  171, 170,
-            170, 62,  196, 195, 67,  63,  141, 140, 140, 62,  142, 141, 13,
-            63,  243, 242, 242, 62,  161, 160, 32,  63,  187, 186, 186, 62,
-            131, 130, 2,   63,  243, 242, 114, 63,  234, 233, 105, 63,  163,
-            162, 34,  63,  183, 182, 54,  63,  145, 144, 16,  62,  155, 154,
-            26,  63,  129, 128, 128, 60,  245, 244, 116, 62,  137, 136, 8,
-            62,  206, 205, 77,  63,  157, 156, 28,  62};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 1;    // {1, 3}
+    int bytes_per_channel = 1;  // {1, 2, 4}
 
-    TEST_CreateFloatImage(1, 1, ref, ConversionType::Weighted);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint8_t* data_ptr = static_cast<uint8_t*>(image.data_.data());
+    data_ptr[0] = 0;
+    data_ptr[1] = 51;
+    data_ptr[2] = 102;
+    data_ptr[3] = 255;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage();
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values, std::vector<float>({0, 0.2, 0.4, 1}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 1
-// bytes per channel: 2
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_1_2) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            0, 172, 201, 70, 0, 199, 75,  71, 0, 160, 75,  70, 0, 85,  67,  71,
-            0, 70,  13,  71, 0, 121, 32,  71, 0, 93,  2,   71, 0, 242, 105, 71,
-            0, 162, 54,  71, 0, 36,  26,  71, 0, 16,  116, 70, 0, 34,  77,  71,
-            0, 78,  204, 70, 0, 8,   217, 69, 0, 248, 95,  70, 0, 130, 85,  71,
-            0, 56,  151, 70, 0, 162, 5,   71, 0, 125, 120, 71, 0, 74,  68,  71,
-            0, 134, 68,  71, 0, 102, 99,  71, 0, 144, 178, 70, 0, 205, 106, 71,
-            0, 17,  114, 71};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 1;
+    int bytes_per_channel = 2;
 
-    TEST_CreateFloatImage(1, 2, ref, ConversionType::Weighted);
+    // unit16_t to float just uses the direct value.
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(image.data_.data());
+    data_ptr[0] = 0;
+    data_ptr[1] = 1;
+    data_ptr[2] = 2;
+    data_ptr[3] = 3;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage();
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values, std::vector<float>({0, 1, 2, 3}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 1
-// bytes per channel: 4
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_1_4) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            214, 100, 199, 203, 232, 50,  85,  195, 70,  141, 121, 160, 93,
-            130, 242, 233, 162, 182, 36,  154, 4,   61,  34,  205, 39,  102,
-            33,  27,  254, 55,  130, 213, 156, 75,  162, 133, 125, 248, 74,
-            196, 134, 196, 102, 227, 72,  89,  205, 234, 17,  242, 134, 21,
-            49,  169, 227, 88,  16,  5,   116, 16,  60,  247, 230, 216, 67,
-            137, 95,  193, 130, 170, 135, 10,  111, 237, 237, 183, 72,  188,
-            163, 90,  175, 42,  112, 224, 211, 84,  58,  227, 89,  175, 243,
-            150, 167, 218, 112, 235, 101, 207, 174, 232};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 1;
+    int bytes_per_channel = 4;
 
-    TEST_CreateFloatImage(1, 4, ref, ConversionType::Weighted);
+    // float to float just uses the direct value.
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    float* data_ptr = reinterpret_cast<float*>(image.data_.data());
+    data_ptr[0] = 0.00;
+    data_ptr[1] = 0.25;
+    data_ptr[2] = 0.50;
+    data_ptr[3] = 1.00;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage();
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values, std::vector<float>({0.00, 0.25, 0.50, 1.00}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 1
-// ColorToIntensityConversionType: Weighted
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_1_Weighted) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            45,  241, 17,  63,  29,  96,  75,  63,  154, 112, 20,  63,  0,
-            241, 3,   63,  180, 56,  4,   63,  139, 60,  58,  63,  115, 8,
-            204, 62,  216, 59,  119, 62,  64,  47,  151, 62,  251, 20,  36,
-            63,  194, 101, 54,  63,  138, 51,  5,   63,  54,  35,  64,  63,
-            94,  59,  32,  63,  29,  161, 44,  63,  137, 77,  46,  63,  199,
-            12,  35,  63,  121, 21,  90,  62,  101, 168, 243, 62,  209, 97,
-            143, 62,  9,   228, 61,  63,  224, 255, 239, 62,  57,  33,  29,
-            63,  197, 186, 3,   63,  145, 27,  72,  63};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 1;
+    auto type = geometry::Image::ColorToIntensityConversionType::Weighted;
 
-    TEST_CreateFloatImage(3, 1, ref, ConversionType::Weighted);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint8_t* data_ptr = static_cast<uint8_t*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 255;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 255;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 255;
+    // Pixel 3
+    data_ptr[9] = 255;
+    data_ptr[10] = 255;
+    data_ptr[11] = 255;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values, std::vector<float>({0.2990, 0.5870, 0.1140, 1}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 1
-// ColorToIntensityConversionType: Equal
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_1_Equal) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            45,  241, 17,  63,  29,  96,  75,  63,  154, 112, 20,  63,  0,
-            241, 3,   63,  180, 56,  4,   63,  139, 60,  58,  63,  115, 8,
-            204, 62,  216, 59,  119, 62,  64,  47,  151, 62,  251, 20,  36,
-            63,  194, 101, 54,  63,  138, 51,  5,   63,  54,  35,  64,  63,
-            94,  59,  32,  63,  29,  161, 44,  63,  137, 77,  46,  63,  199,
-            12,  35,  63,  121, 21,  90,  62,  101, 168, 243, 62,  209, 97,
-            143, 62,  9,   228, 61,  63,  224, 255, 239, 62,  57,  33,  29,
-            63,  197, 186, 3,   63,  145, 27,  72,  63};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 1;
+    auto type = geometry::Image::ColorToIntensityConversionType::Equal;
 
-    TEST_CreateFloatImage(3, 1, ref, ConversionType::Equal);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint8_t* data_ptr = static_cast<uint8_t*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 255;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 255;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 255;
+    // Pixel 3
+    data_ptr[9] = 255;
+    data_ptr[10] = 255;
+    data_ptr[11] = 255;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values,
+             std::vector<float>({1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 2
-// ColorToIntensityConversionType: Weighted
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_2_Weighted) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            16,  146, 27,  71,  44,  160, 31,  71,  234, 31,  69,  71,  39,
-            148, 210, 70,  195, 103, 83,  70,  79,  233, 246, 70,  97,  236,
-            83,  71,  226, 42,  19,  71,  145, 153, 208, 70,  82,  101, 251,
-            69,  235, 227, 88,  71,  45,  27,  31,  71,  209, 107, 72,  71,
-            169, 123, 155, 70,  236, 187, 50,  71,  151, 82,  72,  71,  48,
-            235, 76,  71,  32,  111, 86,  71,  27,  105, 148, 70,  71,  196,
-            219, 70,  12,  108, 22,  71,  198, 41,  183, 70,  225, 5,   23,
-            71,  210, 181, 85,  71,  101, 14,  28,  71};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 2;
+    auto type = geometry::Image::ColorToIntensityConversionType::Weighted;
 
-    TEST_CreateFloatImage(3, 2, ref, ConversionType::Weighted);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 255;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 255;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 255;
+    // Pixel 3
+    data_ptr[9] = 255;
+    data_ptr[10] = 255;
+    data_ptr[11] = 255;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values,
+             std::vector<float>(
+                     {0.2990 * 255, 0.5870 * 255, 0.1140 * 255, 1 * 255}),
+             1e-5);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 2
-// ColorToIntensityConversionType: Equal
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_2_Equal) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            16,  146, 27,  71,  44,  160, 31,  71,  234, 31,  69,  71,  39,
-            148, 210, 70,  195, 103, 83,  70,  79,  233, 246, 70,  97,  236,
-            83,  71,  226, 42,  19,  71,  145, 153, 208, 70,  82,  101, 251,
-            69,  235, 227, 88,  71,  45,  27,  31,  71,  209, 107, 72,  71,
-            169, 123, 155, 70,  236, 187, 50,  71,  151, 82,  72,  71,  48,
-            235, 76,  71,  32,  111, 86,  71,  27,  105, 148, 70,  71,  196,
-            219, 70,  12,  108, 22,  71,  198, 41,  183, 70,  225, 5,   23,
-            71,  210, 181, 85,  71,  101, 14,  28,  71};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 2;
+    auto type = geometry::Image::ColorToIntensityConversionType::Equal;
 
-    TEST_CreateFloatImage(3, 2, ref, ConversionType::Equal);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    uint16_t* data_ptr = reinterpret_cast<uint16_t*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 255;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 255;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 255;
+    // Pixel 3
+    data_ptr[9] = 255;
+    data_ptr[10] = 255;
+    data_ptr[11] = 255;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values,
+             std::vector<float>({255.0 / 3, 255.0 / 3, 255.0 / 3, 255}), 1e-5);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 4
-// ColorToIntensityConversionType: Weighted
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_4_Weighted) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            153, 122, 238, 202, 65,  5,   17,  233, 117, 224, 24,  213, 166,
-            79,  59,  233, 15,  163, 133, 88,  22,  30,  10,  216, 24,  168,
-            218, 222, 111, 170, 219, 233, 198, 232, 16,  109, 227, 84,  156,
-            229, 56,  95,  77,  97,  226, 226, 200, 188, 36,  128, 64,  193,
-            178, 161, 146, 208, 240, 239, 83,  208, 189, 119, 176, 114, 209,
-            111, 82,  249, 14,  45,  72,  210, 222, 97,  25,  247, 179, 223,
-            15,  114, 245, 201, 149, 76,  224, 3,   24,  64,  17,  103, 98,
-            222, 145, 236, 94,  233, 36,  85,  141, 233};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 4;
+    auto type = geometry::Image::ColorToIntensityConversionType::Weighted;
 
-    TEST_CreateFloatImage(3, 4, ref, ConversionType::Weighted);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    float* data_ptr = reinterpret_cast<float*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 1;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 1;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 1;
+    // Pixel 3
+    data_ptr[9] = 1;
+    data_ptr[10] = 1;
+    data_ptr[11] = 1;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values, std::vector<float>({0.2990, 0.5870, 0.1140, 1}));
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configuration:
-// channels: 3
-// bytes per channel: 4
-// ColorToIntensityConversionType: Equal
-// ----------------------------------------------------------------------------
 TEST(Image, CreateFloatImage_3_4_Equal) {
-    // reference data used to validate the creation of the float image
-    std::vector<uint8_t> ref = {
-            153, 122, 238, 202, 65,  5,   17,  233, 117, 224, 24,  213, 166,
-            79,  59,  233, 15,  163, 133, 88,  22,  30,  10,  216, 24,  168,
-            218, 222, 111, 170, 219, 233, 198, 232, 16,  109, 227, 84,  156,
-            229, 56,  95,  77,  97,  226, 226, 200, 188, 36,  128, 64,  193,
-            178, 161, 146, 208, 240, 239, 83,  208, 189, 119, 176, 114, 209,
-            111, 82,  249, 14,  45,  72,  210, 222, 97,  25,  247, 179, 223,
-            15,  114, 245, 201, 149, 76,  224, 3,   24,  64,  17,  103, 98,
-            222, 145, 236, 94,  233, 36,  85,  141, 233};
+    int width = 2;
+    int height = 2;
+    int num_of_channels = 3;
+    int bytes_per_channel = 4;
+    auto type = geometry::Image::ColorToIntensityConversionType::Equal;
 
-    TEST_CreateFloatImage(3, 4, ref, ConversionType::Equal);
+    geometry::Image image;
+    image.Prepare(width, height, num_of_channels, bytes_per_channel);
+    float* data_ptr = reinterpret_cast<float*>(image.data_.data());
+    // Pixel 0
+    data_ptr[0] = 1;
+    data_ptr[1] = 0;
+    data_ptr[2] = 0;
+    // Pixel 1
+    data_ptr[3] = 0;
+    data_ptr[4] = 1;
+    data_ptr[5] = 0;
+    // Pixel 2
+    data_ptr[6] = 0;
+    data_ptr[7] = 0;
+    data_ptr[8] = 1;
+    // Pixel 3
+    data_ptr[9] = 1;
+    data_ptr[10] = 1;
+    data_ptr[11] = 1;
+
+    std::shared_ptr<geometry::Image> float_image = image.CreateFloatImage(type);
+    EXPECT_EQ(float_image->width_, width);
+    EXPECT_EQ(float_image->height_, height);
+    EXPECT_EQ(float_image->num_of_channels_, 1);
+    float* float_data_ptr = reinterpret_cast<float*>(float_image->data_.data());
+    std::vector<float> float_values(float_data_ptr,
+                                    float_data_ptr + width * height);
+    ExpectEQ(float_values,
+             std::vector<float>({1.0 / 3, 1.0 / 3, 1.0 / 3, 1.0}));
 }
 
 TEST(Image, PointerAt) {
@@ -645,12 +741,6 @@ TEST(Image, FlipHorizontalImage) {
     ExpectEQ(flipped, flip_image->data_);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configurations
-// channels: bytes per channel
-// 1: 1/2/4
-// 3: 1/2/4 with either Equal or Weighted type
-// ----------------------------------------------------------------------------
 void TEST_Filter(const std::vector<uint8_t>& ref,
                  const geometry::Image::FilterType& filter) {
     geometry::Image image;
@@ -927,9 +1017,6 @@ TEST(Image, ClipIntensity) {
     ExpectEQ(ref, output->data_);
 }
 
-// ----------------------------------------------------------------------------
-// Tests one of the following configurations
-// ----------------------------------------------------------------------------
 template <typename T>
 void TEST_CreateImageFromFloatImage() {
     geometry::Image image;
@@ -959,16 +1046,10 @@ void TEST_CreateImageFromFloatImage() {
 template void TEST_CreateImageFromFloatImage<uint8_t>();
 template void TEST_CreateImageFromFloatImage<uint16_t>();
 
-// ----------------------------------------------------------------------------
-// Tests the case output image bytes_per_channel = 1.
-// ----------------------------------------------------------------------------
 TEST(Image, CreateImageFromFloatImage_8bit) {
     TEST_CreateImageFromFloatImage<uint8_t>();
 }
 
-// ----------------------------------------------------------------------------
-// Tests the case output image bytes_per_channel = 2.
-// ----------------------------------------------------------------------------
 TEST(Image, CreateImageFromFloatImage_16bit) {
     TEST_CreateImageFromFloatImage<uint16_t>();
 }

--- a/cpp/tests/geometry/RGBDImage.cpp
+++ b/cpp/tests/geometry/RGBDImage.cpp
@@ -233,9 +233,10 @@ TEST(RGBDImage, CreateFromSUNFormat) {
 }
 
 TEST(RGBDImage, CreateFromNYUFormat) {
-    // Skiped. NYU dataset is in .ppm and .pgm format and needs matplotlib's
-    // mpimg reader. Essentially, CreateFromNYUFormat is similar to other RGBD
-    // dataset loader, just with a different scaling and truncation factor.
+    GTEST_SKIP() << "NYU dataset is in .ppm and .pgm format and needs "
+                    "matplotlib's mpimg reader. CreateFromNYUFormat is similar "
+                    "to other RGBD dataset loader, just with a different "
+                    "scaling and truncation factor.";
 }
 
 template <typename T>

--- a/cpp/tests/geometry/RGBDImage.cpp
+++ b/cpp/tests/geometry/RGBDImage.cpp
@@ -238,129 +238,93 @@ TEST(RGBDImage, CreateFromNYUFormat) {
     // dataset loader, just with a different scaling and truncation factor.
 }
 
+template <typename T>
+static std::vector<T> ImageAsVector(const geometry::Image& im) {
+    const T* data_ptr = reinterpret_cast<const T*>(im.data_.data());
+    int num_elements = im.height_ * im.width_ * im.num_of_channels_;
+    std::vector<T> vals(data_ptr, data_ptr + num_elements);
+    return vals;
+}
+
 TEST(RGBDImage, FilterPyramid) {
-    std::vector<std::vector<uint8_t>> ref_color = {
-            {49,  63,  46,  63,  234, 198, 45,  63,  152, 189, 39,  63,  151,
-             141, 36,  63,  165, 233, 38,  63,  44,  66,  47,  63,  54,  137,
-             40,  63,  10,  229, 34,  63,  34,  30,  36,  63,  102, 55,  42,
-             63,  230, 110, 48,  63,  133, 79,  41,  63,  33,  69,  37,  63,
-             126, 99,  38,  63,  234, 215, 40,  63,  91,  21,  49,  63,  92,
-             34,  42,  63,  75,  230, 36,  63,  181, 45,  37,  63,  210, 213,
-             37,  63,  82,  65,  49,  63,  72,  187, 41,  63,  106, 229, 37,
-             63,  255, 106, 40,  63,  94,  171, 45,  63},
-            {159, 3, 43, 63, 135, 253, 38, 63, 128, 50, 43, 63, 2, 65, 39, 63}};
+    int width = 4;
+    int height = 4;
 
-    std::vector<std::vector<uint8_t>> ref_depth = {
-            {38,  31,  30,  58,  91,  210, 16,  58,  248, 34,  42,  58,  238,
-             234, 63,  58,  236, 245, 76,  58,  110, 243, 222, 57,  98,  12,
-             254, 57,  47,  168, 17,  58,  162, 44,  25,  58,  168, 28,  48,
-             58,  39,  160, 9,   58,  4,   196, 14,  58,  243, 74,  4,   58,
-             173, 65,  5,   58,  160, 171, 45,  58,  11,  239, 20,  58,  154,
-             141, 11,  58,  214, 133, 248, 57,  250, 97,  243, 57,  128, 174,
-             11,  58,  56,  200, 138, 57,  214, 164, 156, 57,  33,  250, 200,
-             57,  206, 160, 238, 57,  123, 32,  188, 57},
-            {196, 181, 8, 58, 174, 43, 22, 58, 190, 83, 23, 58, 152, 174, 7,
-             58}};
+    geometry::Image im_color;
+    im_color.Prepare(width, height, 3, 4);
+    float* im_color_data = reinterpret_cast<float*>(im_color.data_.data());
+    std::vector<float> im_color_val{
+            0.0, 0.0, 0.0, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3,
+            0.4, 0.4, 0.4, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, 0.7, 0.7, 0.7,
+            0.8, 0.8, 0.8, 0.9, 0.9, 0.9, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1,
+            1.2, 1.2, 1.2, 1.3, 1.3, 1.3, 1.4, 1.4, 1.4, 1.5, 1.5, 1.5};
+    std::copy(im_color_val.begin(), im_color_val.end(), im_color_data);
 
-    geometry::Image depth;
-    geometry::Image color;
+    geometry::Image im_depth;
+    im_depth.Prepare(width, height, 1, 2);
+    uint16_t* im_depth_data =
+            reinterpret_cast<uint16_t*>(im_depth.data_.data());
+    std::vector<uint16_t> im_depth_val{0, 1, 2,  3,  4,  5,  6,  7,
+                                       8, 9, 10, 11, 12, 13, 14, 15};
+    std::copy(im_depth_val.begin(), im_depth_val.end(), im_depth_data);
 
-    const int size = 5;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromColorAndDepth(im_color, im_depth, 1,
+                                                         1000, true);
+    geometry::RGBDImagePyramid pyramid = im_rgbd->CreatePyramid(2, false);
+    geometry::RGBDImagePyramid pyramid_filtered =
+            geometry::RGBDImage::FilterPyramid(
+                    pyramid, geometry::Image::FilterType::Sobel3Dx);
 
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    size_t num_of_levels = 2;
-    auto rgbd_image =
-            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
-    auto pyramid = rgbd_image->CreatePyramid(num_of_levels);
-    auto filtered = geometry::RGBDImage::FilterPyramid(
-            pyramid, geometry::Image::FilterType::Gaussian3);
-
-    for (size_t j = 0; j < num_of_levels; j++) {
-        ExpectEQ(ref_color[j], filtered[j]->color_.data_);
-        ExpectEQ(ref_depth[j], filtered[j]->depth_.data_);
-    }
+    ExpectEQ(ImageAsVector<float>(pyramid_filtered[0]->color_),
+             std::vector<float>({0.4, 0.8, 0.8, 0.4, 0.4, 0.8, 0.8, 0.4, 0.4,
+                                 0.8, 0.8, 0.4, 0.4, 0.8, 0.8, 0.4}));
+    ExpectEQ(ImageAsVector<float>(pyramid_filtered[0]->depth_),
+             std::vector<float>(
+                     {4, 8, 8, 4, 4, 8, 8, 4, 4, 8, 8, 4, 4, 8, 8, 4}));
+    ExpectEQ(ImageAsVector<float>(pyramid_filtered[1]->color_),
+             std::vector<float>({0.8, 0.8, 0.8, 0.8}));
+    ExpectEQ(ImageAsVector<float>(pyramid_filtered[1]->depth_),
+             std::vector<float>({8, 8, 8, 8}));
 }
 
 TEST(RGBDImage, CreatePyramid) {
-    std::vector<std::vector<uint8_t>> ref_color = {
-            {216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-             72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-             30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-             63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-             19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-             185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-             21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-             63,  207, 89,  38,  63,  56,  66,  57,  63},
-            {96, 244, 44, 63, 151, 211, 36, 63, 137, 61, 45, 63, 40, 111, 37,
-             63}};
+    int width = 4;
+    int height = 4;
 
-    std::vector<std::vector<uint8_t>> ref_depth = {
-            {208, 254, 91,  58,  103, 154, 205, 57,  59,  147, 76,  58,  236,
-             175, 80,  58,  232, 127, 110, 58,  103, 154, 77,  57,  62,  195,
-             174, 57,  139, 118, 72,  58,  22,  236, 143, 57,  66,  243, 16,
-             58,  161, 199, 248, 57,  134, 123, 36,  58,  255, 53,  191, 57,
-             93,  164, 5,   58,  161, 199, 120, 58,  20,  135, 111, 58,  222,
-             137, 38,  58,  79,  25,  59,  58,  198, 8,   20,  57,  126, 80,
-             30,  58,  5,   150, 131, 55,  249, 213, 122, 57,  101, 207, 11,
-             57,  68,  190, 82,  58,  214, 94,  32,  57},
-            {30, 202, 230, 57, 240, 107, 43, 58, 18, 188, 45, 58, 111, 173, 226,
-             57}};
+    geometry::Image im_color;
+    im_color.Prepare(width, height, 3, 4);
+    float* im_color_data = reinterpret_cast<float*>(im_color.data_.data());
+    std::vector<float> im_color_val{
+            0.0, 0.0, 0.0, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3,
+            0.4, 0.4, 0.4, 0.5, 0.5, 0.5, 0.6, 0.6, 0.6, 0.7, 0.7, 0.7,
+            0.8, 0.8, 0.8, 0.9, 0.9, 0.9, 1.0, 1.0, 1.0, 1.1, 1.1, 1.1,
+            1.2, 1.2, 1.2, 1.3, 1.3, 1.3, 1.4, 1.4, 1.4, 1.5, 1.5, 1.5};
+    std::copy(im_color_val.begin(), im_color_val.end(), im_color_data);
 
-    geometry::Image depth;
-    geometry::Image color;
+    geometry::Image im_depth;
+    im_depth.Prepare(width, height, 1, 2);
+    uint16_t* im_depth_data =
+            reinterpret_cast<uint16_t*>(im_depth.data_.data());
+    std::vector<uint16_t> im_depth_val{0, 1, 2,  3,  4,  5,  6,  7,
+                                       8, 9, 10, 11, 12, 13, 14, 15};
+    std::copy(im_depth_val.begin(), im_depth_val.end(), im_depth_data);
 
-    const int size = 5;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromColorAndDepth(im_color, im_depth, 1,
+                                                         1000, true);
+    geometry::RGBDImagePyramid pyramid = im_rgbd->CreatePyramid(2, false);
 
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    size_t num_of_levels = 2;
-    auto rgbd_image =
-            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
-    auto pyramid = rgbd_image->CreatePyramid(num_of_levels);
-
-    for (size_t j = 0; j < num_of_levels; j++) {
-        EXPECT_EQ(ref_color[j], pyramid[j]->color_.data_);
-        EXPECT_EQ(ref_depth[j], pyramid[j]->depth_.data_);
-    }
+    ExpectEQ(ImageAsVector<float>(pyramid[0]->color_),
+             std::vector<float>({0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8,
+                                 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5}));
+    ExpectEQ(ImageAsVector<float>(pyramid[0]->depth_),
+             std::vector<float>(
+                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
+    ExpectEQ(ImageAsVector<float>(pyramid[1]->color_),
+             std::vector<float>({0.25, 0.45, 1.05, 1.25}));
+    ExpectEQ(ImageAsVector<float>(pyramid[1]->depth_),
+             std::vector<float>({2.5, 4.5, 10.5, 12.5}));
 }
 
 }  // namespace tests

--- a/cpp/tests/geometry/RGBDImage.cpp
+++ b/cpp/tests/geometry/RGBDImage.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "open3d/geometry/Image.h"
+#include "open3d/io/ImageIO.h"
 #include "tests/UnitTest.h"
 
 namespace open3d {
@@ -70,271 +71,171 @@ TEST(RGBDImage, Constructor) {
 
 TEST(RGBDImage, DISABLED_MemberData) { NotImplemented(); }
 
+std::pair<float, float> FloatImageMinMax(const geometry::Image& im) {
+    if (im.bytes_per_channel_ != 4) {
+        utility::LogError("im must be a float image.");
+    }
+    if (im.width_ * im.height_ == 0) {
+        return std::make_pair(0.0, 0.0);
+    }
+    const float* float_data = reinterpret_cast<const float*>(im.data_.data());
+    float min_val = float_data[0];
+    float max_val = float_data[0];
+    for (int i = 0; i < im.width_ * im.height_ * im.num_of_channels_; i++) {
+        min_val = std::min(float_data[i], min_val);
+        max_val = std::max(float_data[i], max_val);
+    }
+    return std::make_pair(min_val, max_val);
+}
+
 TEST(RGBDImage, CreateFromColorAndDepth) {
-    std::vector<uint8_t> ref_color = {
-            216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-            72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-            30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-            63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-            19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-            185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-            21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-            63,  207, 89,  38,  63,  56,  66,  57,  63};
+    geometry::Image im_color;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/color/00000.jpg", im_color));
+    EXPECT_EQ(im_color.num_of_channels_, 3);
+    EXPECT_EQ(im_color.bytes_per_channel_, 1);
 
-    std::vector<uint8_t> ref_depth = {
-            208, 254, 91,  58,  103, 154, 205, 57,  59,  147, 76,  58,  236,
-            175, 80,  58,  232, 127, 110, 58,  103, 154, 77,  57,  62,  195,
-            174, 57,  139, 118, 72,  58,  22,  236, 143, 57,  66,  243, 16,
-            58,  161, 199, 248, 57,  134, 123, 36,  58,  255, 53,  191, 57,
-            93,  164, 5,   58,  161, 199, 120, 58,  20,  135, 111, 58,  222,
-            137, 38,  58,  79,  25,  59,  58,  198, 8,   20,  57,  126, 80,
-            30,  58,  5,   150, 131, 55,  249, 213, 122, 57,  101, 207, 11,
-            57,  68,  190, 82,  58,  214, 94,  32,  57};
+    geometry::Image im_depth;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/depth/00000.png", im_depth));
+    EXPECT_EQ(im_depth.num_of_channels_, 1);
+    EXPECT_EQ(im_depth.bytes_per_channel_, 2);
 
-    geometry::Image depth;
-    geometry::Image color;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromColorAndDepth(im_color, im_depth);
+    EXPECT_EQ(im_rgbd->color_.width_, 640);
+    EXPECT_EQ(im_rgbd->color_.height_, 480);
+    EXPECT_EQ(im_rgbd->color_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->color_.bytes_per_channel_, 4);
+    EXPECT_EQ(im_rgbd->depth_.width_, 640);
+    EXPECT_EQ(im_rgbd->depth_.height_, 480);
+    EXPECT_EQ(im_rgbd->depth_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->depth_.bytes_per_channel_, 4);
 
-    const int size = 5;
-
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    auto rgbd_image =
-            geometry::RGBDImage::CreateFromColorAndDepth(color, depth);
-
-    ExpectEQ(ref_color, rgbd_image->color_.data_);
-    ExpectEQ(ref_depth, rgbd_image->depth_.data_);
+    // Check data scale and truncation. These values are determined by inputs.
+    float min_val;
+    float max_val;
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->color_);
+    EXPECT_FLOAT_EQ(min_val, 0.008207843);
+    EXPECT_FLOAT_EQ(max_val, 1.0);
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->depth_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 2.702);
 }
 
 TEST(RGBDImage, CreateFromRedwoodFormat) {
-    std::vector<uint8_t> ref_color = {
-            216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-            72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-            30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-            63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-            19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-            185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-            21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-            63,  207, 89,  38,  63,  56,  66,  57,  63};
+    geometry::Image im_color;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/color/00000.jpg", im_color));
+    EXPECT_EQ(im_color.num_of_channels_, 3);
+    EXPECT_EQ(im_color.bytes_per_channel_, 1);
 
-    std::vector<uint8_t> ref_depth = {
-            208, 254, 91,  58,  103, 154, 205, 57,  59,  147, 76,  58,  236,
-            175, 80,  58,  232, 127, 110, 58,  103, 154, 77,  57,  62,  195,
-            174, 57,  139, 118, 72,  58,  22,  236, 143, 57,  66,  243, 16,
-            58,  161, 199, 248, 57,  134, 123, 36,  58,  255, 53,  191, 57,
-            93,  164, 5,   58,  161, 199, 120, 58,  20,  135, 111, 58,  222,
-            137, 38,  58,  79,  25,  59,  58,  198, 8,   20,  57,  126, 80,
-            30,  58,  5,   150, 131, 55,  249, 213, 122, 57,  101, 207, 11,
-            57,  68,  190, 82,  58,  214, 94,  32,  57};
+    geometry::Image im_depth;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/depth/00000.png", im_depth));
+    EXPECT_EQ(im_depth.num_of_channels_, 1);
+    EXPECT_EQ(im_depth.bytes_per_channel_, 2);
 
-    geometry::Image depth;
-    geometry::Image color;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromRedwoodFormat(im_color, im_depth);
+    EXPECT_EQ(im_rgbd->color_.width_, 640);
+    EXPECT_EQ(im_rgbd->color_.height_, 480);
+    EXPECT_EQ(im_rgbd->color_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->color_.bytes_per_channel_, 4);
+    EXPECT_EQ(im_rgbd->depth_.width_, 640);
+    EXPECT_EQ(im_rgbd->depth_.height_, 480);
+    EXPECT_EQ(im_rgbd->depth_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->depth_.bytes_per_channel_, 4);
 
-    const int size = 5;
-
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    auto rgbd_image =
-            geometry::RGBDImage::CreateFromRedwoodFormat(color, depth);
-
-    ExpectEQ(ref_color, rgbd_image->color_.data_);
-    ExpectEQ(ref_depth, rgbd_image->depth_.data_);
+    // Check data scale and truncation. These values are determined by inputs.
+    float min_val;
+    float max_val;
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->color_);
+    EXPECT_FLOAT_EQ(min_val, 0.008207843);
+    EXPECT_FLOAT_EQ(max_val, 1.0);
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->depth_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 2.702);
 }
 
 TEST(RGBDImage, CreateFromTUMFormat) {
-    std::vector<uint8_t> ref_color = {
-            216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-            72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-            30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-            63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-            19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-            185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-            21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-            63,  207, 89,  38,  63,  56,  66,  57,  63};
+    geometry::Image im_color;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/other_formats/TUM_color.png",
+            im_color));
+    EXPECT_EQ(im_color.num_of_channels_, 3);
+    EXPECT_EQ(im_color.bytes_per_channel_, 1);
 
-    std::vector<uint8_t> ref_depth = {
-            13,  255, 47,  57,  134, 123, 164, 56,  252, 168, 35,  57,  35,
-            243, 38,  57,  186, 204, 62,  57,  134, 123, 36,  56,  101, 207,
-            139, 56,  214, 94,  32,  57,  137, 70,  102, 56,  156, 235, 231,
-            56,  26,  6,   199, 56,  5,   150, 3,   57,  255, 247, 152, 56,
-            200, 211, 213, 56,  26,  6,   71,  57,  68,  159, 63,  57,  24,
-            59,  5,   57,  217, 173, 21,  57,  214, 218, 236, 55,  150, 77,
-            253, 56,  162, 137, 82,  54,  45,  171, 72,  56,  60,  178, 223,
-            55,  54,  152, 40,  57,  222, 75,  0,   56};
+    geometry::Image im_depth;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/other_formats/TUM_depth.png",
+            im_depth));
+    EXPECT_EQ(im_depth.num_of_channels_, 1);
+    EXPECT_EQ(im_depth.bytes_per_channel_, 2);
 
-    geometry::Image depth;
-    geometry::Image color;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromTUMFormat(im_color, im_depth);
+    EXPECT_EQ(im_rgbd->color_.width_, 640);
+    EXPECT_EQ(im_rgbd->color_.height_, 480);
+    EXPECT_EQ(im_rgbd->color_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->color_.bytes_per_channel_, 4);
+    EXPECT_EQ(im_rgbd->depth_.width_, 640);
+    EXPECT_EQ(im_rgbd->depth_.height_, 480);
+    EXPECT_EQ(im_rgbd->depth_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->depth_.bytes_per_channel_, 4);
 
-    const int size = 5;
-
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    auto rgbd_image = geometry::RGBDImage::CreateFromTUMFormat(color, depth);
-
-    ExpectEQ(ref_color, rgbd_image->color_.data_);
-    ExpectEQ(ref_depth, rgbd_image->depth_.data_);
+    // Check data scale and truncation. These values are determined by inputs.
+    float min_val;
+    float max_val;
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->color_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 0.99748623);
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->depth_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 3.994);
 }
 
 TEST(RGBDImage, CreateFromSUNFormat) {
-    std::vector<uint8_t> ref_color = {
-            216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-            72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-            30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-            63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-            19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-            185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-            21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-            63,  207, 89,  38,  63,  56,  66,  57,  63};
+    geometry::Image im_color;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/other_formats/SUN_color.jpg",
+            im_color));
+    EXPECT_EQ(im_color.num_of_channels_, 3);
+    EXPECT_EQ(im_color.bytes_per_channel_, 1);
 
-    std::vector<uint8_t> ref_depth = {
-            145, 158, 240, 194, 183, 111, 222, 2,   251, 170, 237, 226, 0,
-            0,   0,   0,   181, 238, 242, 2,   105, 13,  206, 2,   0,   0,
-            0,   0,   0,   0,   0,   0,   237, 185, 214, 130, 32,  61,  231,
-            162, 0,   0,   0,   0,   41,  174, 233, 2,   253, 240, 190, 57,
-            93,  164, 5,   58,  161, 199, 120, 58,  20,  135, 111, 58,  222,
-            137, 38,  58,  79,  25,  59,  58,  198, 8,   20,  57,  126, 80,
-            30,  58,  5,   150, 131, 55,  249, 213, 122, 57,  101, 207, 11,
-            57,  68,  190, 82,  58,  214, 94,  32,  57};
+    geometry::Image im_depth;
+    EXPECT_TRUE(io::ReadImage(
+            std::string(TEST_DATA_DIR) + "/RGBD/other_formats/SUN_depth.png",
+            im_depth));
+    EXPECT_EQ(im_depth.num_of_channels_, 1);
+    EXPECT_EQ(im_depth.bytes_per_channel_, 2);
 
-    geometry::Image depth;
-    geometry::Image color;
+    std::shared_ptr<geometry::RGBDImage> im_rgbd =
+            geometry::RGBDImage::CreateFromSUNFormat(im_color, im_depth);
+    EXPECT_EQ(im_rgbd->color_.width_, 640);
+    EXPECT_EQ(im_rgbd->color_.height_, 480);
+    EXPECT_EQ(im_rgbd->color_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->color_.bytes_per_channel_, 4);
+    EXPECT_EQ(im_rgbd->depth_.width_, 640);
+    EXPECT_EQ(im_rgbd->depth_.height_, 480);
+    EXPECT_EQ(im_rgbd->depth_.num_of_channels_, 1);
+    EXPECT_EQ(im_rgbd->depth_.bytes_per_channel_, 4);
 
-    const int size = 5;
-
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    auto rgbd_image = geometry::RGBDImage::CreateFromSUNFormat(color, depth);
-
-    ExpectEQ(ref_color, rgbd_image->color_.data_);
-    ExpectEQ(ref_depth, rgbd_image->depth_.data_);
+    // Check data scale and truncation. These values are determined by inputs.
+    float min_val;
+    float max_val;
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->color_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 1.0);
+    std::tie(min_val, max_val) = FloatImageMinMax(im_rgbd->depth_);
+    EXPECT_FLOAT_EQ(min_val, 0.0);
+    EXPECT_FLOAT_EQ(max_val, 6.889);
 }
 
 TEST(RGBDImage, CreateFromNYUFormat) {
-    std::vector<uint8_t> ref_color = {
-            216, 2,   42,  63,  21,  162, 57,  63,  62,  210, 42,  63,  216,
-            72,  38,  63,  116, 49,  38,  63,  55,  245, 52,  63,  150, 19,
-            30,  63,  123, 6,   19,  63,  193, 10,  23,  63,  83,  253, 46,
-            63,  141, 0,   52,  63,  9,   144, 38,  63,  193, 19,  55,  63,
-            19,  179, 45,  63,  56,  160, 49,  63,  26,  10,  50,  63,  121,
-            185, 46,  63,  168, 239, 16,  63,  183, 184, 35,  63,  63,  137,
-            21,  63,  135, 1,   54,  63,  220, 15,  35,  63,  177, 246, 44,
-            63,  207, 89,  38,  63,  56,  66,  57,  63};
-
-    std::vector<uint8_t> ref_depth = {
-            0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-            0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-            0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
-            0,   0,   0,   0,   0,   0,   0,   0,   0,   201, 118, 190, 57,
-            93,  164, 5,   58,  161, 199, 120, 58,  20,  135, 111, 58,  222,
-            137, 38,  58,  79,  25,  59,  58,  198, 8,   20,  57,  126, 80,
-            30,  58,  5,   150, 131, 55,  249, 213, 122, 57,  101, 207, 11,
-            57,  68,  190, 82,  58,  214, 94,  32,  57};
-
-    geometry::Image depth;
-    geometry::Image color;
-
-    const int size = 5;
-
-    // test image dimensions
-    const int depth_width = size;
-    const int depth_height = size;
-    const int depth_num_of_channels = 1;
-    const int depth_bytes_per_channel = 4;
-
-    const int color_width = size;
-    const int color_height = size;
-    const int color_num_of_channels = 3;
-    const int color_bytes_per_channel = 1;
-
-    color.Prepare(color_width, color_height, color_num_of_channels,
-                  color_bytes_per_channel);
-
-    depth.Prepare(depth_width, depth_height, depth_num_of_channels,
-                  depth_bytes_per_channel);
-
-    float* const float_data = depth.PointerAs<float>();
-    Rand(float_data, depth_width * depth_height, 0.0, 1.0, 0);
-    Rand(color.data_, 130, 200, 0);
-
-    auto rgbd_image = geometry::RGBDImage::CreateFromNYUFormat(color, depth);
-
-    ExpectEQ(ref_color, rgbd_image->color_.data_);
-    ExpectEQ(ref_depth, rgbd_image->depth_.data_);
+    // Skiped. NYU dataset is in .ppm and .pgm format and needs matplotlib's
+    // mpimg reader. Essentially, CreateFromNYUFormat is similar to other RGBD
+    // dataset loader, just with a different scaling and truncation factor.
 }
 
 TEST(RGBDImage, FilterPyramid) {


### PR DESCRIPTION
Resolving some failing tests in #2343 in ARM simulator:
```
[  FAILED  ] 11 tests, listed below:
[  FAILED  ] Image.CreateFloatImage_3_2_Weighted
[  FAILED  ] Image.CreateFloatImage_3_2_Equal
[  FAILED  ] Image.CreateFloatImage_3_4_Weighted
[  FAILED  ] Image.CreateFloatImage_3_4_Equal
[  FAILED  ] RGBDImage.CreateFromColorAndDepth
[  FAILED  ] RGBDImage.CreateFromRedwoodFormat
[  FAILED  ] RGBDImage.CreateFromTUMFormat
[  FAILED  ] RGBDImage.CreateFromSUNFormat
[  FAILED  ] RGBDImage.CreateFromNYUFormat
[  FAILED  ] RGBDImage.FilterPyramid
[  FAILED  ] RGBDImage.CreatePyramid
```

The tests are failing because we're comparing float as 4 independent bytes. Since this PR is to support #2343, only a subset of the image tests are refactored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2393)
<!-- Reviewable:end -->
