### PR TITLE
Fix Open3DScene with no background color set not clearing on draw

### DIFF
--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -117,6 +117,7 @@ Open3DScene::Open3DScene(Renderer& renderer) : renderer_(renderer) {
     scene_ = renderer_.CreateScene();
     auto scene = renderer_.GetScene(scene_);
     view_ = scene->AddView(0, 0, 1, 1);
+    scene->SetBackgroundColor({1.0f, 1.0f, 1.0f, 1.0f});
 
     RecreateAxis(scene, bounds_, false);
 }


### PR DESCRIPTION
The bug is that unless you explicitly set the background color, the background is black and the view does not clear on draw, leading to streaking from all the previous draws.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2530)
<!-- Reviewable:end -->
