### PR TITLE
Removed shared_ptr as the pybind holder of GUI objects to prevent crashes caused by Python keeping the object alive after Filament resources are destroyed on the Python side.

### DIFF
--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -92,9 +92,15 @@ private:
 };
 PYBIND11_DECLARE_HOLDER_TYPE(T, UnownedPointer<T>);
 
+
 namespace open3d {
 namespace visualization {
 namespace gui {
+
+template<typename T>
+std::shared_ptr<T> TakeOwnership(UnownedPointer<T> x) {
+    return std::shared_ptr<T>(x.get());
+}
 
 class PythonUnlocker : public Application::EnvUnlocker {
 public:
@@ -258,11 +264,21 @@ void pybind_gui_classes(py::module &m) {
                     "To programmatically destroy the window do window.close()."
                     "Usage: create_window(title, width, height, x, y, flags). "
                     "x, y, and flags are optional.")
+            // We need to tell RunOneTick() not to cleanup. Run() and
+            // RunOneTick() assume a C++ desktop application approach of
+            // init -> run -> cleanup. More problematic for us is that Filament
+            // crashes if we don't cleanup. Also, we don't want to force Python
+            // script writers to remember to cleanup; this is Python, not C++
+            // where you expect to need to thinking about cleanup up after
+            // yourself. So as a Python-script-app, the cleanup happens atexit.
+            // (Init is still required of the script writer.) This means that
+            // run() should NOT cleanup, as it might be called several times
+            // to run a UI to visualize the result of a computation.
             .def(
                     "run",
                     [](Application &instance) {
                         PythonUnlocker unlocker;
-                        while (instance.RunOneTick(unlocker)) {
+                        while (instance.RunOneTick(unlocker, false)) {
                             // Enable Ctrl-C to kill Python
                             if (PyErr_CheckSignals() != 0) {
                                 throw py::error_already_set();
@@ -277,7 +293,7 @@ void pybind_gui_classes(py::module &m) {
                     "run_one_tick",
                     [](Application &instance) {
                         PythonUnlocker unlocker;
-                        auto result = instance.RunOneTick(unlocker);
+                        auto result = instance.RunOneTick(unlocker, false);
                         // Enable Ctrl-C to kill Python
                         if (PyErr_CheckSignals() != 0) {
                             throw py::error_already_set();
@@ -285,7 +301,8 @@ void pybind_gui_classes(py::module &m) {
                         return result;
                     },
                     "Runs the event loop once, returns True if the app is "
-                    "still running, or False if all the windows have closed.")
+                    "still running, or False if all the windows have closed "
+                    "or quit() has been called.")
             .def(
                     "render_to_image",
                     [](Application &instance, rendering::Open3DScene *scene,
@@ -329,7 +346,10 @@ void pybind_gui_classes(py::module &m) {
             "Application.instance.create_window().");
     window.def("__repr__",
                [](const PyWindow &w) { return "Application window"; })
-            .def("add_child", &PyWindow::AddChild,
+            .def("add_child", 
+                 [](PyWindow &w, UnownedPointer<Widget> widget) {
+                     w.AddChild(TakeOwnership<Widget>(widget));
+                 },
                  "Adds a widget to the window")
             .def_property("os_frame", &PyWindow::GetOSFrame,
                           &PyWindow::SetOSFrame,
@@ -381,7 +401,10 @@ void pybind_gui_classes(py::module &m) {
                     "children of the window")
             .def_property_readonly("theme", &PyWindow::GetTheme,
                                    "Get's window's theme info")
-            .def("show_dialog", &PyWindow::ShowDialog, "Displays the dialog")
+            .def("show_dialog",
+                 [](PyWindow &w, UnownedPointer<Dialog> dlg) {
+                     w.ShowDialog(TakeOwnership<Dialog>(dlg));
+                 }, "Displays the dialog")
             .def("close_dialog", &PyWindow::CloseDialog,
                  "Closes the current dialog")
             .def("show_message_box", &PyWindow::ShowMessageBox,
@@ -392,45 +415,44 @@ void pybind_gui_classes(py::module &m) {
                     "Gets the rendering.Renderer object for the Window");
 
     // ---- Menu ----
-    py::class_<Menu, std::shared_ptr<Menu>> menu(
+    py::class_<Menu, UnownedPointer<Menu>> menu(
             m, "Menu", "A menu, possibly a menu tree");
     menu.def(py::init<>())
             .def(
                     "add_item",
-                    [](std::shared_ptr<Menu> menu, const char *text,
+                    [](UnownedPointer<Menu> menu, const char *text,
                        int item_id) { menu->AddItem(text, item_id); },
                     "Adds a menu item with id to the menu")
             .def(
                     "add_menu",
-                    [](std::shared_ptr<Menu> menu, const char *text,
-                       std::shared_ptr<Menu> submenu) {
-                        menu->AddMenu(text, submenu);
+                    [](UnownedPointer<Menu> menu, const char *text,
+                       UnownedPointer<Menu> submenu) {
+                        menu->AddMenu(text, TakeOwnership<Menu>(submenu));
                     },
                     "Adds a submenu to the menu")
             .def("add_separator", &Menu::AddSeparator,
                  "Adds a separator to the menu")
             .def(
                     "set_enabled",
-                    [](std::shared_ptr<Menu> menu, int item_id, bool enabled) {
+                    [](UnownedPointer<Menu> menu, int item_id, bool enabled) {
                         menu->SetEnabled(item_id, enabled);
                     },
                     "Sets menu item enabled or disabled")
             .def(
                     "is_checked",
-                    [](std::shared_ptr<Menu> menu, int item_id) -> bool {
+                    [](UnownedPointer<Menu> menu, int item_id) -> bool {
                         return menu->IsChecked(item_id);
                     },
                     "Returns True if menu item is checked")
             .def(
                     "set_checked",
-                    [](std::shared_ptr<Menu> menu, int item_id, bool checked) {
+                    [](UnownedPointer<Menu> menu, int item_id, bool checked) {
                         menu->SetChecked(item_id, checked);
                     },
                     "Sets menu item (un)checked");
 
     // ---- Color ----
-    py::class_<Color, std::shared_ptr<Color>> color(
-            m, "Color", "Stores color for gui classes");
+    py::class_<Color> color(m, "Color", "Stores color for gui classes");
     color.def(py::init([](float r, float g, float b, float a) {
                   return new Color(r, g, b, a);
               }),
@@ -458,10 +480,9 @@ void pybind_gui_classes(py::module &m) {
 
     // ---- Theme ----
     // Note: no constructor because themes are created by Open3D
-    py::class_<Theme, std::shared_ptr<Theme>> theme(m, "Theme",
-                                                    "Theme parameters such as "
-                                                    "colors used for drawing "
-                                                    "widgets (read-only)");
+    py::class_<Theme> theme(m, "Theme",
+                            "Theme parameters such as colors used for drawing "
+                            "widgets (read-only)");
     theme.def_readonly("font_size", &Theme::font_size,
                        "Font size (which is also the conventional size of the "
                        "em unit) (read-only)")
@@ -514,8 +535,16 @@ void pybind_gui_classes(py::module &m) {
             .def_readwrite("height", &Size::height);
 
     // ---- Widget ----
-    py::class_<Widget, std::shared_ptr<Widget>> widget(m, "Widget",
-                                                       "Base widget class");
+    // The holder for Widget and all derived classes is UnownedPointer because
+    // a Widget may own Filament resources, so we cannot have Python holding
+    // on to a shared_ptr after we cleanup Filament. The object is initially
+    // "leaked" (as in, Python will not clean it up), but it will be claimed
+    // by the object it is added to. There are two consequences to this:
+    //  1) adding an object to multiple objects will cause multiple shared_ptrs
+    //     to think they own it, leading to a double-free and crash, and
+    //  2) if the object is never added, the memory will be leaked.
+    py::class_<Widget, UnownedPointer<Widget>> widget(m, "Widget",
+                                                      "Base widget class");
     widget.def(py::init<>())
             .def("__repr__",
                  [](const Widget &w) {
@@ -525,7 +554,11 @@ void pybind_gui_classes(py::module &m) {
                        << w.GetFrame().height;
                      return s.str();
                  })
-            .def("add_child", &Widget::AddChild, "Adds a child widget")
+            .def("add_child",
+                 [](Widget &w, UnownedPointer<Widget> child) {
+                     w.AddChild(TakeOwnership<Widget>(child));
+                 },
+                 "Adds a child widget")
             .def("get_children", &Widget::GetChildren,
                  "Returns the array of children. Do not modify.")
             .def_property("frame", &Widget::GetFrame, &Widget::SetFrame,
@@ -543,8 +576,8 @@ void pybind_gui_classes(py::module &m) {
                  "properly");
 
     // ---- Button ----
-    py::class_<Button, std::shared_ptr<Button>, Widget> button(m, "Button",
-                                                               "Button");
+    py::class_<Button, UnownedPointer<Button>, Widget> button(m, "Button",
+                                                              "Button");
     button.def(py::init<const char *>(), "Creates a button with the given text")
             .def("__repr__",
                  [](const Button &b) {
@@ -570,7 +603,7 @@ void pybind_gui_classes(py::module &m) {
             // a py::object and cast it ourselves.
             .def_property(
                     "horizontal_padding_em", &Button::GetHorizontalPaddingEm,
-                    [](std::shared_ptr<Button> b, const py::object &em) {
+                    [](UnownedPointer<Button> b, const py::object &em) {
                         auto vert = b->GetVerticalPaddingEm();
                         try {
                             b->SetPaddingEm(em.cast<float>(), vert);
@@ -584,7 +617,7 @@ void pybind_gui_classes(py::module &m) {
                     "Horizontal padding in em units")
             .def_property(
                     "vertical_padding_em", &Button::GetVerticalPaddingEm,
-                    [](std::shared_ptr<Button> b, const py::object &em) {
+                    [](UnownedPointer<Button> b, const py::object &em) {
                         auto horiz = b->GetHorizontalPaddingEm();
                         try {
                             b->SetPaddingEm(horiz, em.cast<float>());
@@ -600,7 +633,7 @@ void pybind_gui_classes(py::module &m) {
                  "Calls passed function when button is pressed");
 
     // ---- Checkbox ----
-    py::class_<Checkbox, std::shared_ptr<Checkbox>, Widget> checkbox(
+    py::class_<Checkbox, UnownedPointer<Checkbox>, Widget> checkbox(
             m, "Checkbox", "Checkbox");
     checkbox.def(py::init<const char *>(),
                  "Creates a checkbox with the given text")
@@ -619,7 +652,7 @@ void pybind_gui_classes(py::module &m) {
                  "Calls passed function when checkbox changes state");
 
     // ---- ColorEdit ----
-    py::class_<ColorEdit, std::shared_ptr<ColorEdit>, Widget> coloredit(
+    py::class_<ColorEdit, UnownedPointer<ColorEdit>, Widget> coloredit(
             m, "ColorEdit", "Color picker");
     coloredit.def(py::init<>())
             .def("__repr__",
@@ -641,7 +674,7 @@ void pybind_gui_classes(py::module &m) {
                  "Calls f(Color) when color changes by user input");
 
     // ---- Combobox ----
-    py::class_<Combobox, std::shared_ptr<Combobox>, Widget> combobox(
+    py::class_<Combobox, UnownedPointer<Combobox>, Widget> combobox(
             m, "Combobox", "Exclusive selection from a pull-down menu");
     combobox.def(py::init<>(),
                  "Creates an empty combobox. Use add_item() to add items")
@@ -679,7 +712,7 @@ void pybind_gui_classes(py::module &m) {
                  "respectively");
 
     // ---- ImageLabel ----
-    py::class_<ImageLabel, std::shared_ptr<ImageLabel>, Widget> imagelabel(
+    py::class_<ImageLabel, UnownedPointer<ImageLabel>, Widget> imagelabel(
             m, "ImageLabel", "Displays a bitmap");
     imagelabel
             .def(py::init<>(
@@ -695,8 +728,8 @@ void pybind_gui_classes(py::module &m) {
     // TODO: add the other functions and UIImage?
 
     // ---- Label ----
-    py::class_<Label, std::shared_ptr<Label>, Widget> label(m, "Label",
-                                                            "Displays text");
+    py::class_<Label, UnownedPointer<Label>, Widget> label(m, "Label",
+                                                           "Displays text");
     label.def(py::init([](const char *title = "") { return new Label(title); }),
               "Creates a Label with the given text")
             .def("__repr__",
@@ -716,7 +749,7 @@ void pybind_gui_classes(py::module &m) {
                           "The color of the text (gui.Color)");
 
     // ---- ListView ----
-    py::class_<ListView, std::shared_ptr<ListView>, Widget> listview(
+    py::class_<ListView, UnownedPointer<ListView>, Widget> listview(
             m, "ListView", "Displays a list of text");
     listview.def(py::init<>(), "Creates an empty list")
             .def("__repr__",
@@ -740,7 +773,7 @@ void pybind_gui_classes(py::module &m) {
                  "selection");
 
     // ---- NumberEdit ----
-    py::class_<NumberEdit, std::shared_ptr<NumberEdit>, Widget> numedit(
+    py::class_<NumberEdit, UnownedPointer<NumberEdit>, Widget> numedit(
             m, "NumberEdit", "Allows the user to enter a number.");
     py::enum_<NumberEdit::Type> numedit_type(numedit, "Type", py::arithmetic());
     // Trick to write docs without listing the members in the enum class again.
@@ -768,7 +801,7 @@ void pybind_gui_classes(py::module &m) {
                  })
             .def_property(
                     "int_value", &NumberEdit::GetIntValue,
-                    [](std::shared_ptr<NumberEdit> ne, int val) {
+                    [](UnownedPointer<NumberEdit> ne, int val) {
                         ne->SetValue(double(val));
                     },
                     "Current value (int)")
@@ -801,7 +834,7 @@ void pybind_gui_classes(py::module &m) {
                     "Sets the preferred width of the NumberEdit");
 
     // ---- ProgressBar----
-    py::class_<ProgressBar, std::shared_ptr<ProgressBar>, Widget> progress(
+    py::class_<ProgressBar, UnownedPointer<ProgressBar>, Widget> progress(
             m, "ProgressBar", "Displays a progress bar");
     progress.def(py::init<>())
             .def("__repr__",
@@ -817,7 +850,7 @@ void pybind_gui_classes(py::module &m) {
                     "The value of the progress bar, ranges from 0.0 to 1.0");
 
     // ---- SceneWidget ----
-    py::class_<SceneWidget, std::shared_ptr<SceneWidget>, Widget> scene(
+    py::class_<SceneWidget, UnownedPointer<SceneWidget>, Widget> scene(
             m, "SceneWidget", "Displays 3D content");
     py::enum_<SceneWidget::Controls> scene_ctrl(scene, "Controls",
                                                 py::arithmetic());
@@ -859,7 +892,7 @@ void pybind_gui_classes(py::module &m) {
                  "[i, j, k] vector of the new sun direction");
 
     // ---- Slider ----
-    py::class_<Slider, std::shared_ptr<Slider>, Widget> slider(
+    py::class_<Slider, UnownedPointer<Slider>, Widget> slider(
             m, "Slider", "A slider widget for visually selecting numbers");
     py::enum_<Slider::Type> slider_type(slider, "Type", py::arithmetic());
     // Trick to write docs without listing the members in the enum class again.
@@ -887,7 +920,7 @@ void pybind_gui_classes(py::module &m) {
                  })
             .def_property(
                     "int_value", &Slider::GetIntValue,
-                    [](std::shared_ptr<Slider> ne, int val) {
+                    [](UnownedPointer<Slider> ne, int val) {
                         ne->SetValue(double(val));
                     },
                     "Slider value (int)")
@@ -908,7 +941,7 @@ void pybind_gui_classes(py::module &m) {
                  "changes widget's value");
 
     // ---- StackedWidget ----
-    py::class_<StackedWidget, std::shared_ptr<StackedWidget>, Widget> stacked(
+    py::class_<StackedWidget, UnownedPointer<StackedWidget>, Widget> stacked(
             m, "StackedWidget", "Like a TabControl but without the tabs");
     stacked.def(py::init<>())
             .def_property("selected_index", &StackedWidget::GetSelectedIndex,
@@ -916,10 +949,14 @@ void pybind_gui_classes(py::module &m) {
                           "Selects the index of the child to display");
 
     // ---- TabControl ----
-    py::class_<TabControl, std::shared_ptr<TabControl>, Widget> tabctrl(
+    py::class_<TabControl, UnownedPointer<TabControl>, Widget> tabctrl(
             m, "TabControl", "Tab control");
     tabctrl.def(py::init<>())
-            .def("add_tab", &TabControl::AddTab,
+            .def("add_tab",
+                 [](TabControl &tabs, const char* name,
+                    UnownedPointer<Widget> panel) {
+                     tabs.AddTab(name, TakeOwnership<Widget>(panel));
+                 },
                  "Adds a tab. The first parameter is the title of the tab, and "
                  "the second parameter is a widget--normally this is a "
                  "layout.")
@@ -930,7 +967,7 @@ void pybind_gui_classes(py::module &m) {
                  "different tab");
 
     // ---- TextEdit ----
-    py::class_<TextEdit, std::shared_ptr<TextEdit>, Widget> textedit(
+    py::class_<TextEdit, UnownedPointer<TextEdit>, Widget> textedit(
             m, "TextEdit", "Allows the user to enter or modify text");
     textedit.def(py::init<>(),
                  "Creates a TextEdit widget with an initial value of an empty "
@@ -958,7 +995,7 @@ void pybind_gui_classes(py::module &m) {
                  "user completes text editing");
 
     // ---- TreeView ----
-    py::class_<TreeView, std::shared_ptr<TreeView>, Widget> treeview(
+    py::class_<TreeView, UnownedPointer<TreeView>, Widget> treeview(
             m, "TreeView", "Hierarchical list");
     treeview.def(py::init<>(), "Creates an empty TreeView widget")
             .def("__repr__",
@@ -973,10 +1010,14 @@ void pybind_gui_classes(py::module &m) {
                  "Returns the root item. This item is invisible, so its child "
                  "are "
                  "the top-level items")
-            .def("add_item", &TreeView::AddItem,
+            .def("add_item",
+                 [](TreeView &tree, TreeView::ItemId parent_id,
+                    UnownedPointer<Widget> item) {
+                     return tree.AddItem(parent_id, TakeOwnership<Widget>(item));
+                 },
                  "Adds a child item to the parent. add_item(parent, widget)")
             .def("add_text_item", &TreeView::AddTextItem,
-                 "Adds a child item to the parent. add_item(parent, text)")
+                 "Adds a child item to the parent. add_text_item(parent, text)")
             .def("remove_item", &TreeView::RemoveItem,
                  "Removes an item and all its children (if any)")
             .def("clear", &TreeView::Clear, "Removes all items")
@@ -997,14 +1038,14 @@ void pybind_gui_classes(py::module &m) {
                  "changes the selection.");
 
     // ---- TreeView cells ----
-    py::class_<CheckableTextTreeCell, std::shared_ptr<CheckableTextTreeCell>,
+    py::class_<CheckableTextTreeCell, UnownedPointer<CheckableTextTreeCell>,
                Widget>
             checkable_cell(m, "CheckableTextTreeCell",
                            "TreeView cell with a checkbox and text");
     checkable_cell
             .def(py::init<>([](const char *text, bool checked,
                                std::function<void(bool)> on_toggled) {
-                     return std::make_shared<CheckableTextTreeCell>(
+                     return new CheckableTextTreeCell(
                              text, checked, on_toggled);
                  }),
                  "Creates a TreeView cell with a checkbox and text. "
@@ -1018,15 +1059,15 @@ void pybind_gui_classes(py::module &m) {
                                    "Returns the label widget "
                                    "(property is read-only)");
 
-    py::class_<LUTTreeCell, std::shared_ptr<LUTTreeCell>, Widget> lut_cell(
+    py::class_<LUTTreeCell, UnownedPointer<LUTTreeCell>, Widget> lut_cell(
             m, "LUTTreeCell",
             "TreeView cell with checkbox, text, and color edit");
     lut_cell.def(py::init<>([](const char *text, bool checked,
                                const Color &color,
                                std::function<void(bool)> on_enabled,
                                std::function<void(const Color &)> on_color) {
-                     return std::make_shared<LUTTreeCell>(text, checked, color,
-                                                          on_enabled, on_color);
+                     return new LUTTreeCell(text, checked, color,
+                                            on_enabled, on_color);
                  }),
                  "Creates a TreeView cell with a checkbox, text, and "
                  "a color editor. LUTTreeCell(text, is_checked, color, "
@@ -1044,7 +1085,7 @@ void pybind_gui_classes(py::module &m) {
                                    "Returns the ColorEdit widget "
                                    "(property is read-only)");
 
-    py::class_<ColormapTreeCell, std::shared_ptr<ColormapTreeCell>, Widget>
+    py::class_<ColormapTreeCell, UnownedPointer<ColormapTreeCell>, Widget>
             colormap_cell(m, "ColormapTreeCell",
                           "TreeView cell with a number edit and color edit");
     colormap_cell
@@ -1052,7 +1093,7 @@ void pybind_gui_classes(py::module &m) {
                                std::function<void(double)> on_value_changed,
                                std::function<void(const Color &)>
                                        on_color_changed) {
-                     return std::make_shared<ColormapTreeCell>(
+                     return new ColormapTreeCell(
                              value, color, on_value_changed, on_color_changed);
                  }),
                  "Creates a TreeView cell with a number and a color edit. "
@@ -1070,7 +1111,7 @@ void pybind_gui_classes(py::module &m) {
                                    "(property is read-only)");
 
     // ---- VectorEdit ----
-    py::class_<VectorEdit, std::shared_ptr<VectorEdit>, Widget> vectoredit(
+    py::class_<VectorEdit, UnownedPointer<VectorEdit>, Widget> vectoredit(
             m, "VectorEdit", "Allows the user to edit a 3-space vector");
     vectoredit.def(py::init<>())
             .def("__repr__",
@@ -1090,7 +1131,7 @@ void pybind_gui_classes(py::module &m) {
                  "changes the value of a component");
 
     // ---- Margins ----
-    py::class_<Margins, std::shared_ptr<Margins>> margins(
+    py::class_<Margins, UnownedPointer<Margins>> margins(
             m, "Margins", "Margins for layouts");
     margins.def(py::init([](int left, int top, int right, int bottom) {
                     return new Margins(left, top, right, bottom);
@@ -1123,7 +1164,7 @@ void pybind_gui_classes(py::module &m) {
             .def("get_vert", &Margins::GetVert);
 
     // ---- Layout1D ----
-    py::class_<Layout1D, std::shared_ptr<Layout1D>, Widget> layout1d(
+    py::class_<Layout1D, UnownedPointer<Layout1D>, Widget> layout1d(
             m, "Layout1D", "Layout base class");
     layout1d
             // TODO: write the proper constructor
@@ -1133,7 +1174,7 @@ void pybind_gui_classes(py::module &m) {
                  "Adds a fixed amount of empty space to the layout")
             .def(
                     "add_fixed",
-                    [](std::shared_ptr<Layout1D> layout, float px) {
+                    [](UnownedPointer<Layout1D> layout, float px) {
                         layout->AddFixed(int(std::round(px)));
                     },
                     "Adds a fixed amount of empty space to the layout")
@@ -1142,7 +1183,7 @@ void pybind_gui_classes(py::module &m) {
                  "extra space as there is available in the layout");
 
     // ---- Vert ----
-    py::class_<Vert, std::shared_ptr<Vert>, Layout1D> vlayout(
+    py::class_<Vert, UnownedPointer<Vert>, Layout1D> vlayout(
             m, "Vert", "Vertical layout");
     vlayout.def(py::init([](int spacing, const Margins &margins) {
                     return new Vert(spacing, margins);
@@ -1162,7 +1203,7 @@ void pybind_gui_classes(py::module &m) {
                  "is the margins. Both default to 0.");
 
     // ---- CollapsableVert ----
-    py::class_<CollapsableVert, std::shared_ptr<CollapsableVert>, Vert>
+    py::class_<CollapsableVert, UnownedPointer<CollapsableVert>, Vert>
             collapsable(m, "CollapsableVert",
                         "Vertical layout with title, whose contents are "
                         "collapsable");
@@ -1194,7 +1235,7 @@ void pybind_gui_classes(py::module &m) {
                  "window is visible");
 
     // ---- Horiz ----
-    py::class_<Horiz, std::shared_ptr<Horiz>, Layout1D> hlayout(
+    py::class_<Horiz, UnownedPointer<Horiz>, Layout1D> hlayout(
             m, "Horiz", "Horizontal layout");
     hlayout.def(py::init([](int spacing, const Margins &margins) {
                     return new Horiz(spacing, margins);
@@ -1216,7 +1257,7 @@ void pybind_gui_classes(py::module &m) {
                  "is the margins. Both default to 0.");
 
     // ---- VGrid ----
-    py::class_<VGrid, std::shared_ptr<VGrid>, Widget> vgrid(m, "VGrid",
+    py::class_<VGrid, UnownedPointer<VGrid>, Widget> vgrid(m, "VGrid",
                                                             "Gride layout");
     vgrid.def(py::init([](int n_cols, int spacing, const Margins &margins) {
                   return new VGrid(n_cols, spacing, margins);
@@ -1248,13 +1289,13 @@ void pybind_gui_classes(py::module &m) {
                                    "Returns the margins");
 
     // ---- Dialog ----
-    py::class_<Dialog, std::shared_ptr<Dialog>, Widget> dialog(m, "Dialog",
+    py::class_<Dialog, UnownedPointer<Dialog>, Widget> dialog(m, "Dialog",
                                                                "Dialog");
     dialog.def(py::init<const char *>(),
                "Creates a dialog with the given title");
 
     // ---- FileDialog ----
-    py::class_<FileDialog, std::shared_ptr<FileDialog>, Dialog> filedlg(
+    py::class_<FileDialog, UnownedPointer<FileDialog>, Dialog> filedlg(
             m, "FileDialog", "File picker dialog");
     py::enum_<FileDialog::Mode> filedlg_mode(filedlg, "Mode", py::arithmetic());
     // Trick to write docs without listing the members in the enum class again.

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -92,12 +92,11 @@ private:
 };
 PYBIND11_DECLARE_HOLDER_TYPE(T, UnownedPointer<T>);
 
-
 namespace open3d {
 namespace visualization {
 namespace gui {
 
-template<typename T>
+template <typename T>
 std::shared_ptr<T> TakeOwnership(UnownedPointer<T> x) {
     return std::shared_ptr<T>(x.get());
 }
@@ -346,11 +345,12 @@ void pybind_gui_classes(py::module &m) {
             "Application.instance.create_window().");
     window.def("__repr__",
                [](const PyWindow &w) { return "Application window"; })
-            .def("add_child", 
-                 [](PyWindow &w, UnownedPointer<Widget> widget) {
-                     w.AddChild(TakeOwnership<Widget>(widget));
-                 },
-                 "Adds a widget to the window")
+            .def(
+                    "add_child",
+                    [](PyWindow &w, UnownedPointer<Widget> widget) {
+                        w.AddChild(TakeOwnership<Widget>(widget));
+                    },
+                    "Adds a widget to the window")
             .def_property("os_frame", &PyWindow::GetOSFrame,
                           &PyWindow::SetOSFrame,
                           "Window rect in OS coords, not device pixels")
@@ -401,10 +401,12 @@ void pybind_gui_classes(py::module &m) {
                     "children of the window")
             .def_property_readonly("theme", &PyWindow::GetTheme,
                                    "Get's window's theme info")
-            .def("show_dialog",
-                 [](PyWindow &w, UnownedPointer<Dialog> dlg) {
-                     w.ShowDialog(TakeOwnership<Dialog>(dlg));
-                 }, "Displays the dialog")
+            .def(
+                    "show_dialog",
+                    [](PyWindow &w, UnownedPointer<Dialog> dlg) {
+                        w.ShowDialog(TakeOwnership<Dialog>(dlg));
+                    },
+                    "Displays the dialog")
             .def("close_dialog", &PyWindow::CloseDialog,
                  "Closes the current dialog")
             .def("show_message_box", &PyWindow::ShowMessageBox,
@@ -415,8 +417,8 @@ void pybind_gui_classes(py::module &m) {
                     "Gets the rendering.Renderer object for the Window");
 
     // ---- Menu ----
-    py::class_<Menu, UnownedPointer<Menu>> menu(
-            m, "Menu", "A menu, possibly a menu tree");
+    py::class_<Menu, UnownedPointer<Menu>> menu(m, "Menu",
+                                                "A menu, possibly a menu tree");
     menu.def(py::init<>())
             .def(
                     "add_item",
@@ -554,11 +556,12 @@ void pybind_gui_classes(py::module &m) {
                        << w.GetFrame().height;
                      return s.str();
                  })
-            .def("add_child",
-                 [](Widget &w, UnownedPointer<Widget> child) {
-                     w.AddChild(TakeOwnership<Widget>(child));
-                 },
-                 "Adds a child widget")
+            .def(
+                    "add_child",
+                    [](Widget &w, UnownedPointer<Widget> child) {
+                        w.AddChild(TakeOwnership<Widget>(child));
+                    },
+                    "Adds a child widget")
             .def("get_children", &Widget::GetChildren,
                  "Returns the array of children. Do not modify.")
             .def_property("frame", &Widget::GetFrame, &Widget::SetFrame,
@@ -952,14 +955,16 @@ void pybind_gui_classes(py::module &m) {
     py::class_<TabControl, UnownedPointer<TabControl>, Widget> tabctrl(
             m, "TabControl", "Tab control");
     tabctrl.def(py::init<>())
-            .def("add_tab",
-                 [](TabControl &tabs, const char* name,
-                    UnownedPointer<Widget> panel) {
-                     tabs.AddTab(name, TakeOwnership<Widget>(panel));
-                 },
-                 "Adds a tab. The first parameter is the title of the tab, and "
-                 "the second parameter is a widget--normally this is a "
-                 "layout.")
+            .def(
+                    "add_tab",
+                    [](TabControl &tabs, const char *name,
+                       UnownedPointer<Widget> panel) {
+                        tabs.AddTab(name, TakeOwnership<Widget>(panel));
+                    },
+                    "Adds a tab. The first parameter is the title of the tab, "
+                    "and "
+                    "the second parameter is a widget--normally this is a "
+                    "layout.")
             .def("set_on_selected_tab_changed",
                  &TabControl::SetOnSelectedTabChanged,
                  "Calls the provided callback function with the index of the "
@@ -1010,12 +1015,14 @@ void pybind_gui_classes(py::module &m) {
                  "Returns the root item. This item is invisible, so its child "
                  "are "
                  "the top-level items")
-            .def("add_item",
-                 [](TreeView &tree, TreeView::ItemId parent_id,
-                    UnownedPointer<Widget> item) {
-                     return tree.AddItem(parent_id, TakeOwnership<Widget>(item));
-                 },
-                 "Adds a child item to the parent. add_item(parent, widget)")
+            .def(
+                    "add_item",
+                    [](TreeView &tree, TreeView::ItemId parent_id,
+                       UnownedPointer<Widget> item) {
+                        return tree.AddItem(parent_id,
+                                            TakeOwnership<Widget>(item));
+                    },
+                    "Adds a child item to the parent. add_item(parent, widget)")
             .def("add_text_item", &TreeView::AddTextItem,
                  "Adds a child item to the parent. add_text_item(parent, text)")
             .def("remove_item", &TreeView::RemoveItem,
@@ -1045,8 +1052,8 @@ void pybind_gui_classes(py::module &m) {
     checkable_cell
             .def(py::init<>([](const char *text, bool checked,
                                std::function<void(bool)> on_toggled) {
-                     return new CheckableTextTreeCell(
-                             text, checked, on_toggled);
+                     return new CheckableTextTreeCell(text, checked,
+                                                      on_toggled);
                  }),
                  "Creates a TreeView cell with a checkbox and text. "
                  "CheckableTextTreeCell(text, is_checked, on_toggled): "
@@ -1066,8 +1073,8 @@ void pybind_gui_classes(py::module &m) {
                                const Color &color,
                                std::function<void(bool)> on_enabled,
                                std::function<void(const Color &)> on_color) {
-                     return new LUTTreeCell(text, checked, color,
-                                            on_enabled, on_color);
+                     return new LUTTreeCell(text, checked, color, on_enabled,
+                                            on_color);
                  }),
                  "Creates a TreeView cell with a checkbox, text, and "
                  "a color editor. LUTTreeCell(text, is_checked, color, "
@@ -1093,8 +1100,8 @@ void pybind_gui_classes(py::module &m) {
                                std::function<void(double)> on_value_changed,
                                std::function<void(const Color &)>
                                        on_color_changed) {
-                     return new ColormapTreeCell(
-                             value, color, on_value_changed, on_color_changed);
+                     return new ColormapTreeCell(value, color, on_value_changed,
+                                                 on_color_changed);
                  }),
                  "Creates a TreeView cell with a number and a color edit. "
                  "ColormapTreeCell(value, color, on_value_changed, "
@@ -1131,8 +1138,8 @@ void pybind_gui_classes(py::module &m) {
                  "changes the value of a component");
 
     // ---- Margins ----
-    py::class_<Margins, UnownedPointer<Margins>> margins(
-            m, "Margins", "Margins for layouts");
+    py::class_<Margins, UnownedPointer<Margins>> margins(m, "Margins",
+                                                         "Margins for layouts");
     margins.def(py::init([](int left, int top, int right, int bottom) {
                     return new Margins(left, top, right, bottom);
                 }),
@@ -1183,8 +1190,8 @@ void pybind_gui_classes(py::module &m) {
                  "extra space as there is available in the layout");
 
     // ---- Vert ----
-    py::class_<Vert, UnownedPointer<Vert>, Layout1D> vlayout(
-            m, "Vert", "Vertical layout");
+    py::class_<Vert, UnownedPointer<Vert>, Layout1D> vlayout(m, "Vert",
+                                                             "Vertical layout");
     vlayout.def(py::init([](int spacing, const Margins &margins) {
                     return new Vert(spacing, margins);
                 }),
@@ -1258,7 +1265,7 @@ void pybind_gui_classes(py::module &m) {
 
     // ---- VGrid ----
     py::class_<VGrid, UnownedPointer<VGrid>, Widget> vgrid(m, "VGrid",
-                                                            "Gride layout");
+                                                           "Grid layout");
     vgrid.def(py::init([](int n_cols, int spacing, const Margins &margins) {
                   return new VGrid(n_cols, spacing, margins);
               }),
@@ -1290,7 +1297,7 @@ void pybind_gui_classes(py::module &m) {
 
     // ---- Dialog ----
     py::class_<Dialog, UnownedPointer<Dialog>, Widget> dialog(m, "Dialog",
-                                                               "Dialog");
+                                                              "Dialog");
     dialog.def(py::init<const char *>(),
                "Creates a dialog with the given title");
 

--- a/examples/python/gui/all-widgets.py
+++ b/examples/python/gui/all-widgets.py
@@ -209,7 +209,6 @@ class ExampleWindow:
         vgrid.add_child(gui.Label("Cars"))
         vgrid.add_child(gui.Label("5 (87% certainty)"))
         collapse.add_child(vgrid)
-        collapse.add_child(vgrid)
 
         # Create a tab control. This is really a set of N layouts on top of each
         # other, but with only one selected.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2501)
<!-- Reviewable:end -->
