### PR TITLE
fix reading float from PCD, instead of float_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Ubuntu 20.04 (Focal) support.
 * Added Line3D/Ray3D/Segment3D classes with plane, point, closest-distance, and AABB tests
 * Add Open3D-ML to Open3D wheel
+* Fix a bug in PointCloud file format, use `float` instead of `float_t`
 
 ## 0.9.0
 

--- a/cpp/open3d/io/file_format/FilePCD.cpp
+++ b/cpp/open3d/io/file_format/FilePCD.cpp
@@ -274,7 +274,7 @@ double UnpackBinaryPCDElement(const char *data_ptr,
         }
     } else if (type == 'F') {
         if (size == 4) {
-            std::float_t data;
+            float data;
             memcpy(&data, data_ptr, sizeof(data));
             return (double)data;
         } else {
@@ -324,7 +324,7 @@ Eigen::Vector3d UnpackASCIIPCDColor(const char *data_ptr,
             std::uint32_t value = std::strtoul(data_ptr, &end, 0);
             memcpy(data, &value, 4);
         } else if (type == 'F') {
-            std::float_t value = std::strtof(data_ptr, &end);
+            float value = std::strtof(data_ptr, &end);
             memcpy(data, &value, 4);
         }
         return utility::ColorToDouble(data[2], data[1], data[0]);


### PR DESCRIPTION
The type float_t can be float, double, or long double, depending on the
architecture and compiler settings. Thus, when reading a "float" value
of size 4 from a PCD file, the code should not use float_t but float.

Fixes #2556 
(edit: fix referenced issue)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2563)
<!-- Reviewable:end -->
