### PR TITLE
Allow creation of octree from point cloud with no color info

### DIFF
--- a/cpp/open3d/geometry/Octree.cpp
+++ b/cpp/open3d/geometry/Octree.cpp
@@ -412,11 +412,13 @@ void Octree::ConvertFromPointCloud(const geometry::PointCloud& point_cloud,
     }
 
     // Insert points
+    const bool has_colors = point_cloud.HasColors();
     for (size_t idx = 0; idx < point_cloud.points_.size(); idx++) {
+        const Eigen::Vector3d& color =
+                has_colors ? point_cloud.colors_[idx] : Eigen::Vector3d::Zero();
         InsertPoint(point_cloud.points_[idx],
                     geometry::OctreeColorLeafNode::GetInitFunction(),
-                    geometry::OctreeColorLeafNode::GetUpdateFunction(
-                            point_cloud.colors_[idx]));
+                    geometry::OctreeColorLeafNode::GetUpdateFunction(color));
     }
 }
 


### PR DESCRIPTION
Fixes #1359, #1871

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2788)
<!-- Reviewable:end -->
