### PR TITLE
Unprojection function in the ViewControl

### DIFF
--- a/cpp/open3d/visualization/visualizer/ViewControl.h
+++ b/cpp/open3d/visualization/visualizer/ViewControl.h
@@ -29,6 +29,7 @@
 #include "open3d/camera/PinholeCameraParameters.h"
 #include "open3d/geometry/BoundingVolume.h"
 #include "open3d/geometry/Geometry.h"
+#include "open3d/geometry/Line3D.h"
 #include "open3d/visualization/utility/GLHelper.h"
 #include "open3d/visualization/visualizer/ViewParameters.h"
 
@@ -100,6 +101,13 @@ public:
     /// \param step The step to change field of view.
     virtual void ChangeFieldOfView(double step);
     virtual void ChangeWindowSize(int width, int height);
+
+    /// Function to unproject a point on the window and obtain a ray from the
+    /// camera to that point in 3D.
+    ///
+    /// \param x The coordinate of the point in x-axis, in pixels
+    /// \param y The coordinate of the point in y-axis, in pixels
+    geometry::Ray3D UnprojectPoint(double x, double y) const;
 
     /// Function to process scaling
     ///

--- a/cpp/open3d/visualization/visualizer/Visualizer.h
+++ b/cpp/open3d/visualization/visualizer/Visualizer.h
@@ -192,6 +192,7 @@ public:
 
     /// Function to retrieve the associated ViewControl
     ViewControl &GetViewControl() { return *view_control_ptr_; }
+    const ViewControl &GetViewControl() const { return *view_control_ptr_; }
     /// Function to retrieve the associated RenderOption.
     RenderOption &GetRenderOption() { return *render_option_ptr_; }
     /// \brief Function to capture screen and store RGB in a float buffer.

--- a/cpp/pybind/visualization/visualizer.cpp
+++ b/cpp/pybind/visualization/visualizer.cpp
@@ -112,7 +112,8 @@ void pybind_visualizer(py::module &m) {
                  "reset_bounding_box"_a = true)
             .def("clear_geometries", &Visualizer::ClearGeometries,
                  "Function to clear geometries from the visualizer")
-            .def("get_view_control", &Visualizer::GetViewControl,
+            .def("get_view_control",
+                 [](Visualizer &vis) { return vis.GetViewControl(); },
                  "Function to retrieve the associated ``ViewControl``",
                  py::return_value_policy::reference_internal)
             .def("get_render_option", &Visualizer::GetRenderOption,


### PR DESCRIPTION
Hi!

I added a function to unproject 2D points to obtain a ray from the camera eye containing the 2D point.
It is useful to perform raycasting queries with clicks on the visualizer.
Also, since this operation is const, I added a const overload to obtain the ViewControl from the visualizer.

The function is aware that the camera may be orthogonal rather than perspective.
For these cases, the origin is in a plane that has look_at - eye_ as normal, and in which eye_ lies.

However, because of the overload, I had to modify the python bindings: I added a lambda instead of a cast, as from what I understand that is what you usually do in these cases. It compiled, but I could not create the pip package, so I could not test that everything still worked in Python.