### PR TITLE
Faster geometry conversion

### DIFF
--- a/cpp/open3d/core/EigenConverter.cpp
+++ b/cpp/open3d/core/EigenConverter.cpp
@@ -26,34 +26,57 @@
 
 #include "open3d/core/EigenConverter.h"
 
+#include <type_traits>
+
 #include "open3d/core/kernel/CPULauncher.h"
 
 namespace open3d {
 namespace core {
 namespace eigen_converter {
 
-Eigen::Vector3d TensorToEigenVector3d(const core::Tensor &tensor) {
-    // TODO: Tensor::To(dtype, device).
-    if (tensor.GetShape() != SizeVector{3}) {
-        utility::LogError("Tensor shape must be {3}, but got {}.",
-                          tensor.GetShape().ToString());
+template <typename T>
+static std::vector<Eigen::Matrix<T, 3, 1>> TensorToEigenVector3xVector(
+        const core::Tensor &tensor) {
+    static_assert(std::is_same<T, double>::value || std::is_same<T, int>::value,
+                  "Only supports double and int (Vector3d and Vector3i).");
+    core::Dtype dtype;
+    if (std::is_same<T, double>::value) {
+        dtype = core::Dtype::Float64;
+    } else if (std::is_same<T, int>::value) {
+        dtype = core::Dtype::Int32;
     }
-    core::Tensor dtensor =
-            tensor.To(core::Dtype::Float64).Copy(core::Device("CPU:0"));
-    return Eigen::Vector3d(dtensor[0].Item<double>(), dtensor[1].Item<double>(),
-                           dtensor[2].Item<double>());
+    if (dtype.ByteSize() * 3 != sizeof(Eigen::Matrix<T, 3, 1>)) {
+        utility::LogError("Internal error: dtype size mismatch {} != {}.",
+                          dtype.ByteSize() * 3, sizeof(Eigen::Matrix<T, 3, 1>));
+    }
+    tensor.AssertShapeCompatible({utility::nullopt, 3});
+
+    // Eigen::Vector3x is not a "fixed-size vectorizable Eigen type" thus it is
+    // safe to write directly into std vector memory, see:
+    // https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html.
+    std::vector<Eigen::Matrix<T, 3, 1>> eigen_vector(tensor.GetLength());
+    core::Tensor t = tensor.Contiguous().To(dtype, /*copy=*/false);
+    MemoryManager::MemcpyToHost(eigen_vector.data(), t.GetDataPtr(),
+                                t.GetDevice(),
+                                t.GetDtype().ByteSize() * t.NumElements());
+    return eigen_vector;
 }
 
-core::Tensor EigenVector3dVectorToTensor(
-        const std::vector<Eigen::Vector3d> &values,
+template <typename T>
+static core::Tensor EigenVector3xVectorToTensor(
+        const std::vector<Eigen::Matrix<T, 3, 1>> &values,
         core::Dtype dtype,
         const core::Device &device) {
+    // Unlike TensorToEigenVector3xVector, more types can be supported here. To
+    // keep consistency, we only allow double and int.
+    static_assert(std::is_same<T, double>::value || std::is_same<T, int>::value,
+                  "Only supports double and int (Vector3d and Vector3i).");
     // Init CPU Tensor.
     int64_t num_values = static_cast<int64_t>(values.size());
     core::Tensor tensor_cpu =
             core::Tensor::Empty({num_values, 3}, dtype, Device("CPU:0"));
 
-    // Fill Tensor.
+    // Fill Tensor. This takes care of dtype conversion at the same time.
     core::Indexer indexer({tensor_cpu}, tensor_cpu,
                           core::DtypePolicy::ALL_SAME);
     DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
@@ -73,6 +96,30 @@ core::Tensor EigenVector3dVectorToTensor(
     } else {
         return tensor_cpu.Copy(device);
     }
+}
+
+std::vector<Eigen::Vector3d> TensorToEigenVector3dVector(
+        const core::Tensor &tensor) {
+    return TensorToEigenVector3xVector<double>(tensor);
+}
+
+std::vector<Eigen::Vector3i> TensorToEigenVector3iVector(
+        const core::Tensor &tensor) {
+    return TensorToEigenVector3xVector<int>(tensor);
+}
+
+core::Tensor EigenVector3dVectorToTensor(
+        const std::vector<Eigen::Vector3d> &values,
+        core::Dtype dtype,
+        const core::Device &device) {
+    return EigenVector3xVectorToTensor(values, dtype, device);
+}
+
+core::Tensor EigenVector3iVectorToTensor(
+        const std::vector<Eigen::Vector3i> &values,
+        core::Dtype dtype,
+        const core::Device &device) {
+    return EigenVector3xVectorToTensor(values, dtype, device);
 }
 
 }  // namespace eigen_converter

--- a/cpp/open3d/core/EigenConverter.h
+++ b/cpp/open3d/core/EigenConverter.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <vector>
 
 #include "open3d/core/Device.h"
 #include "open3d/core/Dtype.h"
@@ -37,18 +38,47 @@ namespace open3d {
 namespace core {
 namespace eigen_converter {
 
-/// Converts a tensor of shape (3,) to Eigen::Vector3d. An exception will be
-/// thrown if the tensor shape is not (3,).
-Eigen::Vector3d TensorToEigenVector3d(const core::Tensor &tensor);
+/// Converts a tensor of shape (N, 3) to std::vector<Eigen::Vector3d>. An
+/// exception will be thrown if the tensor shape is not (N, 3). Regardless of
+/// the tensor dtype, the output will be converted to to double.
+///
+/// \param tensor A tensor of shape (N, 3).
+/// \return A vector of N Eigen::Vector3d values.
+std::vector<Eigen::Vector3d> TensorToEigenVector3dVector(
+        const core::Tensor &tensor);
 
-/// Converts a vector of Eigen::Vector3d to a (N, 3) tensor. This function also
-/// takes care of dtype conversion and device transfer if necessary.
+/// Converts a tensor of shape (N, 3) to std::vector<Eigen::Vector3i>. An
+/// exception will be thrown if the tensor shape is not (N, 3). Regardless of
+/// the tensor dtype, the output will be converted to to double.
+///
+/// \param tensor A tensor of shape (N, 3).
+/// \return A vector of N Eigen::Vector3i values.
+std::vector<Eigen::Vector3i> TensorToEigenVector3iVector(
+        const core::Tensor &tensor);
+
+/// Converts a vector of Eigen::Vector3d to a (N, 3) tensor. This
+/// function also takes care of dtype conversion and device transfer if
+/// necessary.
 ///
 /// \param values A vector of Eigen::Vector3d values, e.g. a list of 3D points.
 /// \param dtype Dtype of the output tensor.
 /// \param device Device of the output tensor.
+/// \return A tensor of shape (N, 3) with the specified dtype and device.
 core::Tensor EigenVector3dVectorToTensor(
         const std::vector<Eigen::Vector3d> &values,
+        core::Dtype dtype,
+        const core::Device &device);
+
+/// Converts a vector of Eigen::Vector3i to a (N, 3) tensor. This
+/// function also takes care of dtype conversion and device transfer if
+/// necessary.
+///
+/// \param values A vector of Eigen::Vector3i values, e.g. a list of 3D points.
+/// \param dtype Dtype of the output tensor.
+/// \param device Device of the output tensor.
+/// \return A tensor of shape (N, 3) with the specified dtype and device.
+core::Tensor EigenVector3iVectorToTensor(
+        const std::vector<Eigen::Vector3i> &values,
         core::Dtype dtype,
         const core::Device &device);
 

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -1255,6 +1255,13 @@ void Tensor::AssertDevice(const Device& expected_device) const {
     }
 }
 
+void Tensor::AssertDtype(const Dtype& expected_dtype) const {
+    if (GetDtype() != expected_dtype) {
+        utility::LogError("Tensor has dtype {}, but is expected to be {}.",
+                          GetDtype().ToString(), expected_dtype.ToString());
+    }
+}
+
 Tensor Tensor::Matmul(const Tensor& rhs) const {
     Tensor output;
     core::Matmul(*this, rhs, output);

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -1012,6 +1012,9 @@ public:
     /// Assert that the Tensor has the specified device.
     void AssertDevice(const Device& expected_device) const;
 
+    /// Assert that the Tensor has the specified dtype.
+    void AssertDtype(const Dtype& expected_dtype) const;
+
 protected:
     std::string ScalarPtrToString(const void* ptr) const;
 

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -39,23 +39,22 @@ namespace open3d {
 namespace t {
 namespace geometry {
 
-PointCloud::PointCloud(core::Dtype dtype, const core::Device &device)
+PointCloud::PointCloud(const core::Device &device)
     : Geometry(Geometry::GeometryType::PointCloud, 3),
       device_(device),
       point_attr_(TensorMap("points")) {
-    SetPoints(core::Tensor::Zeros({0, 3}, dtype, device_));
+    ;
 }
 
 PointCloud::PointCloud(const core::Tensor &points)
-    : PointCloud(points.GetDtype(), points.GetDevice()) {
+    : PointCloud(points.GetDevice()) {
     points.AssertShapeCompatible({utility::nullopt, 3});
     SetPoints(points);
 }
 
 PointCloud::PointCloud(const std::unordered_map<std::string, core::Tensor>
                                &map_keys_to_tensors)
-    : PointCloud(map_keys_to_tensors.at("points").GetDtype(),
-                 map_keys_to_tensors.at("points").GetDevice()) {
+    : PointCloud(map_keys_to_tensors.at("points").GetDevice()) {
     if (map_keys_to_tensors.count("points") == 0) {
         utility::LogError("\"points\" attribute must be specified.");
     }
@@ -104,14 +103,12 @@ geometry::PointCloud PointCloud::FromLegacyPointCloud(
         const open3d::geometry::PointCloud &pcd_legacy,
         core::Dtype dtype,
         const core::Device &device) {
-    geometry::PointCloud pcd(dtype, device);
+    geometry::PointCloud pcd(device);
     if (pcd_legacy.HasPoints()) {
         pcd.SetPoints(core::eigen_converter::EigenVector3dVectorToTensor(
                 pcd_legacy.points_, dtype, device));
     } else {
-        utility::LogWarning(
-                "Creating from an empty legacy pointcloud, an empty pointcloud "
-                "with default dtype and device will be created.");
+        utility::LogWarning("Creating from an empty legacy PointCloud.");
     }
     if (pcd_legacy.HasColors()) {
         pcd.SetPointColors(core::eigen_converter::EigenVector3dVectorToTensor(
@@ -127,28 +124,17 @@ geometry::PointCloud PointCloud::FromLegacyPointCloud(
 open3d::geometry::PointCloud PointCloud::ToLegacyPointCloud() const {
     open3d::geometry::PointCloud pcd_legacy;
     if (HasPoints()) {
-        const core::Tensor &points = GetPoints();
-        pcd_legacy.points_.reserve(points.GetLength());
-        for (int64_t i = 0; i < points.GetLength(); i++) {
-            pcd_legacy.points_.push_back(
-                    core::eigen_converter::TensorToEigenVector3d(points[i]));
-        }
+        pcd_legacy.points_ =
+                core::eigen_converter::TensorToEigenVector3dVector(GetPoints());
     }
     if (HasPointColors()) {
-        const core::Tensor &colors = GetPointColors();
-        pcd_legacy.colors_.reserve(colors.GetLength());
-        for (int64_t i = 0; i < colors.GetLength(); i++) {
-            pcd_legacy.colors_.push_back(
-                    core::eigen_converter::TensorToEigenVector3d(colors[i]));
-        }
+        pcd_legacy.colors_ = core::eigen_converter::TensorToEigenVector3dVector(
+                GetPointColors());
     }
     if (HasPointNormals()) {
-        const core::Tensor &normals = GetPointNormals();
-        pcd_legacy.normals_.reserve(normals.GetLength());
-        for (int64_t i = 0; i < normals.GetLength(); i++) {
-            pcd_legacy.normals_.push_back(
-                    core::eigen_converter::TensorToEigenVector3d(normals[i]));
-        }
+        pcd_legacy.normals_ =
+                core::eigen_converter::TensorToEigenVector3dVector(
+                        GetPointNormals());
     }
     return pcd_legacy;
 }

--- a/cpp/open3d/t/geometry/PointCloud.h
+++ b/cpp/open3d/t/geometry/PointCloud.h
@@ -93,8 +93,7 @@ namespace geometry {
 class PointCloud : public Geometry {
 public:
     /// Construct an empty pointcloud.
-    PointCloud(core::Dtype dtype = core::Dtype::Float32,
-               const core::Device &device = core::Device("CPU:0"));
+    PointCloud(const core::Device &device = core::Device("CPU:0"));
 
     /// Construct a pointcloud from points.
     ///

--- a/cpp/open3d/t/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/t/geometry/TriangleMesh.cpp
@@ -38,20 +38,15 @@ namespace open3d {
 namespace t {
 namespace geometry {
 
-TriangleMesh::TriangleMesh(core::Dtype vertex_dtype,
-                           core::Dtype triangle_dtype,
-                           const core::Device &device)
+TriangleMesh::TriangleMesh(const core::Device &device)
     : Geometry(Geometry::GeometryType::TriangleMesh, 3),
       device_(device),
       vertex_attr_(TensorMap("vertices")),
-      triangle_attr_(TensorMap("triangles")) {
-    SetVertices(core::Tensor({0, 3}, vertex_dtype, device_));
-    SetTriangles(core::Tensor({0, 3}, triangle_dtype, device_));
-}
+      triangle_attr_(TensorMap("triangles")) {}
 
 TriangleMesh::TriangleMesh(const core::Tensor &vertices,
                            const core::Tensor &triangles)
-    : TriangleMesh(vertices.GetDtype(), triangles.GetDtype(), [&]() {
+    : TriangleMesh([&]() {
           if (vertices.GetDevice() != triangles.GetDevice()) {
               utility::LogError(
                       "vertices' device {} does not match triangles' device "
@@ -63,6 +58,80 @@ TriangleMesh::TriangleMesh(const core::Tensor &vertices,
       }()) {
     SetVertices(vertices);
     SetTriangles(triangles);
+}
+
+geometry::TriangleMesh TriangleMesh::FromLegacyTriangleMesh(
+        const open3d::geometry::TriangleMesh &mesh_legacy,
+        core::Dtype float_dtype,
+        core::Dtype int_dtype,
+        const core::Device &device) {
+    if (float_dtype != core::Dtype::Float32 &&
+        float_dtype != core::Dtype::Float64) {
+        utility::LogError("float_dtype must be Float32 or Float64, but got {}.",
+                          float_dtype.ToString());
+    }
+    if (int_dtype != core::Dtype::Int32 && int_dtype != core::Dtype::Int64) {
+        utility::LogError("int_dtype must be Int32 or Int64, but got {}.",
+                          int_dtype.ToString());
+    }
+
+    TriangleMesh mesh(device);
+    if (mesh_legacy.HasVertices()) {
+        mesh.SetVertices(core::eigen_converter::EigenVector3dVectorToTensor(
+                mesh_legacy.vertices_, float_dtype, device));
+    } else {
+        utility::LogWarning("Creating from empty legacy TriangleMesh.");
+    }
+    if (mesh_legacy.HasVertexColors()) {
+        mesh.SetVertexColors(core::eigen_converter::EigenVector3dVectorToTensor(
+                mesh_legacy.vertex_colors_, float_dtype, device));
+    }
+    if (mesh_legacy.HasVertexNormals()) {
+        mesh.SetVertexNormals(
+                core::eigen_converter::EigenVector3dVectorToTensor(
+                        mesh_legacy.vertex_normals_, float_dtype, device));
+    }
+    if (mesh_legacy.HasTriangles()) {
+        mesh.SetTriangles(core::eigen_converter::EigenVector3iVectorToTensor(
+                mesh_legacy.triangles_, int_dtype, device));
+    }
+    if (mesh_legacy.HasTriangleNormals()) {
+        mesh.SetTriangleNormals(
+                core::eigen_converter::EigenVector3dVectorToTensor(
+                        mesh_legacy.triangle_normals_, float_dtype, device));
+    }
+    return mesh;
+}
+
+open3d::geometry::TriangleMesh TriangleMesh::ToLegacyTriangleMesh() const {
+    open3d::geometry::TriangleMesh mesh_legacy;
+    if (HasVertices()) {
+        mesh_legacy.vertices_ =
+                core::eigen_converter::TensorToEigenVector3dVector(
+                        GetVertices());
+    }
+    if (HasVertexColors()) {
+        mesh_legacy.vertex_colors_ =
+                core::eigen_converter::TensorToEigenVector3dVector(
+                        GetVertexColors());
+    }
+    if (HasVertexNormals()) {
+        mesh_legacy.vertex_normals_ =
+                core::eigen_converter::TensorToEigenVector3dVector(
+                        GetVertexNormals());
+    }
+    if (HasTriangles()) {
+        mesh_legacy.triangles_ =
+                core::eigen_converter::TensorToEigenVector3iVector(
+                        GetTriangles());
+    }
+    if (HasTriangleNormals()) {
+        mesh_legacy.triangle_normals_ =
+                core::eigen_converter::TensorToEigenVector3dVector(
+                        GetTriangleNormals());
+    }
+
+    return mesh_legacy;
 }
 
 }  // namespace geometry

--- a/cpp/open3d/t/geometry/TriangleMesh.h
+++ b/cpp/open3d/t/geometry/TriangleMesh.h
@@ -106,9 +106,7 @@ namespace geometry {
 class TriangleMesh : public Geometry {
 public:
     /// Construct an empty trianglemesh.
-    TriangleMesh(core::Dtype vertex_dtype = core::Dtype::Float32,
-                 core::Dtype triangle_dtype = core::Dtype::Int64,
-                 const core::Device &device = core::Device("CPU:0"));
+    TriangleMesh(const core::Device &device = core::Device("CPU:0"));
 
     /// Construct a trianglemesh from vertices and triangles.
     ///
@@ -375,17 +373,20 @@ public:
     core::Device GetDevice() const { return device_; }
 
     /// Create a TriangleMesh from a legacy Open3D TriangleMesh.
-    static geometry::TriangleMesh FromLegacyTrangleMesh(
-            const geometry::TriangleMesh &mesh_legacy,
-            core::Dtype dtype = core::Dtype::Float32,
-            const core::Device &device = core::Device("CPU:0")) {
-        utility::LogError("Unimplemented");
-    }
+    /// \param mesh_legacy Legacy Open3D TriangleMesh.
+    /// \param float_dtype Float32 or Float64, used to store floating point
+    /// values, e.g. vertices, normals, colors.
+    /// \param int_dtype Int32 or Int64, used to store index values, e.g.
+    /// triangles.
+    /// \param device The device where the resulting TriangleMesh resides in.
+    static geometry::TriangleMesh FromLegacyTriangleMesh(
+            const open3d::geometry::TriangleMesh &mesh_legacy,
+            core::Dtype float_dtype = core::Dtype::Float32,
+            core::Dtype int_dtype = core::Dtype::Int64,
+            const core::Device &device = core::Device("CPU:0"));
 
     /// Convert to a legacy Open3D TriangleMesh.
-    geometry::TriangleMesh ToLegacyTriangleMesh() const {
-        utility::LogError("Unimplemented");
-    }
+    open3d::geometry::TriangleMesh ToLegacyTriangleMesh() const;
 
 protected:
     core::Device device_ = core::Device("CPU:0");

--- a/cpp/pybind/t/geometry/pointcloud.cpp
+++ b/cpp/pybind/t/geometry/pointcloud.cpp
@@ -42,9 +42,7 @@ void pybind_pointcloud(py::module& m) {
                        "A pointcloud contains a set of 3D points.");
 
     // Constructors.
-    pointcloud
-            .def(py::init<core::Dtype, const core::Device&>(), "dtype"_a,
-                 "device"_a)
+    pointcloud.def(py::init<const core::Device&>(), "device"_a)
             .def(py::init<const core::Tensor&>(), "points"_a)
             .def(py::init<const std::unordered_map<std::string,
                                                    core::Tensor>&>(),

--- a/cpp/tests/t/geometry/PointCloud.cpp
+++ b/cpp/tests/t/geometry/PointCloud.cpp
@@ -58,9 +58,8 @@ TEST_P(PointCloudPermuteDevices, DefaultConstructor) {
     EXPECT_FALSE(pcd.HasPointColors());
     EXPECT_FALSE(pcd.HasPointNormals());
 
-    // Default dtypes.
-    EXPECT_EQ(pcd.GetPoints().GetDevice(), core::Device("CPU:0"));
-    EXPECT_EQ(pcd.GetPoints().GetDtype(), core::Dtype::Float32);
+    // Default device.
+    EXPECT_EQ(pcd.GetDevice(), core::Device("CPU:0"));
 }
 
 TEST_P(PointCloudPermuteDevices, ConstructFromPoints) {
@@ -102,11 +101,11 @@ TEST_P(PointCloudPermuteDevices, ConstructFromPointDict) {
 
 TEST_P(PointCloudPermuteDevices, GetMinBound_GetMaxBound_GetCenter) {
     core::Device device = GetParam();
-    t::geometry::PointCloud pcd(core::Dtype::Float32, device);
+    t::geometry::PointCloud pcd(device);
 
-    core::Tensor& points = pcd.GetPointAttr("points");
-    points = core::Tensor(std::vector<float>{1, 2, 3, 4, 5, 6}, {2, 3},
-                          core::Dtype::Float32, device);
+    core::Tensor points = core::Tensor(std::vector<float>{1, 2, 3, 4, 5, 6},
+                                       {2, 3}, core::Dtype::Float32, device);
+    pcd.SetPoints(points);
 
     EXPECT_FALSE(pcd.IsEmpty());
     EXPECT_TRUE(pcd.HasPoints());
@@ -121,7 +120,7 @@ TEST_P(PointCloudPermuteDevices, GetMinBound_GetMaxBound_GetCenter) {
 TEST_P(PointCloudPermuteDevices, Translate) {
     core::Device device = GetParam();
 
-    t::geometry::PointCloud pcd(core::Dtype::Float32, device);
+    t::geometry::PointCloud pcd(device);
     core::Tensor translation(std::vector<float>{10, 20, 30}, {3},
                              core::Dtype::Float32, device);
 
@@ -142,10 +141,11 @@ TEST_P(PointCloudPermuteDevices, Translate) {
 
 TEST_P(PointCloudPermuteDevices, Scale) {
     core::Device device = GetParam();
-    t::geometry::PointCloud pcd(core::Dtype::Float32, device);
-    core::Tensor& points = pcd.GetPointAttr("points");
-    points = core::Tensor(std::vector<float>{0, 0, 0, 1, 1, 1, 2, 2, 2}, {3, 3},
-                          core::Dtype::Float32, device);
+    t::geometry::PointCloud pcd(device);
+    core::Tensor points =
+            core::Tensor(std::vector<float>{0, 0, 0, 1, 1, 1, 2, 2, 2}, {3, 3},
+                         core::Dtype::Float32, device);
+    pcd.SetPoints(points);
     core::Tensor center(std::vector<float>{1, 1, 1}, {3}, core::Dtype::Float32,
                         device);
     float scale = 4;
@@ -245,7 +245,7 @@ TEST_P(PointCloudPermuteDevices, Setters) {
     core::Tensor colors = core::Tensor::Ones({2, 3}, dtype, device) * 2;
     core::Tensor labels = core::Tensor::Ones({2, 3}, dtype, device) * 3;
 
-    t::geometry::PointCloud pcd(dtype, device);
+    t::geometry::PointCloud pcd(device);
 
     pcd.SetPoints(points);
     pcd.SetPointColors(colors);
@@ -279,7 +279,7 @@ TEST_P(PointCloudPermuteDevices, Has) {
     core::Device device = GetParam();
     core::Dtype dtype = core::Dtype::Float32;
 
-    t::geometry::PointCloud pcd(dtype, device);
+    t::geometry::PointCloud pcd(device);
     EXPECT_FALSE(pcd.HasPoints());
     EXPECT_FALSE(pcd.HasPointColors());
     EXPECT_FALSE(pcd.HasPointAttr("labels"));

--- a/cpp/tests/t/geometry/TriangleMesh.cpp
+++ b/cpp/tests/t/geometry/TriangleMesh.cpp
@@ -60,11 +60,8 @@ TEST_P(TriangleMeshPermuteDevices, DefaultConstructor) {
     EXPECT_FALSE(mesh.HasTriangles());
     EXPECT_FALSE(mesh.HasTriangleNormals());
 
-    // Default dtypes.
-    EXPECT_EQ(mesh.GetVertices().GetDevice(), core::Device("CPU:0"));
-    EXPECT_EQ(mesh.GetVertices().GetDtype(), core::Dtype::Float32);
-    EXPECT_EQ(mesh.GetTriangles().GetDevice(), core::Device("CPU:0"));
-    EXPECT_EQ(mesh.GetTriangles().GetDtype(), core::Dtype::Int64);
+    // Default device.
+    EXPECT_EQ(mesh.GetDevice(), core::Device("CPU:0"));
 }
 
 TEST_P(TriangleMeshPermuteDevices, ConstructFromVertices) {
@@ -147,8 +144,7 @@ TEST_P(TriangleMeshPermuteDevices, Setters) {
     // Setters are already tested in Getters' unit tests. Here we test that
     // mismatched device should throw an exception. This test is only effective
     // is device is a CUDA device.
-    t::geometry::TriangleMesh mesh(core::Dtype::Float32, core::Dtype::Float64,
-                                   device);
+    t::geometry::TriangleMesh mesh(device);
     core::Device cpu_device = core::Device("CPU:0");
     if (cpu_device != device) {
         core::Tensor cpu_vertices =
@@ -169,8 +165,7 @@ TEST_P(TriangleMeshPermuteDevices, Setters) {
 TEST_P(TriangleMeshPermuteDevices, Has) {
     core::Device device = GetParam();
 
-    t::geometry::TriangleMesh mesh(core::Dtype::Float32, core::Dtype::Float64,
-                                   device);
+    t::geometry::TriangleMesh mesh(device);
     EXPECT_FALSE(mesh.HasVertices());
     EXPECT_FALSE(mesh.HasVertexColors());
     EXPECT_FALSE(mesh.HasVertexNormals());
@@ -199,6 +194,84 @@ TEST_P(TriangleMeshPermuteDevices, Has) {
     mesh.SetTriangleNormals(
             core::Tensor::Ones({10, 3}, core::Dtype::Float32, device));
     EXPECT_TRUE(mesh.HasTriangleNormals());
+}
+
+TEST_P(TriangleMeshPermuteDevices, FromLegacyTriangleMesh) {
+    core::Device device = GetParam();
+    geometry::TriangleMesh legacy_mesh;
+    legacy_mesh.vertices_ = std::vector<Eigen::Vector3d>{
+            Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0)};
+    legacy_mesh.vertex_colors_ = std::vector<Eigen::Vector3d>{
+            Eigen::Vector3d(1, 1, 1), Eigen::Vector3d(1, 1, 1)};
+    legacy_mesh.vertex_normals_ = std::vector<Eigen::Vector3d>{
+            Eigen::Vector3d(2, 2, 2), Eigen::Vector3d(2, 2, 2)};
+    legacy_mesh.triangles_ = std::vector<Eigen::Vector3i>{
+            Eigen::Vector3i(3, 3, 3), Eigen::Vector3i(3, 3, 3)};
+    legacy_mesh.triangle_normals_ = std::vector<Eigen::Vector3d>{
+            Eigen::Vector3d(4, 4, 4), Eigen::Vector3d(4, 4, 4)};
+
+    core::Dtype float_dtype = core::Dtype::Float32;
+    core::Dtype int_dtype = core::Dtype::Int64;
+    t::geometry::TriangleMesh mesh =
+            t::geometry::TriangleMesh::FromLegacyTriangleMesh(
+                    legacy_mesh, float_dtype, int_dtype, device);
+
+    EXPECT_TRUE(mesh.HasVertices());
+    EXPECT_TRUE(mesh.HasVertexColors());
+    EXPECT_TRUE(mesh.HasVertexNormals());
+    EXPECT_TRUE(mesh.HasTriangles());
+    EXPECT_TRUE(mesh.HasTriangleNormals());
+    EXPECT_FALSE(mesh.HasTriangleColors());
+
+    EXPECT_NO_THROW(mesh.GetVertices().AssertDtype(float_dtype));
+    EXPECT_NO_THROW(mesh.GetVertices().AssertDtype(float_dtype));
+    EXPECT_NO_THROW(mesh.GetVertexColors().AssertDtype(float_dtype));
+    EXPECT_NO_THROW(mesh.GetVertexNormals().AssertDtype(float_dtype));
+    EXPECT_NO_THROW(mesh.GetTriangles().AssertDtype(int_dtype));
+    EXPECT_NO_THROW(mesh.GetTriangleNormals().AssertDtype(float_dtype));
+
+    EXPECT_TRUE(mesh.GetVertices().AllClose(
+            core::Tensor::Ones({2, 3}, float_dtype, device) * 0));
+    EXPECT_TRUE(mesh.GetVertexColors().AllClose(
+            core::Tensor::Ones({2, 3}, float_dtype, device) * 1));
+    EXPECT_TRUE(mesh.GetVertexNormals().AllClose(
+            core::Tensor::Ones({2, 3}, float_dtype, device) * 2));
+    EXPECT_TRUE(mesh.GetTriangles().AllClose(
+            core::Tensor::Ones({2, 3}, int_dtype, device) * 3));
+    EXPECT_TRUE(mesh.GetTriangleNormals().AllClose(
+            core::Tensor::Ones({2, 3}, float_dtype, device) * 4));
+}
+
+TEST_P(TriangleMeshPermuteDevices, ToLegacyTriangleMesh) {
+    core::Device device = GetParam();
+
+    core::Dtype float_dtype = core::Dtype::Float32;
+    core::Dtype int_dtype = core::Dtype::Int64;
+
+    t::geometry::TriangleMesh mesh(device);
+    mesh.SetVertices(core::Tensor::Ones({2, 3}, float_dtype, device) * 0);
+    mesh.SetVertexColors(core::Tensor::Ones({2, 3}, float_dtype, device) * 1);
+    mesh.SetVertexNormals(core::Tensor::Ones({2, 3}, float_dtype, device) * 2);
+    mesh.SetTriangles(core::Tensor::Ones({2, 3}, int_dtype, device) * 3);
+    mesh.SetTriangleNormals(core::Tensor::Ones({2, 3}, float_dtype, device) *
+                            4);
+
+    geometry::TriangleMesh legacy_mesh = mesh.ToLegacyTriangleMesh();
+    EXPECT_EQ(legacy_mesh.vertices_,
+              std::vector<Eigen::Vector3d>(
+                      {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0)}));
+    EXPECT_EQ(legacy_mesh.vertex_colors_,
+              std::vector<Eigen::Vector3d>(
+                      {Eigen::Vector3d(1, 1, 1), Eigen::Vector3d(1, 1, 1)}));
+    EXPECT_EQ(legacy_mesh.vertex_normals_,
+              std::vector<Eigen::Vector3d>(
+                      {Eigen::Vector3d(2, 2, 2), Eigen::Vector3d(2, 2, 2)}));
+    EXPECT_EQ(legacy_mesh.triangles_,
+              std::vector<Eigen::Vector3i>(
+                      {Eigen::Vector3i(3, 3, 3), Eigen::Vector3i(3, 3, 3)}));
+    EXPECT_EQ(legacy_mesh.triangle_normals_,
+              std::vector<Eigen::Vector3d>(
+                      {Eigen::Vector3d(4, 4, 4), Eigen::Vector3d(4, 4, 4)}));
 }
 
 }  // namespace tests

--- a/cpp/tests/t/io/PointCloudIO.cpp
+++ b/cpp/tests/t/io/PointCloudIO.cpp
@@ -85,7 +85,7 @@ TEST_P(ReadWriteTPC, Basic) {
     ReadWritePCArgs args = GetParam();
     core::Device device("CPU", 0);
     core::Dtype dtype = core::Dtype::Float64;
-    t::geometry::PointCloud pc1(dtype, device);
+    t::geometry::PointCloud pc1(device);
 
     for (const auto &attr_tensor : pc_data_1) {
         const auto &attr = attr_tensor.first;
@@ -99,7 +99,7 @@ TEST_P(ReadWriteTPC, Basic) {
     EXPECT_TRUE(t::io::WritePointCloud(
             args.filename, pc1,
             {bool(args.write_ascii), bool(args.compressed), true}));
-    t::geometry::PointCloud pc2(dtype, device);
+    t::geometry::PointCloud pc2(device);
     EXPECT_TRUE(t::io::ReadPointCloud(args.filename, pc2,
                                       {"auto", false, false, true}));
 
@@ -115,7 +115,7 @@ TEST_P(ReadWriteTPC, Basic) {
     EXPECT_TRUE(t::io::WritePointCloud(
             args.filename, pc2,
             {bool(args.write_ascii), bool(args.compressed), true}));
-    t::geometry::PointCloud pc3(dtype, device);
+    t::geometry::PointCloud pc3(device);
     EXPECT_TRUE(t::io::ReadPointCloud(args.filename, pc3,
                                       {"auto", false, false, true}));
     for (const auto &attribute_rel_tol : args.attributes_rel_tols) {
@@ -130,7 +130,7 @@ TEST_P(ReadWriteTPC, WriteBadData) {
     ReadWritePCArgs args = GetParam();
     core::Device device("CPU", 0);
     core::Dtype dtype = core::Dtype::Float64;
-    t::geometry::PointCloud pc1(dtype, device);
+    t::geometry::PointCloud pc1(device);
 
     for (const auto &attr_tensor : pc_data_bad) {
         const auto &attr = attr_tensor.first;

--- a/python/test/t/geometry/test_pointcloud.py
+++ b/python/test/t/geometry/test_pointcloud.py
@@ -52,8 +52,8 @@ def test_constructor_and_accessors(device):
     dtype = o3c.Dtype.Float32
 
     # Constructor.
-    pcd = o3d.t.geometry.PointCloud(dtype, device)
-    assert "points" in pcd.point
+    pcd = o3d.t.geometry.PointCloud(device)
+    assert "points" not in pcd.point
     assert "colors" not in pcd.point
     assert isinstance(pcd.point, o3d.t.geometry.TensorMap)
 
@@ -96,7 +96,7 @@ def test_from_legacy_pointcloud(device):
 def test_to_legacy_pointcloud(device):
     dtype = o3c.Dtype.Float32
 
-    pcd = o3d.t.geometry.PointCloud(dtype, device)
+    pcd = o3d.t.geometry.PointCloud(device)
     pcd.point["points"] = o3c.Tensor([[0, 1, 2], [3, 4, 5]], dtype, device)
     pcd.point["colors"] = o3c.Tensor([[6, 7, 8], [9, 10, 11]], dtype, device)
 
@@ -112,7 +112,7 @@ def test_member_functions(device):
     dtype = o3c.Dtype.Float32
 
     # get_min_bound, get_max_bound, get_center.
-    pcd = o3d.t.geometry.PointCloud(dtype, device)
+    pcd = o3d.t.geometry.PointCloud(device)
     pcd.point["points"] = o3c.Tensor([[1, 10, 20], [30, 2, 40], [50, 60, 3]],
                                      dtype, device)
     assert pcd.get_min_bound().allclose(o3c.Tensor([1, 2, 3], dtype, device))
@@ -124,7 +124,7 @@ def test_member_functions(device):
         pcd.transform(o3c.Tensor.eye(4, dtype, device))
 
     # translate.
-    pcd = o3d.t.geometry.PointCloud(dtype, device)
+    pcd = o3d.t.geometry.PointCloud(device)
     transloation = o3c.Tensor([10, 20, 30], dtype, device)
 
     pcd.point["points"] = o3c.Tensor([[0, 1, 2], [6, 7, 8]], dtype, device)
@@ -138,7 +138,7 @@ def test_member_functions(device):
         o3c.Tensor([[7, 17, 27], [13, 23, 33]], dtype, device))
 
     # scale
-    pcd = o3d.t.geometry.PointCloud(dtype, device)
+    pcd = o3d.t.geometry.PointCloud(device)
     pcd.point["points"] = o3c.Tensor([[0, 0, 0], [1, 1, 1], [2, 2, 2]], dtype,
                                      device)
     center = o3c.Tensor([1, 1, 1], dtype, device)


### PR DESCRIPTION
- Add mesh conversion functions
- Constructor of pointcloud and trianglemesh no longer takes dtypes
- Several orders of magnitudes faster conversion to legacy `PointCloud` and `TriangleMesh`.

```
# Before: 1,000 points, 1,000 colors
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
ToLegacyPointCloud/CPU        21.5 ms         21.5 ms           30
ToLegacyPointCloud/CUDA       4470 ms         4470 ms            1


# After: 1,000 points, 1,000 colors
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
ToLegacyPointCloud/CPU       0.030 ms        0.030 ms        20128
ToLegacyPointCloud/CUDA       4.47 ms         4.47 ms          152


# After: 1,000,000 points, 1,000,000 colors
------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations
------------------------------------------------------------------
ToLegacyPointCloud/CPU        31.9 ms         30.0 ms           26
ToLegacyPointCloud/CUDA       23.3 ms         23.3 ms           30
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2719)
<!-- Reviewable:end -->
