### PR TITLE
voxelize op for torch and tensorflow

### DIFF
--- a/cpp/open3d/ml/impl/misc/FixedRadiusSearch.cuh
+++ b/cpp/open3d/ml/impl/misc/FixedRadiusSearch.cuh
@@ -260,7 +260,7 @@ __global__ void CountNeighborsKernel(
 
             Vec3<T> p(&points[idx * 3 + 0]);
             if (IGNORE_QUERY_POINT) {
-                if (query_pos == p) continue;
+                if ((query_pos == p).all()) continue;
             }
 
             T dist;
@@ -411,7 +411,7 @@ __global__ void WriteNeighborsIndicesAndDistancesKernel(
 
             Vec3<T> p(&points[idx * 3 + 0]);
             if (IGNORE_QUERY_POINT) {
-                if (query_pos == p) continue;
+                if ((query_pos == p).all()) continue;
             }
 
             T dist;

--- a/cpp/open3d/ml/impl/misc/RaggedToDense.h
+++ b/cpp/open3d/ml/impl/misc/RaggedToDense.h
@@ -1,0 +1,102 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <tbb/parallel_for.h>
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+/// Creates a dense tensor from a ragged tensor.
+///
+/// Example where each value has size 2:
+///  values = [[0,0],[1,1],[2,2],[3,3],[4,4]]
+///  row_splits = [0,2,5]
+///  out_col_size=3
+///  default_value=[-1,-1]
+///  default_value_size = 2
+///
+///  will return
+///
+///  out_values = [[[0,0],[1,1],[-1,-1]], [[2,2],[3,3],[4,4]]]
+///
+///
+/// \param values    Linear memory with all values.
+///
+/// \param row_splits    Defines the start and end of each entry in the ragged
+///        tensor. This is an exclusive prefix sum with 0 as the first element
+///        and the length of all values as the last element.
+///
+/// \param row_splits_size    The length of the row_splits vector.
+///
+/// \param out_col_size    The output column size. This is the second dim of
+///        the dense output tensor.
+///
+/// \param default_value    The default value to use if there are not enough
+///        values for filling the row.
+///
+/// \param default_value_size    The size of the default value.
+///
+/// \param out_values    This is the output array. The size of the array must
+///        be [row_splits_size-1, out_col_size, default_value_size].
+///
+template <class T>
+void RaggedToDenseCPU(const T* const values,
+                      const int64_t* const row_splits,
+                      const size_t row_splits_size,
+                      const size_t out_col_size,
+                      const T* const default_value,
+                      const size_t default_value_size,
+                      T* out_values) {
+    tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, row_splits_size - 1),
+            [&](const tbb::blocked_range<size_t>& r) {
+                for (int64_t i = r.begin(); i != r.end(); ++i) {
+                    const int64_t start = row_splits[i];
+                    const int64_t end = std::min(int64_t(out_col_size) + start,
+                                                 row_splits[i + 1]);
+
+                    T* out_ptr =
+                            out_values + i * out_col_size * default_value_size;
+
+                    std::copy(values + start * default_value_size,
+                              values + end * default_value_size, out_ptr);
+
+                    // fill remaining columns with the default value
+                    out_ptr = out_ptr + (end - start) * default_value_size;
+                    for (int64_t j = end - start; j < out_col_size;
+                         ++j, out_ptr += default_value_size) {
+                        std::copy(default_value,
+                                  default_value + default_value_size, out_ptr);
+                    }
+                }
+            });
+}
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Voxelize.cuh
+++ b/cpp/open3d/ml/impl/misc/Voxelize.cuh
@@ -1,0 +1,614 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <thrust/sequence.h>
+
+#include <cub/cub.cuh>
+
+#include "open3d/ml/impl/misc/MemoryAllocation.h"
+#include "open3d/utility/Helper.h"
+#include "open3d/utility/MiniVec.h"
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+namespace {
+
+using namespace open3d::utility;
+
+template <class T, bool LARGE_ARRAY>
+__global__ void IotaCUDAKernel(T* first, int64_t len, T value) {
+    int64_t linear_idx;
+    const int64_t x = blockDim.x * blockIdx.x + threadIdx.x;
+    if (LARGE_ARRAY) {
+        const int64_t y = blockDim.y * blockIdx.y + threadIdx.y;
+        const int64_t z = blockDim.z * blockIdx.z + threadIdx.z;
+        linear_idx = z * gridDim.x * blockDim.x * gridDim.y +
+                     y * gridDim.x * blockDim.x + x;
+    } else {
+        linear_idx = x;
+    }
+    if (linear_idx < len) {
+        T* ptr = first + linear_idx;
+        value += linear_idx;
+        *ptr = value;
+    }
+}
+
+/// Iota function for CUDA
+template <class T>
+void IotaCUDA(const cudaStream_t& stream, T* first, T* last, T value) {
+    ptrdiff_t len = last - first;
+    if (len) {
+        const int BLOCKSIZE = 128;
+        dim3 block(BLOCKSIZE, 1, 1);
+        dim3 grid;
+        if (len > block.x * INT32_MAX) {
+            grid.y = std::ceil(std::cbrt(len));
+            grid.z = grid.y;
+            grid.x = DivUp(len, int64_t(grid.z) * grid.y * block.x);
+            IotaCUDAKernel<T, true>
+                    <<<grid, block, 0, stream>>>(first, len, value);
+        } else {
+            grid = dim3(DivUp(len, block.x), 1, 1);
+            IotaCUDAKernel<T, false>
+                    <<<grid, block, 0, stream>>>(first, len, value);
+        }
+    }
+}
+
+template <class T, int NDIM>
+__global__ void ComputeHashKernel(
+        int64_t* __restrict__ hashes,
+        int64_t num_points,
+        const T* const __restrict__ points,
+        const open3d::utility::MiniVec<T, NDIM> points_range_min_vec,
+        const open3d::utility::MiniVec<T, NDIM> points_range_max_vec,
+        const open3d::utility::MiniVec<T, NDIM> inv_voxel_size,
+        const open3d::utility::MiniVec<int64_t, NDIM> strides,
+        const int64_t invalid_hash) {
+    typedef MiniVec<T, NDIM> Vec_t;
+    int64_t linear_idx;
+    const int64_t x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int64_t y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int64_t z = blockDim.z * blockIdx.z + threadIdx.z;
+    linear_idx = z * gridDim.x * blockDim.x * gridDim.y +
+                 y * gridDim.x * blockDim.x + x;
+
+    if (linear_idx >= num_points) return;
+
+    Vec_t point(points + linear_idx * NDIM);
+
+    if ((point >= points_range_min_vec && point <= points_range_max_vec)
+                .all()) {
+        auto coords = ((point - points_range_min_vec) * inv_voxel_size)
+                              .template cast<int64_t>();
+        int64_t h = coords.dot(strides);
+        hashes[linear_idx] = h;  // add 1 and use 0 as invalid
+    } else {
+        hashes[linear_idx] = invalid_hash;  // 0 means invalid
+    }
+}
+
+/// This function computes the a hash (linear index+1) for each point.
+/// Points outside the range will get a specific hash value.
+///
+/// \tparam T    The floating point type for the points
+/// \tparam NDIM    The number of dimensions, e.g., 3.
+///
+/// \param hashes    The output vector with the hashes/linear indexes.
+/// \param num_points    The number of points.
+/// \param points    The array with the point coordinates. The shape is
+///        [num_points,NDIM] and the storage order is row-major.
+/// \param points_range_min_vec    The minimum range for a point to be valid.
+/// \param points_range_max_vec    The maximum range for a point to be valid.
+/// \param inv_voxel_size    The reciprocal of the voxel edge lengths in each
+///        dimension
+/// \param strides    The strides for computing the linear index.
+/// \param invalid_hash    The value to use for points outside the range.
+template <class T, int NDIM>
+void ComputeHash(const cudaStream_t& stream,
+                 int64_t* hashes,
+                 int64_t num_points,
+                 const T* const points,
+                 const MiniVec<T, NDIM> points_range_min_vec,
+                 const MiniVec<T, NDIM> points_range_max_vec,
+                 const MiniVec<T, NDIM> inv_voxel_size,
+                 const MiniVec<int64_t, NDIM> strides,
+                 const int64_t invalid_hash) {
+    if (num_points) {
+        const int BLOCKSIZE = 128;
+        dim3 block(BLOCKSIZE, 1, 1);
+        dim3 grid;
+        grid.y = std::ceil(std::cbrt(num_points));
+        grid.z = grid.y;
+        grid.x = DivUp(num_points, int64_t(grid.z) * grid.y * block.x);
+        ComputeHashKernel<T, NDIM><<<grid, block, 0, stream>>>(
+                hashes, num_points, points, points_range_min_vec,
+                points_range_max_vec, inv_voxel_size, strides, invalid_hash);
+    }
+}
+
+template <class T>
+__global__ void LimitCountsKernel(T* counts, int64_t num, T limit) {
+    int64_t linear_idx;
+    const int64_t x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int64_t y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int64_t z = blockDim.z * blockIdx.z + threadIdx.z;
+    linear_idx = z * gridDim.x * blockDim.x * gridDim.y +
+                 y * gridDim.x * blockDim.x + x;
+
+    if (linear_idx >= num) return;
+
+    if (counts[linear_idx] > limit) {
+        counts[linear_idx] = limit;
+    }
+}
+
+/// This function performs an element-wise minimum operation.
+///
+/// \param counts    The input and output array.
+/// \param num    Number of input elements.
+/// \param limit    The second operator for the minimum operation.
+template <class T>
+void LimitCounts(const cudaStream_t& stream, T* counts, int64_t num, T limit) {
+    if (num) {
+        const int BLOCKSIZE = 128;
+        dim3 block(BLOCKSIZE, 1, 1);
+        dim3 grid;
+        grid.y = std::ceil(std::cbrt(num));
+        grid.z = grid.y;
+        grid.x = DivUp(num, int64_t(grid.z) * grid.y * block.x);
+        LimitCountsKernel<<<grid, block, 0, stream>>>(counts, num, limit);
+    }
+}
+
+template <class T, int NDIM>
+__global__ void ComputeVoxelCoordsKernel(
+        int32_t* __restrict__ voxel_coords,
+        const T* const __restrict__ points,
+        const int64_t* const __restrict__ point_indices,
+        const int64_t* const __restrict__ prefix_sum,
+        const MiniVec<T, NDIM> points_range_min_vec,
+        const MiniVec<T, NDIM> inv_voxel_size,
+        int64_t num_voxels) {
+    typedef MiniVec<T, NDIM> Vec_t;
+    int64_t linear_idx;
+    const int64_t x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int64_t y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int64_t z = blockDim.z * blockIdx.z + threadIdx.z;
+    linear_idx = z * gridDim.x * blockDim.x * gridDim.y +
+                 y * gridDim.x * blockDim.x + x;
+
+    if (linear_idx >= num_voxels) return;
+
+    int64_t point_idx;
+    if (0 == linear_idx) {
+        point_idx = point_indices[0];
+    } else {
+        point_idx = point_indices[prefix_sum[linear_idx - 1]];
+    }
+
+    Vec_t point(points + point_idx * NDIM);
+    auto coords = ((point - points_range_min_vec) * inv_voxel_size)
+                          .template cast<int32_t>();
+
+    for (int i = 0; i < NDIM; ++i) {
+        voxel_coords[linear_idx * NDIM + i] = coords[i];
+    }
+}
+
+/// Computes the coordinates for each voxel
+///
+/// \param voxel_coords    The output array with shape [num_voxels, NDIM].
+/// \param points    The array with the point coordinates.
+/// \param point_indices    The array with the point indices for all voxels.
+/// \param prefix_sum    Inclusive prefix sum defining where the point indices
+///        for each voxels end.
+/// \param points_range_min    The lower bound of the domain to be
+///        voxelized.
+/// \param points_range_max    The upper bound of the domain to be
+///        voxelized.
+/// \param inv_voxel_size    The reciprocal of the voxel edge lengths for each
+///        dimension.
+/// \param num_voxels    The number of voxels.
+template <class T, int NDIM>
+void ComputeVoxelCoords(const cudaStream_t& stream,
+                        int32_t* voxel_coords,
+                        const T* const points,
+                        const int64_t* const point_indices,
+                        const int64_t* const prefix_sum,
+                        const MiniVec<T, NDIM> points_range_min_vec,
+                        const MiniVec<T, NDIM> inv_voxel_size,
+                        int64_t num_voxels) {
+    if (num_voxels) {
+        const int BLOCKSIZE = 128;
+        dim3 block(BLOCKSIZE, 1, 1);
+        dim3 grid;
+        grid.y = std::ceil(std::cbrt(num_voxels));
+        grid.z = grid.y;
+        grid.x = DivUp(num_voxels, int64_t(grid.z) * grid.y * block.x);
+        ComputeVoxelCoordsKernel<<<grid, block, 0, stream>>>(
+                voxel_coords, points, point_indices, prefix_sum,
+                points_range_min_vec, inv_voxel_size, num_voxels);
+    }
+}
+
+__global__ void CopyPointIndicesKernel(
+        int64_t* __restrict__ out,
+        const int64_t* const __restrict__ point_indices,
+        const int64_t* const __restrict__ prefix_sum_in,
+        const int64_t* const __restrict__ prefix_sum_out,
+        const int64_t num_voxels) {
+    // TODO data coalescing can be optimized
+    int64_t linear_idx;
+    const int64_t x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int64_t y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int64_t z = blockDim.z * blockIdx.z + threadIdx.z;
+    linear_idx = z * gridDim.x * blockDim.x * gridDim.y +
+                 y * gridDim.x * blockDim.x + x;
+
+    if (linear_idx >= num_voxels) return;
+
+    int64_t begin_out;
+    if (0 == linear_idx) {
+        begin_out = 0;
+    } else {
+        begin_out = prefix_sum_out[linear_idx - 1];
+    }
+    int64_t end_out = prefix_sum_out[linear_idx];
+
+    int64_t num_points = end_out - begin_out;
+
+    int64_t in_idx;
+    if (0 == linear_idx) {
+        in_idx = 0;
+    } else {
+        in_idx = prefix_sum_in[linear_idx - 1];
+    }
+
+    for (int64_t out_idx = begin_out; out_idx < end_out; ++out_idx, ++in_idx) {
+        out[out_idx] = point_indices[in_idx];
+    }
+}
+
+/// Copies the point indices for each voxel to the output.
+///
+/// \param out    The output array with the point indices for all voxels.
+/// \param point_indices    The array with the point indices for all voxels.
+/// \param prefix_sum_in    Inclusive prefix sum defining where the point
+///        indices for each voxels end.
+/// \param prefix_sum_out    Inclusive prefix sum defining where the point
+///        indices for each voxels end.
+/// \param num_voxels    The number of voxels.
+///
+void CopyPointIndices(const cudaStream_t& stream,
+                      int64_t* out,
+                      const int64_t* const point_indices,
+                      const int64_t* const prefix_sum_in,
+                      const int64_t* const prefix_sum_out,
+                      const int64_t num_voxels) {
+    if (num_voxels) {
+        const int BLOCKSIZE = 128;
+        dim3 block(BLOCKSIZE, 1, 1);
+        dim3 grid;
+        grid.y = std::ceil(std::cbrt(num_voxels));
+        grid.z = grid.y;
+        grid.x = DivUp(num_voxels, int64_t(grid.z) * grid.y * block.x);
+        CopyPointIndicesKernel<<<grid, block, 0, stream>>>(
+                out, point_indices, prefix_sum_in, prefix_sum_out, num_voxels);
+    }
+}
+
+}  // namespace
+
+/// This function voxelizes a point cloud.
+/// The function returns the integer coordinates of the voxels that
+/// contain points and a compact list of the indices that associate the
+/// voxels to the points.
+///
+/// All pointer arguments point to device memory unless stated
+/// otherwise.
+///
+/// \tparam T    Floating-point data type for the point positions.
+///
+/// \tparam NDIM    The number of dimensions of the points.
+///
+/// \tparam OUTPUT_ALLOCATOR    Type of the output_allocator. See
+///         \p output_allocator for more information.
+///
+/// \param stream    The cuda stream for all kernel launches.
+///
+/// \param temp    Pointer to temporary memory. If nullptr then the required
+///        size of temporary memory will be written to \p temp_size and no
+///        work is done.
+///
+/// \param temp_size    The size of the temporary memory in bytes. This is
+///        used as an output if temp is nullptr
+///
+/// \param texture_alignment    The texture alignment in bytes. This is used
+///        for allocating segments within the temporary memory.
+///
+/// \param num_points    The number of points.
+///
+/// \param points    Array with the point positions. The shape is
+///        [num_points,NDIM].
+///
+/// \param voxel_size    The edge lenghts of the voxel. The shape is
+///        [NDIM]. This pointer points to host memory!
+///
+/// \param points_range_min    The lower bound of the domain to be
+/// voxelized.
+///        The shape is [NDIM].
+///        This pointer points to host memory!
+///
+/// \param points_range_max    The upper bound of the domain to be
+/// voxelized.
+///        The shape is [NDIM].
+///        This pointer points to host memory!
+///
+/// \param max_points_per_voxel    This parameter limits the number of
+/// points
+///        that are recorderd for each voxel.
+///
+/// \param max_voxels    This parameter limits the number of voxels that
+///        will be generated.
+///
+/// \param output_allocator    An object that implements functions for
+///         allocating the output arrays. The object must implement
+///         functions AllocVoxelCoords(int32_t** ptr, int64_t rows,
+///         int64_t cols), AllocVoxelPointIndices(int64_t** ptr, int64_t
+///         size), and AllocVoxelPointRowSplits(int64_t** ptr, int64_t
+///         size). All functions should allocate memory and return a
+///         pointer to that memory in ptr. The argments size, rows, and
+///         cols define the size of the array as the number of elements.
+///         All functions must accept zero size arguments. In this case
+///         ptr does not need to be set.
+///
+template <class T, int NDIM, class OUTPUT_ALLOCATOR>
+void VoxelizeCUDA(const cudaStream_t& stream,
+                  void* temp,
+                  size_t& temp_size,
+                  int texture_alignment,
+                  size_t num_points,
+                  const T* const points,
+                  const T* const voxel_size,
+                  const T* const points_range_min,
+                  const T* const points_range_max,
+                  const int64_t max_points_per_voxel,
+                  const int64_t max_voxels,
+                  OUTPUT_ALLOCATOR& output_allocator) {
+    using namespace open3d::utility;
+    typedef MiniVec<T, NDIM> Vec_t;
+
+    const bool get_temp_size = !temp;
+
+    if (get_temp_size) {
+        temp = (char*)1;  // worst case pointer alignment
+        temp_size = std::numeric_limits<int64_t>::max();
+    }
+
+    MemoryAllocation mem_temp(temp, temp_size, texture_alignment);
+
+    const Vec_t inv_voxel_size = T(1) / Vec_t(voxel_size);
+    const Vec_t points_range_min_vec(points_range_min);
+    const Vec_t points_range_max_vec(points_range_max);
+    MiniVec<int32_t, NDIM> extents =
+            ceil((points_range_max_vec - points_range_min_vec) * inv_voxel_size)
+                    .template cast<int32_t>();
+    MiniVec<int64_t, NDIM> strides;
+    for (int i = 0; i < NDIM; ++i) {
+        strides[i] = 1;
+        for (int j = 0; j < i; ++j) {
+            strides[i] *= extents[j];
+        }
+    }
+    const int64_t invalid_hash = strides[NDIM - 1] * extents[NDIM - 1];
+
+    // use double buffers for the sorting
+    std::pair<int64_t*, size_t> point_indices =
+            mem_temp.Alloc<int64_t>(num_points);
+    std::pair<int64_t*, size_t> point_indices_alt =
+            mem_temp.Alloc<int64_t>(num_points);
+    std::pair<int64_t*, size_t> hashes = mem_temp.Alloc<int64_t>(num_points);
+    std::pair<int64_t*, size_t> hashes_alt =
+            mem_temp.Alloc<int64_t>(num_points);
+
+    cub::DoubleBuffer<int64_t> point_indices_dbuf(point_indices.first,
+                                                  point_indices_alt.first);
+    cub::DoubleBuffer<int64_t> hashes_dbuf(hashes.first, hashes_alt.first);
+
+    if (!get_temp_size) {
+        IotaCUDA(stream, point_indices.first,
+                 point_indices.first + point_indices.second, int64_t(0));
+        ComputeHash(stream, hashes.first, num_points, points,
+                    points_range_min_vec, points_range_max_vec, inv_voxel_size,
+                    strides, invalid_hash);
+    }
+
+    {
+        // TODO compute end_bit for radix sort
+        std::pair<void*, size_t> sort_pairs_temp(nullptr, 0);
+        cub::DeviceRadixSort::SortPairs(
+                sort_pairs_temp.first, sort_pairs_temp.second, hashes_dbuf,
+                point_indices_dbuf, num_points, 0, sizeof(int64_t) * 8, stream);
+        sort_pairs_temp = mem_temp.Alloc(sort_pairs_temp.second);
+        if (!get_temp_size) {
+            cub::DeviceRadixSort::SortPairs(sort_pairs_temp.first,
+                                            sort_pairs_temp.second, hashes_dbuf,
+                                            point_indices_dbuf, num_points, 0,
+                                            sizeof(int64_t) * 8, stream);
+        }
+        mem_temp.Free(sort_pairs_temp);
+    }
+
+    // reuse the alternate buffers
+    std::pair<int64_t*, size_t> unique_hashes(hashes_dbuf.Alternate(),
+                                              hashes.second);
+    std::pair<int64_t*, size_t> unique_hashes_count(
+            point_indices_dbuf.Alternate(), point_indices.second);
+
+    int64_t num_voxels = 0;
+    int64_t last_hash = 0;  // 0 is a valid hash value
+    {
+        std::pair<void*, size_t> encode_temp(nullptr, 0);
+        std::pair<int64_t*, size_t> num_voxels_mem = mem_temp.Alloc<int64_t>(1);
+
+        cub::DeviceRunLengthEncode::Encode(
+                encode_temp.first, encode_temp.second, hashes_dbuf.Current(),
+                unique_hashes.first, unique_hashes_count.first,
+                num_voxels_mem.first, num_points, stream);
+
+        encode_temp = mem_temp.Alloc(encode_temp.second);
+        if (!get_temp_size) {
+            cub::DeviceRunLengthEncode::Encode(
+                    encode_temp.first, encode_temp.second,
+                    hashes_dbuf.Current(), unique_hashes.first,
+                    unique_hashes_count.first, num_voxels_mem.first, num_points,
+                    stream);
+
+            // get the number of voxels
+            cudaMemcpyAsync(&num_voxels, num_voxels_mem.first, sizeof(int64_t),
+                            cudaMemcpyDeviceToHost, stream);
+            // get the last hash value
+            cudaMemcpyAsync(&last_hash,
+                            hashes_dbuf.Current() + hashes.second - 1,
+                            sizeof(int64_t), cudaMemcpyDeviceToHost, stream);
+            // wait for the async copies
+            while (cudaErrorNotReady == cudaStreamQuery(stream)) { /*empty*/
+            }
+        }
+        mem_temp.Free(encode_temp);
+    }
+    if (invalid_hash == last_hash) {
+        // the last hash is invalid we have one voxel less
+        --num_voxels;
+    }
+    num_voxels = std::min(int64_t(num_voxels), max_voxels);
+
+    // reuse the hashes buffer
+    std::pair<int64_t*, size_t> unique_hashes_count_prefix_sum(
+            hashes_dbuf.Current(), hashes.second);
+
+    // compute the prefix sum for unique_hashes_count
+    {
+        std::pair<void*, size_t> inclusive_scan_temp(nullptr, 0);
+
+        cub::DeviceScan::InclusiveSum(
+                inclusive_scan_temp.first, inclusive_scan_temp.second,
+                unique_hashes_count.first, unique_hashes_count_prefix_sum.first,
+                unique_hashes_count.second, stream);
+
+        inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
+        if (!get_temp_size) {
+            // We only need the prefix sum for the first num_voxels.
+            cub::DeviceScan::InclusiveSum(
+                    inclusive_scan_temp.first, inclusive_scan_temp.second,
+                    unique_hashes_count.first,
+                    unique_hashes_count_prefix_sum.first, num_voxels, stream);
+        }
+        mem_temp.Free(inclusive_scan_temp);
+    }
+
+    int64_t* out_voxel_row_splits = nullptr;
+    if (!get_temp_size) {
+        output_allocator.AllocVoxelPointRowSplits(&out_voxel_row_splits,
+                                                  num_voxels + 1);
+    }
+
+    if (!get_temp_size) {
+        // set first element to 0
+        cudaMemsetAsync(out_voxel_row_splits, 0, sizeof(int64_t), stream);
+    }
+
+    if (max_points_per_voxel < num_points) {
+        // Limit the number of output points to max_points_per_voxel by
+        // limiting the unique_hashes_count.
+        if (!get_temp_size) {
+            LimitCounts(stream, unique_hashes_count.first, num_voxels,
+                        max_points_per_voxel);
+        }
+
+        std::pair<void*, size_t> inclusive_scan_temp(nullptr, 0);
+
+        cub::DeviceScan::InclusiveSum(
+                inclusive_scan_temp.first, inclusive_scan_temp.second,
+                unique_hashes_count.first, out_voxel_row_splits + 1, num_voxels,
+                stream);
+
+        inclusive_scan_temp = mem_temp.Alloc(inclusive_scan_temp.second);
+        if (!get_temp_size) {
+            cub::DeviceScan::InclusiveSum(
+                    inclusive_scan_temp.first, inclusive_scan_temp.second,
+                    unique_hashes_count.first, out_voxel_row_splits + 1,
+                    num_voxels, stream);
+        }
+        mem_temp.Free(inclusive_scan_temp);
+
+    } else {
+        if (!get_temp_size) {
+            cudaMemcpyAsync(out_voxel_row_splits + 1,
+                            unique_hashes_count_prefix_sum.first,
+                            sizeof(int64_t) * num_voxels,
+                            cudaMemcpyDeviceToDevice, stream);
+        }
+    }
+
+    if (get_temp_size) {
+        // return the memory peak as the required temporary memory size.
+        temp_size = mem_temp.MaxUsed();
+        return;
+    }
+
+    int32_t* out_voxel_coords = nullptr;
+    output_allocator.AllocVoxelCoords(&out_voxel_coords, num_voxels, NDIM);
+    ComputeVoxelCoords(stream, out_voxel_coords, points,
+                       point_indices_dbuf.Current(),
+                       unique_hashes_count_prefix_sum.first,
+                       points_range_min_vec, inv_voxel_size, num_voxels);
+
+    int64_t num_valid_points = 0;
+    {
+        cudaMemcpyAsync(&num_valid_points, out_voxel_row_splits + num_voxels,
+                        sizeof(int64_t), cudaMemcpyDeviceToHost, stream);
+        // wait for the async copies
+        while (cudaErrorNotReady == cudaStreamQuery(stream)) { /*empty*/
+        }
+    }
+    int64_t* out_point_indices = nullptr;
+    output_allocator.AllocVoxelPointIndices(&out_point_indices,
+                                            num_valid_points);
+    CopyPointIndices(stream, out_point_indices, point_indices_dbuf.Current(),
+                     unique_hashes_count_prefix_sum.first,
+                     out_voxel_row_splits + 1, num_voxels);
+}
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Voxelize.h
+++ b/cpp/open3d/ml/impl/misc/Voxelize.h
@@ -29,8 +29,6 @@
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_sort.h>
 
