### PR TITLE
GCE GPU CI fixes

### DIFF
--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -66,16 +66,13 @@ jobs:
           project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: GCloud setup for docker
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh gcloud-setup
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh gcloud-setup
 
       - name: Build docker image
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-build
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-build
 
       - name: Push the Docker image to Google Container Registry
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-push
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-push
 
 
   build-install-test:
@@ -111,18 +108,15 @@ jobs:
           ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh create-vm
 
       - name: Config, build and run C++ unit tests
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-ci
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-ci
 
       - name: Run Python unit tests
         if: env.CI_CONFIG_ID == '4-ML-RPC-bionic' || env.CI_CONFIG_ID == '5-ML-RPC-focal'
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-python-ci
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-python-ci
 
       - name: Delete VM
         if: always()
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-vm
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-vm
 
   cleanup:
     name: Clean-up container image
@@ -150,5 +144,4 @@ jobs:
           project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: Delete container image
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-image
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-image

--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -44,12 +44,19 @@ jobs:
 
     env:
       UBUNTU_VERSION: ${{ matrix.UBUNTU_VERSION }}
+      OPEN3D_ML_ROOT: ${{ github.workspace }}/Open3D-ML
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+
+      - name: Checkout Open3D-ML source code
+        uses: actions/checkout@v2
+        with:
+          repository: intel-isl/Open3D-ML
+          path: ${{ env.OPEN3D_ML_ROOT }}
 
       - name: GCloud CLI setup
         uses: google-github-actions/setup-gcloud@master
@@ -80,7 +87,8 @@ jobs:
       fail-fast: false
       max-parallel: 4     # Limit parallel runs to max GPU quota (4)
       matrix:
-        CI_CONFIG_ID: [2, 3, 4, 5]   # See gce-ubuntu-docker-run.sh for details. These need GPU.
+        # See gce-ubuntu-docker-run.sh for details. These need GPU.
+        CI_CONFIG_ID: ['2-bionic', '3-ML-bionic', '4-ML-RPC-bionic', '5-ML-RPC-focal']
 
     env:
       CI_CONFIG_ID: ${{ matrix.CI_CONFIG_ID }}
@@ -102,9 +110,14 @@ jobs:
         run: |
           ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh create-vm
 
-      - name: Config, build and run unit tests
+      - name: Config, build and run C++ unit tests
         run: |
           ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-ci
+
+      - name: Run Python unit tests
+        if: env.CI_CONFIG_ID == '4-ML-RPC-bionic' || env.CI_CONFIG_ID == '5-ML-RPC-focal'
+        run: |
+          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-python-ci
 
       - name: Delete VM
         if: always()

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -178,13 +178,16 @@ jobs:
           export_default_credentials: true
 
       - name: Upload wheel to GCE for GPU tests
+        continue-on-error: true
+        env:
+          CLOUDSDK_CORE_PROJECT: ${{ secrets.GCE_PROJECT }}
         run: |
           for CI_CONFIG_ID in 4 5 ; do
             VM_INSTANCE="ci-gpu-vm-${GITHUB_SHA::8}-${CI_CONFIG_ID}"
-            gcloud config set compute/zone \
-              $(gcloud compute instances list --filter="name~${VM_INSTANCE}" | tail -n1 | cut -d' ' -f3)
+            export CLOUDSDK_COMPUTE_ZONE=$(gcloud compute instances list \
+              --filter="name~${VM_INSTANCE}" | tail -n1 | cut -d' ' -f3)
             gcloud compute scp build/lib/python_package/pip_package/${{ env.PIP_PKG_NAME }} \
-              ${VM_INSTANCE}:~  || true
+              ${VM_INSTANCE}:~ || true
           done
 
       - name: Upload wheel to GCS bucket

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -178,6 +178,16 @@ jobs:
           project_id: ${{ secrets.GCE_DOCS_PROJECT }}
           export_default_credentials: true
 
