### PR TITLE
Upgrade CMake requirement to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.18.0)
 # CMake 3.15+ is required to allow linking with OBJECT libraries,
 # to prevent erroneous -gencode option deduplication with CUDA,
 # and to simplify generator expressions for selecting compile flags.


### PR DESCRIPTION
On Windows, CMake has a bug: https://gitlab.kitware.com/cmake/cmake/-/issues/20236. This causes the following error with TBB according to @prewettg .

```
"MSVC_RUNTIME_LIBRARY value 'MultiThreadedDebug' not known for this ASM_MASM compiler" in the config step for ext_tbb.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2434)
<!-- Reviewable:end -->
