### PR TITLE
remove openmp macro guards for color map optimization

### DIFF
--- a/cpp/open3d/pipelines/color_map/RigidOptimizer.cpp
+++ b/cpp/open3d/pipelines/color_map/RigidOptimizer.cpp
@@ -164,9 +164,7 @@ geometry::TriangleMesh RunRigidOptimizer(
         utility::LogDebug("[Iteration {:04d}] ", itr + 1);
         double residual = 0.0;
         total_num_ = 0;
-#ifdef _OPENMP
 #pragma omp parallel for schedule(static)
-#endif
         for (int c = 0; c < n_camera; c++) {
             Eigen::Matrix4d pose;
             pose = opt_camera_trajectory.parameters_[c].extrinsic_;
@@ -202,9 +200,7 @@ geometry::TriangleMesh RunRigidOptimizer(
                                                                          JTr);
             pose = delta * pose;
             opt_camera_trajectory.parameters_[c].extrinsic_ = pose;
-#ifdef _OPENMP
 #pragma omp critical
-#endif
             {
                 residual += r2;
                 total_num_ += int(visibility_image_to_vertex[c].size());


### PR DESCRIPTION
Since #2408, openmp macro guards are no longer required. This is a quick-fix PR for #2832 to remove macro guards for color map optimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2835)
<!-- Reviewable:end -->
