### PR TITLE
Expose caching related functions in Python

### DIFF
--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -724,8 +724,16 @@ void SceneWidget::SetRenderQuality(Quality quality) {
         impl_->current_render_quality_ = quality;
         if (quality == Quality::FAST) {
             impl_->scene_->SetLOD(rendering::Open3DScene::LOD::FAST);
+            if (impl_->scene_caching_enabled_) {
+                impl_->scene_->GetRenderer().EnableCaching(false);
+                impl_->scene_->GetScene()->SetViewActive(impl_->view_id_, true);
+            }
         } else {
             impl_->scene_->SetLOD(rendering::Open3DScene::LOD::HIGH_DETAIL);
+            if (impl_->scene_caching_enabled_) {
+                impl_->scene_->GetRenderer().EnableCaching(true);
+                impl_->scene_->GetScene()->SetRenderOnce(impl_->view_id_);
+            }
         }
     }
 }

--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -585,6 +585,7 @@ struct SceneWidget::Impl {
     double last_fast_time_ = 0.0;
     bool frame_rect_changed_ = false;
     SceneWidget::Quality current_render_quality_ = SceneWidget::Quality::BEST;
+    bool scene_caching_enabled_ = false;
 };
 
 SceneWidget::SceneWidget() : impl_(new Impl()) {}
@@ -701,7 +702,18 @@ void SceneWidget::SetViewControls(Controls mode) {
     }
 }
 
+void SceneWidget::EnableSceneCaching(bool enable) {
+    impl_->scene_caching_enabled_ = enable;
+    if (!enable) {
+        impl_->scene_->GetRenderer().EnableCaching(false);
+        impl_->scene_->GetScene()->SetViewActive(impl_->view_id_, true);
+    }
+}
+
 void SceneWidget::ForceRedraw() {
+    // ForceRedraw only applies when scene caching is enabled
+    if (!impl_->scene_caching_enabled_) return;
+
     impl_->scene_->GetRenderer().EnableCaching(true);
     impl_->scene_->GetScene()->SetRenderOnce(impl_->view_id_);
 }

--- a/cpp/open3d/visualization/gui/SceneWidget.h
+++ b/cpp/open3d/visualization/gui/SceneWidget.h
@@ -82,6 +82,10 @@ public:
 
     rendering::View* GetRenderView() const;  // is nullptr if no scene
 
+    /// Enable (or disable) caching of scene to improve UI responsiveness when
+    /// dealing with large scenes (especially point clouds)
+    void EnableSceneCaching(bool enable);
+
     /// Forces the scene to redraw regardless of Renderer caching
     /// settings.
     void ForceRedraw();

--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -326,14 +326,6 @@ void Open3DScene::SetLOD(LOD lod) {
         for (auto& g : geometries_) {
             SetGeometryToLOD(g.second, lod);
         }
-
-        if (lod == LOD::HIGH_DETAIL) {
-            renderer_.EnableCaching(true);
-            GetScene()->SetRenderOnce(view_);
-        } else {
-            renderer_.EnableCaching(false);
-            GetScene()->SetViewActive(view_, true);
-        }
     }
 }
 

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -623,6 +623,7 @@ void GuiVisualizer::Init() {
                 lighting.sun_dir = new_dir.normalized();
                 impl_->settings_.model_.SetCustomLighting(lighting);
             });
+    impl_->scene_wgt_->EnableSceneCaching(true);
 
     // Create light
     auto &settings = impl_->settings_;

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -758,6 +758,10 @@ void pybind_gui_classes(py::module &m) {
             .def_property(
                     "scene", &SceneWidget::GetScene, &SceneWidget::SetScene,
                     "The rendering.Open3DScene that the SceneWidget renders")
+            .def("enable_scene_caching", &SceneWidget::EnableSceneCaching,
+                 "Enable/Disable caching of scene content when the view or "
+                 "model is not changing. Scene caching can help improve UI "
+                 "responsiveness for large models and point clouds")
             .def("force_redraw", &SceneWidget::ForceRedraw,
                  "Ensures scene redraws even when scene caching is enabled.")
             .def("set_view_controls", &SceneWidget::SetViewControls,

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -758,6 +758,8 @@ void pybind_gui_classes(py::module &m) {
             .def_property(
                     "scene", &SceneWidget::GetScene, &SceneWidget::SetScene,
                     "The rendering.Open3DScene that the SceneWidget renders")
+            .def("force_redraw", &SceneWidget::ForceRedraw,
+                 "Ensures scene redraws even when scene caching is enabled.")
             .def("set_view_controls", &SceneWidget::SetViewControls,
                  "Sets mouse interaction, e.g. ROTATE_OBJ")
             .def("setup_camera", &SceneWidget::SetupCamera,


### PR DESCRIPTION
Note: with this change scene caching is disabled by default and must be enabled explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2409)
<!-- Reviewable:end -->