-#include <mutex>
-
 #include "open3d/core/Atomic.h"
 #include "open3d/utility/MiniVec.h"
 #include "open3d/utility/ParallelScan.h"
@@ -105,6 +103,7 @@ void VoxelizeCPU(size_t num_points,
             strides[i] *= extents[j];
         }
     }
+    const int64_t invalid_hash = strides[NDIM - 1] * extents[NDIM - 1];
 
     auto CoordFn = [&](const Vec_t& point) {
         auto coords = ((point - points_range_min_vec) * inv_voxel_size)
@@ -119,7 +118,7 @@ void VoxelizeCPU(size_t num_points,
             int64_t linear_idx = coords.dot(strides);
             return linear_idx;
         }
-        return int64_t(-1);
+        return invalid_hash;
     };
 
     std::vector<std::pair<int64_t, int64_t>> hashes_indices(num_points);
@@ -133,10 +132,7 @@ void VoxelizeCPU(size_t num_points,
                       });
     tbb::parallel_sort(hashes_indices);
 
-    uint64_t num_voxels = 0;
-    if (hashes_indices[0].first != -1) {
-        num_voxels = 1;
-    }
+    uint64_t num_voxels = 1;
     tbb::parallel_for(tbb::blocked_range<int64_t>(1, hashes_indices.size()),
                       [&](const tbb::blocked_range<int64_t>& r) {
                           for (int64_t i = r.begin(); i != r.end(); ++i) {
@@ -146,6 +142,9 @@ void VoxelizeCPU(size_t num_points,
                               }
                           }
                       });
