### PR TITLE
Fix nvidia download error

### DIFF
--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -61,11 +61,23 @@ install_cuda_toolkit() {
     fi
     options="$(echo "$@" | tr ' ' '|')"
     if [[ "with-cudnn" =~ ^($options)$ ]]; then
-        echo "Installing cuDNN ${CUDNN_VERSION} with apt ..."
-        $SUDO apt-add-repository "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"
-        $SUDO apt-get install --yes --no-install-recommends \
-            "libcudnn${CUDNN_MAJOR_VERSION}=$CUDNN_VERSION" \
-            "libcudnn${CUDNN_MAJOR_VERSION}-dev=$CUDNN_VERSION"
+        # The repository method can cause "File has unexpected size" error so
+        # we use a tar file copy approach instead. The scripts are taken from
+        # CentOS 6 nvidia-docker scripts. The CUDA version and CUDNN version
+        # should be the same as the repository method. Ref:
+        # https://gitlab.com/nvidia/container-images/cuda/-/blob/2d67fde701915bd88a15038895203c894b36d3dd/dist/10.1/centos6-x86_64/devel/cudnn7/Dockerfile#L9
+        CUDNN_DOWNLOAD_SUM=7eaec8039a2c30ab0bc758d303588767693def6bf49b22485a2c00bf2e136cb3
+        curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-x64-v7.6.5.32.tgz -O
+        echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.6.5.32.tgz" | sha256sum -c -
+        $SUDO tar --no-same-owner -xzf cudnn-10.1-linux-x64-v7.6.5.32.tgz -C /usr/local
+        rm cudnn-10.1-linux-x64-v7.6.5.32.tgz
+        $SUDO ldconfig
+        # We may revisit the repository approach in the future.
+        # echo "Installing cuDNN ${CUDNN_VERSION} with apt ..."
+        # $SUDO apt-add-repository "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"
+        # $SUDO apt-get install --yes --no-install-recommends \
+        #     "libcudnn${CUDNN_MAJOR_VERSION}=$CUDNN_VERSION" \
+        #     "libcudnn${CUDNN_MAJOR_VERSION}-dev=$CUDNN_VERSION"
     fi
     CUDA_TOOLKIT_DIR=/usr/local/cuda-${CUDA_VERSION[1]}
     [ -e /usr/local/cuda ] || $SUDO ln -s "$CUDA_TOOLKIT_DIR" /usr/local/cuda

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -66,6 +66,7 @@ install_cuda_toolkit() {
         # CentOS 6 nvidia-docker scripts. The CUDA version and CUDNN version
         # should be the same as the repository method. Ref:
         # https://gitlab.com/nvidia/container-images/cuda/-/blob/2d67fde701915bd88a15038895203c894b36d3dd/dist/10.1/centos6-x86_64/devel/cudnn7/Dockerfile#L9
+        $SUDO apt-get install --yes --no-install-recommends curl
         CUDNN_DOWNLOAD_SUM=7eaec8039a2c30ab0bc758d303588767693def6bf49b22485a2c00bf2e136cb3
         curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v7.6.5/cudnn-10.1-linux-x64-v7.6.5.32.tgz -O
         echo "$CUDNN_DOWNLOAD_SUM  cudnn-10.1-linux-x64-v7.6.5.32.tgz" | sha256sum -c -


### PR DESCRIPTION
```
E: Failed to fetch https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/Packages.gz  File has unexpected size (47871 != 49498). Mirror sync in progress? [IP: 152.195.19.142 443]
   Hashes of expected file:
    - Filesize:49498 [weak]
    - SHA256:332f3ee4e353b8a5e5a2bdd8fdbd47cf140c73822b82b328815f122e09e195a0
    - SHA1:4dc8ef9a3ee3c97b3c26d46e07fdd83997e6880b [weak]
    - MD5Sum:bbff3b9c3462257479d72521ee78ec29 [weak]
   Release file created at: Wed, 23 Sep 2020 22:09:13 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2423)
<!-- Reviewable:end -->
