### PR TITLE
Allow arbitrary pinhole camera

### DIFF
--- a/cpp/open3d/visualization/visualizer/ViewControl.cpp
+++ b/cpp/open3d/visualization/visualizer/ViewControl.cpp
@@ -188,16 +188,40 @@ bool ViewControl::ConvertToPinholeCameraParameters(
     return true;
 }
 
-bool ViewControl::ConvertFromArbitraryPinholeCameraParameters(
-        const camera::PinholeCameraParameters &parameters) {
+bool ViewControl::ConvertFromPinholeCameraParameters(
+        const camera::PinholeCameraParameters &parameters,
+        bool allow_arbitrary) {
     auto intrinsic = parameters.intrinsic_;
     auto extrinsic = parameters.extrinsic_;
-
+    if (!allow_arbitrary && (window_height_ <= 0 || window_width_ <= 0 ||
+        window_height_ != intrinsic.height_ ||
+        window_width_ != intrinsic.width_ ||
+        intrinsic.intrinsic_matrix_(0, 2) !=
+                (double)window_width_ / 2.0 - 0.5 ||
+        intrinsic.intrinsic_matrix_(1, 2) !=
+                (double)window_height_ / 2.0 - 0.5)) {
+        utility::LogWarning(
+                "[ViewControl] ConvertFromPinholeCameraParameters() failed "
+                "because window height and width do not match.");
+        return false;
+    }
     double tan_half_fov =
             (double)window_height_ / (intrinsic.intrinsic_matrix_(1, 1) * 2.0);
     double fov_rad = std::atan(tan_half_fov) * 2.0;
+    double old_fov = field_of_view_;
     field_of_view_ = fov_rad * 180.0 / M_PI;
-
+    if (!allow_arbitrary) {
+        field_of_view_ =
+                std::max(std::min(field_of_view_, FIELD_OF_VIEW_MAX),
+                         FIELD_OF_VIEW_MIN);
+        if (GetProjectionType() == ProjectionType::Orthogonal) {
+            field_of_view_ = old_fov;
+            utility::LogWarning(
+                    "[ViewControl] ConvertFromPinholeCameraParameters() failed "
+                    "because field of view is impossible.");
+            return false;
+        }
+    }
     right_ = extrinsic.block<1, 3>(0, 0).transpose();
     up_ = -extrinsic.block<1, 3>(1, 0).transpose();
     front_ = -extrinsic.block<1, 3>(2, 0).transpose();
@@ -210,54 +234,9 @@ bool ViewControl::ConvertFromArbitraryPinholeCameraParameters(
                         std::tan(field_of_view_ * 0.5 / 180.0 * M_PI) /
                         bounding_box_.GetMaxExtent();
     zoom_ = ideal_zoom;
-    view_ratio_ = zoom_ * bounding_box_.GetMaxExtent();
-    distance_ = view_ratio_ / std::tan(field_of_view_ * 0.5 / 180.0 * M_PI);
-    lookat_ = eye_ - front_ * distance_;
-    return true;
-}
-
-bool ViewControl::ConvertFromPinholeCameraParameters(
-        const camera::PinholeCameraParameters &parameters) {
-    auto intrinsic = parameters.intrinsic_;
-    auto extrinsic = parameters.extrinsic_;
-    if (window_height_ <= 0 || window_width_ <= 0 ||
-        window_height_ != intrinsic.height_ ||
-        window_width_ != intrinsic.width_ ||
-        intrinsic.intrinsic_matrix_(0, 2) !=
-                (double)window_width_ / 2.0 - 0.5 ||
-        intrinsic.intrinsic_matrix_(1, 2) !=
-                (double)window_height_ / 2.0 - 0.5) {
-        utility::LogWarning(
-                "[ViewControl] ConvertFromPinholeCameraParameters() failed "
-                "because window height and width do not match.");
-        return false;
+    if (!allow_arbitrary) {
+        zoom_ = std::max(std::min(ideal_zoom, ZOOM_MAX), ZOOM_MIN);
     }
-    double tan_half_fov =
-            (double)window_height_ / (intrinsic.intrinsic_matrix_(1, 1) * 2.0);
-    double fov_rad = std::atan(tan_half_fov) * 2.0;
-    double old_fov = field_of_view_;
-    field_of_view_ =
-            std::max(std::min(fov_rad * 180.0 / M_PI, FIELD_OF_VIEW_MAX),
-                     FIELD_OF_VIEW_MIN);
-    if (GetProjectionType() == ProjectionType::Orthogonal) {
-        field_of_view_ = old_fov;
-        utility::LogWarning(
-                "[ViewControl] ConvertFromPinholeCameraParameters() failed "
-                "because field of view is impossible.");
-        return false;
-    }
-    right_ = extrinsic.block<1, 3>(0, 0).transpose();
-    up_ = -extrinsic.block<1, 3>(1, 0).transpose();
-    front_ = -extrinsic.block<1, 3>(2, 0).transpose();
-    eye_ = extrinsic.block<3, 3>(0, 0).inverse() *
-           (extrinsic.block<3, 1>(0, 3) * -1.0);
-
-    auto bb_center = bounding_box_.GetCenter();
-    double ideal_distance = std::abs((eye_ - bb_center).dot(front_));
-    double ideal_zoom = ideal_distance *
-                        std::tan(field_of_view_ * 0.5 / 180.0 * M_PI) /
-                        bounding_box_.GetMaxExtent();
-    zoom_ = std::max(std::min(ideal_zoom, ZOOM_MAX), ZOOM_MIN);
     view_ratio_ = zoom_ * bounding_box_.GetMaxExtent();
     distance_ = view_ratio_ / std::tan(field_of_view_ * 0.5 / 180.0 * M_PI);
     lookat_ = eye_ - front_ * distance_;

--- a/cpp/open3d/visualization/visualizer/ViewControl.cpp
+++ b/cpp/open3d/visualization/visualizer/ViewControl.cpp
@@ -194,12 +194,12 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
     auto intrinsic = parameters.intrinsic_;
     auto extrinsic = parameters.extrinsic_;
     if (!allow_arbitrary && (window_height_ <= 0 || window_width_ <= 0 ||
-        window_height_ != intrinsic.height_ ||
-        window_width_ != intrinsic.width_ ||
-        intrinsic.intrinsic_matrix_(0, 2) !=
-                (double)window_width_ / 2.0 - 0.5 ||
-        intrinsic.intrinsic_matrix_(1, 2) !=
-                (double)window_height_ / 2.0 - 0.5)) {
+                             window_height_ != intrinsic.height_ ||
+                             window_width_ != intrinsic.width_ ||
+                             intrinsic.intrinsic_matrix_(0, 2) !=
+                                     (double)window_width_ / 2.0 - 0.5 ||
+                             intrinsic.intrinsic_matrix_(1, 2) !=
+                                     (double)window_height_ / 2.0 - 0.5)) {
         utility::LogWarning(
                 "[ViewControl] ConvertFromPinholeCameraParameters() failed "
                 "because window height and width do not match.");
@@ -211,9 +211,8 @@ bool ViewControl::ConvertFromPinholeCameraParameters(
     double old_fov = field_of_view_;
     field_of_view_ = fov_rad * 180.0 / M_PI;
     if (!allow_arbitrary) {
-        field_of_view_ =
-                std::max(std::min(field_of_view_, FIELD_OF_VIEW_MAX),
-                         FIELD_OF_VIEW_MIN);
+        field_of_view_ = std::max(std::min(field_of_view_, FIELD_OF_VIEW_MAX),
+                                  FIELD_OF_VIEW_MIN);
         if (GetProjectionType() == ProjectionType::Orthogonal) {
             field_of_view_ = old_fov;
             utility::LogWarning(

--- a/cpp/open3d/visualization/visualizer/ViewControl.h
+++ b/cpp/open3d/visualization/visualizer/ViewControl.h
@@ -82,21 +82,15 @@ public:
     bool ConvertToPinholeCameraParameters(
             camera::PinholeCameraParameters &parameters);
 
-    /// Function to get view controller from arbitrary pinhole camera
-    /// parameters. In this function, it is responsibility of the users to
-    /// verify the validity of the parameters, in contrast to
-    /// ConvertFromPinholeCameraParameters() function. This can be useful to
-    /// render images or depthmaps without any restriction in FOV, zoom, etc.
-    ///
-    /// \param parameters The pinhole camera parameter to convert from.
-    bool ConvertFromArbitraryPinholeCameraParameters(
-            const camera::PinholeCameraParameters &parameters);
-
     /// Function to get view controller from pinhole camera parameters.
     ///
     /// \param parameters The pinhole camera parameter to convert from.
+    /// \param allow_arbitrary Allow an arbitrary pinhole camera parameters.
+    /// This can be useful to render images or depthmaps without any restriction
+    /// in window size, FOV and zoom.
     bool ConvertFromPinholeCameraParameters(
-            const camera::PinholeCameraParameters &parameters);
+            const camera::PinholeCameraParameters &parameters,
+            bool allow_arbitrary=false);
 
     ProjectionType GetProjectionType() const;
     void SetProjectionParameters();

--- a/cpp/open3d/visualization/visualizer/ViewControl.h
+++ b/cpp/open3d/visualization/visualizer/ViewControl.h
@@ -90,7 +90,7 @@ public:
     /// in window size, FOV and zoom.
     bool ConvertFromPinholeCameraParameters(
             const camera::PinholeCameraParameters &parameters,
-            bool allow_arbitrary=false);
+            bool allow_arbitrary = false);
 
     ProjectionType GetProjectionType() const;
     void SetProjectionParameters();

--- a/cpp/open3d/visualization/visualizer/ViewControl.h
+++ b/cpp/open3d/visualization/visualizer/ViewControl.h
@@ -81,6 +81,17 @@ public:
     /// \param parameters The pinhole camera parameter to convert to.
     bool ConvertToPinholeCameraParameters(
             camera::PinholeCameraParameters &parameters);
+
+    /// Function to get view controller from arbitrary pinhole camera
+    /// parameters. In this function, it is responsibility of the users to
+    /// verify the validity of the parameters, in contrast to
+    /// ConvertFromPinholeCameraParameters() function. This can be useful to
+    /// render images or depthmaps without any restriction in FOV, zoom, etc.
+    ///
+    /// \param parameters The pinhole camera parameter to convert from.
+    bool ConvertFromArbitraryPinholeCameraParameters(
+            const camera::PinholeCameraParameters &parameters);
+
     /// Function to get view controller from pinhole camera parameters.
     ///
     /// \param parameters The pinhole camera parameter to convert from.

--- a/cpp/pybind/visualization/viewcontrol.cpp
+++ b/cpp/pybind/visualization/viewcontrol.cpp
@@ -111,9 +111,10 @@ void pybind_viewcontrol(py::module &m) {
                  "Set the zoom of the visualizer", "zoom"_a);
     docstring::ClassMethodDocInject(m, "ViewControl", "change_field_of_view",
                                     map_view_control_docstrings);
-    docstring::ClassMethodDocInject(m, "ViewControl",
-                                    "convert_from_arbitrary_pinhole_camera_parameters",
-                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(
+            m, "ViewControl",
+            "convert_from_arbitrary_pinhole_camera_parameters",
+            map_view_control_docstrings);
     docstring::ClassMethodDocInject(m, "ViewControl",
                                     "convert_from_pinhole_camera_parameters",
                                     map_view_control_docstrings);

--- a/cpp/pybind/visualization/viewcontrol.cpp
+++ b/cpp/pybind/visualization/viewcontrol.cpp
@@ -66,6 +66,9 @@ void pybind_viewcontrol(py::module &m) {
                     },
                     "Function to convert ViewControl to "
                     "camera::PinholeCameraParameters")
+            .def("convert_from_arbitrary_pinhole_camera_parameters",
+                 &ViewControl::ConvertFromArbitraryPinholeCameraParameters,
+                 "parameter"_a)
             .def("convert_from_pinhole_camera_parameters",
                  &ViewControl::ConvertFromPinholeCameraParameters,
                  "parameter"_a)
@@ -107,6 +110,9 @@ void pybind_viewcontrol(py::module &m) {
             .def("set_zoom", &ViewControl::SetZoom,
                  "Set the zoom of the visualizer", "zoom"_a);
     docstring::ClassMethodDocInject(m, "ViewControl", "change_field_of_view",
+                                    map_view_control_docstrings);
+    docstring::ClassMethodDocInject(m, "ViewControl",
+                                    "convert_from_arbitrary_pinhole_camera_parameters",
                                     map_view_control_docstrings);
     docstring::ClassMethodDocInject(m, "ViewControl",
                                     "convert_from_pinhole_camera_parameters",

--- a/cpp/pybind/visualization/viewcontrol.cpp
+++ b/cpp/pybind/visualization/viewcontrol.cpp
@@ -66,12 +66,9 @@ void pybind_viewcontrol(py::module &m) {
                     },
                     "Function to convert ViewControl to "
                     "camera::PinholeCameraParameters")
-            .def("convert_from_arbitrary_pinhole_camera_parameters",
-                 &ViewControl::ConvertFromArbitraryPinholeCameraParameters,
-                 "parameter"_a)
             .def("convert_from_pinhole_camera_parameters",
                  &ViewControl::ConvertFromPinholeCameraParameters,
-                 "parameter"_a)
+                 "parameter"_a, "allow_arbitrary"_a = false)
             .def("scale", &ViewControl::Scale, "Function to process scaling",
                  "scale"_a)
             .def("rotate", &ViewControl::Rotate, "Function to process rotation",
@@ -111,10 +108,6 @@ void pybind_viewcontrol(py::module &m) {
                  "Set the zoom of the visualizer", "zoom"_a);
     docstring::ClassMethodDocInject(m, "ViewControl", "change_field_of_view",
                                     map_view_control_docstrings);
-    docstring::ClassMethodDocInject(
-            m, "ViewControl",
-            "convert_from_arbitrary_pinhole_camera_parameters",
-            map_view_control_docstrings);
     docstring::ClassMethodDocInject(m, "ViewControl",
                                     "convert_from_pinhole_camera_parameters",
                                     map_view_control_docstrings);


### PR DESCRIPTION
Function to get view controller from arbitrary pinhole camera parameters. In this function, it is responsibility of the users to
verify the validity of the parameters, in contrast to `ConvertFromPinholeCameraParameters()` function. This can be useful to render images or depthmaps without any restriction in FOV, zoom, etc.

Example of use (python): https://github.com/pablospe/open3D_depthmap_example
(code is already compiled, and can be installed with pip).

This PR is related to the following git issues: #1417, #497, #727, #834, #1389, #2443, #1164, #2036, #2190.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2564)
<!-- Reviewable:end -->
