### PR TITLE
Added max error threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Corrected documentation of PointCloud.h
 * Added ISS Keypoint Detector
 * Added an RPC interface for external visualizers running in a separate process
+* Added `maximum_error` parameter to `simplify_quadric_decimation`
 
 ## 0.9.0
 

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -415,8 +415,10 @@ public:
     /// \param target_number_of_triangles defines the number of triangles that
     /// the simplified mesh should have. It is not guaranteed that this number
     /// will be reached.
+    /// \param maximum_error defines the maximum error where a vertex is allowed
+    /// to be merged
     std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-            int target_number_of_triangles, float maximum_error) const;
+            int target_number_of_triangles, double maximum_error) const;
 
     /// Function to select points from \p input TriangleMesh into
     /// output TriangleMesh

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -416,7 +416,7 @@ public:
     /// the simplified mesh should have. It is not guaranteed that this number
     /// will be reached.
     std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-            int target_number_of_triangles) const;
+            int target_number_of_triangles, float maximum_error) const;
 
     /// Function to select points from \p input TriangleMesh into
     /// output TriangleMesh

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -263,7 +263,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
 }
 
 std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
-        int target_number_of_triangles, double maximum_error=std::numeric_limits<double>::infinity()) const {
+        int target_number_of_triangles,
+        double maximum_error = std::numeric_limits<double>::infinity()) const {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -263,7 +263,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
 }
 
 std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
-        int target_number_of_triangles) const {
+        int target_number_of_triangles, float maximum_error=std::numeric_limits<float>::infinity()) const {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "
@@ -394,6 +394,10 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
         int vidx0, vidx1;
         std::tie(cost, vidx0, vidx1) = queue.top();
         queue.pop();
+
+        if (cost > maximum_error) {
+            break;
+        }
 
         // test if the edge has been updated (reinserted into queue)
         Eigen::Vector2i edge(vidx0, vidx1);

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -263,7 +263,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
 }
 
 std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
-        int target_number_of_triangles, float maximum_error=std::numeric_limits<float>::infinity()) const {
+        int target_number_of_triangles, double maximum_error=std::numeric_limits<double>::infinity()) const {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -266,7 +266,7 @@ void pybind_trianglemesh(py::module &m) {
                  "Decimation by "
                  "Garland and Heckbert",
                  "target_number_of_triangles"_a,
-                 "maximum_error"_a=std::numeric_limits<double>::infinity())
+                 "maximum_error"_a = std::numeric_limits<double>::infinity())
             .def("compute_convex_hull", &TriangleMesh::ComputeConvexHull,
                  "Computes the convex hull of the triangle mesh.")
             .def("cluster_connected_triangles",
@@ -599,7 +599,7 @@ void pybind_trianglemesh(py::module &m) {
               "The number of triangles that the simplified mesh should have. "
               "It is not guaranteed that this number will be reached."},
              {"maximum_error",
-                     "The maximum error where a vertex is allowed to be merged"}});
+              "The maximum error where a vertex is allowed to be merged"}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "cluster_connected_triangles");

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -266,7 +266,7 @@ void pybind_trianglemesh(py::module &m) {
                  "Decimation by "
                  "Garland and Heckbert",
                  "target_number_of_triangles"_a,
-                 "maximum_error"_a=std::numeric_limits<float>::infinity())
+                 "maximum_error"_a=std::numeric_limits<double>::infinity())
             .def("compute_convex_hull", &TriangleMesh::ComputeConvexHull,
                  "Computes the convex hull of the triangle mesh.")
             .def("cluster_connected_triangles",
@@ -597,7 +597,9 @@ void pybind_trianglemesh(py::module &m) {
             m, "TriangleMesh", "simplify_quadric_decimation",
             {{"target_number_of_triangles",
               "The number of triangles that the simplified mesh should have. "
-              "It is not guaranteed that this number will be reached."}});
+              "It is not guaranteed that this number will be reached."},
+             {"maximum_error",
+                     "The maximum error where a vertex is allowed to be merged"}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "cluster_connected_triangles");

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -265,7 +265,8 @@ void pybind_trianglemesh(py::module &m) {
                  "Function to simplify mesh using Quadric Error Metric "
                  "Decimation by "
                  "Garland and Heckbert",
-                 "target_number_of_triangles"_a)
+                 "target_number_of_triangles"_a,
+                 "maximum_error"_a=std::numeric_limits<float>::infinity())
             .def("compute_convex_hull", &TriangleMesh::ComputeConvexHull,
                  "Computes the convex hull of the triangle mesh.")
             .def("cluster_connected_triangles",


### PR DESCRIPTION
This pull request adds a maximum error threshold to `SimplifyQuadricDecimation`. This allows a user to target a particular quality rather than only targeting a specific triangle count. For example, a user could generate two levels of detail like so:

```python
lq = mesh.simplify_quadric_decimation(2, maximum_error=1e-6)
hq = mesh.simplify_quadric_decimation(2, maximum_error=1e-10)
```

The algorithm will attempt to reduce the mesh to 2 faces, but will exit when it exceeds the specified maximum error.

Closes #1972 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2411)
<!-- Reviewable:end -->