+    if (invalid_hash == hashes_indices.back().first) {
+        --num_voxels;
+    }
     num_voxels = std::min(int64_t(num_voxels), max_voxels);
 
     int32_t* out_voxel_coords = nullptr;
@@ -156,33 +155,28 @@ void VoxelizeCPU(size_t num_points,
 
     std::vector<int64_t> tmp_point_indices;
     {
-        size_t out_voxel_row_splits_idx = 0;
-        int64_t points_per_voxel = 0;
-        size_t i = 0;
-
-        while (hashes_indices[i].first == -1) {
-            ++i;
-        }
-        for (; i < hashes_indices.size() &&
-               out_voxel_row_splits_idx <= num_voxels;
-             ++i) {
-            if (i == 0 ||
-                hashes_indices[i - 1].first != hashes_indices[i].first) {
-                out_voxel_row_splits[out_voxel_row_splits_idx] =
-                        tmp_point_indices.size();
-
-                auto coord = CoordFn(
-                        Vec_t(points + hashes_indices[i].second * NDIM));
-                for (int d = 0; d < NDIM; ++d) {
-                    out_voxel_coords[out_voxel_row_splits_idx * NDIM + d] =
-                            coord[d];
-                }
-                ++out_voxel_row_splits_idx;
-                points_per_voxel = 0;
+        int64_t hash_i = 0;  // index into the vector hashes_indices
+        for (int64_t voxel_i = 0; voxel_i < num_voxels; ++voxel_i) {
+            // compute voxel coord and the prefix sum value
+            auto coord = CoordFn(
+                    Vec_t(points + hashes_indices[hash_i].second * NDIM));
+            for (int d = 0; d < NDIM; ++d) {
+                out_voxel_coords[voxel_i * NDIM + d] = coord[d];
             }
-            if (points_per_voxel < max_points_per_voxel) {
-                tmp_point_indices.push_back(hashes_indices[i].second);
-                ++points_per_voxel;
+            out_voxel_row_splits[voxel_i] = tmp_point_indices.size();
+
+            // add up to max_points_per_voxel indices for this voxel
+            int64_t points_per_voxel = 0;
+            const int64_t current_hash = hashes_indices[hash_i].first;
+            for (; hash_i < hashes_indices.size(); ++hash_i) {
+                if (current_hash != hashes_indices[hash_i].first) {
+                    // new voxel starts -> break
+                    break;
+                }
+                if (points_per_voxel < max_points_per_voxel) {
+                    tmp_point_indices.push_back(hashes_indices[hash_i].second);
+                    ++points_per_voxel;
+                }
             }
         }
         out_voxel_row_splits[num_voxels] = tmp_point_indices.size();

--- a/cpp/open3d/ml/impl/misc/Voxelize.h
+++ b/cpp/open3d/ml/impl/misc/Voxelize.h
@@ -1,0 +1,199 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_sort.h>
+
+#include <mutex>
+
+#include "open3d/core/Atomic.h"
+#include "open3d/utility/MiniVec.h"
+#include "open3d/utility/ParallelScan.h"
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+/// This function voxelizes a point cloud.
+/// The function returns the integer coordinates of the voxels that contain
+/// points and a compact list of the indices that associate the voxels to the
+/// points.
+///
+/// \tparam T    Floating-point data type for the point positions.
+///
+/// \tparam NDIM    The number of dimensions of the points.
+///
+/// \tparam OUTPUT_ALLOCATOR    Type of the output_allocator. See
+///         \p output_allocator for more information.
+///
+///
+/// \param num_points    The number of points.
+///
+/// \param points    Array with the point positions. The shape is
+///        [num_points,NDIM].
+///
+/// \param voxel_size    The edge lenghts of the voxel. The shape is [NDIM]
+///
+/// \param points_range_min    The lower bound of the domain to be voxelized.
+///        The shape is [NDIM].
+///
+/// \param points_range_max    The upper bound of the domain to be voxelized.
+///        The shape is [NDIM].
+///
+/// \param max_points_per_voxel    This parameter limits the number of points
+///        that are recorderd for each voxel.
+///
+/// \param max_voxels    This parameter limits the number of voxels that will
+///        be generated.
+///
+/// \param output_allocator    An object that implements functions for
+///         allocating the output arrays. The object must implement functions
+///         AllocVoxelCoords(int32_t** ptr, int64_t rows, int64_t cols),
+///         AllocVoxelPointIndices(int64_t** ptr, int64_t size), and
+///         AllocVoxelPointRowSplits(int64_t** ptr, int64_t size). All
+///         functions should allocate memory and return a pointer to that memory
+///         in ptr. The argments size, rows, and cols define the size of the
+///         array as the number of elements. All functions must accept zero
+///         size arguments. In this case ptr does not need to be set.
+///
+template <class T, int NDIM, class OUTPUT_ALLOCATOR>
+void VoxelizeCPU(size_t num_points,
+                 const T* const points,
+                 const T* const voxel_size,
+                 const T* const points_range_min,
+                 const T* const points_range_max,
+                 const int64_t max_points_per_voxel,
+                 const int64_t max_voxels,
+                 OUTPUT_ALLOCATOR& output_allocator) {
+    using namespace open3d::utility;
+    typedef MiniVec<T, NDIM> Vec_t;
+    const Vec_t inv_voxel_size = T(1) / Vec_t(voxel_size);
+    const Vec_t points_range_min_vec(points_range_min);
+    const Vec_t points_range_max_vec(points_range_max);
+    MiniVec<int32_t, NDIM> extents =
+            ceil((points_range_max_vec - points_range_min_vec) * inv_voxel_size)
+                    .template cast<int32_t>();
+    MiniVec<int64_t, NDIM> strides;
+    for (int i = 0; i < NDIM; ++i) {
+        strides[i] = 1;
+        for (int j = 0; j < i; ++j) {
+            strides[i] *= extents[j];
+        }
+    }
+
+    auto CoordFn = [&](const Vec_t& point) {
+        auto coords = ((point - points_range_min_vec) * inv_voxel_size)
+                              .template cast<int64_t>();
+        return coords;
+    };
+
+    auto HashFn = [&](const Vec_t& point) {
+        if ((point >= points_range_min_vec && point <= points_range_max_vec)
+                    .all()) {
+            auto coords = CoordFn(point);
+            int64_t linear_idx = coords.dot(strides);
+            return linear_idx;
+        }
+        return int64_t(-1);
+    };
+
+    std::vector<std::pair<int64_t, int64_t>> hashes_indices(num_points);
+    tbb::parallel_for(tbb::blocked_range<int64_t>(0, num_points),
+                      [&](const tbb::blocked_range<int64_t>& r) {
+                          for (int64_t i = r.begin(); i != r.end(); ++i) {
+                              Vec_t pos(points + NDIM * i);
+                              hashes_indices[i].first = HashFn(pos);
+                              hashes_indices[i].second = i;
+                          }
+                      });
+    tbb::parallel_sort(hashes_indices);
+
+    uint64_t num_voxels = 0;
+    if (hashes_indices[0].first != -1) {
+        num_voxels = 1;
+    }
+    tbb::parallel_for(tbb::blocked_range<int64_t>(1, hashes_indices.size()),
+                      [&](const tbb::blocked_range<int64_t>& r) {
+                          for (int64_t i = r.begin(); i != r.end(); ++i) {
+                              if (hashes_indices[i - 1].first !=
+                                  hashes_indices[i].first) {
+                                  core::AtomicFetchAddRelaxed(&num_voxels, 1);
+                              }
+                          }
+                      });
+    num_voxels = std::min(int64_t(num_voxels), max_voxels);
+
+    int32_t* out_voxel_coords = nullptr;
+    output_allocator.AllocVoxelCoords(&out_voxel_coords, num_voxels, NDIM);
+    int64_t* out_voxel_row_splits = nullptr;
+    output_allocator.AllocVoxelPointRowSplits(&out_voxel_row_splits,
+                                              num_voxels + 1);
+
+    std::vector<int64_t> tmp_point_indices;
+    {
+        size_t out_voxel_row_splits_idx = 0;
+        int64_t points_per_voxel = 0;
+        size_t i = 0;
+
+        while (hashes_indices[i].first == -1) {
+            ++i;
+        }
+        for (;
+             i < hashes_indices.size() && out_voxel_row_splits_idx < num_voxels;
+             ++i) {
+            if (i == 0 ||
+                hashes_indices[i - 1].first != hashes_indices[i].first) {
+                out_voxel_row_splits[out_voxel_row_splits_idx] =
+                        tmp_point_indices.size();
+
+                auto coord = CoordFn(
+                        Vec_t(points + hashes_indices[i].second * NDIM));
+                for (int d = 0; d < NDIM; ++d) {
+                    out_voxel_coords[out_voxel_row_splits_idx * NDIM + d] =
+                            coord[d];
+                }
+                ++out_voxel_row_splits_idx;
+                points_per_voxel = 0;
+            }
+            if (points_per_voxel < max_points_per_voxel) {
+                tmp_point_indices.push_back(hashes_indices[i].second);
+                ++points_per_voxel;
+            }
+        }
+        out_voxel_row_splits[num_voxels] = tmp_point_indices.size();
+    }
+    int64_t* out_point_indices = nullptr;
+    output_allocator.AllocVoxelPointIndices(&out_point_indices,
+                                            tmp_point_indices.size());
+    memcpy(out_point_indices, tmp_point_indices.data(),
+           tmp_point_indices.size() * sizeof(int64_t));
+}
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Voxelize.h
+++ b/cpp/open3d/ml/impl/misc/Voxelize.h
@@ -29,6 +29,8 @@
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_sort.h>
 
+#include <vector>
+
 #include "open3d/core/Atomic.h"
 #include "open3d/utility/MiniVec.h"
 #include "open3d/utility/ParallelScan.h"

--- a/cpp/open3d/ml/impl/misc/Voxelize.h
+++ b/cpp/open3d/ml/impl/misc/Voxelize.h
@@ -163,8 +163,8 @@ void VoxelizeCPU(size_t num_points,
         while (hashes_indices[i].first == -1) {
             ++i;
         }
-        for (;
-             i < hashes_indices.size() && out_voxel_row_splits_idx < num_voxels;
+        for (; i < hashes_indices.size() &&
+               out_voxel_row_splits_idx <= num_voxels;
              ++i) {
             if (i == 0 ||
                 hashes_indices[i - 1].first != hashes_indices[i].first) {

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -47,6 +47,7 @@ set(TORCH_OPS_CUDA_SOURCES
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
+    "misc/RaggedToDenseOpKernel.cu"
 )
 
 if(BUILD_CUDA_MODULE)

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -33,6 +33,8 @@ set(TORCH_OPS_SOURCES
     "misc/ReduceSubarraysSumOpKernel.cpp"
     "misc/VoxelPoolingOps.cpp"
     "misc/FixedRadiusSearchOpKernel.cpp"
+    "misc/RaggedToDenseOps.cpp"
+    "misc/RaggedToDenseOpKernel.cpp"
 )
 
 set(TORCH_OPS_CUDA_SOURCES

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -35,6 +35,8 @@ set(TORCH_OPS_SOURCES
     "misc/FixedRadiusSearchOpKernel.cpp"
     "misc/RaggedToDenseOps.cpp"
     "misc/RaggedToDenseOpKernel.cpp"
+    "misc/VoxelizeOps.cpp"
+    "misc/VoxelizeOpKernel.cpp"
 )
 
 set(TORCH_OPS_CUDA_SOURCES
@@ -48,6 +50,7 @@ set(TORCH_OPS_CUDA_SOURCES
     "misc/ReduceSubarraysSumOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
     "misc/RaggedToDenseOpKernel.cu"
+    "misc/VoxelizeOpKernel.cu"
 )
 
 if(BUILD_CUDA_MODULE)

--- a/cpp/open3d/ml/pytorch/TorchHelper.h
+++ b/cpp/open3d/ml/pytorch/TorchHelper.h
@@ -125,9 +125,9 @@ inline bool SameDeviceType(std::initializer_list<torch::Tensor> tensors) {
 // convenience function to check if all tensors have the same dtype
 inline bool SameDtype(std::initializer_list<torch::Tensor> tensors) {
     if (tensors.size()) {
-        auto device_type = tensors.begin()->dtype();
+        auto dtype = tensors.begin()->dtype();
         for (auto t : tensors) {
-            if (device_type != t.dtype()) {
+            if (dtype != t.dtype()) {
                 return false;
             }
         }

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cpp
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cpp
@@ -25,9 +25,10 @@
 // ----------------------------------------------------------------------------
 //
 
+#include "open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h"
+
 #include "open3d/ml/impl/misc/RaggedToDense.h"
 #include "open3d/ml/pytorch/TorchHelper.h"
-#include "open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h"
 #include "torch/script.h"
 
 template <class T>

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cpp
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cpp
@@ -1,0 +1,61 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+
+#include "open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h"
+
+#include "open3d/ml/impl/misc/RaggedToDense.h"
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "torch/script.h"
+
+template <class T>
+torch::Tensor RaggedToDenseCPU(const torch::Tensor& values,
+                               const torch::Tensor& row_splits,
+                               const int64_t out_col_size,
+                               const torch::Tensor& default_value) {
+    auto out_shape = values.sizes().vec();
+    out_shape.erase(out_shape.begin());
+    out_shape.insert(out_shape.begin(), {row_splits.size(0) - 1, out_col_size});
+    torch::Tensor out =
+            torch::empty(out_shape, torch::dtype(ToTorchDtype<T>()));
+
+    open3d::ml::impl::RaggedToDenseCPU(
+            values.data_ptr<T>(), row_splits.data_ptr<int64_t>(),
+            row_splits.size(0), out_col_size, default_value.data_ptr<T>(),
+            default_value.numel(), out.data_ptr<T>());
+
+    return out;
+}
+
+#define INSTANTIATE(T)                                                 \
+    template torch::Tensor RaggedToDenseCPU<T>(                        \
+            const torch::Tensor&, const torch::Tensor&, const int64_t, \
+            const torch::Tensor&);
+
+INSTANTIATE(int32_t)
+INSTANTIATE(int64_t)
+INSTANTIATE(float)
+INSTANTIATE(double)

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cu
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.cu
@@ -25,24 +25,28 @@
 // ----------------------------------------------------------------------------
 //
 
-#include "open3d/ml/impl/misc/RaggedToDense.h"
+#include "ATen/cuda/CUDAContext.h"
+#include "open3d/ml/impl/misc/RaggedToDense.cuh"
 #include "open3d/ml/pytorch/TorchHelper.h"
 #include "open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h"
 #include "torch/script.h"
 
 template <class T>
-torch::Tensor RaggedToDenseCPU(const torch::Tensor& values,
-                               const torch::Tensor& row_splits,
-                               const int64_t out_col_size,
-                               const torch::Tensor& default_value) {
+torch::Tensor RaggedToDenseCUDA(const torch::Tensor& values,
+                                const torch::Tensor& row_splits,
+                                const int64_t out_col_size,
+                                const torch::Tensor& default_value) {
     auto out_shape = values.sizes().vec();
     out_shape.erase(out_shape.begin());
     out_shape.insert(out_shape.begin(), {row_splits.size(0) - 1, out_col_size});
-    torch::Tensor out =
-            torch::empty(out_shape, torch::dtype(ToTorchDtype<T>()));
+    auto device = values.device();
+    torch::Tensor out = torch::empty(
+            out_shape, torch::dtype(ToTorchDtype<T>()).device(device));
 
-    open3d::ml::impl::RaggedToDenseCPU(
-            values.data_ptr<T>(), row_splits.data_ptr<int64_t>(),
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    open3d::ml::impl::RaggedToDenseCUDA(
+            stream, values.data_ptr<T>(), row_splits.data_ptr<int64_t>(),
             row_splits.size(0), out_col_size, default_value.data_ptr<T>(),
             default_value.numel(), out.data_ptr<T>());
 
@@ -50,7 +54,7 @@ torch::Tensor RaggedToDenseCPU(const torch::Tensor& values,
 }
 
 #define INSTANTIATE(T)                                                 \
-    template torch::Tensor RaggedToDenseCPU<T>(                        \
+    template torch::Tensor RaggedToDenseCUDA<T>(                       \
             const torch::Tensor&, const torch::Tensor&, const int64_t, \
             const torch::Tensor&);
 

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h
@@ -1,0 +1,43 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+#pragma once
+
+#include "torch/script.h"
+
+template <class T>
+torch::Tensor RaggedToDenseCPU(const torch::Tensor& values,
+                               const torch::Tensor& row_splits,
+                               const int64_t out_col_size,
+                               const torch::Tensor& default_value);
+
+#ifdef BUILD_CUDA_MODULE
+template <class T>
+torch::Tensor RaggedToDenseCUDA(const torch::Tensor& values,
+                                const torch::Tensor& row_splits,
+                                const int64_t out_col_size,
+                                const torch::Tensor& default_value);
+#endif

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOps.cpp
@@ -1,0 +1,105 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+
+#include <vector>
+
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "open3d/ml/pytorch/misc/RaggedToDenseOpKernel.h"
+#include "torch/script.h"
+
+torch::Tensor RaggedToDense(torch::Tensor values,
+                            torch::Tensor row_splits,
+                            const int64_t out_col_size,
+                            torch::Tensor default_value) {
+    values = values.contiguous();
+    row_splits = row_splits.contiguous();
+    default_value = default_value.contiguous();
+    CHECK_TYPE(row_splits, kInt64);
+    CHECK_SAME_DTYPE(values, default_value);
+
+    // check input shapes
+    {
+        using namespace open3d::ml::op_util;
+        Dim num_rows("num_rows");
+        CHECK_SHAPE(row_splits, num_rows + 1);
+        if (default_value.sizes().size()) {
+            Dim item_size("item_size");
+            CHECK_SHAPE_COMBINE_LAST_DIMS(default_value, item_size);
+            CHECK_SHAPE_COMBINE_LAST_DIMS(values, Dim(), item_size);
+            // check shape tail
+            std::vector<int64_t> item_shape(values.sizes().begin() + 1,
+                                            values.sizes().end());
+            TORCH_CHECK(default_value.sizes().vec() == item_shape,
+                        "default_value " + default_value.toString() +
+                                " has incompatible with the shape of items in "
+                                "values " +
+                                values.toString());
+        } else  // scalar default_value
+        {
+            Dim num_values("num_values");
+            CHECK_SHAPE_COMBINE_LAST_DIMS(values, num_values);
+        }
+    }
+
+    // make sure everything is on the same device as 'values'
+    auto device = values.device();
+    row_splits = row_splits.to(device);
+    default_value = default_value.to(device);
+
+    const auto& value_type = values.dtype();
+
+#define CALL(value_t, fn)                                                    \
+    if (CompareTorchDtype<value_t>(value_type)) {                            \
+        return fn<value_t>(values, row_splits, out_col_size, default_value); \
+    }
+
+    if (values.is_cuda()) {
+#ifdef BUILD_CUDA_MODULE
+        // pass to cuda function
+        // CALL(int32_t, RaggedToDenseCUDA)
+        // CALL(int64_t, RaggedToDenseCUDA)
+        // CALL(float, RaggedToDenseCUDA)
+        // CALL(double, RaggedToDenseCUDA)
+#else
+        TORCH_CHECK(false, "RaggedToDense was not compiled with CUDA support")
+#endif
+    } else {
+        CALL(int32_t, RaggedToDenseCPU)
+        CALL(int64_t, RaggedToDenseCPU)
+        CALL(float, RaggedToDenseCPU)
+        CALL(double, RaggedToDenseCPU)
+    }
+    TORCH_CHECK(false, "RaggedToDense does not support " + values.toString() +
+                               " as input for values")
+    return torch::Tensor();
+}
+
+static auto registry = torch::RegisterOperators(
+        "open3d::ragged_to_dense(Tensor values, Tensor row_splits, int "
+        "out_col_size, Tensor default_value)"
+        " -> Tensor out",
+        &RaggedToDense);

--- a/cpp/open3d/ml/pytorch/misc/RaggedToDenseOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/RaggedToDenseOps.cpp
@@ -80,14 +80,20 @@ torch::Tensor RaggedToDense(torch::Tensor values,
     if (values.is_cuda()) {
 #ifdef BUILD_CUDA_MODULE
         // pass to cuda function
-        // CALL(int32_t, RaggedToDenseCUDA)
-        // CALL(int64_t, RaggedToDenseCUDA)
-        // CALL(float, RaggedToDenseCUDA)
-        // CALL(double, RaggedToDenseCUDA)
+        CALL(uint8_t, RaggedToDenseCUDA)
+        CALL(int8_t, RaggedToDenseCUDA)
+        CALL(int16_t, RaggedToDenseCUDA)
+        CALL(int32_t, RaggedToDenseCUDA)
+        CALL(int64_t, RaggedToDenseCUDA)
+        CALL(float, RaggedToDenseCUDA)
+        CALL(double, RaggedToDenseCUDA)
 #else
         TORCH_CHECK(false, "RaggedToDense was not compiled with CUDA support")
 #endif
     } else {
+        CALL(uint8_t, RaggedToDenseCPU)
+        CALL(int8_t, RaggedToDenseCPU)
+        CALL(int16_t, RaggedToDenseCPU)
         CALL(int32_t, RaggedToDenseCPU)
         CALL(int64_t, RaggedToDenseCPU)
         CALL(float, RaggedToDenseCPU)

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cpp
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cpp
@@ -1,0 +1,86 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+
+#include "open3d/ml/impl/misc/Voxelize.h"
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "open3d/ml/pytorch/misc/VoxelizeOpKernel.h"
+#include "torch/script.h"
+
+using namespace open3d::ml::impl;
+
+template <class T>
+void VoxelizeCPU(const torch::Tensor& points,
+                 const torch::Tensor& voxel_size,
+                 const torch::Tensor& points_range_min,
+                 const torch::Tensor& points_range_max,
+                 const int64_t max_points_per_voxel,
+                 const int64_t max_voxels,
+                 torch::Tensor& voxel_coords,
+                 torch::Tensor& voxel_point_indices,
+                 torch::Tensor& voxel_point_row_splits) {
+    VoxelizeOutputAllocator output_allocator(points.device().type(),
+                                             points.device().index());
+
+    switch (points.size(1)) {
+#define CASE(NDIM)                                                        \
+    case NDIM:                                                            \
+        VoxelizeCPU<T, NDIM>(                                             \
+                points.size(0), points.data_ptr<T>(),                     \
+                voxel_size.data_ptr<T>(), points_range_min.data_ptr<T>(), \
+                points_range_max.data_ptr<T>(), max_points_per_voxel,     \
+                max_voxels, output_allocator);                            \
+        break;
+        CASE(1)
+        CASE(2)
+        CASE(3)
+        CASE(4)
+        CASE(5)
+        CASE(6)
+        CASE(7)
+        CASE(8)
+        default:
+            break;  // will be handled by the generic torch function
+
+#undef CASE
+    }
+
+    voxel_coords = output_allocator.VoxelCoords();
+    voxel_point_indices = output_allocator.VoxelPointIndices();
+    voxel_point_row_splits = output_allocator.VoxelPointRowSplits();
+}
+
+#define INSTANTIATE(T)                                                       \
+    template void VoxelizeCPU<T>(                                            \
+            const torch::Tensor& points, const torch::Tensor& voxel_size,    \
+            const torch::Tensor& points_range_min,                           \
+            const torch::Tensor& points_range_max,                           \
+            const int64_t max_points_per_voxel, const int64_t max_voxels,    \
+            torch::Tensor& voxel_coords, torch::Tensor& voxel_point_indices, \
+            torch::Tensor& voxel_point_row_splits);
+
+INSTANTIATE(float)
+INSTANTIATE(double)

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cpp
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cpp
@@ -25,9 +25,10 @@
 // ----------------------------------------------------------------------------
 //
 
+#include "open3d/ml/pytorch/misc/VoxelizeOpKernel.h"
+
 #include "open3d/ml/impl/misc/Voxelize.h"
 #include "open3d/ml/pytorch/TorchHelper.h"
-#include "open3d/ml/pytorch/misc/VoxelizeOpKernel.h"
 #include "torch/script.h"
 
 using namespace open3d::ml::impl;

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cu
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.cu
@@ -1,0 +1,104 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+
+#include "ATen/cuda/CUDAContext.h"
+#include "open3d/ml/impl/misc/Voxelize.cuh"
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "open3d/ml/pytorch/misc/VoxelizeOpKernel.h"
+#include "torch/script.h"
+
+using namespace open3d::ml::impl;
+
+template <class T>
+void VoxelizeCUDA(const torch::Tensor& points,
+                  const torch::Tensor& voxel_size,
+                  const torch::Tensor& points_range_min,
+                  const torch::Tensor& points_range_max,
+                  const int64_t max_points_per_voxel,
+                  const int64_t max_voxels,
+                  torch::Tensor& voxel_coords,
+                  torch::Tensor& voxel_point_indices,
+                  torch::Tensor& voxel_point_row_splits) {
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto cuda_device_props = at::cuda::getCurrentDeviceProperties();
+    const int texture_alignment = cuda_device_props->textureAlignment;
+
+    VoxelizeOutputAllocator output_allocator(points.device().type(),
+                                             points.device().index());
+
+    switch (points.size(1)) {
+#define CASE(NDIM)                                                        \
+    case NDIM: {                                                          \
+        void* temp_ptr = nullptr;                                         \
+        size_t temp_size = 0;                                             \
+        VoxelizeCUDA<T, NDIM>(                                            \
+                stream, temp_ptr, temp_size, texture_alignment,           \
+                points.size(0), points.data_ptr<T>(),                     \
+                voxel_size.data_ptr<T>(), points_range_min.data_ptr<T>(), \
+                points_range_max.data_ptr<T>(), max_points_per_voxel,     \
+                max_voxels, output_allocator);                            \
+                                                                          \
+        auto temp_tensor =                                                \
+                CreateTempTensor(temp_size, points.device(), &temp_ptr);  \
+                                                                          \
+        VoxelizeCUDA<T, NDIM>(                                            \
+                stream, temp_ptr, temp_size, texture_alignment,           \
+                points.size(0), points.data_ptr<T>(),                     \
+                voxel_size.data_ptr<T>(), points_range_min.data_ptr<T>(), \
+                points_range_max.data_ptr<T>(), max_points_per_voxel,     \
+                max_voxels, output_allocator);                            \
+    } break;
+        CASE(1)
+        CASE(2)
+        CASE(3)
+        CASE(4)
+        CASE(5)
+        CASE(6)
+        CASE(7)
+        CASE(8)
+        default:
+            break;  // will be handled by the generic torch function
+
+#undef CASE
+    }
+
+    voxel_coords = output_allocator.VoxelCoords();
+    voxel_point_indices = output_allocator.VoxelPointIndices();
+    voxel_point_row_splits = output_allocator.VoxelPointRowSplits();
+}
+
+#define INSTANTIATE(T)                                                       \
+    template void VoxelizeCUDA<T>(                                           \
+            const torch::Tensor& points, const torch::Tensor& voxel_size,    \
+            const torch::Tensor& points_range_min,                           \
+            const torch::Tensor& points_range_max,                           \
+            const int64_t max_points_per_voxel, const int64_t max_voxels,    \
+            torch::Tensor& voxel_coords, torch::Tensor& voxel_point_indices, \
+            torch::Tensor& voxel_point_row_splits);
+
+INSTANTIATE(float)
+INSTANTIATE(double)

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.h
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.h
@@ -26,6 +26,7 @@
 //
 #pragma once
 
+#include "open3d/ml/pytorch/TorchHelper.h"
 #include "torch/script.h"
 
 template <class T>

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.h
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOpKernel.h
@@ -1,0 +1,95 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+#pragma once
+
+#include "torch/script.h"
+
+template <class T>
+void VoxelizeCPU(const torch::Tensor& points,
+                 const torch::Tensor& voxel_size,
+                 const torch::Tensor& points_range_min,
+                 const torch::Tensor& points_range_max,
+                 const int64_t max_points_per_voxel,
+                 const int64_t max_voxels,
+                 torch::Tensor& voxel_coords,
+                 torch::Tensor& voxel_point_indices,
+                 torch::Tensor& voxel_point_row_splits);
+
+#ifdef BUILD_CUDA_MODULE
+template <class T>
+void VoxelizeCUDA(const torch::Tensor& points,
+                  const torch::Tensor& voxel_size,
+                  const torch::Tensor& points_range_min,
+                  const torch::Tensor& points_range_max,
+                  const int64_t max_points_per_voxel,
+                  const int64_t max_voxels,
+                  torch::Tensor& voxel_coords,
+                  torch::Tensor& voxel_point_indices,
+                  torch::Tensor& voxel_point_row_splits);
+#endif
+
+class VoxelizeOutputAllocator {
+public:
+    VoxelizeOutputAllocator(torch::DeviceType device_type, int device_idx)
+        : device_type(device_type), device_idx(device_idx) {}
+
+    void AllocVoxelCoords(int32_t** ptr, int64_t rows, int64_t cols) {
+        voxel_coords = torch::empty({rows, cols},
+                                    torch::dtype(ToTorchDtype<int32_t>())
+                                            .device(device_type, device_idx));
+        *ptr = voxel_coords.data_ptr<int32_t>();
+    }
+
+    void AllocVoxelPointIndices(int64_t** ptr, int64_t num) {
+        voxel_point_indices =
+                torch::empty({num}, torch::dtype(ToTorchDtype<int64_t>())
+                                            .device(device_type, device_idx));
+        *ptr = voxel_point_indices.data_ptr<int64_t>();
+    }
+
+    void AllocVoxelPointRowSplits(int64_t** ptr, int64_t num) {
+        voxel_point_row_splits =
+                torch::empty({num}, torch::dtype(ToTorchDtype<int64_t>())
+                                            .device(device_type, device_idx));
+        *ptr = voxel_point_row_splits.data_ptr<int64_t>();
+    }
+
+    const torch::Tensor& VoxelCoords() const { return voxel_coords; }
+    const torch::Tensor& VoxelPointIndices() const {
+        return voxel_point_indices;
+    }
+    const torch::Tensor& VoxelPointRowSplits() const {
+        return voxel_point_row_splits;
+    }
+
+private:
+    torch::Tensor voxel_coords;
+    torch::Tensor voxel_point_indices;
+    torch::Tensor voxel_point_row_splits;
+    torch::DeviceType device_type;
+    int device_idx;
+};

--- a/cpp/open3d/ml/pytorch/misc/VoxelizeOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/VoxelizeOps.cpp
@@ -1,0 +1,101 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+//
+
+#include <vector>
+
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "open3d/ml/pytorch/misc/VoxelizeOpKernel.h"
+#include "torch/script.h"
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> Voxelize(
+        torch::Tensor points,
+        torch::Tensor voxel_size,
+        torch::Tensor points_range_min,
+        torch::Tensor points_range_max,
+        const int64_t max_points_per_voxel,
+        const int64_t max_voxels) {
+    points = points.contiguous();
+
+    // make sure that these tensors are on the cpu
+    voxel_size = voxel_size.to(torch::kCPU).contiguous();
+    points_range_min = points_range_min.to(torch::kCPU).contiguous();
+    points_range_max = points_range_max.to(torch::kCPU).contiguous();
+
+    CHECK_SAME_DTYPE(points, voxel_size, points_range_min, points_range_max);
+
+    // check input shapes
+    {
+        using namespace open3d::ml::op_util;
+        Dim num_points("num_points");
+        Dim ndim("ndim");
+        CHECK_SHAPE(points, num_points, ndim);
+        CHECK_SHAPE(voxel_size, ndim);
+        CHECK_SHAPE(points_range_min, ndim);
+        CHECK_SHAPE(points_range_max, ndim);
+        TORCH_CHECK(0 < ndim.value() && ndim.value() < 9,
+                    "the number of dimensions must be in [1,..,8]");
+    }
+
+    const auto& points_dtype = points.dtype();
+
+    // output tensors
+    torch::Tensor voxel_coords, voxel_point_indices, voxel_point_row_splits;
+
+#define CALL(point_t, fn)                                                   \
+    if (CompareTorchDtype<point_t>(points_dtype)) {                         \
+        fn<point_t>(points, voxel_size, points_range_min, points_range_max, \
+                    max_points_per_voxel, max_voxels, voxel_coords,         \
+                    voxel_point_indices, voxel_point_row_splits);           \
+        return std::make_tuple(voxel_coords, voxel_point_indices,           \
+                               voxel_point_row_splits);                     \
+    }
+
+    if (points.is_cuda()) {
+#ifdef BUILD_CUDA_MODULE
+        // pass to cuda function
+        CALL(float, VoxelizeCUDA)
+        CALL(double, VoxelizeCUDA)
+#else
+        TORCH_CHECK(false, "Voxelize was not compiled with CUDA support")
+#endif
+    } else {
+        CALL(float, VoxelizeCPU)
+        CALL(double, VoxelizeCPU)
+    }
+    TORCH_CHECK(false, "Voxelize does not support " + points.toString() +
+                               " as input for values")
+    return std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>();
+}
+
+static auto registry = torch::RegisterOperators(
+        "open3d::voxelize(Tensor points, Tensor voxel_size, Tensor "
+        "points_range_min, Tensor points_range_max, int "
+        "max_points_per_voxel=9223372036854775807 , "
+        "int max_voxels=9223372036854775807) -> (Tensor voxel_coords, Tensor "
+        "voxel_point_indices, "
+        "Tensor voxel_point_row_splits)",
+        &Voxelize);

--- a/cpp/open3d/ml/tensorflow/CMakeLists.txt
+++ b/cpp/open3d/ml/tensorflow/CMakeLists.txt
@@ -57,6 +57,7 @@ set(TF_OPS_CUDA_SOURCES
     "misc/BuildSpatialHashTableOpKernel.cu"
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
+    "misc/VoxelizeOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
 )
 

--- a/cpp/open3d/ml/tensorflow/CMakeLists.txt
+++ b/cpp/open3d/ml/tensorflow/CMakeLists.txt
@@ -37,6 +37,8 @@ set(TF_OPS_SOURCES
     "misc/FixedRadiusSearchOpKernel.cpp"
     "misc/KnnSearchOps.cpp"
     "misc/VoxelPoolingOpKernel.cpp"
+    "misc/VoxelizeOpKernel.cpp"
+    "misc/VoxelizeOps.cpp"
     "tf_neighbors/tf_batch_neighbors.cpp"
     "tf_neighbors/tf_neighbors.cpp"
     "tf_subsampling/tf_batch_subsampling.cpp"

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cpp
@@ -1,0 +1,80 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "VoxelizeOpKernel.h"
+#include "open3d/ml/impl/misc/Voxelize.h"
+
+using namespace open3d::ml::impl;
+using namespace voxelize_opkernel;
+using namespace tensorflow;
+
+template <class T>
+class VoxelizeOpKernelCPU : public VoxelizeOpKernel {
+public:
+    explicit VoxelizeOpKernelCPU(OpKernelConstruction* construction)
+        : VoxelizeOpKernel(construction) {}
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& points,
+                const tensorflow::Tensor& voxel_size,
+                const tensorflow::Tensor& points_range_min,
+                const tensorflow::Tensor& points_range_max) {
+        OutputAllocator output_allocator(context);
+
+        switch (points.dim_size(1)) {
+#define CASE(NDIM)                                                        \
+    case NDIM:                                                            \
+        VoxelizeCPU<T, NDIM>(points.dim_size(0), points.flat<T>().data(), \
+                             voxel_size.flat<T>().data(),                 \
+                             points_range_min.flat<T>().data(),           \
+                             points_range_max.flat<T>().data(),           \
+                             max_points_per_voxel, max_voxels,            \
+                             output_allocator);                           \
+        break;
+            CASE(1)
+            CASE(2)
+            CASE(3)
+            CASE(4)
+            CASE(5)
+            CASE(6)
+            CASE(7)
+            CASE(8)
+            default:
+                break;  // will be handled by the base class
+
+#undef CASE
+        }
+    }
+};
+
+#define REG_KB(type)                                            \
+    REGISTER_KERNEL_BUILDER(Name("Open3DVoxelize")              \
+                                    .Device(DEVICE_CPU)         \
+                                    .TypeConstraint<type>("T"), \
+                            VoxelizeOpKernelCPU<type>);
+REG_KB(float)
+REG_KB(double)
+#undef REG_KB

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cpp
@@ -25,6 +25,7 @@
 // ----------------------------------------------------------------------------
 
 #include "VoxelizeOpKernel.h"
+
 #include "open3d/ml/impl/misc/Voxelize.h"
 
 using namespace open3d::ml::impl;

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cu
@@ -1,0 +1,111 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#define EIGEN_USE_GPU
+#include "VoxelizeOpKernel.h"
+#include "open3d/ml/Helper.h"
+#include "open3d/ml/impl/misc/Voxelize.cuh"
+
+using namespace open3d::ml;
+using namespace open3d::ml::impl;
+using namespace voxelize_opkernel;
+using namespace tensorflow;
+
+template <class T>
+class VoxelizeOpKernelCUDA : public VoxelizeOpKernel {
+public:
+    explicit VoxelizeOpKernelCUDA(OpKernelConstruction* construction)
+        : VoxelizeOpKernel(construction) {
+        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+    }
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& points,
+                const tensorflow::Tensor& voxel_size,
+                const tensorflow::Tensor& points_range_min,
+                const tensorflow::Tensor& points_range_max) {
+        auto device = context->eigen_gpu_device();
+
+        OutputAllocator output_allocator(context);
+
+        switch (points.dim_size(1)) {
+#define CASE(NDIM)                                                          \
+    case NDIM: {                                                            \
+        void* temp_ptr = nullptr;                                           \
+        size_t temp_size = 0;                                               \
+        VoxelizeCUDA<T, NDIM>(                                              \
+                device.stream(), temp_ptr, temp_size, texture_alignment,    \
+                points.dim_size(0), points.flat<T>().data(),                \
+                voxel_size.flat<T>().data(),                                \
+                points_range_min.flat<T>().data(),                          \
+                points_range_max.flat<T>().data(), max_points_per_voxel,    \
+                max_voxels, output_allocator);                              \
+                                                                            \
+        Tensor temp_tensor;                                                 \
+        TensorShape temp_shape({ssize_t(temp_size)});                       \
+        OP_REQUIRES_OK(context,                                             \
+                       context->allocate_temp(DataTypeToEnum<uint8_t>::v(), \
+                                              temp_shape, &temp_tensor));   \
+        temp_ptr = temp_tensor.flat<uint8_t>().data();                      \
+                                                                            \
+        VoxelizeCUDA<T, NDIM>(                                              \
+                device.stream(), temp_ptr, temp_size, texture_alignment,    \
+                points.dim_size(0), points.flat<T>().data(),                \
+                voxel_size.flat<T>().data(),                                \
+                points_range_min.flat<T>().data(),                          \
+                points_range_max.flat<T>().data(), max_points_per_voxel,    \
+                max_voxels, output_allocator);                              \
+    } break;
+            CASE(1)
+            CASE(2)
+            CASE(3)
+            CASE(4)
+            CASE(5)
+            CASE(6)
+            CASE(7)
+            CASE(8)
+            default:
+                break;  // will be handled by the base class
+
+#undef CASE
+        }
+    }
+
+private:
+    int texture_alignment;
+};
+
+#define REG_KB(type)                                                 \
+    REGISTER_KERNEL_BUILDER(Name("Open3DVoxelize")                   \
+                                    .Device(DEVICE_GPU)              \
+                                    .TypeConstraint<type>("T")       \
+                                    .HostMemory("voxel_size")        \
+                                    .HostMemory("points_range_min")  \
+                                    .HostMemory("points_range_max"), \
+                            VoxelizeOpKernelCUDA<type>);
+REG_KB(float)
+REG_KB(double)
+#undef REG_KB

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.h
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.h
@@ -1,0 +1,122 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+#pragma once
+
+//#include "open3d/ml/impl/misc/VoxelPooling.h"
+#include "open3d/ml/tensorflow/TensorFlowHelper.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+/// @cond
+// namespace for code that is common for all kernels
+namespace voxelize_opkernel {
+
+class OutputAllocator {
+public:
+    OutputAllocator(tensorflow::OpKernelContext* context) : context(context) {}
+
+    void AllocVoxelCoords(int32_t** ptr, int64_t rows, int64_t cols) {
+        using namespace tensorflow;
+        *ptr = nullptr;
+        Tensor* tensor = 0;
+        TensorShape shape({rows, cols});
+        OP_REQUIRES_OK(context, context->allocate_output(0, shape, &tensor));
+        auto flat_tensor = tensor->flat<int32_t>();
+        *ptr = flat_tensor.data();
+    }
+
+    void AllocVoxelPointIndices(int64_t** ptr, int64_t num) {
+        using namespace tensorflow;
+        *ptr = nullptr;
+        Tensor* tensor = 0;
+        TensorShape shape({num});
+        OP_REQUIRES_OK(context, context->allocate_output(1, shape, &tensor));
+        auto flat_tensor = tensor->flat<int64>();
+        *ptr = (int64_t*)flat_tensor.data();
+    }
+
+    void AllocVoxelPointRowSplits(int64_t** ptr, int64_t num) {
+        using namespace tensorflow;
+        *ptr = nullptr;
+        Tensor* tensor = 0;
+        TensorShape shape({num});
+        OP_REQUIRES_OK(context, context->allocate_output(2, shape, &tensor));
+        auto flat_tensor = tensor->flat<int64>();
+        *ptr = (int64_t*)flat_tensor.data();
+    }
+
+private:
+    tensorflow::OpKernelContext* context;
+};
+
+// Base class with common code for the OpKernel implementations
+class VoxelizeOpKernel : public tensorflow::OpKernel {
+public:
+    explicit VoxelizeOpKernel(tensorflow::OpKernelConstruction* construction)
+        : OpKernel(construction) {
+        OP_REQUIRES_OK(construction,
+                       construction->GetAttr("max_points_per_voxel",
+                                             &max_points_per_voxel));
+        OP_REQUIRES_OK(construction,
+                       construction->GetAttr("max_voxels", &max_voxels));
+    }
+
+    void Compute(tensorflow::OpKernelContext* context) override {
+        using namespace tensorflow;
+        const Tensor& points = context->input(0);
+        const Tensor& voxel_size = context->input(1);
+        const Tensor& points_range_min = context->input(2);
+        const Tensor& points_range_max = context->input(3);
+
+        {
+            using namespace open3d::ml::op_util;
+            Dim num_points("num_points");
+            Dim ndim("ndim");
+            CHECK_SHAPE(context, points, num_points, ndim);
+            CHECK_SHAPE(context, voxel_size, ndim);
+            CHECK_SHAPE(context, points_range_min, ndim);
+            CHECK_SHAPE(context, points_range_max, ndim);
+            OP_REQUIRES(
+                    context, ndim.value() > 0 && ndim.value() < 9,
+                    errors::InvalidArgument(
+                            "the number of dimensions must be in [1,..,8]"));
+        }
+
+        Kernel(context, points, voxel_size, points_range_min, points_range_max);
+    }
+
+    // Function with the device specific code
+    virtual void Kernel(tensorflow::OpKernelContext* context,
+                        const tensorflow::Tensor& points,
+                        const tensorflow::Tensor& voxel_size,
+                        const tensorflow::Tensor& points_range_min,
+                        const tensorflow::Tensor& points_range_max) = 0;
+
+protected:
+    tensorflow::int64 max_points_per_voxel;
+    tensorflow::int64 max_voxels;
+};
+
+}  // namespace voxelize_opkernel
+/// @endcond

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
@@ -75,57 +75,33 @@ REGISTER_OP("Open3DVoxelize")
         })
         .Doc(R"doc(
 Voxelization for point clouds.
-Spatial pooling for point clouds by combining points that fall into the same voxel bin.
 
-The voxel grid used for pooling is always aligned to the origin (0,0,0) to 
-simplify building voxel grid hierarchies. The order of the returned voxels is
-not defined as can be seen in the following example::
+The function returns the integer coordinates of the voxels that contain
+points and a compact list of the indices that associate the voxels to the
+points.
+
+Minimal example::
 
   import open3d.ml.tf as ml3d
 
-  positions = [
+  points = [
       [0.1,0.1,0.1], 
       [0.5,0.5,0.5], 
       [1.7,1.7,1.7],
       [1.8,1.8,1.8],
-      [0.3,2.4,1.4]]
+      [9.3,9.4,9.4]]
 
-  features = [[1.0,2.0],
-              [1.1,2.3],
-              [4.2,0.1],
-              [1.3,3.4],
-              [2.3,1.9]]
+  ml3d.ops.voxelize(points, 
+                    voxel_size=[1.0,1.0,1.0], 
+                    points_range_min=[0,0,0], 
+                    points_range_max=[2,2,2])
 
-  ml3d.ops.voxel_pooling(positions, features, 1.0, 
-                         position_fn='center', feature_fn='max')
-
-  # or with pytorch
-  import torch
-  import open3d.ml.torch as ml3d
-
-  positions = torch.Tensor([
-      [0.1,0.1,0.1], 
-      [0.5,0.5,0.5], 
-      [1.7,1.7,1.7],
-      [1.8,1.8,1.8],
-      [0.3,2.4,1.4]])
-
-  features = torch.Tensor([
-              [1.0,2.0],
-              [1.1,2.3],
-              [4.2,0.1],
-              [1.3,3.4],
-              [2.3,1.9]])
-
-  ml3d.ops.voxel_pooling(positions, features, 1.0, 
-                         position_fn='center', feature_fn='max')
-
-  # returns the voxel centers  [[0.5, 2.5, 1.5],
-  #                             [1.5, 1.5, 1.5],
-  #                             [0.5, 0.5, 0.5]]
-  # and the max pooled features for each voxel [[2.3, 1.9],
-  #                                             [4.2, 3.4],
-  #                                             [1.1, 2.3]]
+  # returns the voxel coordinates  [[0, 0, 0],
+  #                                 [1, 1, 1]]
+  #
+  #         the point indices      [0, 1, 2, 3]
+  #
+  #         and the point row splits [0, 2, 4] 
 
 points: The point positions with shape [N,D] with N as the number of points and
   D as the number of dimensions, which must be 0 < D < 9.

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
@@ -103,6 +103,29 @@ Minimal example::
   #
   #         and the point row splits [0, 2, 4] 
 
+  # or with pytorch
+  import torch
+  import open3d.ml.torch as ml3d
+
+  points = torch.Tensor([
+      [0.1,0.1,0.1], 
+      [0.5,0.5,0.5], 
+      [1.7,1.7,1.7],
+      [1.8,1.8,1.8],
+      [9.3,9.4,9.4]])
+
+  ml3d.ops.voxelize(points, 
+                    voxel_size=torch.Tensor([1.0,1.0,1.0]), 
+                    points_range_min=torch.Tensor([0,0,0]), 
+                    points_range_max=torch.Tensor([2,2,2]))
+
+  # returns the voxel coordinates  [[0, 0, 0],
+  #                                 [1, 1, 1]]
+  #
+  #         the point indices      [0, 1, 2, 3]
+  #
+  #         and the point row splits [0, 2, 4] 
+
 points: The point positions with shape [N,D] with N as the number of points and
   D as the number of dimensions, which must be 0 < D < 9.
 

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOps.cpp
@@ -1,0 +1,155 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/ml/tensorflow/TensorFlowHelper.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Open3DVoxelize")
+        .Attr("T: {float, double}")  // type for the point positions
+        .Attr("max_points_per_voxel: int = 9223372036854775807")
+        .Attr("max_voxels: int = 9223372036854775807")
+        .Input("points: T")
+        .Input("voxel_size: T")
+        .Input("points_range_min: T")
+        .Input("points_range_max: T")
+        .Output("voxel_coords: int32")
+        .Output("voxel_point_indices: int64")
+        .Output("voxel_point_row_splits: int64")
+        .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+            using namespace ::tensorflow::shape_inference;
+            using namespace open3d::ml::op_util;
+            ShapeHandle points, voxel_size, points_range_min, points_range_max,
+                    max_points_per_voxel, max_voxels, voxel_coords,
+                    voxel_point_indices, voxel_point_row_splits;
+
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &points));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &voxel_size));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &points_range_min));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 1, &points_range_max));
+
+            Dim num_points("num_points");
+            Dim ndim("ndim");
+            CHECK_SHAPE_HANDLE(c, points, num_points, ndim);
+            CHECK_SHAPE_HANDLE(c, voxel_size, ndim);
+            CHECK_SHAPE_HANDLE(c, points_range_min, ndim);
+            CHECK_SHAPE_HANDLE(c, points_range_max, ndim);
+
+            voxel_coords =
+                    c->MakeShape({c->UnknownDim(), c->MakeDim(ndim.value())});
+            c->set_output(0, voxel_coords);
+
+            voxel_point_indices = c->MakeShape({c->UnknownDim()});
+            c->set_output(1, voxel_point_indices);
+            voxel_point_row_splits = c->MakeShape({c->UnknownDim()});
+            c->set_output(2, voxel_point_row_splits);
+
+            return Status::OK();
+        })
+        .Doc(R"doc(
+Voxelization for point clouds.
+Spatial pooling for point clouds by combining points that fall into the same voxel bin.
+
+The voxel grid used for pooling is always aligned to the origin (0,0,0) to 
+simplify building voxel grid hierarchies. The order of the returned voxels is
+not defined as can be seen in the following example::
+
+  import open3d.ml.tf as ml3d
+
+  positions = [
+      [0.1,0.1,0.1], 
+      [0.5,0.5,0.5], 
+      [1.7,1.7,1.7],
+      [1.8,1.8,1.8],
+      [0.3,2.4,1.4]]
+
+  features = [[1.0,2.0],
+              [1.1,2.3],
+              [4.2,0.1],
+              [1.3,3.4],
+              [2.3,1.9]]
+
+  ml3d.ops.voxel_pooling(positions, features, 1.0, 
+                         position_fn='center', feature_fn='max')
+
+  # or with pytorch
+  import torch
+  import open3d.ml.torch as ml3d
+
+  positions = torch.Tensor([
+      [0.1,0.1,0.1], 
+      [0.5,0.5,0.5], 
+      [1.7,1.7,1.7],
+      [1.8,1.8,1.8],
+      [0.3,2.4,1.4]])
+
+  features = torch.Tensor([
+              [1.0,2.0],
+              [1.1,2.3],
+              [4.2,0.1],
+              [1.3,3.4],
+              [2.3,1.9]])
+
+  ml3d.ops.voxel_pooling(positions, features, 1.0, 
+                         position_fn='center', feature_fn='max')
+
+  # returns the voxel centers  [[0.5, 2.5, 1.5],
+  #                             [1.5, 1.5, 1.5],
+  #                             [0.5, 0.5, 0.5]]
+  # and the max pooled features for each voxel [[2.3, 1.9],
+  #                                             [4.2, 3.4],
+  #                                             [1.1, 2.3]]
+
+points: The point positions with shape [N,D] with N as the number of points and
+  D as the number of dimensions, which must be 0 < D < 9.
+
+voxel_size: The voxel size with shape [D].
+
+points_range_min: The minimum range for valid points to be voxelized. This 
+  vector has shape [D] and is used as the origin for computing the voxel_indices.
+
+points_range_min: The maximum range for valid points to be voxelized. This 
+  vector has shape [D].
+
+max_points_per_voxel: The maximum number of points to consider for a voxel.
+
+max_voxels: The maximum number of voxels to generate.
+
+voxel_coords: The integer voxel coordinates.The shape of this tensor is [M, D]
+  with M as the number of voxels and D as the number of dimensions.
+
+voxel_point_indices: A flat list of all the points that have been voxelized.
+  The start and end of each voxel is defined in voxel_point_row_splits.
+
+voxel_point_row_splits: This is an exclusive prefix sum that includes the total
+  number of points in the last element. This can be used to find the start and
+  end of the point indices for each voxel. The shape of this tensor is [M+1].
+
+)doc");

--- a/cpp/open3d/utility/MiniVec.h
+++ b/cpp/open3d/utility/MiniVec.h
@@ -73,6 +73,18 @@ struct MiniVec {
         return r;
     }
 
+    FN_SPECIFIERS bool all() const {
+        bool result = true;
+        for (int i = 0; i < N && result; ++i) result = result && operator[](i);
+        return result;
+    }
+
+    FN_SPECIFIERS bool any() const {
+        for (int i = 0; i < N; ++i)
+            if (operator[](i)) return true;
+        return false;
+    }
+
     T arr[N];
 };
 
@@ -90,22 +102,31 @@ FN_SPECIFIERS MiniVec<double, N> floor(const MiniVec<double, N>& a) {
     return r;
 }
 
-template <class T, int N>
-FN_SPECIFIERS bool operator==(const MiniVec<T, N>& a, const MiniVec<T, N>& b) {
-    bool result = true;
-    for (int i = 0; i < N && result; ++i) result = result && a[i] == b[i];
-    return result;
+template <int N>
+FN_SPECIFIERS MiniVec<float, N> ceil(const MiniVec<float, N>& a) {
+    MiniVec<float, N> r;
+    for (int i = 0; i < N; ++i) r[i] = ceilf(a[i]);
+    return r;
 }
 
-template <class T, int N>
-FN_SPECIFIERS bool operator!=(const MiniVec<T, N>& a, const MiniVec<T, N>& b) {
-    return !(a == b);
+template <int N>
+FN_SPECIFIERS MiniVec<double, N> ceil(const MiniVec<double, N>& a) {
+    MiniVec<double, N> r;
+    for (int i = 0; i < N; ++i) r[i] = std::ceil(a[i]);
+    return r;
 }
 
 template <class T, int N>
 FN_SPECIFIERS MiniVec<T, N> operator-(const MiniVec<T, N>& a) {
     MiniVec<T, N> r;
     for (int i = 0; i < N; ++i) r[i] = -a[i];
+    return r;
+}
+
+template <class T, int N>
+FN_SPECIFIERS MiniVec<T, N> operator!(const MiniVec<T, N>& a) {
+    MiniVec<T, N> r;
+    for (int i = 0; i < N; ++i) r[i] = !a[i];
     return r;
 }
 
@@ -147,6 +168,39 @@ DEFINE_OPERATOR(+, +=)
 DEFINE_OPERATOR(-, -=)
 DEFINE_OPERATOR(*, *=)
 DEFINE_OPERATOR(/, /=)
+#undef DEFINE_OPERATOR
+
+#define DEFINE_OPERATOR(op)                                                   \
+    template <class T, int N>                                                 \
+    FN_SPECIFIERS MiniVec<bool, N> operator op(const MiniVec<T, N>& a,        \
+                                               const MiniVec<T, N>& b) {      \
+        MiniVec<bool, N> c;                                                   \
+        for (int i = 0; i < N; ++i) c[i] = a[i] op b[i];                      \
+        return c;                                                             \
+    }                                                                         \
+                                                                              \
+    template <class T, int N>                                                 \
+    FN_SPECIFIERS MiniVec<bool, N> operator op(const MiniVec<T, N>& a, T b) { \
+        MiniVec<T, N> c;                                                      \
+        for (int i = 0; i < N; ++i) c[i] = a[i] op b;                         \
+        return c;                                                             \
+    }                                                                         \
+                                                                              \
+    template <class T, int N>                                                 \
+    FN_SPECIFIERS MiniVec<T, N> operator op(T a, const MiniVec<T, N>& b) {    \
+        MiniVec<bool, N> c;                                                   \
+        for (int i = 0; i < N; ++i) c[i] = a op b[i];                         \
+        return c;                                                             \
+    }
+
+DEFINE_OPERATOR(<)
+DEFINE_OPERATOR(<=)
+DEFINE_OPERATOR(>)
+DEFINE_OPERATOR(>=)
+DEFINE_OPERATOR(==)
+DEFINE_OPERATOR(!=)
+DEFINE_OPERATOR(&&)
+DEFINE_OPERATOR(||)
 #undef DEFINE_OPERATOR
 #undef FN_SPECIFIERS
 

--- a/python/test/ml_ops/mltest.py
+++ b/python/test/ml_ops/mltest.py
@@ -185,4 +185,10 @@ parametrize = SimpleNamespace(
     ml_gpu_only=pytest.mark.parametrize(
         'ml',
         [v for k, v in _ml_modules.items() if is_gpu_device_name(v.device)]),
+    ml_torch_only=pytest.mark.parametrize(
+        'ml',
+        [v for k, v in _ml_modules.items() if v.module.__name__ == 'torch']),
+    ml_tf_only=pytest.mark.parametrize('ml', [
+        v for k, v in _ml_modules.items() if v.module.__name__ == 'tensorflow'
+    ]),
 )

--- a/python/test/ml_ops/test_ragged_to_dense.py
+++ b/python/test/ml_ops/test_ragged_to_dense.py
@@ -1,0 +1,82 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import numpy as np
+import pytest
+import mltest
+
+# skip all tests if the tf ops were not built and disable warnings caused by
+# tensorflow
+pytestmark = mltest.default_marks
+
+# the supported dtypes for the values
+dtypes = pytest.mark.parametrize('dtype',
+                                 [np.int32, np.int64, np.float32, np.float64])
+
+
+# this op is only available for torch
+@dtypes
+@mltest.parametrize.ml_torch_only
+def test_ragged_to_dense(dtype, ml):
+
+    values = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=dtype)
+    row_splits = np.array([0, 2, 4, 4, 5, 12, 13], dtype=np.int64)
+    out_col_size = 4
+    default_value = np.array(-1, dtype=dtype)
+
+    ans = mltest.run_op(ml, ml.device, True, ml.ops.ragged_to_dense, values,
+                        row_splits, out_col_size, default_value)
+
+    expected = np.full((row_splits.shape[0] - 1, out_col_size), default_value)
+    for i in range(row_splits.shape[0] - 1):
+        for j, value_idx in enumerate(range(row_splits[i], row_splits[i + 1])):
+            if j < expected.shape[1]:
+                expected[i, j] = values[value_idx]
+
+    np.testing.assert_equal(ans, expected)
+
+    # test with more dimensions
+    values = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6],
+                       [7, 7], [8, 8], [9, 9], [10, 10], [11, 11], [12, 12]],
+                      dtype=dtype)
+    row_splits = np.array([0, 2, 4, 4, 5, 12, 13], dtype=np.int64)
+    out_col_size = 4
+    default_value = np.array([-1, -1], dtype=dtype)
+
+    ans = mltest.run_op(ml, ml.device, True, ml.ops.ragged_to_dense, values,
+                        row_splits, out_col_size, default_value)
+
+    expected = np.full((
+        row_splits.shape[0] - 1,
+        out_col_size,
+    ) + default_value.shape, default_value)
+    for i in range(row_splits.shape[0] - 1):
+        for j, value_idx in enumerate(range(row_splits[i], row_splits[i + 1])):
+            if j < expected.shape[1]:
+                expected[i, j] = values[value_idx]
+
+    np.testing.assert_equal(ans, expected)

--- a/python/test/ml_ops/test_voxelize.py
+++ b/python/test/ml_ops/test_voxelize.py
@@ -87,7 +87,7 @@ def assert_equal_voxel_dicts(out, ref):
 iteration = 0
 
 
-@mltest.parametrize.ml_tf_only
+@mltest.parametrize.ml
 @point_dtypes
 @pytest.mark.parametrize('point_range_max', ([11, 11, 11], [2, 2, 2]))
 @pytest.mark.parametrize('max_voxels', [1000, 2, 1, 0])
@@ -145,7 +145,7 @@ def test_voxelize_simple(ml, point_dtype, point_range_max, max_voxels,
     assert_equal_voxel_dicts(voxels, ref=voxels_reference)
 
 
-@mltest.parametrize.ml_tf_only
+@mltest.parametrize.ml
 @point_dtypes
 @ndims
 @pytest.mark.parametrize('max_voxels', [10000, 16, 1, 0])

--- a/python/test/ml_ops/test_voxelize.py
+++ b/python/test/ml_ops/test_voxelize.py
@@ -1,0 +1,181 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import numpy as np
+import pytest
+import mltest
+from check_gradients import check_gradients
+
+# skip all tests if the ml ops were not built
+pytestmark = mltest.default_marks
+
+# the supported dtypes
+point_dtypes = pytest.mark.parametrize('point_dtype', [np.float32, np.float64])
+
+# the supported dimensions
+ndims = pytest.mark.parametrize('ndim', range(1, 9))
+
+
+def voxelize_python(points,
+                    voxel_size,
+                    point_range_min,
+                    point_range_max,
+                    max_points_per_voxel=None,
+                    max_voxels=None):
+    if max_points_per_voxel is None:
+        max_points_per_voxel = points.shape[0]
+    if max_voxels is None:
+        max_voxels = points.shape[0]
+
+    valid = np.logical_and(
+        np.all(points >= point_range_min[np.newaxis, :], axis=1),
+        np.all(points <= point_range_max[np.newaxis, :], axis=1))
+    inv_voxel_size = 1 / voxel_size[np.newaxis, :]
+    voxel_coords = ((points - point_range_min[np.newaxis, :]) *
+                    inv_voxel_size).astype(np.int32)
+
+    voxels = {tuple(c): [] for i, c in enumerate(voxel_coords) if valid[i]}
+    for i, c in enumerate(voxel_coords):
+        if valid[i] and len(voxels[tuple(c)]) < max_points_per_voxel:
+            voxels[tuple(c)].append(i)
+
+    voxel_keys = list(voxels.keys())
+    voxel_keys.sort(key=lambda x: x[::-1])
+    voxel_keys = voxel_keys[:min(max_voxels, len(voxel_keys))]
+    return {k: set(voxels[k]) for k in voxel_keys}
+
+
+def convert_output_to_voxel_dict(out):
+    voxels = {}
+    for i, c in enumerate(out.voxel_coords):
+        point_indices = out.voxel_point_indices[
+            out.voxel_point_row_splits[i]:out.voxel_point_row_splits[i + 1]]
+        voxels[tuple(c)] = set(point_indices)
+    return voxels
+
+
+def assert_equal_voxel_dicts(out, ref):
+    assert sorted(out.keys()) == sorted(ref.keys())
+    for k in out:
+        assert out[k] == ref[k]
+
+
+iteration = 0
+
+
+@mltest.parametrize.ml_tf_only
+@point_dtypes
+@pytest.mark.parametrize('point_range_max', ([11, 11, 11], [2, 2, 2]))
+@pytest.mark.parametrize('max_voxels', [1000, 2, 1, 0])
+@pytest.mark.parametrize('max_points_per_voxel', [1000, 2, 1, 0])
+def test_voxelize_simple(ml, point_dtype, point_range_max, max_voxels,
+                         max_points_per_voxel):
+    # global iteration
+    # if iteration > 0:
+    # return
+    # iteration += 1
+    # if 'GPU' in ml.device:
+    # return
+    # yapf: disable
+
+    points = np.array([
+        # 3 points in voxel
+        [0.5, 0.5, 0.5],
+        [0.7, 0.2, 0.3],
+        [0.7, 0.5, 0.9],
+        # 1 point in another voxel
+        [10.7, 10.2, 10.3],
+        # 2 points in another voxel
+        [1.4, 1.5, 1.4],
+        [1.7, 1.2, 1.3],
+        ], dtype=point_dtype)
+
+    # yapf: enable
+
+    voxel_size = np.array([1.0, 1.1, 1.2], dtype=point_dtype)
+    point_range_min = np.zeros((3,), dtype=point_dtype)
+    point_range_max = np.array(point_range_max, dtype=point_dtype)
+    ans = mltest.run_op(ml,
+                        ml.device,
+                        True,
+                        ml.ops.voxelize,
+                        points,
+                        voxel_size,
+                        point_range_min,
+                        point_range_max,
+                        max_points_per_voxel=max_points_per_voxel,
+                        max_voxels=max_voxels)
+
+    voxels = convert_output_to_voxel_dict(ans)
+    voxels_reference = voxelize_python(
+        points,
+        voxel_size,
+        point_range_min,
+        point_range_max,
+        max_points_per_voxel=max_points_per_voxel,
+        max_voxels=max_voxels)
+    # print(voxels)
+    # print(voxels_reference)
+    # print('max_voxels', max_voxels, 'max_points_per_voxel',
+    # max_points_per_voxel)
+    assert_equal_voxel_dicts(voxels, ref=voxels_reference)
+
+
+@mltest.parametrize.ml_tf_only
+@point_dtypes
+@ndims
+@pytest.mark.parametrize('max_voxels', [10000, 16, 1, 0])
+@pytest.mark.parametrize('max_points_per_voxel', [10000, 16, 1, 0])
+def test_voxelize_random(ml, point_dtype, ndim, max_voxels,
+                         max_points_per_voxel):
+    rng = np.random.RandomState(123)
+    points = rng.rand(rng.randint(0, 10000), ndim).astype(point_dtype)
+
+    voxel_size = rng.uniform(0.01, 0.1, size=(ndim,)).astype(point_dtype)
+    point_range_min = rng.uniform(0.0, 0.3, size=(ndim,)).astype(point_dtype)
+    point_range_max = rng.uniform(0.7, 1.0, size=(ndim,)).astype(point_dtype)
+
+    ans = mltest.run_op(ml,
+                        ml.device,
+                        True,
+                        ml.ops.voxelize,
+                        points,
+                        voxel_size,
+                        point_range_min,
+                        point_range_max,
+                        max_points_per_voxel=max_points_per_voxel,
+                        max_voxels=max_voxels)
+
+    voxels = convert_output_to_voxel_dict(ans)
+    voxels_reference = voxelize_python(
+        points,
+        voxel_size,
+        point_range_min,
+        point_range_max,
+        max_points_per_voxel=max_points_per_voxel,
+        max_voxels=max_voxels)
+    assert_equal_voxel_dicts(voxels, ref=voxels_reference)


### PR DESCRIPTION
This PR adds 
- an op for voxelization of point clouds
- an op for converting ragged to dense tensors for torch
- unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2607)
<!-- Reviewable:end -->
