### PR TITLE
Rework Python API for creating windows to avoid crash on exit in some simple situations.

### DIFF
--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -253,7 +253,11 @@ void pybind_gui_classes(py::module &m) {
                         return w.get();
                     },
                     "title"_a = std::string(), "width"_a = -1, "height"_a = -1,
-                    "x"_a = -1, "y"_a = -1, "flags"_a = 0)
+                    "x"_a = -1, "y"_a = -1, "flags"_a = 0,
+                    "Creates a window and adds it to the application. "
+                    "To programmatically destroy the window do window.close()."
+                    "Usage: create_window(title, width, height, x, y, flags). "
+                    "x, y, and flags are optional.")
             .def(
                     "run",
                     [](Application &instance) {
@@ -320,7 +324,9 @@ void pybind_gui_classes(py::module &m) {
     py::class_<Window, UnownedPointer<Window>> window_base(
             m, "WindowBase", "Application window");
     py::class_<PyWindow, UnownedPointer<PyWindow>, Window> window(
-            m, "Window", "Application window");
+            m, "Window",
+            "Application window. Create with "
+            "Application.instance.create_window().");
     window.def("__repr__",
                [](const PyWindow &w) { return "Application window"; })
             .def("add_child", &PyWindow::AddChild,

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -60,6 +60,39 @@
 #include "pybind/docstring.h"
 #include "pybind11/functional.h"
 
+// We cannot give out a shared_ptr to objects like Window which reference
+// Filament objects, because we cannot guarantee that the Python script is
+// not holding on to a reference when we cleanup Filament. The Open3D library
+// will clear its shared_ptrs expecting the dependent object(s) to clean up,
+// but they won't because Python still has a shared_ptr, leading to a crash
+// when the variable goes of scope on the Python side.
+// The following would crash gui.Window's holder is std::shared_ptr:
+//   import open3d.visualization.gui as gui
+//   def main():
+//       gui.Application.instance.initialize()
+//       w = gui.Application.instance.create_window("Crash", 640, 480)
+//       gui.Application.instance.run()
+//   if __name__ == "__main__":
+//       main()
+// However, if remove the 'w = ' part, it would not crash.
+template<typename T>
+class UnownedPointer {
+public:
+    UnownedPointer() : ptr_(nullptr) {}
+    explicit UnownedPointer(T* p) : ptr_(p) {}
+    ~UnownedPointer() {}  // don't delete!
+
+    T* get() { return ptr_; }
+    T& operator*() { return *ptr_; }
+    T* operator->() { return ptr_; }
+    void reset() { ptr_ = nullptr; }  // don't delete!
+
+private:
+    T *ptr_;
+};
+PYBIND11_DECLARE_HOLDER_TYPE(T, UnownedPointer<T>);
+
+
 namespace open3d {
 namespace visualization {
 namespace gui {
@@ -204,6 +237,23 @@ void pybind_gui_classes(py::module &m) {
                     "provided by the caller. One of the `initialize` functions "
                     "_must_ be called prior to using anything in the gui "
                     "module")
+            .def("create_window",
+                 [](Application &instance, const std::string &title,
+                    int width, int height, int x, int y, int flags) {
+                     std::shared_ptr<PyWindow> w;
+                     if (x < 0 && y < 0 && width < 0 && height < 0) {
+                         w.reset(new PyWindow(title, flags));
+                     } else if (x < 0 && y < 0) {
+                         w.reset(new PyWindow(title, width, height, flags));
+                     } else {
+                         w.reset(new PyWindow(title, x, y, width, height,
+                                              flags));
+                     }
+                     instance.AddWindow(w);
+                     return w.get();
+                 },
+                 "title"_a = std::string(), "width"_a = -1, "height"_a = -1,
+                 "x"_a = -1, "y"_a = -1, "flags"_a = 0)
             .def(
                     "run",
                     [](Application &instance) {
@@ -257,11 +307,7 @@ void pybind_gui_classes(py::module &m) {
             .def_property("menubar", &Application::GetMenubar,
                           &Application::SetMenubar,
                           "The Menu for the application (initially None)")
-            .def("add_window", &Application::AddWindow,
-                 "Adds the window to the application")
-            .def("remove_window", &Application::AddWindow,
-                 "Removes the window from the application, closing it. If "
-                 "there are no open windows left the event loop will exit.")
+            // Note: we cannot export AddWindow and RemoveWindow
             .def_property_readonly("resource_path",
                                    &Application::GetResourcePath,
                                    "Returns a string with the path to the "
@@ -269,24 +315,13 @@ void pybind_gui_classes(py::module &m) {
 
     // ---- Window ----
     // Pybind appears to need to know about the base class. It doesn't have
-    // to be named the same as the C++ class, though.
-    py::class_<Window, std::shared_ptr<Window>> window_base(
+    // to be named the same as the C++ class, though. The holder object cannot
+    // be a shared_ptr or we can crash (see comment for UnownedPointer).
+    py::class_<Window, UnownedPointer<Window>> window_base(
             m, "WindowBase", "Application window");
-    py::class_<PyWindow, std::shared_ptr<PyWindow>, Window> window(
+    py::class_<PyWindow, UnownedPointer<PyWindow>, Window> window(
             m, "Window", "Application window");
-    window.def(py::init([](const std::string &title, int width, int height,
-                           int x, int y, int flags) {
-                   if (x < 0 && y < 0 && width < 0 && height < 0) {
-                       return new PyWindow(title, flags);
-                   } else if (x < 0 && y < 0) {
-                       return new PyWindow(title, width, height, flags);
-                   } else {
-                       return new PyWindow(title, x, y, width, height, flags);
-                   }
-               }),
-               "title"_a = std::string(), "width"_a = -1, "height"_a = -1,
-               "x"_a = -1, "y"_a = -1, "flags"_a = 0)
-            .def("__repr__",
+    window.def("__repr__",
                  [](const PyWindow &w) { return "Application window"; })
             .def("add_child", &PyWindow::AddChild,
                  "Adds a widget to the window")

--- a/docs/versions.js
+++ b/docs/versions.js
@@ -22,10 +22,6 @@ document.write('\
             <td><a href="http://www.open3d.org/docs/release/cpp_api">0.11.0 C++</a></td>\
         </tr>\
         <tr>\
-            <td><a href="http://www.open3d.org/docs/0.10.1">0.10.1</a></td>\
-            <td><a href="http://www.open3d.org/docs/0.10.1/cpp_api">0.10.1 C++</a></td>\
-        </tr>\
-        <tr>\
             <td><a href="http://www.open3d.org/docs/0.10.0">0.10.0</a></td>\
             <td><a href="http://www.open3d.org/docs/0.10.0/cpp_api">0.10.0 C++</a></td>\
         </tr>\

--- a/examples/python/gui/all-widgets.py
+++ b/examples/python/gui/all-widgets.py
@@ -11,9 +11,10 @@ class ExampleWindow:
     MENU_QUIT = 3
 
     def __init__(self):
-        self.window = gui.Window("Test")
-        # self.window = gui.Window("Test", 640, 480)
-        # self.window = gui.Window("Test", 640, 480, x=50, y=100)
+        self.window = gui.Application.instance.create_window("Test")
+#        self.window = gui.Application.instance.create_window("Test", 400, 768)
+#        self.window = gui.Application.instance.create_window("Test", 400, 768,
+#                                                             x=50, y=100)
         w = self.window  # for more concise code
 
         # Rather than specifying sizes in pixels, which may vary in size based
@@ -383,7 +384,6 @@ def main():
     gui.Application.instance.initialize()
 
     w = ExampleWindow()
-    gui.Application.instance.add_window(w.window)  # make the window visible
 
     # Run the event loop. This will not return until the last window is closed.
     gui.Application.instance.run()

--- a/examples/python/gui/all-widgets.py
+++ b/examples/python/gui/all-widgets.py
@@ -11,8 +11,7 @@ class ExampleWindow:
     MENU_QUIT = 3
 
     def __init__(self):
-        self.window = gui.Application.instance.create_window("Test")
-#        self.window = gui.Application.instance.create_window("Test", 400, 768)
+        self.window = gui.Application.instance.create_window("Test", 400, 768)
 #        self.window = gui.Application.instance.create_window("Test", 400, 768,
 #                                                             x=50, y=100)
         w = self.window  # for more concise code

--- a/examples/python/gui/vis-gui.py
+++ b/examples/python/gui/vis-gui.py
@@ -197,7 +197,8 @@ class AppWindow:
         resource_path = gui.Application.instance.resource_path
         self.settings.new_ibl_name = resource_path + "/" + AppWindow.DEFAULT_IBL
 
-        self.window = gui.Window("Open3D", width, height)
+        self.window = gui.Application.instance.create_window("Open3D", width,
+                                                             height)
         w = self.window  # to make the code more concise
 
         # 3D widget
@@ -761,9 +762,6 @@ def main():
     gui.Application.instance.initialize()
 
     w = AppWindow(1024, 768)
-
-    # Add the window to the applicaiton, which will make it visible
-    gui.Application.instance.add_window(w.window)
 
     if len(sys.argv) > 1:
         path = sys.argv[1]


### PR DESCRIPTION
In particular:
```
def main():
    gui.Application.instance.inititalize()
    w = Window("Crash")
    gui.Application.instance.add_window(w)
    gui.Application.instance.run()  # C++ cleans up filament, but Python still has a shared_ptr ref in w
    # crash here, Python, frees its pointer, Window's refcount goes to zero, but the filament object it references is destroyed
if __name__ == "__main__":
   main()
```
This also prevents Python users from forgetting to call add_window() which would lead to problems with layouts. And it should have the side-effect of preventing crash-on-exit if the Python script exits prematurely after the window is created due to an exception.

The API has been changed. The above code should be:
```
def main():
    gui.Application.instance.inititalize()
    w = gui.Application.instance.create_window("No crash")
    gui.Application.instance.run()
if __name__ == "__main__":
   main()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2485)
<!-- Reviewable:end -->
