### PR TITLE
Lazy load renderer when creating window in case Python crashes before window becomes visible

### DIFF
--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -361,7 +361,7 @@ Window::Window(const std::string& title,
     //   w = o3d.visualization.Application.instance
     //          .create_window("Crash", 640, 480)
     //   <anything that throws an exception>
-#endif // !WIN32
+#endif  // !WIN32
 }
 
 void Window::CreateRenderer() {

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -348,6 +348,9 @@ Window::Window(const std::string& title,
     // after pressing "Open".)
     RestoreDrawContext(oldContext);
 
+#ifndef WIN32
+    CreateRenderer();
+#else
     // Don't create the renderer yet. If the program exits before the first
     // draw callback from the operating system (Windows in particular),
     // Filament's rendering may not have had time to start yet, so destroying
@@ -358,6 +361,7 @@ Window::Window(const std::string& title,
     //   w = o3d.visualization.Application.instance
     //          .create_window("Crash", 640, 480)
     //   <anything that throws an exception>
+#endif // !WIN32
 }
 
 void Window::CreateRenderer() {
@@ -381,7 +385,7 @@ void Window::CreateRenderer() {
     // If the given font path is invalid, ImGui will silently fall back to
     // proggy, which is a tiny "pixel art" texture that is compiled into the
     // library.
-    auto &theme = GetTheme();
+    auto& theme = GetTheme();
     if (!theme.font_path.empty()) {
         ImGuiIO& io = ImGui::GetIO();
         int en_fonts = 0;

--- a/cpp/open3d/visualization/gui/Window.h
+++ b/cpp/open3d/visualization/gui/Window.h
@@ -176,6 +176,7 @@ protected:
     const std::vector<std::shared_ptr<Widget>>& GetChildren() const;
 
 private:
+    void CreateRenderer();
     enum DrawResult { NONE, REDRAW };
     DrawResult OnDraw();
     Widget::DrawResult DrawOnce(bool is_layout_pass);


### PR DESCRIPTION
This fixes the following Python script hanging on Windows:
```
#!/usr/bin/env python
import open3d as o3d

def main():
    o3d.visualization.gui.Application.instance.initialize()
    w = o3d.visualization.gui.Application.instance.create_window("Crash", 640, 480)

    crash

if __name__ == "__main__":
    main()
```

On Windows it seems that if the program exits before the first draw message is received, the Filament render (or command?) thread has not started yet. The Window destructor will destroy the Filament renderer, which will clean up some stuff and then hang at filament/src/Renderer.cpp:130 (FRenderer::terminate() at Fence::waitAndDestroy()). It is not clear to me if this is a timing problem or something else. If the script exits shortly after the renderer is created in the draw, the script may still hang. (To test, try setting an on_layout callback and throwing an exception there.)

This PR does not change the behavior on macOS / Linux (which crash before and after this PR)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2819)
<!-- Reviewable:end -->
