### PR TITLE
fixed shape check for faces and lines in SetMeshData

### DIFF
--- a/cpp/open3d/io/rpc/RemoteFunctions.cpp
+++ b/cpp/open3d/io/rpc/RemoteFunctions.cpp
@@ -236,8 +236,8 @@ bool SetMeshData(const core::Tensor& vertices,
         } else if (faces.NumDims() != 2) {
             LogError("SetMeshData: faces must have rank 2 but is {}",
                      faces.NumDims());
-        } else if (faces.GetShape()[1] >= 3) {
-            LogError("SetMeshData: last dim of faces must be >3 but is {}",
+        } else if (faces.GetShape()[1] < 3) {
+            LogError("SetMeshData: last dim of faces must be >=3 but is {}",
                      faces.GetShape()[1]);
         } else {
             tensor_cache.push_back(PrepareTensor(faces));
@@ -270,8 +270,8 @@ bool SetMeshData(const core::Tensor& vertices,
         } else if (lines.NumDims() != 2) {
             LogError("SetMeshData: lines must have rank 2 but is {}",
                      lines.NumDims());
-        } else if (lines.GetShape()[1] >= 2) {
-            LogError("SetMeshData: last dim of lines must be >2 but is {}",
+        } else if (lines.GetShape()[1] < 2) {
+            LogError("SetMeshData: last dim of lines must be >=2 but is {}",
                      lines.GetShape()[1]);
         } else {
             tensor_cache.push_back(PrepareTensor(lines));


### PR DESCRIPTION
This PR fixes a wrong shape check for the faces and lines tensor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2623)
<!-- Reviewable:end -->
