### PR TITLE
Feature/dec preserve edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Corrected documentation of PointCloud.h
 * Added ISS Keypoint Detector
 * Added an RPC interface for external visualizers running in a separate process
-* Added `maximum_error` parameter to `simplify_quadric_decimation`
+* Added `maximum_error` and `boundary_weight` parameter to `simplify_quadric_decimation`
 
 ## 0.9.0
 

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -417,8 +417,9 @@ public:
     /// will be reached.
     /// \param maximum_error defines the maximum error where a vertex is allowed
     /// to be merged
+    /// \param boundary_weight a weight applied to edge vertices used to preserve boundaries
     std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-            int target_number_of_triangles, double maximum_error) const;
+            int target_number_of_triangles, double maximum_error, double boundary_weight) const;
 
     /// Function to select points from \p input TriangleMesh into
     /// output TriangleMesh

--- a/cpp/open3d/geometry/TriangleMesh.h
+++ b/cpp/open3d/geometry/TriangleMesh.h
@@ -417,9 +417,12 @@ public:
     /// will be reached.
     /// \param maximum_error defines the maximum error where a vertex is allowed
     /// to be merged
-    /// \param boundary_weight a weight applied to edge vertices used to preserve boundaries
+    /// \param boundary_weight a weight applied to edge vertices used to
+    /// preserve boundaries
     std::shared_ptr<TriangleMesh> SimplifyQuadricDecimation(
-            int target_number_of_triangles, double maximum_error, double boundary_weight) const;
+            int target_number_of_triangles,
+            double maximum_error,
+            double boundary_weight) const;
 
     /// Function to select points from \p input TriangleMesh into
     /// output TriangleMesh

--- a/cpp/open3d/geometry/TriangleMeshSimplification.cpp
+++ b/cpp/open3d/geometry/TriangleMeshSimplification.cpp
@@ -264,7 +264,8 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyVertexClustering(
 
 std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
         int target_number_of_triangles,
-        double maximum_error = std::numeric_limits<double>::infinity()) const {
+        double maximum_error = std::numeric_limits<double>::infinity(),
+        double boundary_weight = 1.0) const {
     if (HasTriangleUvs()) {
         utility::LogWarning(
                 "[SimplifyQuadricDecimation] This mesh contains triangle uvs "
@@ -317,7 +318,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SimplifyQuadricDecimation(
         const auto& vert2 = mesh->vertices_[vidx2];
         Eigen::Vector3d vert2p = (vert2 - vert0).cross(vert2 - vert1);
         Eigen::Vector4d plane = ComputeTrianglePlane(vert0, vert1, vert2p);
-        Quadric quad(plane, area);
+        Quadric quad(plane, area * boundary_weight);
         Qs[vidx0] += quad;
         Qs[vidx1] += quad;
     };

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -602,7 +602,8 @@ void pybind_trianglemesh(py::module &m) {
              {"maximum_error",
               "The maximum error where a vertex is allowed to be merged"},
              {"boundary_weight",
-                     "A weight applied to edge vertices used to preserve boundaries"}});
+              "A weight applied to edge vertices used to preserve "
+              "boundaries"}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "cluster_connected_triangles");

--- a/cpp/pybind/geometry/trianglemesh.cpp
+++ b/cpp/pybind/geometry/trianglemesh.cpp
@@ -266,7 +266,8 @@ void pybind_trianglemesh(py::module &m) {
                  "Decimation by "
                  "Garland and Heckbert",
                  "target_number_of_triangles"_a,
-                 "maximum_error"_a = std::numeric_limits<double>::infinity())
+                 "maximum_error"_a = std::numeric_limits<double>::infinity(),
+                 "boundary_weight"_a = 1.0)
             .def("compute_convex_hull", &TriangleMesh::ComputeConvexHull,
                  "Computes the convex hull of the triangle mesh.")
             .def("cluster_connected_triangles",
@@ -599,7 +600,9 @@ void pybind_trianglemesh(py::module &m) {
               "The number of triangles that the simplified mesh should have. "
               "It is not guaranteed that this number will be reached."},
              {"maximum_error",
-              "The maximum error where a vertex is allowed to be merged"}});
+              "The maximum error where a vertex is allowed to be merged"},
+             {"boundary_weight",
+                     "A weight applied to edge vertices used to preserve boundaries"}});
     docstring::ClassMethodDocInject(m, "TriangleMesh", "compute_convex_hull");
     docstring::ClassMethodDocInject(m, "TriangleMesh",
                                     "cluster_connected_triangles");


### PR DESCRIPTION
This pull request adds a `boundary_weight` parameter that can be used to preserve edge boundaries when performing `SimplifyQuadricDecimation`.

Closes #2418 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2427)
<!-- Reviewable:end -->
