### PR TITLE
Allow Scene::AddGeometry to accept bounding boxes

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -38,8 +38,7 @@ namespace rendering {
 class TemporaryLineSetBuilder : public LineSetBuffersBuilder {
 public:
     explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
-        : LineSetBuffersBuilder(*lines), lines_(lines)
-    {}
+        : LineSetBuffersBuilder(*lines), lines_(lines) {}
 
 private:
     std::shared_ptr<geometry::LineSet> lines_;
@@ -62,16 +61,17 @@ std::unique_ptr<GeometryBuffersBuilder> GeometryBuffersBuilder::GetBuilder(
             return std::make_unique<LineSetBuffersBuilder>(
                     static_cast<const geometry::LineSet&>(geometry));
         case GT::OrientedBoundingBox: {
-            auto obb = static_cast<const geometry::OrientedBoundingBox&>(
-                                                                    geometry);
+            auto obb =
+                    static_cast<const geometry::OrientedBoundingBox&>(geometry);
             auto lines = geometry::LineSet::CreateFromOrientedBoundingBox(obb);
             lines->PaintUniformColor(obb.color_);
             return std::make_unique<TemporaryLineSetBuilder>(lines);
         }
         case GT::AxisAlignedBoundingBox: {
             auto aabb = static_cast<const geometry::AxisAlignedBoundingBox&>(
-                                                                    geometry);
-            auto lines = geometry::LineSet::CreateFromAxisAlignedBoundingBox(aabb);
+                    geometry);
+            auto lines =
+                    geometry::LineSet::CreateFromAxisAlignedBoundingBox(aabb);
             lines->PaintUniformColor(aabb.color_);
             return std::make_unique<TemporaryLineSetBuilder>(lines);
         }

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -26,6 +26,7 @@
 
 #include "open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.h"
 
+#include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/LineSet.h"
 #include "open3d/geometry/PointCloud.h"
 #include "open3d/geometry/TriangleMesh.h"
@@ -33,6 +34,16 @@
 namespace open3d {
 namespace visualization {
 namespace rendering {
+
+class TemporaryLineSetBuilder: public LineSetBuffersBuilder {
+public:
+    explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
+    : LineSetBuffersBuilder(*lines), lines_(lines)
+    {}
+
+private:
+    std::shared_ptr<geometry::LineSet> lines_;
+};
 
 std::unique_ptr<GeometryBuffersBuilder> GeometryBuffersBuilder::GetBuilder(
         const geometry::Geometry3D& geometry) {
@@ -50,6 +61,14 @@ std::unique_ptr<GeometryBuffersBuilder> GeometryBuffersBuilder::GetBuilder(
         case GT::LineSet:
             return std::make_unique<LineSetBuffersBuilder>(
                     static_cast<const geometry::LineSet&>(geometry));
+        case GT::OrientedBoundingBox:
+            return std::make_unique<TemporaryLineSetBuilder>(
+                geometry::LineSet::CreateFromOrientedBoundingBox(
+                   static_cast<const geometry::OrientedBoundingBox&>(geometry)));
+        case GT::AxisAlignedBoundingBox:
+            return std::make_unique<TemporaryLineSetBuilder>(
+                geometry::LineSet::CreateFromAxisAlignedBoundingBox(
+                static_cast<const geometry::AxisAlignedBoundingBox&>(geometry)));
         default:
             break;
     }

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -39,7 +39,9 @@ class TemporaryLineSetBuilder: public LineSetBuffersBuilder {
 public:
     explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
     : LineSetBuffersBuilder(*lines), lines_(lines)
-    {}
+    {
+        lines_->PaintUniformColor({1.0, 1.0, 1.0});
+    }
 
 private:
     std::shared_ptr<geometry::LineSet> lines_;

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -38,9 +38,8 @@ namespace rendering {
 class TemporaryLineSetBuilder : public LineSetBuffersBuilder {
 public:
     explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
-        : LineSetBuffersBuilder(*lines), lines_(lines) {
-        lines_->PaintUniformColor({1.0, 1.0, 1.0});
-    }
+        : LineSetBuffersBuilder(*lines), lines_(lines)
+    {}
 
 private:
     std::shared_ptr<geometry::LineSet> lines_;
@@ -62,17 +61,20 @@ std::unique_ptr<GeometryBuffersBuilder> GeometryBuffersBuilder::GetBuilder(
         case GT::LineSet:
             return std::make_unique<LineSetBuffersBuilder>(
                     static_cast<const geometry::LineSet&>(geometry));
-        case GT::OrientedBoundingBox:
-            return std::make_unique<TemporaryLineSetBuilder>(
-                    geometry::LineSet::CreateFromOrientedBoundingBox(
-                            static_cast<const geometry::OrientedBoundingBox&>(
-                                    geometry)));
-        case GT::AxisAlignedBoundingBox:
-            return std::make_unique<TemporaryLineSetBuilder>(
-                    geometry::LineSet::CreateFromAxisAlignedBoundingBox(
-                            static_cast<
-                                    const geometry::AxisAlignedBoundingBox&>(
-                                    geometry)));
+        case GT::OrientedBoundingBox: {
+            auto obb = static_cast<const geometry::OrientedBoundingBox&>(
+                                                                    geometry);
+            auto lines = geometry::LineSet::CreateFromOrientedBoundingBox(obb);
+            lines->PaintUniformColor(obb.color_);
+            return std::make_unique<TemporaryLineSetBuilder>(lines);
+        }
+        case GT::AxisAlignedBoundingBox: {
+            auto aabb = static_cast<const geometry::AxisAlignedBoundingBox&>(
+                                                                    geometry);
+            auto lines = geometry::LineSet::CreateFromAxisAlignedBoundingBox(aabb);
+            lines->PaintUniformColor(aabb.color_);
+            return std::make_unique<TemporaryLineSetBuilder>(lines);
+        }
         default:
             break;
     }

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -38,8 +38,7 @@ namespace rendering {
 class TemporaryLineSetBuilder : public LineSetBuffersBuilder {
 public:
     explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
-        : LineSetBuffersBuilder(*lines), lines_(lines)
-    {
+        : LineSetBuffersBuilder(*lines), lines_(lines) {
         lines_->PaintUniformColor({1.0, 1.0, 1.0});
     }
 

--- a/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentGeometryBuffersBuilder.cpp
@@ -38,7 +38,7 @@ namespace rendering {
 class TemporaryLineSetBuilder : public LineSetBuffersBuilder {
 public:
     explicit TemporaryLineSetBuilder(std::shared_ptr<geometry::LineSet> lines)
-        : LineSetBuffersBuilder(*lines), lines_(lines) {}
+        : LineSetBuffersBuilder(*lines), lines_(lines)
     {
         lines_->PaintUniformColor({1.0, 1.0, 1.0});
     }

--- a/cpp/open3d/visualization/rendering/filament/TriangleMeshBuffers.cpp
+++ b/cpp/open3d/visualization/rendering/filament/TriangleMeshBuffers.cpp
@@ -228,14 +228,15 @@ std::tuple<vbdata, ibdata> CreateColoredBuffers(
     ibdata index_data;
 
     vertex_data.vertices_count = geometry.vertices_.size();
-    vertex_data.byte_count = vertex_data.vertices_count * sizeof(ColoredVertex);
+    vertex_data.byte_count =
+            vertex_data.vertices_count * sizeof(TexturedVertex);
     vertex_data.bytes_to_copy = vertex_data.byte_count;
     vertex_data.bytes = malloc(vertex_data.byte_count);
 
-    const ColoredVertex kDefault;
-    auto colored_vertices = static_cast<ColoredVertex*>(vertex_data.bytes);
+    const TexturedVertex kDefault;
+    auto vertices = static_cast<TexturedVertex*>(vertex_data.bytes);
     for (size_t i = 0; i < vertex_data.vertices_count; ++i) {
-        ColoredVertex& element = colored_vertices[i];
+        TexturedVertex& element = vertices[i];
 
         SetVertexPosition(element, geometry.vertices_[i]);
         if (tangents != nullptr) {
@@ -406,15 +407,15 @@ GeometryBuffersBuilder::Buffers TriangleMeshBuffersBuilder::ConstructBuffers() {
         orientation->getQuats(float4v_tangents, n_vertices);
     } else {
         utility::LogWarning(
-                "Trying to create mesh without vertex normals. Shading would "
-                "not work correctly. Consider to generate vertex normals "
+                "Trying to create mesh without vertex normals. Shading will"
+                "not work correctly. Consider generating vertex normals "
                 "first.");
     }
 
     // NOTE: Both default lit and unlit material shaders require per-vertex
     // colors so we unconditionally assume the triangle mesh has color.
     const bool has_colors = true;
-    const bool has_uvs = geometry_.HasTriangleUvs();
+    bool has_uvs = geometry_.HasTriangleUvs();
 
     // We take ownership of vbdata.bytes and ibdata.bytes here.
     std::tuple<vbdata, ibdata> buffers_data;
@@ -424,7 +425,8 @@ GeometryBuffersBuilder::Buffers TriangleMeshBuffersBuilder::ConstructBuffers() {
         stride = sizeof(TexturedVertex);
     } else if (has_colors) {
         buffers_data = CreateColoredBuffers(float4v_tangents, geometry_);
-        stride = sizeof(ColoredVertex);
+        stride = sizeof(TexturedVertex);
+        has_uvs = true;
     } else {
         buffers_data = CreatePlainBuffers(float4v_tangents, geometry_);
     }


### PR DESCRIPTION
The old `draw_geometries()` would accept bounding boxes. Right now we have to convert them into a LineSet first. See #2448

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2520)
<!-- Reviewable:end -->
