### PR TITLE
fix out of bounds memory access in ragged_to_dense op

### DIFF
--- a/cpp/open3d/ml/impl/misc/RaggedToDense.cuh
+++ b/cpp/open3d/ml/impl/misc/RaggedToDense.cuh
@@ -47,7 +47,7 @@ __global__ void RaggedToDenseCUDAKernel(
         const size_t default_value_size,
         T* __restrict__ out_values) {
     const int i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i >= row_splits_size) return;
+    if (i + 1 >= row_splits_size) return;
 
     const int64_t start = row_splits[i];
     const int64_t end = min(int64_t(out_col_size) + start, row_splits[i + 1]);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2751)
<!-- Reviewable:end -->
