### PR TITLE
fix undefined reference in Debug build with gcc

### DIFF
--- a/cpp/open3d/visualization/visualizer/GuiSettingsModel.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiSettingsModel.cpp
@@ -81,6 +81,13 @@ private:
 
 }  // namespace
 
+// static member definition
+constexpr const char* GuiSettingsModel::DEFAULT_IBL;
+constexpr const char* GuiSettingsModel::CUSTOM_IBL;
+constexpr const char* GuiSettingsModel::DEFAULT_MATERIAL_NAME;
+constexpr const char* GuiSettingsModel::MATERIAL_FROM_FILE_NAME;
+constexpr const char* GuiSettingsModel::POINT_CLOUD_PROFILE_NAME;
+
 const std::vector<GuiSettingsModel::LightingProfile>
         GuiSettingsModel::lighting_profiles_ = {
                 LightingProfileBuilder()


### PR DESCRIPTION
This PR fixes a link error in debug builds with gcc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2744)
<!-- Reviewable:end -->
