### PR TITLE
Add __file__ and __line__ for error message

### DIFF
--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -193,8 +193,8 @@ inline void _LogError [[noreturn]] (const char *fname,
 // the behavior of pruning trailing comma with ##__VA_ARGS__ is not officially
 // standard.
 // Ref: https://tinyurl.com/ybh8wezk
-// __FUNCTION__ is not a preprocessor macro, and [[noreturn]] will be omitted.
-// Ref: https://tinyurl.com/yc523n74
+// __FUNCTION__ is not reported due to a GCC bug.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
 #define LogError(args...) _LogError(__FILE__, __LINE__, args)
 
 template <typename... Args>

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -194,7 +194,7 @@ inline void _LogError [[noreturn]] (const char *fname,
 }
 
 // Compiler-specific function macro.
-// Ref: https://tinyurl.com/y8pbw8s8
+// Ref: https://stackoverflow.com/a/4384825
 #ifdef _WIN32
 #define __FN__ __FUNCSIG__
 #else
@@ -202,11 +202,11 @@ inline void _LogError [[noreturn]] (const char *fname,
 #endif
 
 // Mimic 'macro in namespace' by concatenating utility:: and _LogError.
-// Ref: https://tinyurl.com/yc2cmt83
+// Ref: https://stackoverflow.com/a/11791202
 // We avoid using (format, ...) since in this case __VA_ARGS__ can be
 // empty, and the behavior of pruning trailing comma with ##__VA_ARGS__ is not
 // officially standard.
-// Ref: https://tinyurl.com/ybh8wezk
+// Ref: https://stackoverflow.com/a/28074198
 // __PRETTY_FUNCTION__ has to be converted, otherwise a bug regarding [noreturn]
 // will be triggered.
 // Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -193,17 +193,25 @@ inline void _LogError [[noreturn]] (const char *fname,
                        fmt::make_format_args(args...));
 }
 
+// Compiler-specific function macro.
+// Ref: https://tinyurl.com/y8pbw8s8
+#ifdef _WIN32
+#define __FN__ __FUNCSIG__
+#else
+#define __FN__ __PRETTY_FUNCTION__
+#endif
+
 // Mimic 'macro in namespace' by concatenating utility:: and _LogError.
 // Ref: https://tinyurl.com/yc2cmt83
-// We also avoid using (format, __VA_ARGS__) since __VA_ARGS__ can be empty, and
-// the behavior of pruning trailing comma with ##__VA_ARGS__ is not officially
-// standard.
+// We avoid using (format, ...) since in this case __VA_ARGS__ can be
+// empty, and the behavior of pruning trailing comma with ##__VA_ARGS__ is not
+// officially standard.
 // Ref: https://tinyurl.com/ybh8wezk
 // __PRETTY_FUNCTION__ has to be converted, otherwise a bug regarding [noreturn]
 // will be triggered.
 // Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
-#define LogError(args...) \
-    _LogError(__FILE__, __LINE__, (const char *)__PRETTY_FUNCTION__, args)
+#define LogError(...) \
+    _LogError(__FILE__, __LINE__, (const char *)__FN__, __VA_ARGS__)
 
 template <typename... Args>
 inline void LogWarning(const char *format, const Args &... args) {

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -194,7 +194,7 @@ inline void _LogError [[noreturn]] (const char *fname,
 // standard.
 // Ref: https://tinyurl.com/ybh8wezk
 // __FUNCTION__ is not reported due to a GCC bug.
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
+// Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
 #define LogError(args...) _LogError(__FILE__, __LINE__, args)
 
 template <typename... Args>


### PR DESCRIPTION
Now the more detailed error message looks like this:
```
In function open3d::t::geometry::TSDFVoxelGrid::TSDFVoxelGrid(std::unordered_map<std::__cxx11::basic_string<char>, open3d::core::Dtype>, float, float, int64_t, int64_t, const open3d::core::Device&):
/home/wei/Workspace/code/Open3D/cpp/open3d/t/geometry/TSDFVoxelGrid.cpp:100 [Open3D Error] SDF trunc is too large. Please make sure sdf trunc is smaller than half block size (i.e., block_resolution * voxel_size * 0.5)
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2829)
<!-- Reviewable:end -->
