### PR TITLE
nms op for pytorch and tensorflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ __pycache__
 node_modules/
 static/
 *.old*
+dist/
 compile_commands.json
 
 # Example resources

--- a/cpp/open3d/ml/Helper.h
+++ b/cpp/open3d/ml/Helper.h
@@ -36,6 +36,17 @@
 
 #endif  // #ifdef BUILD_CUDA_MODULE
 
+#include <stdio.h>
+
+#include <stdexcept>
+#include <string>
+
+#ifdef BUILD_CUDA_MODULE
+/// TODO: Link Open3D and use OPEN3D_CUDA_CHECK instead.
+#define OPEN3D_ML_CUDA_CHECK(err) \
+    { open3d::ml::__OPEN3D_ML_CUDA_CHECK((err), __FILE__, __LINE__); }
+#endif
+
 namespace open3d {
 namespace ml {
 
@@ -60,6 +71,20 @@ inline int GetCUDACurrentDeviceTextureAlignment() {
                 std::string(cudaGetErrorString(err)));
     }
     return value;
+}
+
+/// TODO: Link Open3D and use OPEN3D_CUDA_CHECK instead.
+inline void __OPEN3D_ML_CUDA_CHECK(cudaError_t err,
+                                   const char *file,
+                                   int line,
+                                   bool abort = true) {
+    if (err != cudaSuccess) {
+        fprintf(stderr, "%s:%d CUDA runtime error: %s\n", file, line,
+                cudaGetErrorString(err));
+        if (abort) {
+            exit(err);
+        }
+    }
 }
 #endif
 

--- a/cpp/open3d/ml/impl/misc/Nms.cpp
+++ b/cpp/open3d/ml/impl/misc/Nms.cpp
@@ -1,0 +1,137 @@
+#include "open3d/ml/impl/misc/Nms.h"
+
+#include <iostream>
+#include <numeric>
+
+#include "open3d/ml/impl/misc/NmsImpl.h"
+
+#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+template <typename T>
+static std::vector<int64_t> SortIndexes(const T *v,
+                                        int64_t num,
+                                        bool descending = false) {
+    std::vector<int64_t> indices(num);
+    std::iota(indices.begin(), indices.end(), 0);
+    if (descending) {
+        std::stable_sort(indices.begin(), indices.end(),
+                         [&v](int64_t i, int64_t j) { return v[i] > v[j]; });
+    } else {
+        std::stable_sort(indices.begin(), indices.end(),
+                         [&v](int64_t i, int64_t j) { return v[i] < v[j]; });
+    }
+    return indices;
+}
+
+static void AllPairsIoUCPU(const float *boxes,
+                           const float *scores,
+                           const int64_t *sort_indices,
+                           uint64_t *mask,
+                           int N,
+                           double nms_overlap_thresh) {
+    const int num_block_cols = DIVUP(N, NMS_BLOCK_SIZE);
+    const int num_block_rows = DIVUP(N, NMS_BLOCK_SIZE);
+
+    // We need the concept of "block" since the mask is a uint64_t binary bit
+    // map, and the block size is exactly 64x64. This is also consistent with
+    // the CUDA implementation.
+    for (int block_col_idx = 0; block_col_idx < num_block_cols;
+         block_col_idx++) {
+        for (int block_row_idx = 0; block_row_idx < num_block_rows;
+             ++block_row_idx) {
+            // Local block row size.
+            const int row_size =
+                    fminf(N - block_row_idx * NMS_BLOCK_SIZE, NMS_BLOCK_SIZE);
+            // Local block col size.
+            const int col_size =
+                    fminf(N - block_col_idx * NMS_BLOCK_SIZE, NMS_BLOCK_SIZE);
+
+            // Comparing src and dst. In one block, the following src and dst
+            // indices are compared:
+            // - src: BS * block_row_idx : BS * block_row_idx + row_size
+            // - dst: BS * block_col_idx : BS * block_col_idx + col_size
+            //
+            // With all blocks, all src and dst indices are compared.
+            //
+            // Result:
+            // mask[i, j] is a 64-bit integer where mask[i, j][k] (k counted
+            // from right) is 1 iff box[i] overlaps with box[BS*j+k].
+            for (int src_idx = NMS_BLOCK_SIZE * block_row_idx;
+                 src_idx < NMS_BLOCK_SIZE * block_row_idx + row_size;
+                 src_idx++) {
+                uint64_t t = 0;
+                for (int dst_idx = NMS_BLOCK_SIZE * block_col_idx;
+                     dst_idx < NMS_BLOCK_SIZE * block_col_idx + col_size;
+                     dst_idx++) {
+                    // Unlike the CUDA impl, both src_idx and dst_idx here are
+                    // indexes to the global memory. Thus we need to compute the
+                    // local index for dst_idx.
+                    if (iou_bev(boxes + sort_indices[src_idx] * 5,
+                                boxes + sort_indices[dst_idx] * 5) >
+                        nms_overlap_thresh) {
+                        t |= 1ULL << (dst_idx - NMS_BLOCK_SIZE * block_col_idx);
+                    }
+                }
+                mask[src_idx * num_block_cols + block_col_idx] = t;
+            }
+        }
+    }
+}
+
+// [inputs]
+// boxes             : (N, 5) float32
+// scores            : (N,) float32
+// nms_overlap_thresh: double
+//
+// [return]
+// keep_indices      : (M,) int64, the selected box indices
+std::vector<int64_t> NmsCPUKernel(const float *boxes,
+                                  const float *scores,
+                                  int N,
+                                  double nms_overlap_thresh) {
+    std::vector<int64_t> sort_indices = SortIndexes(scores, N, true);
+
+    const int num_block_cols = DIVUP(N, NMS_BLOCK_SIZE);
+
+    // Call kernel. Results will be saved in masks.
+    // boxes: (N, 5)
+    // mask:  (N, N/BS)
+    std::vector<uint64_t> mask_vec(N * num_block_cols);
+    uint64_t *mask = mask_vec.data();
+    AllPairsIoUCPU(boxes, scores, sort_indices.data(), mask, N,
+                   nms_overlap_thresh);
+
+    // Write to keep.
+    // remv_cpu has N bits in total. If the bit is 1, the corresponding
+    // box will be removed.
+    std::vector<uint64_t> remv_cpu(num_block_cols, 0);
+    std::vector<int64_t> keep_indices;
+    for (int i = 0; i < N; i++) {
+        int block_col_idx = i / NMS_BLOCK_SIZE;
+        int inner_block_col_idx = i % NMS_BLOCK_SIZE;  // threadIdx.x
+
+        // Querying the i-th bit in remv_cpu, counted from the right.
+        // - remv_cpu[block_col_idx]: the block bitmap containing the query
+        // - 1ULL << inner_block_col_idx: the one-hot bitmap to extract i
+        if (!(remv_cpu[block_col_idx] & (1ULL << inner_block_col_idx))) {
+            // Keep the i-th box.
+            keep_indices.push_back(sort_indices[i]);
+
+            // Any box that overlaps with the i-th box will be removed.
+            uint64_t *p = mask + i * num_block_cols;
+            for (int j = block_col_idx; j < num_block_cols; j++) {
+                remv_cpu[j] |= p[j];
+            }
+        }
+    }
+
+    return keep_indices;
+}
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Nms.cpp
+++ b/cpp/open3d/ml/impl/misc/Nms.cpp
@@ -41,8 +41,7 @@
 #include <numeric>
 
 #include "open3d/ml/impl/misc/NmsImpl.h"