+      - name: Upload wheel to GCE for GPU tests
+        run: |
+          for CI_CONFIG_ID in 4 5 ; do
+            VM_INSTANCE="ci-gpu-vm-${GITHUB_SHA::8}-${CI_CONFIG_ID}"
+            gcloud config set compute/zone \
+              $(gcloud compute instances list --filter="name~${VM_INSTANCE}" | tail -n1 | cut -d' ' -f3)
+            gcloud compute scp build/lib/python_package/pip_package/${{ env.PIP_PKG_NAME }} \
+              ${VM_INSTANCE}:~  || true
+          done
+
       - name: Upload wheel to GCS bucket
         if: ${{ github.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -170,7 +170,6 @@ jobs:
           if-no-files-found: error
 
       - name: GCloud CLI setup
-        if: ${{ github.ref == 'refs/heads/master' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           version: ${{ env.GCE_CLI_GHA_VERSION }}

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -203,6 +203,9 @@ install_azure_kinect_dependencies() {
 
 build_all() {
 
+    echo "Using cmake: $(which cmake)"
+    cmake --version
+
     mkdir -p build
     cd build
 
@@ -225,11 +228,9 @@ build_all() {
     echo Running cmake "${cmakeOptions[@]}" ..
     cmake "${cmakeOptions[@]}" ..
     echo
-    echo "build & install Open3D..."
+    echo "Build & install Open3D..."
     make VERBOSE=1 -j"$NPROC"
     make install -j"$NPROC"
-    make VERBOSE=1 install-pip-package -j"$NPROC"
-    echo
 }
 
 build_pip_conda_package() {
@@ -322,9 +323,14 @@ build_pip_conda_package() {
 test_wheel() {
     wheel_path="$1"
     python -m venv open3d_test.venv
+    # shellcheck disable=SC1091
     source open3d_test.venv/bin/activate
     python -m pip install --upgrade pip=="$PIP_VER" wheel=="$WHEEL_VER" \
         setuptools=="$STOOLS_VER"
+    echo "Using python: $(which python)"
+    python --version
+    echo -n "Using pip: "
+    python -m pip --version
     echo "Installing Open3D wheel $wheel_path in virtual environment..."
     python -m pip install "$wheel_path"
     python -c "import open3d; print('Installed:', open3d)"
@@ -354,11 +360,12 @@ test_wheel() {
         echo "importing in the normal order"
         python -c "import open3d.ml.torch as o3d; import tensorflow as tf"
     fi
-    deactivate
+    deactivate open3d_test.venv # argument prevents unbound variable error
 }
 
 # Run in virtual environment
 run_python_tests() {
+    # shellcheck disable=SC1091
     source open3d_test.venv/bin/activate
     python -m pip install -U pytest=="$PYTEST_VER"
     python -m pip install -U scipy=="$SCIPY_VER"
@@ -368,7 +375,7 @@ run_python_tests() {
         pytest_args+=(--ignore "$OPEN3D_SOURCE_ROOT"/python/test/ml_ops/)
     fi
     python -m pytest "${pytest_args[@]}"
-    deactivate
+    deactivate open3d_test.venv # argument prevents unbound variable error
 }
 
 # Use: run_unit_tests

--- a/util/docker/open3d-gpu/Dockerfile
+++ b/util/docker/open3d-gpu/Dockerfile
@@ -1,14 +1,32 @@
-# eg: docker build --build-arg UBUNTU_VERSION=focal
+# Example build command:
+# docker build \
+#   --build-arg UBUNTU_VERSION=focal \
+#   --build-arg NVIDIA_DRIVER_VERSION=455 \
+#   -t open3d-gpu-ci-focal:latest \
+#   -f ./util/docker/open3d-gpu/Dockerfile \
+#    .
+# Example run command:
+#    docker run --rm --gpus all \
+#        --env NPROC=4 \
+#        --env SHARED=OFF \
+#        --env BUILD_CUDA_MODULE=ON \
+#        --env BUILD_RPC_INTERFACE=ON \
+#        --env BUILD_TENSORFLOW_OPS=ON \
+#        --env BUILD_PYTORCH_OPS=ON \
+#        --env OPEN3D_ML_ROOT=/root/Open3D/Open3D-ML \
+#        open3d-gpu-ci-focal:latest
+
 ARG UBUNTU_VERSION
-FROM ubuntu:${UBUNTU_VERSION}
+FROM ubuntu:${UBUNTU_VERSION} AS open3d-gpu
 # Persist ARG for the rest of the build
 ARG UBUNTU_VERSION
-ARG NVIDIA_DRIVER_VERSION=440
-LABEL name="open3d-dev/open3d-gpu-ci-${UBUNTU_VERSION}" \
-            vendor="open3d.org" \
-            architecture="x86_64" \
-            os="linux" \
-            maintainer="sameer.sheorey@intel.com"
+ARG NVIDIA_DRIVER_VERSION=455
+LABEL name="open3d-dev/open3d-gpu-ci-${UBUNTU_VERSION}"
+LABEL vendor="open3d.org"
+LABEL architecture="x86_64"
+LABEL os="linux"
+LABEL version="0.12.0"
+LABEL maintainer="open3d-info@osvf.org"
 
 ENV DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles SUDO=command
 # Install Python 3, cmake>=3.12 and nvidia drivers (only if not installed)
@@ -31,6 +49,6 @@ ENV PATH=/usr/local/cuda/bin:$PATH \
          NVIDIA_REQUIRE_CUDA="cuda>=10.1"
 
 COPY . /root/Open3D
-WORKDIR /root/Open3D
 
-ENTRYPOINT util/run_ci.sh
+WORKDIR /root/Open3D
+ENTRYPOINT /bin/bash

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -12,7 +12,8 @@ UBUNTU_VERSION=${UBUNTU_VERSION:="$(lsb_release -cs)"} # Empty in macOS
 $SUDO apt-get update
 $SUDO apt-get --yes install git software-properties-common
 echo "Installing Python3 and setting as default python"
-$SUDO apt-get --yes --no-install-recommends install python3 python3-pip python3-setuptools
+$SUDO apt-get --yes --no-install-recommends install python3 python3-pip \
+    python3-setuptools python3-venv
 if ! which python || python -V 2>/dev/null | grep -q ' 2.'; then
     echo 'Making python3 the default python'
     $SUDO ln -s /usr/bin/python3 /usr/local/bin/python

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -13,6 +13,7 @@ set -e
 # GITHUB_SHA
 ## CI test matrix:
 CI_CONFIG_ID=${CI_CONFIG_ID:=0}
+CI_CONFIG_ID=${CI_CONFIG_ID%%-*} # '3-ML-bionic' -> '3'
 
 # CI configuration specification
 SHARED=(OFF ON OFF ON OFF OFF)
@@ -44,11 +45,13 @@ GCE_ZID=${GCE_ZID:=0} # Persist between calls of this script
 GCE_GPU="count=1,type=nvidia-tesla-t4"
 GCE_BOOT_DISK_TYPE=pd-ssd
 GCE_BOOT_DISK_SIZE=32GB
-NVIDIA_DRIVER_VERSION=440 # Must be present in Ubuntu repos 20.04: {390, 418, 430, 435, 440}
+NVIDIA_DRIVER_VERSION=455 # Must be present in Ubuntu repos 20.04: {390, 418, 430, 435, 440, 450, 455}
 GCE_VM_BASE_OS=ubuntu20.04
 GCE_VM_IMAGE_SPEC=(--image-project=ubuntu-os-cloud --image-family=ubuntu-2004-lts)
 GCE_VM_CUSTOM_IMAGE_FAMILY=ubuntu-os-docker-gpu-2004-lts
+GCE_VM_CUSTOM_IMAGE=open3d-gpu-ci-base-20201228
 VM_IMAGE=open3d-gpu-ci-base-$(date +%Y%m%d)
+GCE_CI_TIMEOUT=5400 # Self delete VM after timeout (seconds)
 
 # Container configuration
 REGISTRY_HOSTNAME=gcr.io
@@ -68,7 +71,7 @@ gcloud-setup)
 docker-build)
     # Pull previous image as cache
     docker pull "$DC_IMAGE_LATEST_TAG" || true
-    docker build -t "$DC_IMAGE_TAG" \
+    DOCKER_BUILDKIT=1 docker build -t "$DC_IMAGE_TAG" \
         -f util/docker/open3d-gpu/Dockerfile \
         --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \
         --build-arg NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION}" \
@@ -118,16 +121,22 @@ create-base-vm-image)
 
 create-vm)
     # Try creating a VM instance in each zone
-    until ((GCE_ZID >= ${#GCE_INSTANCE_ZONE[@]})) ||
-        gcloud compute instances create "$GCE_INSTANCE" \
-            --zone="${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
-            --accelerator="$GCE_GPU" \
-            --maintenance-policy=TERMINATE \
-            --machine-type=$GCE_INSTANCE_TYPE \
-            --boot-disk-size=$GCE_BOOT_DISK_SIZE \
-            --boot-disk-type=$GCE_BOOT_DISK_TYPE \
-            --image-family="$GCE_VM_CUSTOM_IMAGE_FAMILY" \
-            --service-account="$GCE_GPU_CI_SA"; do
+    until
+        ((GCE_ZID >= ${#GCE_INSTANCE_ZONE[@]})) ||
+            gcloud compute instances create "$GCE_INSTANCE" \
+                --zone="${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
+                --accelerator="$GCE_GPU" \
+                --maintenance-policy=TERMINATE \
+                --machine-type=$GCE_INSTANCE_TYPE \
+                --boot-disk-type=$GCE_BOOT_DISK_TYPE \
+                --image="$GCE_VM_CUSTOM_IMAGE" \
+                --service-account="$GCE_GPU_CI_SA" \
+                --scopes=default,compute-rw \
+                --metadata=startup-script="\
+                sleep ${GCE_CI_TIMEOUT};\
+                gcloud --quiet compute instances delete ${GCE_INSTANCE} \
+                --zone=${GCE_INSTANCE_ZONE[$GCE_ZID]}"
+    do
         ((GCE_ZID = GCE_ZID + 1))
     done
     sleep 30 # wait for instance ssh service startup
@@ -138,21 +147,49 @@ create-vm)
 
 run-ci)
     gcloud compute ssh "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}" --command \
-        "sudo docker run --rm --gpus all \
+        "sudo docker run --detach --interactive --name open3d_gpu_ci --gpus all \
             --env NPROC=$NPROC \
             --env SHARED=${SHARED[$CI_CONFIG_ID]} \
             --env BUILD_CUDA_MODULE=${BUILD_CUDA_MODULE[$CI_CONFIG_ID]} \
+            --env BUILD_RPC_INTERFACE=${BUILD_RPC_INTERFACE[$CI_CONFIG_ID]} \
             --env BUILD_TENSORFLOW_OPS=${BUILD_TENSORFLOW_OPS[$CI_CONFIG_ID]} \
             --env BUILD_PYTORCH_OPS=${BUILD_PYTORCH_OPS[$CI_CONFIG_ID]} \
-            --env BUILD_RPC_INTERFACE=${BUILD_RPC_INTERFACE[$CI_CONFIG_ID]} \
-            $DC_IMAGE_TAG"
+            --env OPEN3D_ML_ROOT=/root/Open3D/Open3D-ML \
+            $DC_IMAGE_TAG; \
+            sudo docker exec --interactive  open3d_gpu_ci util/run_ci.sh"
+    ;;
+
+run-python-ci)
+    # Wait for wheel to be downloaded from ubuntu.yml CI
+    gcloud compute ssh "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
+        --command <<"WHEEL_WAIT"
+    bash -c 'for wait_time in $(seq 0 30 1200); do
+        whlstat="$(ls -l --full-time ~/open3d*.whl 2>/dev/null)"
+        sleep 30
+        if [ -n "$whlstat" ] && \
+        [[ "$(ls -l --full-time ~/open3d*.whl)" == "$whlstat" ]]; then
+            echo Wheel available!
+            break
+        fi;
+        echo Waiting for wheel since ${wait_time}s
+    done'
+WHEEL_WAIT
+    # Copy wheel into docker
+    gcloud compute ssh "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
+        --command "sudo docker cp ~/open3d*.whl open3d_gpu_ci:/root/"
+    # Run Python CI
+    gcloud compute ssh "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
+        --command "sudo docker exec --interactive open3d_gpu_ci bash -o \
+        errexit,nounset,pipefail,verbose -c \
+        'source util/ci_utils.sh; test_wheel /root/open3d*.whl; run_python_tests'"
     ;;
 
 delete-image)
     gcloud container images untag "$DC_IMAGE_TAG" --quiet
     # Clean up images without tags - keep :latest
-    gcloud container images list-tags "$DC_IMAGE" --filter='-tags:*' --format='get(digest)' --limit=unlimited |
-        xargs -I {arg} gcloud container images delete "${DC_IMAGE}@{arg}" --quiet
+    gcloud container images list-tags "$DC_IMAGE" --filter='-tags:*' \
+        --format='get(digest)' --limit=unlimited |
+        xargs -I "{arg}" gcloud container images delete "${DC_IMAGE}@{arg}" --quiet
     ;;
 
 delete-vm)

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -162,7 +162,7 @@ run-ci)
 run-python-ci)
     # Wait for wheel to be downloaded from ubuntu.yml CI
     gcloud compute ssh "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
-        --command <<"WHEEL_WAIT"
+        <<"WHEEL_WAIT"
     bash -c 'for wait_time in $(seq 0 30 1200); do
         whlstat="$(ls -l --full-time ~/open3d*.whl 2>/dev/null)"
         sleep 30

--- a/util/run_ci.sh
+++ b/util/run_ci.sh
@@ -5,10 +5,12 @@ set -euo pipefail
 # shellcheck source=ci_utils.sh
 source "$(dirname "$0")"/ci_utils.sh
 
+set -x
+
 echo "nproc = $(getconf _NPROCESSORS_ONLN) NPROC = ${NPROC}"
 
 if [ "$BUILD_CUDA_MODULE" == "ON" ] &&
-    ! nvcc --version | grep -q "release ${CUDA_VERSION[1]}" 2>/dev/null; then
+    ! nvcc --version 2>/dev/null | grep -q "release ${CUDA_VERSION[1]}"; then
     install_cuda_toolkit with-cudnn purge-cache
     nvcc --version
 fi
@@ -19,36 +21,20 @@ else
     install_python_dependencies with-unit-test purge-cache
 fi
 
-echo "using python: $(which python)"
-python --version
-echo -n "Using pip: "
-python -m pip --version
-echo -n "Using pytest:"
-python -m pytest --version
-echo "using cmake: $(which cmake)"
-cmake --version
-
 build_all
 
 echo "Building examples iteratively..."
 make VERBOSE=1 -j"$NPROC" build-examples-iteratively
 echo
 
-echo "running Open3D C++ unit tests..."
+echo "Running Open3D C++ unit tests..."
 run_cpp_unit_tests
-
-# Run on GPU only. CPU versions run on Github already
-if nvidia-smi 2>&1 >/dev/null; then
-    echo "try importing Open3D Python package"
-    test_wheel lib/python_package/pip_package/open3d*.whl
-    echo "running Open3D Python tests..."
-    run_python_tests
-    echo
-fi
 
 echo "Test building a C++ example with installed Open3D..."
 test_cpp_example "${runExample:=ON}"
 echo
 
-echo "test uninstalling Open3D..."
+echo "Test uninstalling Open3D..."
 make uninstall
+
+set +x


### PR DESCRIPTION
Fixes for:

1. Github glitch can prevent GCE VM deletion: Auto delete GCE VM after timeout (set to 1.5 hours).
2. CUDA driver and library version mismatch due to updated drivers from NVIDIA. `apt` would install multiple CUDA library versions. Updated NVIDIA driver version from 440 to 455. New base VM image created on GCE: `open3d-gpu-ci-base-20201228`. C++ tests still ran fine, though.
3. Python tests on GPU:  Separate Python build and run test step in CI. Added Open3D-ML to docker image. Python wheel is transferred from GHA to GCE for Python tests on bionic and focal.
4. Remove redundant `make install-pip-package` from `build_all`. This is tested in `build_wheel`.
5. CI configurations appear with names in GHA for easier debugging: `['2-bionic', '3-ML-bionic', '4-ML-RPC-bionic', '5-ML-RPC-focal']`
6. Dockerfile maintainer changed to `open3d-info@osvf.org`. Is there a better email for Open3D?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2711)
<!-- Reviewable:end -->
