### PR TITLE
cmake-3.18 required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@
 if (WIN32)
     cmake_minimum_required(VERSION 3.18)
 else()
-    # If you're using Ubuntu 18.04 or older, we suggest you install the latest
+    # If you're using Ubuntu 18.04, we suggest you install the latest
     # CMake from the official repository https://apt.kitware.com/.
-    # CMake 3.15+ is required to allow linking with OBJECT libraries,
+    # CMake 3.18+ is required to allow linking with OBJECT libraries,
     # to prevent erroneous -gencode option deduplication with CUDA,
     # and to simplify generator expressions for selecting compile flags.
-    cmake_minimum_required(VERSION 3.15)
+    cmake_minimum_required(VERSION 3.18)
 endif()
 
 set (CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING


### PR DESCRIPTION
[cmake min required - 3.17 by faiss.]
* [Updated] cmake min required to 3.18.
Now, as both Windows and Ubuntu require 3.18, the if(WIN32) case can be removed. (However, I didn't remove it, as it will be convenient to update the version requirement for either in the future separately.)
* [Changed] "Ubuntu 18.04 and older" to "Ubuntu 18.04" as the package is incompatible with previous versions of Ubuntu, as libc++7-dev required by the package is not available in previous versions of Ubuntu.

To Do:
* Documentation to be updated accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2664)
<!-- Reviewable:end -->
