### PR TITLE
cmake-3.17 required

### DIFF
--- a/.github/workflows/openblas.yml
+++ b/.github/workflows/openblas.yml
@@ -127,6 +127,13 @@ jobs:
             python --version
             pip install pytest=="6.0.1" -U
             pip install wheel=="0.35.1" -U
+            # Get pre-compiled CMake
+            wget https://github.com/intel-isl/Open3D/releases/download/v0.11.0/cmake-3.18-aarch64.tar.gz
+            tar -xvf cmake-3.18-aarch64.tar.gz
+            cp -ar cmake-3.18-aarch64 ${HOME}
+            PATH=${HOME}/cmake-3.18-aarch64/bin:$PATH
+            which cmake
+            cmake --version
 
           # Build and run Open3D tests
           run: |

--- a/.github/workflows/openblas.yml
+++ b/.github/workflows/openblas.yml
@@ -108,7 +108,7 @@ jobs:
           # Install dependencies
           install: |
             apt-get update -q -y
-            apt-get install -y apt-utils build-essential git cmake
+            apt-get install -y apt-utils build-essential git wget
             apt-get install -y python3 python3-dev python3-pip python3-virtualenv
             apt-get install -y xorg-dev libglu1-mesa-dev ccache
             apt-get install -y libblas-dev liblapack-dev liblapacke-dev

--- a/.github/workflows/openblas.yml
+++ b/.github/workflows/openblas.yml
@@ -138,6 +138,7 @@ jobs:
           # Build and run Open3D tests
           run: |
             PATH=/usr/lib/ccache:$PATH
+            PATH=${HOME}/cmake-3.18-aarch64/bin:$PATH
             ccache -s
             source ${HOME}/venv/bin/activate
             mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@
 if (WIN32)
     cmake_minimum_required(VERSION 3.18)
 else()
-    # If you're using Ubuntu 18.04 or older, we suggest you install the latest
+    # If you're using Ubuntu 18.04, we suggest you install the latest
     # CMake from the official repository https://apt.kitware.com/.
-    # CMake 3.15+ is required to allow linking with OBJECT libraries,
+    # CMake 3.17+ is required to allow linking with OBJECT libraries,
     # to prevent erroneous -gencode option deduplication with CUDA,
     # and to simplify generator expressions for selecting compile flags.
-    cmake_minimum_required(VERSION 3.15)
+    cmake_minimum_required(VERSION 3.17)
 endif()
 
 set (CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -11,7 +11,7 @@ System requirements
 * Ubuntu 18.04+: GCC 5+, Clang 7+
 * macOS 10.14+: XCode 8.0+
 * Windows 10 (64-bit): Visual Studio 2019+
-* CMake: 3.15+ for Ubuntu and macOS, 3.18+ for Windows
+* CMake: 3.17+ for Ubuntu and macOS, 3.18+ for Windows
 
   * Ubuntu (18.04):
 


### PR DESCRIPTION
* [Updated] CMake min requirement from 3.15 to 3.17 as required by faiss.
[3.18 is not supported by current CI Tests configuration]
* [Updated] CMake-3.18-aarch64 for arm64-filament-only CI, install wget

* [Modified] "Ubuntu 18.04 and below" to "Ubuntu 18.04" as the package is incompatible with previous versions of Ubuntu, as libc++7-dev required by the package is not available in previous versions of Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2665)
<!-- Reviewable:end -->
