### PR TITLE
Remove unused variable from SolveJacobianSystemAndObtainExtrinsicMatrix

### DIFF
--- a/cpp/open3d/utility/Eigen.cpp
+++ b/cpp/open3d/utility/Eigen.cpp
@@ -121,9 +121,6 @@ Eigen::Vector6d TransformMatrix4dToVector6d(const Eigen::Matrix4d &input) {
 
 std::tuple<bool, Eigen::Matrix4d> SolveJacobianSystemAndObtainExtrinsicMatrix(
         const Eigen::Matrix6d &JTJ, const Eigen::Vector6d &JTr) {
-    std::vector<Eigen::Matrix4d, Matrix4d_allocator> output_matrix_array;
-    output_matrix_array.clear();
-
     bool solution_exist;
     Eigen::Vector6d x;
     std::tie(solution_exist, x) = SolveLinearSystemPSD(JTJ, -JTr);
@@ -131,9 +128,8 @@ std::tuple<bool, Eigen::Matrix4d> SolveJacobianSystemAndObtainExtrinsicMatrix(
     if (solution_exist) {
         Eigen::Matrix4d extrinsic = TransformVector6dToMatrix4d(x);
         return std::make_tuple(solution_exist, std::move(extrinsic));
-    } else {
-        return std::make_tuple(false, Eigen::Matrix4d::Identity());
     }
+    return std::make_tuple(false, Eigen::Matrix4d::Identity());
 }
 
 std::tuple<bool, std::vector<Eigen::Matrix4d, Matrix4d_allocator>>


### PR DESCRIPTION
While looking into the Eigen utilities  I found this small unused variable. Is not a big thing, but better to remove it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2398)
<!-- Reviewable:end -->