-
-#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+#include "open3d/utility/Helper.h"
 
 namespace open3d {
 namespace ml {
@@ -74,8 +73,8 @@ static void AllPairsIoU(const float *boxes,
                         uint64_t *mask,
                         int n,
                         double nms_overlap_thresh) {
-    const int num_block_cols = DIVUP(n, NMS_BLOCK_SIZE);
-    const int num_block_rows = DIVUP(n, NMS_BLOCK_SIZE);
+    const int num_block_cols = utility::DivUp(n, NMS_BLOCK_SIZE);
+    const int num_block_rows = utility::DivUp(n, NMS_BLOCK_SIZE);
 
     // We need the concept of "block" since the mask is a uint64_t binary bit
     // map, and the block size is exactly 64x64. This is also consistent with
@@ -142,7 +141,7 @@ std::vector<int64_t> NmsCPUKernel(const float *boxes,
                                   double nms_overlap_thresh) {
     std::vector<int64_t> sort_indices = SortIndexes(scores, n, true);
 
-    const int num_block_cols = DIVUP(n, NMS_BLOCK_SIZE);
+    const int num_block_cols = utility::DivUp(n, NMS_BLOCK_SIZE);
 
     // Call kernel. Results will be saved in masks.
     // boxes: (n, 5)

--- a/cpp/open3d/ml/impl/misc/Nms.cu
+++ b/cpp/open3d/ml/impl/misc/Nms.cu
@@ -138,6 +138,10 @@ std::vector<int64_t> NmsCUDAKernel(const float *boxes,
                                    const float *scores,
                                    int n,
                                    double nms_overlap_thresh) {
+    if (n == 0) {
+        return {};
+    }
+
     // Cololum-wise number of blocks.
     const int num_block_cols = utility::DivUp(n, NMS_BLOCK_SIZE);
 

--- a/cpp/open3d/ml/impl/misc/Nms.cu
+++ b/cpp/open3d/ml/impl/misc/Nms.cu
@@ -99,7 +99,7 @@ __global__ void NmsKernel(const float *boxes,
     __shared__ float block_boxes[NMS_BLOCK_SIZE * 5];
     if (threadIdx.x < col_size) {
         float *dst = block_boxes + threadIdx.x * 5;
-        const int src_idx = NMS_BLOCK_SIZE * block_row_idx + threadIdx.x;
+        const int src_idx = NMS_BLOCK_SIZE * block_col_idx + threadIdx.x;
         const float *src = boxes + sort_indices[src_idx] * 5;
         dst[0] = src[0];
         dst[1] = src[1];

--- a/cpp/open3d/ml/impl/misc/Nms.cu
+++ b/cpp/open3d/ml/impl/misc/Nms.cu
@@ -1,0 +1,200 @@
+/*
+3D IoU Calculation and Rotated NMS(modified from 2D NMS written by others)
+Written by Shaoshuai Shi
+All Rights Reserved 2018.
+*/
+
+#include <stdio.h>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include "open3d/ml/impl/misc/Nms.h"
+#include "open3d/ml/impl/misc/NmsImpl.h"
+
+#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+
+#define CHECK_ERROR(ans) \
+    { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code,
+                      const char *file,
+                      int line,
+                      bool abort = true) {
+    if (code != cudaSuccess) {
+        fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file,
+                line);
+        if (abort) exit(code);
+    }
+}
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+static void SortIndices(float *values,
+                        int64_t *sort_indices,
+                        int64_t N,
+                        bool descending = false) {
+    // Cast to thrust device pointer.
+    thrust::device_ptr<float> values_dptr = thrust::device_pointer_cast(values);
+    thrust::device_ptr<int64_t> sort_indices_dptr =
+            thrust::device_pointer_cast(sort_indices);
+
+    // Fill sort_indices with 0, 1, ..., N-1.
+    thrust::sequence(sort_indices_dptr, sort_indices_dptr + N, 0);
+
+    // Sort values and sort_indices together.
+    if (descending) {
+        thrust::stable_sort_by_key(values_dptr, values_dptr + N,
+                                   sort_indices_dptr, thrust::greater<float>());
+    } else {
+        thrust::stable_sort_by_key(values_dptr, values_dptr + N,
+                                   sort_indices_dptr);
+    }
+}
+
+__global__ void nms_kernel(const float *boxes,
+                           const int64_t *sort_indices,
+                           uint64_t *mask,
+                           const int N,
+                           const double nms_overlap_thresh) {
+    // boxes: (N, 5)
+    // mask:  (N, N/BS)
+    //
+    // Kernel launch
+    // blocks : (N/BS, N/BS)
+    // threads: BS
+
+    // Row-wise block index.
+    const int block_row_idx = blockIdx.y;
+    // Column-wise block index.
+    const int block_col_idx = blockIdx.x;
+
+    // Local block row size.
+    const int row_size =
+            fminf(N - block_row_idx * NMS_BLOCK_SIZE, NMS_BLOCK_SIZE);
+    // Local block col size.
+    const int col_size =
+            fminf(N - block_col_idx * NMS_BLOCK_SIZE, NMS_BLOCK_SIZE);
+
+    // Cololum-wise number of blocks.
+    const int num_block_cols = DIVUP(N, NMS_BLOCK_SIZE);
+
+    // Fill local block_boxes by fetching the global box memory.
+    // block_boxes = boxes[NBS*block_col_idx : NBS*block_col_idx+col_size, :].
+    //
+    // TODO: It is also possible to load the comparison target to the shared
+    // memory as well.
+    __shared__ float block_boxes[NMS_BLOCK_SIZE * 5];
+    if (threadIdx.x < col_size) {
+        float *dst = block_boxes + threadIdx.x * 5;
+        const int src_idx = NMS_BLOCK_SIZE * block_row_idx + threadIdx.x;
+        const float *src = boxes + sort_indices[src_idx] * 5;
+        dst[0] = src[0];
+        dst[1] = src[1];
+        dst[2] = src[2];
+        dst[3] = src[3];
+        dst[4] = src[4];
+    }
+    __syncthreads();
+
+    // Comparing src and dst. In one block, the following src and dst indices
+    // are compared:
+    // - src: BS * block_row_idx : BS * block_row_idx + row_size
+    // - dst: BS * block_col_idx : BS * block_col_idx + col_size
+    //
+    // With all blocks, all src and dst indices are compared.
+    //
+    // Result:
+    // mask[i, j] is a 64-bit integer where mask[i, j][k] (k counted from right)
+    // is 1 iff box[i] overlaps with box[BS*j+k].
+    if (threadIdx.x < row_size) {
+        // src_idx indices the global memory.
+        const int src_idx = NMS_BLOCK_SIZE * block_row_idx + threadIdx.x;
+        // dst_idx indices the shared memory.
+        int dst_idx = block_row_idx == block_col_idx ? threadIdx.x + 1 : 0;
+
+        uint64_t t = 0;
+        while (dst_idx < col_size) {
+            if (iou_bev(boxes + sort_indices[src_idx] * 5,
+                        block_boxes + dst_idx * 5) > nms_overlap_thresh) {
+                t |= 1ULL << dst_idx;
+            }
+            dst_idx++;
+        }
+        mask[src_idx * num_block_cols + block_col_idx] = t;
+    }
+}
+
+std::vector<int64_t> NmsCUDAKernel(const float *boxes,
+                                   const float *scores,
+                                   int N,
+                                   double nms_overlap_thresh) {
+    const int num_block_cols = DIVUP(N, NMS_BLOCK_SIZE);
+
+    // Compute sort indices.
+    float *scores_copy = nullptr;
+    CHECK_ERROR(cudaMalloc((void **)&scores_copy, N * sizeof(float)));
+    CHECK_ERROR(cudaMemcpy(scores_copy, scores, N * sizeof(float),
+                           cudaMemcpyDeviceToDevice));
+    int64_t *sort_indices = nullptr;
+    CHECK_ERROR(cudaMalloc((void **)&sort_indices, N * sizeof(int64_t)));
+    SortIndices(scores_copy, sort_indices, N, true);
+
+    // Allocate masks on device.
+    uint64_t *mask_ptr = nullptr;
+    CHECK_ERROR(cudaMalloc((void **)&mask_ptr,
+                           N * num_block_cols * sizeof(uint64_t)));
+
+    // Launch kernel.
+    dim3 blocks(DIVUP(N, NMS_BLOCK_SIZE), DIVUP(N, NMS_BLOCK_SIZE));
+    dim3 threads(NMS_BLOCK_SIZE);
+    nms_kernel<<<blocks, threads>>>(boxes, sort_indices, mask_ptr, N,
+                                    nms_overlap_thresh);
+
+    // Copy cuda masks to cpu.
+    std::vector<uint64_t> mask_vec(N * num_block_cols);
+    uint64_t *mask = mask_vec.data();
+    CHECK_ERROR(cudaMemcpy(mask_vec.data(), mask_ptr,
+                           N * num_block_cols * sizeof(uint64_t),
+                           cudaMemcpyDeviceToHost));
+    CHECK_ERROR(cudaFree(mask_ptr));
+
+    // Copy sort_indices to cpu.
+    std::vector<int64_t> sort_indices_cpu(N);
+    CHECK_ERROR(cudaMemcpy(sort_indices_cpu.data(), sort_indices,
+                           N * sizeof(int64_t), cudaMemcpyDeviceToHost));
+
+    // Write to keep_indices in CPU.
+    // remv_cpu has N bits in total. If the bit is 1, the corresponding
+    // box will be removed.
+    // TODO: This part can be implemented in CUDA. We use the original author's
+    // implementation here.
+    std::vector<uint64_t> remv_cpu(num_block_cols, 0);
+    std::vector<int64_t> keep_indices;
+    for (int i = 0; i < N; i++) {
+        int block_col_idx = i / NMS_BLOCK_SIZE;
+        int inner_block_col_idx = i % NMS_BLOCK_SIZE;  // threadIdx.x
+
+        // Querying the i-th bit in remv_cpu, counted from the right.
+        // - remv_cpu[block_col_idx]: the block bitmap containing the query
+        // - 1ULL << inner_block_col_idx: the one-hot bitmap to extract i
+        if (!(remv_cpu[block_col_idx] & (1ULL << inner_block_col_idx))) {
+            // Keep the i-th box.
+            keep_indices.push_back(sort_indices_cpu[i]);
+
+            // Any box that overlaps with the i-th box will be removed.
+            uint64_t *p = mask + i * num_block_cols;
+            for (int j = block_col_idx; j < num_block_cols; j++) {
+                remv_cpu[j] |= p[j];
+            }
+        }
+    }
+    CHECK_ERROR(cudaFree(sort_indices));
+    return keep_indices;
+}
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Nms.cu
+++ b/cpp/open3d/ml/impl/misc/Nms.cu
@@ -141,6 +141,7 @@ std::vector<int64_t> NmsCUDAKernel(const float *boxes,
     int64_t *sort_indices = nullptr;
     CHECK_ERROR(cudaMalloc((void **)&sort_indices, N * sizeof(int64_t)));
     SortIndices(scores_copy, sort_indices, N, true);
+    CHECK_ERROR(cudaFree(scores_copy));
 
     // Allocate masks on device.
     uint64_t *mask_ptr = nullptr;

--- a/cpp/open3d/ml/impl/misc/Nms.h
+++ b/cpp/open3d/ml/impl/misc/Nms.h
@@ -1,0 +1,50 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+#ifdef BUILD_CUDA_MODULE
+std::vector<int64_t> NmsCUDAKernel(const float *boxes,
+                                   const float *scores,
+                                   int N,
+                                   double nms_overlap_thresh);
+#endif
+
+std::vector<int64_t> NmsCPUKernel(const float *boxes,
+                                  const float *scores,
+                                  int N,
+                                  double nms_overlap_thresh);
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/Nms.h
+++ b/cpp/open3d/ml/impl/misc/Nms.h
@@ -23,6 +23,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
+//
+// Reference:
+// https://github.com/open-mmlab/OpenPCDet/blob/master/pcdet/ops/iou3d_nms/src/iou3d_nms_kernel.cu
+//
+// Reference:
+// https://github.com/open-mmlab/mmdetection3d/blob/master/mmdet3d/ops/iou3d/src/iou3d_kernel.cu
+// 3D IoU Calculation and Rotated NMS(modified from 2D NMS written by others)
+// Written by Shaoshuai Shi
+// All Rights Reserved 2019-2020.
 
 #pragma once
 
@@ -34,15 +43,28 @@ namespace ml {
 namespace impl {
 
 #ifdef BUILD_CUDA_MODULE
+
+/// \param boxes (n, 5) float32.
+/// \param scores (n,) float32.
+/// \param n Number of boxes.
+/// \param nms_overlap_thresh When a high-score box is selected, other remaining
+/// boxes with IoU > nms_overlap_thresh will be discarded.
+/// \return Selected box indices to keep.
 std::vector<int64_t> NmsCUDAKernel(const float *boxes,
                                    const float *scores,
-                                   int N,
+                                   int n,
                                    double nms_overlap_thresh);
 #endif
 
+/// \param boxes (n, 5) float32.
+/// \param scores (n,) float32.
+/// \param n Number of boxes.
+/// \param nms_overlap_thresh When a high-score box is selected, other remaining
+/// boxes with IoU > nms_overlap_thresh will be discarded.
+/// \return Selected box indices to keep.
 std::vector<int64_t> NmsCPUKernel(const float *boxes,
                                   const float *scores,
-                                  int N,
+                                  int n,
                                   double nms_overlap_thresh);
 
 }  // namespace impl

--- a/cpp/open3d/ml/impl/misc/NmsImpl.h
+++ b/cpp/open3d/ml/impl/misc/NmsImpl.h
@@ -1,0 +1,261 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2019 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <math.h>
+
+#include "open3d/core/CUDAUtils.h"
+
+namespace open3d {
+namespace ml {
+namespace impl {
+
+constexpr int NMS_BLOCK_SIZE = sizeof(uint64_t) * 8;
+constexpr float EPS = 1e-8;
+
+struct Point {
+    OPEN3D_HOST_DEVICE Point() {}
+
+    OPEN3D_HOST_DEVICE Point(double x, double y) : x(x), y(y) {}
+
+    OPEN3D_HOST_DEVICE void set(float x, float y) {
+        this->x = x;
+        this->y = y;
+    }
+
+    OPEN3D_HOST_DEVICE Point operator+(const Point &b) const {
+        return Point(x + b.x, y + b.y);
+    }
+
+    OPEN3D_HOST_DEVICE Point operator-(const Point &b) const {
+        return Point(x - b.x, y - b.y);
+    }
+
+    float x, y;
+};
+
+OPEN3D_HOST_DEVICE inline float cross(const Point &a, const Point &b) {
+    return a.x * b.y - a.y * b.x;
+}
+
+OPEN3D_HOST_DEVICE inline float cross(const Point &p1,
+                                      const Point &p2,
+                                      const Point &p0) {
+    return (p1.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (p1.y - p0.y);
+}
+
+OPEN3D_HOST_DEVICE inline int check_rect_cross(const Point &p1,
+                                               const Point &p2,
+                                               const Point &q1,
+                                               const Point &q2) {
+    int ret = fmin(p1.x, p2.x) <= fmax(q1.x, q2.x) &&
+              fmin(q1.x, q2.x) <= fmax(p1.x, p2.x) &&
+              fmin(p1.y, p2.y) <= fmax(q1.y, q2.y) &&
+              fmin(q1.y, q2.y) <= fmax(p1.y, p2.y);
+    return ret;
+}
+
+OPEN3D_HOST_DEVICE inline int check_in_box2d(const float *box, const Point &p) {
+    // box (5): [x1, y1, x2, y2, angle]
+    const float MARGIN = 1e-5;
+
+    float center_x = (box[0] + box[2]) / 2;
+    float center_y = (box[1] + box[3]) / 2;
+    float angle_cos = cos(-box[4]),
+          angle_sin = sin(-box[4]);  // rotate the point in the opposite
+                                     // direction of box
+    float rot_x = (p.x - center_x) * angle_cos + (p.y - center_y) * angle_sin +
+                  center_x;
+    float rot_y = -(p.x - center_x) * angle_sin + (p.y - center_y) * angle_cos +
+                  center_y;
+    return (rot_x > box[0] - MARGIN && rot_x < box[2] + MARGIN &&
+            rot_y > box[1] - MARGIN && rot_y < box[3] + MARGIN);
+}
+
+OPEN3D_HOST_DEVICE inline int intersection(const Point &p1,
+                                           const Point &p0,
+                                           const Point &q1,
+                                           const Point &q0,
+                                           Point &ans) {
+    // Fast exclusion.
+    if (check_rect_cross(p0, p1, q0, q1) == 0) return 0;
+
+    // Check cross standing
+    float s1 = cross(q0, p1, p0);
+    float s2 = cross(p1, q1, p0);
+    float s3 = cross(p0, q1, q0);
+    float s4 = cross(q1, p1, q0);
+
+    if (!(s1 * s2 > 0 && s3 * s4 > 0)) return 0;
+
+    // Calculate intersection of two lines.
+    float s5 = cross(q1, p1, p0);
+    if (fabs(s5 - s1) > EPS) {
+        ans.x = (s5 * q0.x - s1 * q1.x) / (s5 - s1);
+        ans.y = (s5 * q0.y - s1 * q1.y) / (s5 - s1);
+
+    } else {
+        float a0 = p0.y - p1.y, b0 = p1.x - p0.x,
+              c0 = p0.x * p1.y - p1.x * p0.y;
+        float a1 = q0.y - q1.y, b1 = q1.x - q0.x,
+              c1 = q0.x * q1.y - q1.x * q0.y;
+        float D = a0 * b1 - a1 * b0;
+
+        ans.x = (b0 * c1 - b1 * c0) / D;
+        ans.y = (a1 * c0 - a0 * c1) / D;
+    }
+
+    return 1;
+}
+
+OPEN3D_HOST_DEVICE inline void rotate_around_center(const Point &center,
+                                                    const float angle_cos,
+                                                    const float angle_sin,
+                                                    Point &p) {
+    float new_x = (p.x - center.x) * angle_cos + (p.y - center.y) * angle_sin +
+                  center.x;
+    float new_y = -(p.x - center.x) * angle_sin + (p.y - center.y) * angle_cos +
+                  center.y;
+    p.set(new_x, new_y);
+}
+
+OPEN3D_HOST_DEVICE inline int point_cmp(const Point &a,
+                                        const Point &b,
+                                        const Point &center) {
+    return atan2(a.y - center.y, a.x - center.x) >
+           atan2(b.y - center.y, b.x - center.x);
+}
+
+OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
+                                            const float *box_b) {
+    // box_a (5) [x1, y1, x2, y2, angle]
+    // box_b (5) [x1, y1, x2, y2, angle]
+
+    float a_x1 = box_a[0], a_y1 = box_a[1], a_x2 = box_a[2], a_y2 = box_a[3],
+          a_angle = box_a[4];
+    float b_x1 = box_b[0], b_y1 = box_b[1], b_x2 = box_b[2], b_y2 = box_b[3],
+          b_angle = box_b[4];
+
+    Point center_a((a_x1 + a_x2) / 2, (a_y1 + a_y2) / 2);
+    Point center_b((b_x1 + b_x2) / 2, (b_y1 + b_y2) / 2);
+
+    Point box_a_corners[5];
+    box_a_corners[0].set(a_x1, a_y1);
+    box_a_corners[1].set(a_x2, a_y1);
+    box_a_corners[2].set(a_x2, a_y2);
+    box_a_corners[3].set(a_x1, a_y2);
+
+    Point box_b_corners[5];
+    box_b_corners[0].set(b_x1, b_y1);
+    box_b_corners[1].set(b_x2, b_y1);
+    box_b_corners[2].set(b_x2, b_y2);
+    box_b_corners[3].set(b_x1, b_y2);
+
+    // Get oriented corners.
+    float a_angle_cos = cos(a_angle), a_angle_sin = sin(a_angle);
+    float b_angle_cos = cos(b_angle), b_angle_sin = sin(b_angle);
+
+    for (int k = 0; k < 4; k++) {
+        rotate_around_center(center_a, a_angle_cos, a_angle_sin,
+                             box_a_corners[k]);
+        rotate_around_center(center_b, b_angle_cos, b_angle_sin,
+                             box_b_corners[k]);
+    }
+
+    box_a_corners[4] = box_a_corners[0];
+    box_b_corners[4] = box_b_corners[0];
+
+    // Get intersection of lines.
+    Point cross_points[16];
+    Point poly_center;
+    int cnt = 0, flag = 0;
+
+    poly_center.set(0, 0);
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+            flag = intersection(box_a_corners[i + 1], box_a_corners[i],
+                                box_b_corners[j + 1], box_b_corners[j],
+                                cross_points[cnt]);
+            if (flag) {
+                poly_center = poly_center + cross_points[cnt];
+                cnt++;
+            }
+        }
+    }
+
+    // Check corners.
+    for (int k = 0; k < 4; k++) {
+        if (check_in_box2d(box_a, box_b_corners[k])) {
+            poly_center = poly_center + box_b_corners[k];
+            cross_points[cnt] = box_b_corners[k];
+            cnt++;
+        }
+        if (check_in_box2d(box_b, box_a_corners[k])) {
+            poly_center = poly_center + box_a_corners[k];
+            cross_points[cnt] = box_a_corners[k];
+            cnt++;
+        }
+    }
+
+    poly_center.x /= cnt;
+    poly_center.y /= cnt;
+
+    // Sort the points of polygon.
+    Point temp;
+    for (int j = 0; j < cnt - 1; j++) {
+        for (int i = 0; i < cnt - j - 1; i++) {
+            if (point_cmp(cross_points[i], cross_points[i + 1], poly_center)) {
+                temp = cross_points[i];
+                cross_points[i] = cross_points[i + 1];
+                cross_points[i + 1] = temp;
+            }
+        }
+    }
+
+    // Get the overlap areas.
+    float area = 0;
+    for (int k = 0; k < cnt - 1; k++) {
+        area += cross(cross_points[k] - cross_points[0],
+                      cross_points[k + 1] - cross_points[0]);
+    }
+
+    return fabs(area) / 2.0;
+}
+
+OPEN3D_HOST_DEVICE inline float iou_bev(const float *box_a,
+                                        const float *box_b) {
+    // params: box_a (5) [x1, y1, x2, y2, angle]
+    // params: box_b (5) [x1, y1, x2, y2, angle]
+    float sa = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1]);
+    float sb = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1]);
+    float s_overlap = box_overlap(box_a, box_b);
+    return s_overlap / fmaxf(sa + sb - s_overlap, EPS);
+}
+
+}  // namespace impl
+}  // namespace ml
+}  // namespace open3d

--- a/cpp/open3d/ml/impl/misc/NmsImpl.h
+++ b/cpp/open3d/ml/impl/misc/NmsImpl.h
@@ -39,122 +39,116 @@ constexpr float EPS = 1e-8;
 
 struct Point {
     OPEN3D_HOST_DEVICE Point() {}
-
-    OPEN3D_HOST_DEVICE Point(double x, double y) : x(x), y(y) {}
-
+    OPEN3D_HOST_DEVICE Point(double x, double y) : x_(x), y_(y) {}
     OPEN3D_HOST_DEVICE void set(float x, float y) {
-        this->x = x;
-        this->y = y;
+        x_ = x;
+        y_ = y;
     }
-
     OPEN3D_HOST_DEVICE Point operator+(const Point &b) const {
-        return Point(x + b.x, y + b.y);
+        return Point(x_ + b.x_, y_ + b.y_);
     }
-
     OPEN3D_HOST_DEVICE Point operator-(const Point &b) const {
-        return Point(x - b.x, y - b.y);
+        return Point(x_ - b.x_, y_ - b.y_);
     }
-
-    float x, y;
+    float x_, y_;
 };
 
-OPEN3D_HOST_DEVICE inline float cross(const Point &a, const Point &b) {
-    return a.x * b.y - a.y * b.x;
+OPEN3D_HOST_DEVICE inline float Cross(const Point &a, const Point &b) {
+    return a.x_ * b.y_ - a.y_ * b.x_;
 }
 
-OPEN3D_HOST_DEVICE inline float cross(const Point &p1,
+OPEN3D_HOST_DEVICE inline float Cross(const Point &p1,
                                       const Point &p2,
                                       const Point &p0) {
-    return (p1.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (p1.y - p0.y);
+    return (p1.x_ - p0.x_) * (p2.y_ - p0.y_) -
+           (p2.x_ - p0.x_) * (p1.y_ - p0.y_);
 }
 
-OPEN3D_HOST_DEVICE inline int check_rect_cross(const Point &p1,
-                                               const Point &p2,
-                                               const Point &q1,
-                                               const Point &q2) {
-    int ret = fmin(p1.x, p2.x) <= fmax(q1.x, q2.x) &&
-              fmin(q1.x, q2.x) <= fmax(p1.x, p2.x) &&
-              fmin(p1.y, p2.y) <= fmax(q1.y, q2.y) &&
-              fmin(q1.y, q2.y) <= fmax(p1.y, p2.y);
+OPEN3D_HOST_DEVICE inline int CheckRectCross(const Point &p1,
+                                             const Point &p2,
+                                             const Point &q1,
+                                             const Point &q2) {
+    int ret = fmin(p1.x_, p2.x_) <= fmax(q1.x_, q2.x_) &&
+              fmin(q1.x_, q2.x_) <= fmax(p1.x_, p2.x_) &&
+              fmin(p1.y_, p2.y_) <= fmax(q1.y_, q2.y_) &&
+              fmin(q1.y_, q2.y_) <= fmax(p1.y_, p2.y_);
     return ret;
 }
 
-OPEN3D_HOST_DEVICE inline int check_in_box2d(const float *box, const Point &p) {
-    // box (5): [x1, y1, x2, y2, angle]
+OPEN3D_HOST_DEVICE inline int CheckInBox2D(const float *box, const Point &p) {
+    // box (5): [x1, y1, x2, y2, angle].
     const float MARGIN = 1e-5;
 
     float center_x = (box[0] + box[2]) / 2;
     float center_y = (box[1] + box[3]) / 2;
-    float angle_cos = cos(-box[4]),
-          angle_sin = sin(-box[4]);  // rotate the point in the opposite
-                                     // direction of box
-    float rot_x = (p.x - center_x) * angle_cos + (p.y - center_y) * angle_sin +
-                  center_x;
-    float rot_y = -(p.x - center_x) * angle_sin + (p.y - center_y) * angle_cos +
-                  center_y;
+    // Rotate the point in the opposite direction of box.
+    float angle_cos = cos(-box[4]), angle_sin = sin(-box[4]);
+    float rot_x = (p.x_ - center_x) * angle_cos +
+                  (p.y_ - center_y) * angle_sin + center_x;
+    float rot_y = -(p.x_ - center_x) * angle_sin +
+                  (p.y_ - center_y) * angle_cos + center_y;
     return (rot_x > box[0] - MARGIN && rot_x < box[2] + MARGIN &&
             rot_y > box[1] - MARGIN && rot_y < box[3] + MARGIN);
 }
 
-OPEN3D_HOST_DEVICE inline int intersection(const Point &p1,
+OPEN3D_HOST_DEVICE inline int Intersection(const Point &p1,
                                            const Point &p0,
                                            const Point &q1,
                                            const Point &q0,
                                            Point &ans) {
     // Fast exclusion.
-    if (check_rect_cross(p0, p1, q0, q1) == 0) return 0;
+    if (CheckRectCross(p0, p1, q0, q1) == 0) return 0;
 
-    // Check cross standing
-    float s1 = cross(q0, p1, p0);
-    float s2 = cross(p1, q1, p0);
-    float s3 = cross(p0, q1, q0);
-    float s4 = cross(q1, p1, q0);
+    // Check Cross standing
+    float s1 = Cross(q0, p1, p0);
+    float s2 = Cross(p1, q1, p0);
+    float s3 = Cross(p0, q1, q0);
+    float s4 = Cross(q1, p1, q0);
 
     if (!(s1 * s2 > 0 && s3 * s4 > 0)) return 0;
 
-    // Calculate intersection of two lines.
-    float s5 = cross(q1, p1, p0);
+    // Calculate Intersection of two lines.
+    float s5 = Cross(q1, p1, p0);
     if (fabs(s5 - s1) > EPS) {
-        ans.x = (s5 * q0.x - s1 * q1.x) / (s5 - s1);
-        ans.y = (s5 * q0.y - s1 * q1.y) / (s5 - s1);
+        ans.x_ = (s5 * q0.x_ - s1 * q1.x_) / (s5 - s1);
+        ans.y_ = (s5 * q0.y_ - s1 * q1.y_) / (s5 - s1);
 
     } else {
-        float a0 = p0.y - p1.y, b0 = p1.x - p0.x,
-              c0 = p0.x * p1.y - p1.x * p0.y;
-        float a1 = q0.y - q1.y, b1 = q1.x - q0.x,
-              c1 = q0.x * q1.y - q1.x * q0.y;
+        float a0 = p0.y_ - p1.y_, b0 = p1.x_ - p0.x_,
+              c0 = p0.x_ * p1.y_ - p1.x_ * p0.y_;
+        float a1 = q0.y_ - q1.y_, b1 = q1.x_ - q0.x_,
+              c1 = q0.x_ * q1.y_ - q1.x_ * q0.y_;
         float D = a0 * b1 - a1 * b0;
 
-        ans.x = (b0 * c1 - b1 * c0) / D;
-        ans.y = (a1 * c0 - a0 * c1) / D;
+        ans.x_ = (b0 * c1 - b1 * c0) / D;
+        ans.y_ = (a1 * c0 - a0 * c1) / D;
     }
 
     return 1;
 }
 
-OPEN3D_HOST_DEVICE inline void rotate_around_center(const Point &center,
-                                                    const float angle_cos,
-                                                    const float angle_sin,
-                                                    Point &p) {
-    float new_x = (p.x - center.x) * angle_cos + (p.y - center.y) * angle_sin +
-                  center.x;
-    float new_y = -(p.x - center.x) * angle_sin + (p.y - center.y) * angle_cos +
-                  center.y;
+OPEN3D_HOST_DEVICE inline void RotateAroundCenter(const Point &center,
+                                                  const float angle_cos,
+                                                  const float angle_sin,
+                                                  Point &p) {
+    float new_x = (p.x_ - center.x_) * angle_cos +
+                  (p.y_ - center.y_) * angle_sin + center.x_;
+    float new_y = -(p.x_ - center.x_) * angle_sin +
+                  (p.y_ - center.y_) * angle_cos + center.y_;
     p.set(new_x, new_y);
 }
 
-OPEN3D_HOST_DEVICE inline int point_cmp(const Point &a,
-                                        const Point &b,
-                                        const Point &center) {
-    return atan2(a.y - center.y, a.x - center.x) >
-           atan2(b.y - center.y, b.x - center.x);
+OPEN3D_HOST_DEVICE inline int PointCmp(const Point &a,
+                                       const Point &b,
+                                       const Point &center) {
+    return atan2(a.y_ - center.y_, a.x_ - center.x_) >
+           atan2(b.y_ - center.y_, b.x_ - center.x_);
 }
 
-OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
-                                            const float *box_b) {
-    // box_a (5) [x1, y1, x2, y2, angle]
-    // box_b (5) [x1, y1, x2, y2, angle]
-
+OPEN3D_HOST_DEVICE inline float BoxOverlap(const float *box_a,
+                                           const float *box_b) {
+    // box_a (5) [x1, y1, x2, y2, angle].
+    // box_b (5) [x1, y1, x2, y2, angle].
     float a_x1 = box_a[0], a_y1 = box_a[1], a_x2 = box_a[2], a_y2 = box_a[3],
           a_angle = box_a[4];
     float b_x1 = box_b[0], b_y1 = box_b[1], b_x2 = box_b[2], b_y2 = box_b[3],
@@ -180,16 +174,16 @@ OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
     float b_angle_cos = cos(b_angle), b_angle_sin = sin(b_angle);
 
     for (int k = 0; k < 4; k++) {
-        rotate_around_center(center_a, a_angle_cos, a_angle_sin,
-                             box_a_corners[k]);
-        rotate_around_center(center_b, b_angle_cos, b_angle_sin,
-                             box_b_corners[k]);
+        RotateAroundCenter(center_a, a_angle_cos, a_angle_sin,
+                           box_a_corners[k]);
+        RotateAroundCenter(center_b, b_angle_cos, b_angle_sin,
+                           box_b_corners[k]);
     }
 
     box_a_corners[4] = box_a_corners[0];
     box_b_corners[4] = box_b_corners[0];
 
-    // Get intersection of lines.
+    // Get Intersection of lines.
     Point cross_points[16];
     Point poly_center;
     int cnt = 0, flag = 0;
@@ -197,7 +191,7 @@ OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
     poly_center.set(0, 0);
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
-            flag = intersection(box_a_corners[i + 1], box_a_corners[i],
+            flag = Intersection(box_a_corners[i + 1], box_a_corners[i],
                                 box_b_corners[j + 1], box_b_corners[j],
                                 cross_points[cnt]);
             if (flag) {
@@ -209,26 +203,26 @@ OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
 
     // Check corners.
     for (int k = 0; k < 4; k++) {
-        if (check_in_box2d(box_a, box_b_corners[k])) {
+        if (CheckInBox2D(box_a, box_b_corners[k])) {
             poly_center = poly_center + box_b_corners[k];
             cross_points[cnt] = box_b_corners[k];
             cnt++;
         }
-        if (check_in_box2d(box_b, box_a_corners[k])) {
+        if (CheckInBox2D(box_b, box_a_corners[k])) {
             poly_center = poly_center + box_a_corners[k];
             cross_points[cnt] = box_a_corners[k];
             cnt++;
         }
     }
 
-    poly_center.x /= cnt;
-    poly_center.y /= cnt;
+    poly_center.x_ /= cnt;
+    poly_center.y_ /= cnt;
 
     // Sort the points of polygon.
     Point temp;
     for (int j = 0; j < cnt - 1; j++) {
         for (int i = 0; i < cnt - j - 1; i++) {
-            if (point_cmp(cross_points[i], cross_points[i + 1], poly_center)) {
+            if (PointCmp(cross_points[i], cross_points[i + 1], poly_center)) {
                 temp = cross_points[i];
                 cross_points[i] = cross_points[i + 1];
                 cross_points[i + 1] = temp;
@@ -239,20 +233,19 @@ OPEN3D_HOST_DEVICE inline float box_overlap(const float *box_a,
     // Get the overlap areas.
     float area = 0;
     for (int k = 0; k < cnt - 1; k++) {
-        area += cross(cross_points[k] - cross_points[0],
+        area += Cross(cross_points[k] - cross_points[0],
                       cross_points[k + 1] - cross_points[0]);
     }
 
     return fabs(area) / 2.0;
 }
 
-OPEN3D_HOST_DEVICE inline float iou_bev(const float *box_a,
-                                        const float *box_b) {
-    // params: box_a (5) [x1, y1, x2, y2, angle]
-    // params: box_b (5) [x1, y1, x2, y2, angle]
+OPEN3D_HOST_DEVICE inline float IouBev(const float *box_a, const float *box_b) {
+    // params: box_a (5) [x1, y1, x2, y2, angle].
+    // params: box_b (5) [x1, y1, x2, y2, angle].
     float sa = (box_a[2] - box_a[0]) * (box_a[3] - box_a[1]);
     float sb = (box_b[2] - box_b[0]) * (box_b[3] - box_b[1]);
-    float s_overlap = box_overlap(box_a, box_b);
+    float s_overlap = BoxOverlap(box_a, box_b);
     return s_overlap / fmaxf(sa + sb - s_overlap, EPS);
 }
 

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -33,6 +33,8 @@ set(TORCH_OPS_SOURCES
     "misc/ReduceSubarraysSumOpKernel.cpp"
     "misc/VoxelPoolingOps.cpp"
     "misc/FixedRadiusSearchOpKernel.cpp"
+    "misc/NmsOps.cpp"
+    "../impl/misc/Nms.cpp"
 )
 
 set(TORCH_OPS_CUDA_SOURCES
@@ -45,6 +47,7 @@ set(TORCH_OPS_CUDA_SOURCES
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
+    "../impl/misc/Nms.cu"
 )
 
 if(BUILD_CUDA_MODULE)

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -33,6 +33,10 @@ set(TORCH_OPS_SOURCES
     "misc/ReduceSubarraysSumOpKernel.cpp"
     "misc/VoxelPoolingOps.cpp"
     "misc/FixedRadiusSearchOpKernel.cpp"
+    "misc/RaggedToDenseOps.cpp"
+    "misc/RaggedToDenseOpKernel.cpp"
+    "misc/VoxelizeOps.cpp"
+    "misc/VoxelizeOpKernel.cpp"
     "misc/NmsOps.cpp"
     "../impl/misc/Nms.cpp"
 )
@@ -46,6 +50,8 @@ set(TORCH_OPS_CUDA_SOURCES
     "misc/BuildSpatialHashTableOpKernel.cu"
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
+    "misc/RaggedToDenseOpKernel.cu"
+    "misc/VoxelizeOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
     "../impl/misc/Nms.cu"
 )

--- a/cpp/open3d/ml/pytorch/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/pytorch/misc/NmsOps.cpp
@@ -1,0 +1,68 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------q
+
+#include <vector>
+
+#include "open3d/ml/impl/misc/Nms.h"
+#include "open3d/ml/pytorch/TorchHelper.h"
+#include "torch/script.h"
+
+torch::Tensor Nms(torch::Tensor boxes,
+                  torch::Tensor scores,
+                  double nms_overlap_thresh) {
+    boxes = boxes.contiguous();
+    CHECK_TYPE(boxes, kFloat);
+    CHECK_TYPE(scores, kFloat);
+
+    if (boxes.is_cuda()) {
+#ifdef BUILD_CUDA_MODULE
+        std::vector<int64_t> keep_indices = open3d::ml::impl::NmsCUDAKernel(
+                boxes.data_ptr<float>(), scores.data_ptr<float>(),
+                boxes.size(0), nms_overlap_thresh);
+        return torch::from_blob(keep_indices.data(),
+                                {static_cast<int64_t>(keep_indices.size())},
+                                torch::TensorOptions().dtype(torch::kLong))
+                .to(boxes.device());
+#else
+        TORCH_CHECK(false, "Nms was not compiled with CUDA support")
+
+#endif
+    } else {
+        std::vector<int64_t> keep_indices = open3d::ml::impl::NmsCPUKernel(
+                boxes.data_ptr<float>(), scores.data_ptr<float>(),
+                boxes.size(0), nms_overlap_thresh);
+        return torch::from_blob(keep_indices.data(),
+                                {static_cast<int64_t>(keep_indices.size())},
+                                torch::TensorOptions().dtype(torch::kLong))
+                .clone();
+    }
+}
+
+static auto registry = torch::RegisterOperators(
+        "open3d::nms(Tensor boxes, Tensor scores, float "
+        "nms_overlap_thresh) -> "
+        "Tensor keep_indices",
+        &Nms);

--- a/cpp/open3d/ml/tensorflow/CMakeLists.txt
+++ b/cpp/open3d/ml/tensorflow/CMakeLists.txt
@@ -37,6 +37,8 @@ set(TF_OPS_SOURCES
     "misc/FixedRadiusSearchOpKernel.cpp"
     "misc/KnnSearchOps.cpp"
     "misc/VoxelPoolingOpKernel.cpp"
+    "misc/VoxelizeOpKernel.cpp"
+    "misc/VoxelizeOps.cpp"
     "misc/NmsOpKernel.cpp"
     "misc/NmsOps.cpp"
     "tf_neighbors/tf_batch_neighbors.cpp"
@@ -58,6 +60,7 @@ set(TF_OPS_CUDA_SOURCES
     "misc/BuildSpatialHashTableOpKernel.cu"
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
+    "misc/VoxelizeOpKernel.cu"
     "misc/NmsOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
     "../impl/misc/Nms.cu"
@@ -77,7 +80,7 @@ endif()
 add_library(open3d_tf_ops SHARED ${open3d_tf_ops_SOURCES})
 # do not use open3d_set_global_properties(open3d_tf_ops) here because some
 # options are not compatible for tf op libraries
-# open3d_show_and_abort_on_warning(open3d_tf_ops)
+open3d_show_and_abort_on_warning(open3d_tf_ops)
 
 # Set output directory according to architecture (cpu/cuda)
 get_target_property(TF_OPS_DIR open3d_tf_ops LIBRARY_OUTPUT_DIRECTORY)

--- a/cpp/open3d/ml/tensorflow/CMakeLists.txt
+++ b/cpp/open3d/ml/tensorflow/CMakeLists.txt
@@ -37,6 +37,8 @@ set(TF_OPS_SOURCES
     "misc/FixedRadiusSearchOpKernel.cpp"
     "misc/KnnSearchOps.cpp"
     "misc/VoxelPoolingOpKernel.cpp"
+    "misc/NmsOpKernel.cpp"
+    "misc/NmsOps.cpp"
     "tf_neighbors/tf_batch_neighbors.cpp"
     "tf_neighbors/tf_neighbors.cpp"
     "tf_subsampling/tf_batch_subsampling.cpp"
@@ -44,6 +46,7 @@ set(TF_OPS_SOURCES
     "../contrib/Cloud.cpp"
     "../contrib/GridSubsampling.cpp"
     "../contrib/neighbors.cpp"
+    "../impl/misc/Nms.cpp"
 )
 
 set(TF_OPS_CUDA_SOURCES
@@ -55,7 +58,9 @@ set(TF_OPS_CUDA_SOURCES
     "misc/BuildSpatialHashTableOpKernel.cu"
     "misc/InvertNeighborsListOpKernel.cu"
     "misc/ReduceSubarraysSumOpKernel.cu"
+    "misc/NmsOpKernel.cu"
     "../impl/continuous_conv/ContinuousConvCUDAKernels.cu"
+    "../impl/misc/Nms.cu"
 )
 
 if(BUILD_CUDA_MODULE)
@@ -72,7 +77,7 @@ endif()
 add_library(open3d_tf_ops SHARED ${open3d_tf_ops_SOURCES})
 # do not use open3d_set_global_properties(open3d_tf_ops) here because some
 # options are not compatible for tf op libraries
-open3d_show_and_abort_on_warning(open3d_tf_ops)
+# open3d_show_and_abort_on_warning(open3d_tf_ops)
 
 # Set output directory according to architecture (cpu/cuda)
 get_target_property(TF_OPS_DIR open3d_tf_ops LIBRARY_OUTPUT_DIRECTORY)
@@ -111,6 +116,7 @@ target_include_directories(open3d_tf_ops SYSTEM PRIVATE
     ${Tensorflow_INCLUDE_DIR}
     ${nanoflann_INCLUDE_DIR}
     ${parallelstl_INCLUDE_DIR}
+    ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 )
 
 target_link_libraries(open3d_tf_ops PRIVATE

--- a/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cpp
@@ -1,0 +1,60 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/ml/tensorflow/misc/NmsOpKernel.h"
+
+#include "open3d/ml/impl/misc/Nms.h"
+
+using namespace nms_opkernel;
+using namespace tensorflow;
+
+class NmsOpKernelCPU : public NmsOpKernel {
+public:
+    explicit NmsOpKernelCPU(OpKernelConstruction* construction)
+        : NmsOpKernel(construction) {}
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& boxes,
+                const tensorflow::Tensor& scores) {
+        std::vector<int64_t> keep_indices = open3d::ml::impl::NmsCPUKernel(
+                boxes.flat<float>().data(), scores.flat<float>().data(),
+                boxes.dim_size(0), this->nms_overlap_thresh);
+
+        OutputAllocator output_allocator(context);
+        int64_t* ret_keep_indices = nullptr;
+        output_allocator.AllocKeepIndices(&ret_keep_indices,
+                                          keep_indices.size());
+        memcpy(ret_keep_indices, keep_indices.data(),
+               keep_indices.size() * sizeof(int64_t));
+    }
+};
+
+#define REG_KB(type)                                                        \
+    REGISTER_KERNEL_BUILDER(                                                \
+            Name("Open3DNms").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
+            NmsOpKernelCPU);
+REG_KB(float)
+#undef REG_KB

--- a/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
@@ -24,24 +24,12 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/ml/Helper.h"
 #include "open3d/ml/impl/misc/Nms.h"
 #include "open3d/ml/tensorflow/misc/NmsOpKernel.h"
 
 using namespace nms_opkernel;
 using namespace tensorflow;
-
-#define CHECK_ERROR(ans) \
-    { gpuAssert((ans), __FILE__, __LINE__); }
-inline void gpuAssert(cudaError_t code,
-                      const char* file,
-                      int line,
-                      bool abort = true) {
-    if (code != cudaSuccess) {
-        fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file,
-                line);
-        if (abort) exit(code);
-    }
-}
 
 class NmsOpKernelCUDA : public NmsOpKernel {
 public:
@@ -59,9 +47,9 @@ public:
         int64_t* ret_keep_indices = nullptr;
         output_allocator.AllocKeepIndices(&ret_keep_indices,
                                           keep_indices.size());
-        CHECK_ERROR(cudaMemcpy(ret_keep_indices, keep_indices.data(),
-                               boxes.dim_size(0) * sizeof(int64_t),
-                               cudaMemcpyHostToDevice));
+        OPEN3D_ML_CUDA_CHECK(cudaMemcpy(ret_keep_indices, keep_indices.data(),
+                                        boxes.dim_size(0) * sizeof(int64_t),
+                                        cudaMemcpyHostToDevice));
     }
 };
 

--- a/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
@@ -1,0 +1,73 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/ml/impl/misc/Nms.h"
+#include "open3d/ml/tensorflow/misc/NmsOpKernel.h"
+
+using namespace nms_opkernel;
+using namespace tensorflow;
+
+#define CHECK_ERROR(ans) \
+    { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code,
+                      const char* file,
+                      int line,
+                      bool abort = true) {
+    if (code != cudaSuccess) {
+        fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file,
+                line);
+        if (abort) exit(code);
+    }
+}
+
+class NmsOpKernelCUDA : public NmsOpKernel {
+public:
+    explicit NmsOpKernelCUDA(OpKernelConstruction* construction)
+        : NmsOpKernel(construction) {}
+
+    void Kernel(tensorflow::OpKernelContext* context,
+                const tensorflow::Tensor& boxes,
+                const tensorflow::Tensor& scores) {
+        std::vector<int64_t> keep_indices = open3d::ml::impl::NmsCUDAKernel(
+                boxes.flat<float>().data(), scores.flat<float>().data(),
+                boxes.dim_size(0), this->nms_overlap_thresh);
+
+        OutputAllocator output_allocator(context);
+        int64_t* ret_keep_indices = nullptr;
+        output_allocator.AllocKeepIndices(&ret_keep_indices,
+                                          keep_indices.size());
+        CHECK_ERROR(cudaMemcpy(ret_keep_indices, keep_indices.data(),
+                               boxes.dim_size(0) * sizeof(int64_t),
+                               cudaMemcpyHostToDevice));
+    }
+};
+
+#define REG_KB(type)                                                        \
+    REGISTER_KERNEL_BUILDER(                                                \
+            Name("Open3DNms").Device(DEVICE_GPU).TypeConstraint<type>("T"), \
+            NmsOpKernelCUDA);
+REG_KB(float)
+#undef REG_KB

--- a/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.h
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.h
@@ -1,0 +1,89 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+#pragma once
+
+//#include "open3d/ml/impl/misc/VoxelPooling.h"
+#include "open3d/ml/tensorflow/TensorFlowHelper.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+/// @cond
+// namespace for code that is common for all kernels
+namespace nms_opkernel {
+
+class OutputAllocator {
+public:
+    OutputAllocator(tensorflow::OpKernelContext* context) : context(context) {}
+
+    void AllocKeepIndices(int64_t** ptr, int64_t num) {
+        using namespace tensorflow;
+        *ptr = nullptr;
+        Tensor* tensor = 0;
+        TensorShape shape({num});
+        OP_REQUIRES_OK(context, context->allocate_output(0, shape, &tensor));
+        auto flat_tensor = tensor->flat<int64>();
+        *ptr = (int64_t*)flat_tensor.data();
+    }
+
+private:
+    tensorflow::OpKernelContext* context;
+};
+
+// Base class with common code for the OpKernel implementations
+class NmsOpKernel : public tensorflow::OpKernel {
+public:
+    explicit NmsOpKernel(tensorflow::OpKernelConstruction* construction)
+        : OpKernel(construction) {
+        OP_REQUIRES_OK(construction,
+                       construction->GetAttr("nms_overlap_thresh",
+                                             &nms_overlap_thresh));
+    }
+
+    void Compute(tensorflow::OpKernelContext* context) override {
+        using namespace tensorflow;
+        const Tensor& boxes = context->input(0);
+        const Tensor& scores = context->input(1);
+
+        {
+            using namespace open3d::ml::op_util;
+            Dim num_points("num_points");
+            Dim five(5, "five");
+            CHECK_SHAPE(context, boxes, num_points, five);
+            CHECK_SHAPE(context, scores, num_points);
+        }
+
+        Kernel(context, boxes, scores);
+    }
+
+    // Function with the device specific code
+    virtual void Kernel(tensorflow::OpKernelContext* context,
+                        const tensorflow::Tensor& boxes,
+                        const tensorflow::Tensor& scores) = 0;
+
+protected:
+    float nms_overlap_thresh;
+};
+
+}  // namespace nms_opkernel
+/// @endcond

--- a/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
@@ -1,0 +1,60 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/ml/tensorflow/TensorFlowHelper.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/shape_inference.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+using namespace tensorflow;
+
+REGISTER_OP("Open3DNms")
+        .Attr("T: {float}")  // type for boxes and scores
+        .Attr("nms_overlap_thresh: float")
+        .Input("boxes: T")
+        .Input("scores: T")
+        .Output("keep_indices: int64")
+        .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+            using namespace ::tensorflow::shape_inference;
+            using namespace open3d::ml::op_util;
+            ShapeHandle boxes, scores, keep_indices;
+
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 2, &boxes));
+            TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 2, &scores));
+
+            Dim num_points("num_points");
+            Dim five(5, "five");
+            CHECK_SHAPE_HANDLE(c, boxes, num_points, five);
+            CHECK_SHAPE_HANDLE(c, scores, num_points);
+
+            keep_indices = c->MakeShape({c->UnknownDim()});
+            c->set_output(0, keep_indices);
+            return Status::OK();
+        })
+        .Doc(R"doc(
+undocumented for now
+)doc");

--- a/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
@@ -73,6 +73,7 @@ indices.
   scores = np.array([3, 1.1, 5, 2, 1, 0], dtype=np.float32)
   nms_overlap_thresh = 0.7
   keep_indices = ml3d.ops.nms(boxes, scores, nms_overlap_thresh)
+  print(keep_indices)
 
   # PyTorch example.
   import torch

--- a/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
@@ -56,5 +56,46 @@ REGISTER_OP("Open3DNms")
             return Status::OK();
         })
         .Doc(R"doc(
-undocumented for now
+Performs non-maximum suppression of bounding boxes and returns the selected box
+indices.
+
+  # TensorFlow example.
+  import open3d.ml.tf as ml3d
+  import numpy as np
+
+  boxes = np.array([[15.0811, -7.9803, 15.6721, -6.8714, 0.5152],
+                    [15.1166, -7.9261, 15.7060, -6.8137, 0.6501],
+                    [15.1304, -7.8129, 15.7069, -6.8903, 0.7296],
+                    [15.2050, -7.8447, 15.8311, -6.7437, 1.0506],
+                    [15.1343, -7.8136, 15.7121, -6.8479, 1.0352],
+                    [15.0931, -7.9552, 15.6675, -7.0056, 0.5979]],
+                   dtype=np.float32)
+  scores = np.array([3, 1.1, 5, 2, 1, 0], dtype=np.float32)
+  nms_overlap_thresh = 0.7
+  keep_indices = ml3d.ops.nms(boxes, scores, nms_overlap_thresh)
+
+  # PyTorch example.
+  import torch
+  import open3d.ml.torch as ml3d
+
+  boxes = torch.Tensor([[15.0811, -7.9803, 15.6721, -6.8714, 0.5152],
+                        [15.1166, -7.9261, 15.7060, -6.8137, 0.6501],
+                        [15.1304, -7.8129, 15.7069, -6.8903, 0.7296],
+                        [15.2050, -7.8447, 15.8311, -6.7437, 1.0506],
+                        [15.1343, -7.8136, 15.7121, -6.8479, 1.0352],
+                        [15.0931, -7.9552, 15.6675, -7.0056, 0.5979]])
+  scores = torch.Tensor([3, 1.1, 5, 2, 1, 0])
+  nms_overlap_thresh = 0.7
+  keep_indices = ml3d.ops.nms(boxes, scores, nms_overlap_thresh)
+  print(keep_indices)
+
+boxes: (N, 5) float32 tensor. Bounding boxes are represented as (x0, y0, x1, y1, rotate).
+
+scores: (N,) float32 tensor. A higher score means a more confident bounding box.
+
+nms_overlap_thresh: float value between 0 and 1. When a high-score box is
+  selected, other remaining boxes with IoU > nms_overlap_thresh will be discarded.
+  A higher nms_overlap_thresh means more boxes will be kept.
+
+returns (M,) int64 tensor. The selected box indices.
 )doc");

--- a/cpp/open3d/utility/MiniVec.h
+++ b/cpp/open3d/utility/MiniVec.h
@@ -53,7 +53,9 @@ struct MiniVec {
     }
 
     FN_SPECIFIERS const T operator[](size_t i) const { return arr[i]; }
+
     FN_SPECIFIERS T& operator[](size_t i) { return arr[i]; }
+
     template <class T2>
     FN_SPECIFIERS MiniVec<T2, N> cast() const {
         MiniVec<T2, N> a;

--- a/python/test/ml_ops/test_nms.py
+++ b/python/test/ml_ops/test_nms.py
@@ -25,14 +25,10 @@
 # ----------------------------------------------------------------------------
 
 import open3d as o3d
-import open3d.ml.torch
 import numpy as np
-import pytest
 import mltest
-import torch
-import time
 
-# skip all tests if the ml ops were not built
+# Skip all tests if the ml ops were not built.
 pytestmark = mltest.default_marks
 
 

--- a/python/test/ml_ops/test_nms.py
+++ b/python/test/ml_ops/test_nms.py
@@ -1,0 +1,61 @@
+# ----------------------------------------------------------------------------
+# -                        Open3D: www.open3d.org                            -
+# ----------------------------------------------------------------------------
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 www.open3d.org
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ----------------------------------------------------------------------------
+
+import open3d as o3d
+import open3d.ml.torch
+import numpy as np
+import pytest
+import mltest
+import torch
+import time
+
+# skip all tests if the ml ops were not built
+pytestmark = mltest.default_marks
+
+
+@mltest.parametrize.ml
+def test_nms(ml):
+    boxes = np.array([[15.0811, -7.9803, 15.6721, -6.8714, 0.5152],
+                      [15.1166, -7.9261, 15.7060, -6.8137, 0.6501],
+                      [15.1304, -7.8129, 15.7069, -6.8903, 0.7296],
+                      [15.2050, -7.8447, 15.8311, -6.7437, 1.0506],
+                      [15.1343, -7.8136, 15.7121, -6.8479, 1.0352],
+                      [15.0931, -7.9552, 15.6675, -7.0056, 0.5979]],
+                     dtype=np.float32)
+    scores = np.array([3, 1.1, 5, 2, 1, 0], dtype=np.float32)
+    nms_overlap_thresh = 0.7
+    keep_indices_ref = np.array([2, 3, 5]).astype(np.int64)
+
+    keep_indices = mltest.run_op(ml,
+                                 ml.device,
+                                 True,
+                                 ml.ops.nms,
+                                 boxes,
+                                 scores,
+                                 nms_overlap_thresh=nms_overlap_thresh)
+
+    np.testing.assert_equal(keep_indices, keep_indices_ref)
+    assert keep_indices.dtype == keep_indices_ref.dtype

--- a/python/test/ml_ops/test_nms.py
+++ b/python/test/ml_ops/test_nms.py
@@ -55,3 +55,22 @@ def test_nms(ml):
 
     np.testing.assert_equal(keep_indices, keep_indices_ref)
     assert keep_indices.dtype == keep_indices_ref.dtype
+
+
+@mltest.parametrize.ml
+def test_nms_empty(ml):
+    boxes = np.zeros((0, 5), dtype=np.float32)
+    scores = np.array([], dtype=np.float32)
+    nms_overlap_thresh = 0.7
+    keep_indices_ref = np.array([]).astype(np.int64)
+
+    keep_indices = mltest.run_op(ml,
+                                 ml.device,
+                                 True,
+                                 ml.ops.nms,
+                                 boxes,
+                                 scores,
+                                 nms_overlap_thresh=nms_overlap_thresh)
+
+    np.testing.assert_equal(keep_indices, keep_indices_ref)
+    assert keep_indices.dtype == keep_indices_ref.dtype


### PR DESCRIPTION
Some notes:
1. In the original impl, the op is implemented in Python + CPP. Where the Python part does the sorting in PyTorch. In this implementation, the sorting part is moved to C++ and it is done by thrust. This is required since in TensorFlow we cannot use PyTorch's sorting. 
2. Added CPU implementation.
3. Same as the original impl, the CUDA op requires host + device operations.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2615)
<!-- Reviewable:end -->
