### PR TITLE
Fixes bug for preloading libc++ and libc++abi in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+* Fixes bug for preloading libc++ and libc++abi in Python
 * Added GUI widgets and model-viewing app
 * Fixes travis for race-condition on macOS
 * Fixes appveyor configuration and to build all branches

--- a/python/open3d/__init__.py
+++ b/python/open3d/__init__.py
@@ -51,8 +51,8 @@ from open3d._build_config import _build_config
 if _build_config["BUILD_GUI"] and not (_find_library('c++abi') or
                                        _find_library('c++')):
     try:  # Preload libc++.so and libc++abi.so (required by filament)
-        _CDLL(next((_Path(__file__).parent).glob('*c++abi*')))
-        _CDLL(next((_Path(__file__).parent).glob('*c++*')))
+        _CDLL(next((_Path(__file__).parent).glob('*c++abi.*')))
+        _CDLL(next((_Path(__file__).parent).glob('*c++.*')))
     except StopIteration:  # Not found: check system paths while loading
         pass
 


### PR DESCRIPTION
Resolves #2518 per @jwnimmer-tri's suggestion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2527)
<!-- Reviewable:end -->
