### PR TITLE
core::Scalar class and refactor arange

### DIFF
--- a/cpp/open3d/core/Scalar.h
+++ b/cpp/open3d/core/Scalar.h
@@ -81,13 +81,13 @@ public:
         }
         return value_.d;
     }
-    double ToInt64() const {
+    int64_t ToInt64() const {
         if (!IsInt64()) {
             utility::LogError("Scalar is not a ScalarType:Int64 type.");
         }
         return value_.i;
     }
-    double ToBool() const {
+    bool ToBool() const {
         if (!IsBool()) {
             utility::LogError("Scalar is not a ScalarType:Bool type.");
         }

--- a/cpp/open3d/core/Scalar.h
+++ b/cpp/open3d/core/Scalar.h
@@ -1,0 +1,168 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "open3d/core/Dtype.h"
+#include "open3d/utility/Console.h"
+
+namespace open3d {
+namespace core {
+
+/// Scalar is a stores one of {double, int64, bool}. Typically Scalar is used to
+/// accept C++ scalar arguments of different types via implicit conversion
+/// constructor. Doing so can avoid the need for templates.
+class Scalar {
+public:
+    enum class ScalarType { Double, Int64, Bool };
+
+    Scalar(float v) {
+        scalar_mode_ = ScalarType::Double;
+        value_.d = static_cast<double>(v);
+    }
+    Scalar(double v) {
+        scalar_mode_ = ScalarType::Double;
+        value_.d = static_cast<double>(v);
+    }
+    Scalar(int v) {
+        scalar_mode_ = ScalarType::Int64;
+        value_.i = static_cast<int64_t>(v);
+    }
+    Scalar(int64_t v) {
+        scalar_mode_ = ScalarType::Int64;
+        value_.i = static_cast<int64_t>(v);
+    }
+    Scalar(uint8_t v) {
+        scalar_mode_ = ScalarType::Int64;
+        value_.i = static_cast<int64_t>(v);
+    }
+    Scalar(uint16_t v) {
+        scalar_mode_ = ScalarType::Int64;
+        value_.i = static_cast<int64_t>(v);
+    }
+    Scalar(bool v) {
+        scalar_mode_ = ScalarType::Bool;
+        value_.b = static_cast<bool>(v);
+    }
+
+    bool IsDouble() const { return scalar_mode_ == ScalarType::Double; }
+    bool IsInt64() const { return scalar_mode_ == ScalarType::Int64; }
+    bool IsBool() const { return scalar_mode_ == ScalarType::Bool; }
+
+    double ToDouble() const {
+        if (!IsDouble()) {
+            utility::LogError("Scalar is not a ScalarType:Double type.");
+        }
+        return value_.d;
+    }
+    double ToInt64() const {
+        if (!IsInt64()) {
+            utility::LogError("Scalar is not a ScalarType:Int64 type.");
+        }
+        return value_.i;
+    }
+    double ToBool() const {
+        if (!IsBool()) {
+            utility::LogError("Scalar is not a ScalarType:Bool type.");
+        }
+        return value_.b;
+    }
+
+    void AssertSameScalarType(Scalar other,
+                              const std::string& error_msg) const {
+        if (scalar_mode_ != other.scalar_mode_) {
+            if (error_msg.empty()) {
+                utility::LogError("Scalar mode {} are not the same as {}.",
+                                  ToString(), other.ToString());
+            } else {
+                utility::LogError("Scalar mode {} are not the same as {}: {}",
+                                  ToString(), other.ToString(), error_msg);
+            }
+        }
+    }
+
+    std::string ToString() const {
+        std::string scalar_mode_str;
+        std::string value_str;
+        if (scalar_mode_ == ScalarType::Double) {
+            scalar_mode_str = "Double";
+            value_str = std::to_string(value_.d);
+        } else if (scalar_mode_ == ScalarType::Int64) {
+            scalar_mode_str = "Int64";
+            value_str = std::to_string(value_.i);
+        } else if (scalar_mode_ == ScalarType::Bool) {
+            scalar_mode_str = "Bool";
+            value_str = value_.b ? "true" : "false";
+        } else {
+            utility::LogError("ScalarTypeToString: ScalarType not supported.");
+        }
+        return scalar_mode_str + ":" + value_str;
+    }
+
+    template <typename T>
+    bool Equal(T value) const {
+        if (scalar_mode_ == ScalarType::Double) {
+            return value_.d == value;
+        } else if (scalar_mode_ == ScalarType::Int64) {
+            return value_.i == value;
+        } else if (scalar_mode_ == ScalarType::Bool) {
+            return false;  // Boolean does not equal to non-boolean values.
+        } else {
+            utility::LogError("Equals: ScalarType not supported.");
+        }
+    }
+
+    bool Equal(bool value) const {
+        return scalar_mode_ == ScalarType::Bool && value_.b == value;
+    }
+
+    bool Equal(Scalar other) const {
+        if (other.scalar_mode_ == ScalarType::Double) {
+            return Equal(other.ToDouble());
+        } else if (other.scalar_mode_ == ScalarType::Int64) {
+            return Equal(other.ToInt64());
+        } else if (other.scalar_mode_ == ScalarType::Bool) {
+            return scalar_mode_ == ScalarType::Bool &&
+                   value_.b == other.value_.b;
+        } else {
+            utility::LogError("Equals: ScalarType not supported.");
+        }
+    }
+
+private:
+    ScalarType scalar_mode_;
+    union value_t {
+        double d;
+        int64_t i;
+        bool b;
+    } value_;
+};
+
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/Scalar.h
+++ b/cpp/open3d/core/Scalar.h
@@ -75,19 +75,25 @@ public:
     bool IsInt64() const { return scalar_type_ == ScalarType::Int64; }
     bool IsBool() const { return scalar_type_ == ScalarType::Bool; }
 
-    double ToDouble() const {
+    /// Returns double value from Scalar. Only works when scalar_type_ is
+    /// ScalarType::Double.
+    double GetDouble() const {
         if (!IsDouble()) {
             utility::LogError("Scalar is not a ScalarType:Double type.");
         }
         return value_.d;
     }
-    int64_t ToInt64() const {
+    /// Returns int64 value from Scalar. Only works when scalar_type_ is
+    /// ScalarType::Int64.
+    int64_t GetInt64() const {
         if (!IsInt64()) {
             utility::LogError("Scalar is not a ScalarType:Int64 type.");
         }
         return value_.i;
     }
-    bool ToBool() const {
+    /// Returns bool value from Scalar. Only works when scalar_type_ is
+    /// ScalarType::Bool.
+    bool GetBool() const {
         if (!IsBool()) {
             utility::LogError("Scalar is not a ScalarType:Bool type.");
         }
@@ -158,9 +164,9 @@ public:
 
     bool Equal(Scalar other) const {
         if (other.scalar_type_ == ScalarType::Double) {
-            return Equal(other.ToDouble());
+            return Equal(other.GetDouble());
         } else if (other.scalar_type_ == ScalarType::Int64) {
-            return Equal(other.ToInt64());
+            return Equal(other.GetInt64());
         } else if (other.scalar_type_ == ScalarType::Bool) {
             return scalar_type_ == ScalarType::Bool &&
                    value_.b == other.value_.b;

--- a/cpp/open3d/core/Scalar.h
+++ b/cpp/open3d/core/Scalar.h
@@ -43,37 +43,37 @@ public:
     enum class ScalarType { Double, Int64, Bool };
 
     Scalar(float v) {
-        scalar_mode_ = ScalarType::Double;
+        scalar_type_ = ScalarType::Double;
         value_.d = static_cast<double>(v);
     }
     Scalar(double v) {
-        scalar_mode_ = ScalarType::Double;
+        scalar_type_ = ScalarType::Double;
         value_.d = static_cast<double>(v);
     }
     Scalar(int v) {
-        scalar_mode_ = ScalarType::Int64;
+        scalar_type_ = ScalarType::Int64;
         value_.i = static_cast<int64_t>(v);
     }
     Scalar(int64_t v) {
-        scalar_mode_ = ScalarType::Int64;
+        scalar_type_ = ScalarType::Int64;
         value_.i = static_cast<int64_t>(v);
     }
     Scalar(uint8_t v) {
-        scalar_mode_ = ScalarType::Int64;
+        scalar_type_ = ScalarType::Int64;
         value_.i = static_cast<int64_t>(v);
     }
     Scalar(uint16_t v) {
-        scalar_mode_ = ScalarType::Int64;
+        scalar_type_ = ScalarType::Int64;
         value_.i = static_cast<int64_t>(v);
     }
     Scalar(bool v) {
-        scalar_mode_ = ScalarType::Bool;
+        scalar_type_ = ScalarType::Bool;
         value_.b = static_cast<bool>(v);
     }
 
-    bool IsDouble() const { return scalar_mode_ == ScalarType::Double; }
-    bool IsInt64() const { return scalar_mode_ == ScalarType::Int64; }
-    bool IsBool() const { return scalar_mode_ == ScalarType::Bool; }
+    bool IsDouble() const { return scalar_type_ == ScalarType::Double; }
+    bool IsInt64() const { return scalar_type_ == ScalarType::Int64; }
+    bool IsBool() const { return scalar_type_ == ScalarType::Bool; }
 
     double ToDouble() const {
         if (!IsDouble()) {
@@ -96,7 +96,7 @@ public:
 
     void AssertSameScalarType(Scalar other,
                               const std::string& error_msg) const {
-        if (scalar_mode_ != other.scalar_mode_) {
+        if (scalar_type_ != other.scalar_type_) {
             if (error_msg.empty()) {
                 utility::LogError("Scalar mode {} are not the same as {}.",
                                   ToString(), other.ToString());
@@ -108,30 +108,30 @@ public:
     }
 
     std::string ToString() const {
-        std::string scalar_mode_str;
+        std::string scalar_type_str;
         std::string value_str;
-        if (scalar_mode_ == ScalarType::Double) {
-            scalar_mode_str = "Double";
+        if (scalar_type_ == ScalarType::Double) {
+            scalar_type_str = "Double";
             value_str = std::to_string(value_.d);
-        } else if (scalar_mode_ == ScalarType::Int64) {
-            scalar_mode_str = "Int64";
+        } else if (scalar_type_ == ScalarType::Int64) {
+            scalar_type_str = "Int64";
             value_str = std::to_string(value_.i);
-        } else if (scalar_mode_ == ScalarType::Bool) {
-            scalar_mode_str = "Bool";
+        } else if (scalar_type_ == ScalarType::Bool) {
+            scalar_type_str = "Bool";
             value_str = value_.b ? "true" : "false";
         } else {
             utility::LogError("ScalarTypeToString: ScalarType not supported.");
         }
-        return scalar_mode_str + ":" + value_str;
+        return scalar_type_str + ":" + value_str;
     }
 
     template <typename T>
     bool Equal(T value) const {
-        if (scalar_mode_ == ScalarType::Double) {
+        if (scalar_type_ == ScalarType::Double) {
             return value_.d == value;
-        } else if (scalar_mode_ == ScalarType::Int64) {
+        } else if (scalar_type_ == ScalarType::Int64) {
             return value_.i == value;
-        } else if (scalar_mode_ == ScalarType::Bool) {
+        } else if (scalar_type_ == ScalarType::Bool) {
             return false;  // Boolean does not equal to non-boolean values.
         } else {
             utility::LogError("Equals: ScalarType not supported.");
@@ -139,16 +139,16 @@ public:
     }
 
     bool Equal(bool value) const {
-        return scalar_mode_ == ScalarType::Bool && value_.b == value;
+        return scalar_type_ == ScalarType::Bool && value_.b == value;
     }
 
     bool Equal(Scalar other) const {
-        if (other.scalar_mode_ == ScalarType::Double) {
+        if (other.scalar_type_ == ScalarType::Double) {
             return Equal(other.ToDouble());
-        } else if (other.scalar_mode_ == ScalarType::Int64) {
+        } else if (other.scalar_type_ == ScalarType::Int64) {
             return Equal(other.ToInt64());
-        } else if (other.scalar_mode_ == ScalarType::Bool) {
-            return scalar_mode_ == ScalarType::Bool &&
+        } else if (other.scalar_type_ == ScalarType::Bool) {
+            return scalar_type_ == ScalarType::Bool &&
                    value_.b == other.value_.b;
         } else {
             utility::LogError("Equals: ScalarType not supported.");
@@ -156,7 +156,7 @@ public:
     }
 
 private:
-    ScalarType scalar_mode_;
+    ScalarType scalar_type_;
     union value_t {
         double d;
         int64_t i;

--- a/cpp/open3d/core/Scalar.h
+++ b/cpp/open3d/core/Scalar.h
@@ -94,6 +94,20 @@ public:
         return value_.b;
     }
 
+    /// To<T>() does not check for scalar type and overflows.
+    template <typename T>
+    T To() const {
+        if (scalar_type_ == ScalarType::Double) {
+            return static_cast<T>(value_.d);
+        } else if (scalar_type_ == ScalarType::Int64) {
+            return static_cast<T>(value_.i);
+        } else if (scalar_type_ == ScalarType::Bool) {
+            return static_cast<T>(value_.b);
+        } else {
+            utility::LogError("To: ScalarType not supported.");
+        }
+    }
+
     void AssertSameScalarType(Scalar other,
                               const std::string& error_msg) const {
         if (scalar_type_ != other.scalar_type_) {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -230,7 +230,7 @@ Tensor Tensor::Arange(Scalar start,
     Tensor t_start;
     Tensor t_stop;
     Tensor t_step;
-    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+    DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
         scalar_t s_start;
         scalar_t s_stop;
         scalar_t s_step;
@@ -242,10 +242,6 @@ Tensor Tensor::Arange(Scalar start,
             s_start = static_cast<scalar_t>(start.ToInt64());
             s_stop = static_cast<scalar_t>(stop.ToInt64());
             s_step = static_cast<scalar_t>(step.ToInt64());
-        } else if (start.IsBool()) {
-            s_start = static_cast<scalar_t>(start.ToBool());
-            s_stop = static_cast<scalar_t>(stop.ToBool());
-            s_step = static_cast<scalar_t>(step.ToBool());
         } else {
             utility::LogError("Arange: ScalarType not supported.");
         }

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -210,10 +210,51 @@ Tensor Tensor::Diag(const Tensor& input) {
     return diag;
 }
 
-Tensor Tensor::Arange(const Tensor& start,
-                      const Tensor& stop,
-                      const Tensor& step) {
-    return kernel::Arange(start, stop, step);
+Tensor Tensor::Arange(Scalar start,
+                      Scalar stop,
+                      Scalar step,
+                      Dtype dtype,
+                      const Device& device) {
+    start.AssertSameScalarType(stop,
+                               "start must have the same scalar type as stop.");
+    start.AssertSameScalarType(step,
+                               "start must have the same scalar type as step.");
+
+    if (step.Equal(0)) {
+        utility::LogError("Step cannot be 0.");
+    }
+    if (stop.Equal(start)) {
+        return Tensor({0}, dtype, device);
+    }
+
+    Tensor t_start;
+    Tensor t_stop;
+    Tensor t_step;
+    DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dtype, [&]() {
+        scalar_t s_start;
+        scalar_t s_stop;
+        scalar_t s_step;
+        if (start.IsDouble()) {
+            s_start = static_cast<scalar_t>(start.ToDouble());
+            s_stop = static_cast<scalar_t>(stop.ToDouble());
+            s_step = static_cast<scalar_t>(step.ToDouble());
+        } else if (start.IsInt64()) {
+            s_start = static_cast<scalar_t>(start.ToInt64());
+            s_stop = static_cast<scalar_t>(stop.ToInt64());
+            s_step = static_cast<scalar_t>(step.ToInt64());
+        } else if (start.IsBool()) {
+            s_start = static_cast<scalar_t>(start.ToBool());
+            s_stop = static_cast<scalar_t>(stop.ToBool());
+            s_step = static_cast<scalar_t>(step.ToBool());
+        } else {
+            utility::LogError("Arange: ScalarType not supported.");
+        }
+        t_start = Tensor::Full({}, s_start, dtype, device);
+        t_stop = Tensor::Full({}, s_stop, dtype, device);
+        t_step = Tensor::Full({}, s_step, dtype, device);
+    });
+
+    return kernel::Arange(t_start, t_stop, t_step);
 }
 
 Tensor Tensor::GetItem(const TensorKey& tk) const {

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -231,23 +231,9 @@ Tensor Tensor::Arange(Scalar start,
     Tensor t_stop;
     Tensor t_step;
     DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-        scalar_t s_start;
-        scalar_t s_stop;
-        scalar_t s_step;
-        if (start.IsDouble()) {
-            s_start = static_cast<scalar_t>(start.ToDouble());
-            s_stop = static_cast<scalar_t>(stop.ToDouble());
-            s_step = static_cast<scalar_t>(step.ToDouble());
-        } else if (start.IsInt64()) {
-            s_start = static_cast<scalar_t>(start.ToInt64());
-            s_stop = static_cast<scalar_t>(stop.ToInt64());
-            s_step = static_cast<scalar_t>(step.ToInt64());
-        } else {
-            utility::LogError("Arange: ScalarType not supported.");
-        }
-        t_start = Tensor::Full({}, s_start, dtype, device);
-        t_stop = Tensor::Full({}, s_stop, dtype, device);
-        t_step = Tensor::Full({}, s_step, dtype, device);
+        t_start = Tensor::Full({}, start.To<scalar_t>(), dtype, device);
+        t_stop = Tensor::Full({}, stop.To<scalar_t>(), dtype, device);
+        t_step = Tensor::Full({}, step.To<scalar_t>(), dtype, device);
     });
 
     return kernel::Arange(t_start, t_stop, t_step);

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -36,6 +36,7 @@
 #include "open3d/core/DLPack.h"
 #include "open3d/core/Device.h"
 #include "open3d/core/Dtype.h"
+#include "open3d/core/Scalar.h"
 #include "open3d/core/ShapeUtil.h"
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/TensorKey.h"
@@ -181,8 +182,8 @@ public:
 
     /// \brief Fill the whole Tensor with a scalar value, the scalar will be
     /// casted to the Tensor's dtype.
-    template <typename Scalar>
-    void Fill(Scalar v);
+    template <typename S>
+    void Fill(S v);
 
     template <typename Object>
     void FillObject(const Object& v);
@@ -333,28 +334,11 @@ public:
     static Tensor Diag(const Tensor& input);
 
     /// Create a 1D tensor with evenly spaced values in the given interval.
-    static Tensor Arange(const Tensor& start,
-                         const Tensor& stop,
-                         const Tensor& step);
-
-    template <typename T>
-    static Tensor Arange(T start,
-                         T stop,
-                         T step = 1,
-                         const Device& device = core::Device("CPU:0")) {
-        Dtype dtype = Dtype::FromType<T>();
-        if (step == 0) {
-            utility::LogError("Step cannot be 0");
-        }
-        if (stop == start) {
-            return Tensor({0}, dtype, device);
-        }
-
-        Tensor tstart = Tensor::Full({}, start, dtype, device);
-        Tensor tstop = Tensor::Full({}, stop, dtype, device);
-        Tensor tstep = Tensor::Full({}, step, dtype, device);
-        return Arange(tstart, tstop, tstep);
-    }
+    static Tensor Arange(Scalar start,
+                         Scalar stop,
+                         Scalar step = 1,
+                         Dtype dtype = Dtype::Int64,
+                         const Device& device = core::Device("CPU:0"));
 
     /// Pythonic __getitem__ for tensor.
     ///
@@ -1264,8 +1248,8 @@ inline bool Tensor::Item() const {
     return static_cast<bool>(value);
 }
 
-template <typename Scalar>
-inline void Tensor::Fill(Scalar v) {
+template <typename S>
+inline void Tensor::Fill(S v) {
     DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(GetDtype(), [&]() {
         scalar_t casted_v = static_cast<scalar_t>(v);
         Tensor tmp(std::vector<scalar_t>({casted_v}), SizeVector({}),

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -188,12 +188,12 @@ public:
     template <typename Object>
     void FillObject(const Object& v);
 
-    /// Create a tensor with uninitilized values.
+    /// Create a tensor with uninitialized values.
     static Tensor Empty(const SizeVector& shape,
                         Dtype dtype,
                         const Device& device = Device("CPU:0"));
 
-    /// Create a tensor with uninitilized values with the same dtype and device
+    /// Create a tensor with uninitialized values with the same dtype and device
     /// as the other tensor.
     static Tensor EmptyLike(const Tensor& other) {
         return Tensor::Empty(other.shape_, other.dtype_, other.GetDevice());
@@ -231,7 +231,7 @@ public:
         return Tensor(ele_list, shape, type, device);
     };
 
-    /// Create a 1-D tensor with initilizer list.
+    /// Create a 1-D tensor with initializer list.
     /// For example,
     /// core::Tensor::Init<float>({1,2,3});
     template <typename T>
@@ -245,7 +245,7 @@ public:
         return Tensor(ele_list, shape, type, device);
     };
 
-    /// Create a 2-D tensor with nested initilizer list.
+    /// Create a 2-D tensor with nested initializer list.
     /// For example,
     /// core::Tensor::Init<float>({{1,2,3},{4,5,6}});
     template <typename T>
@@ -273,7 +273,7 @@ public:
         return Tensor(ele_list, shape, type, device);
     };
 
-    /// Create a 3-D tensor with nested initilizer list.
+    /// Create a 3-D tensor with nested initializer list.
     /// For example,
     /// core::Tensor::Init<float>({{{1,2,3},{4,5,6}},{{7,8,9},{10,11,12}}});
     template <typename T>

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -280,49 +280,55 @@ void pybind_core_tensor(py::module& m) {
             "n"_a, "dtype"_a = py::none(), "device"_a = py::none());
     tensor.def_static("diag", &Tensor::Diag);
 
-    // Tensor creation from arange for int
+    // Tensor creation from arange for int.
     tensor.def_static(
             "arange",
-            [](int64_t stop, utility::optional<Device> device) {
-                return Tensor::Arange<int64_t>(
+            [](int64_t stop, utility::optional<Dtype> dtype,
+               utility::optional<Device> device) {
+                return Tensor::Arange(
                         0, stop, 1,
+                        dtype.has_value() ? dtype.value() : Dtype::Int64,
                         device.has_value() ? device.value() : Device("CPU:0"));
             },
-            "stop"_a, "device"_a = py::none());
+            "stop"_a, "dtype"_a = py::none(), "device"_a = py::none());
     tensor.def_static(
             "arange",
             [](utility::optional<int64_t> start, int64_t stop,
-               utility::optional<int64_t> step,
+               utility::optional<int64_t> step, utility::optional<Dtype> dtype,
                utility::optional<Device> device) {
-                return Tensor::Arange<int64_t>(
+                return Tensor::Arange(
                         start.has_value() ? start.value() : 0, stop,
                         step.has_value() ? step.value() : 1,
+                        dtype.has_value() ? dtype.value() : Dtype::Int64,
                         device.has_value() ? device.value() : Device("CPU:0"));
             },
             "start"_a = py::none(), "stop"_a, "step"_a = py::none(),
-            "device"_a = py::none());
+            "dtype"_a = py::none(), "device"_a = py::none());
 
-    // Tensor creation from arange for float
+    // Tensor creation from arange for float.
     tensor.def_static(
             "arange",
-            [](double stop, utility::optional<Device> device) {
-                return Tensor::Arange<double>(
+            [](double stop, utility::optional<Dtype> dtype,
+               utility::optional<Device> device) {
+                return Tensor::Arange(
                         0.0, stop, 1.0,
+                        dtype.has_value() ? dtype.value() : Dtype::Float64,
                         device.has_value() ? device.value() : Device("CPU:0"));
             },
-            "stop"_a, "device"_a = py::none());
+            "stop"_a, "dtype"_a = py::none(), "device"_a = py::none());
     tensor.def_static(
             "arange",
             [](utility::optional<double> start, double stop,
-               utility::optional<double> step,
+               utility::optional<double> step, utility::optional<Dtype> dtype,
                utility::optional<Device> device) {
-                return Tensor::Arange<double>(
+                return Tensor::Arange(
                         start.has_value() ? start.value() : 0.0, stop,
                         step.has_value() ? step.value() : 1.0,
+                        dtype.has_value() ? dtype.value() : Dtype::Float64,
                         device.has_value() ? device.value() : Device("CPU:0"));
             },
             "start"_a = py::none(), "stop"_a, "step"_a = py::none(),
-            "device"_a = py::none());
+            "dtype"_a = py::none(), "device"_a = py::none());
 
     // Tensor copy.
     tensor.def("shallow_copy_from", &Tensor::ShallowCopyFrom);

--- a/cpp/tests/core/Scalar.cpp
+++ b/cpp/tests/core/Scalar.cpp
@@ -106,5 +106,11 @@ TEST(Scalar, LiteralEquality) {
     EXPECT_FALSE(core::Scalar(0).Equal(false));
 }
 
+TEST(Scalar, To) {
+    EXPECT_EQ(ToScalar(1.25f).To<float>(), 1.25f);
+    EXPECT_EQ(ToScalar(1.25f).To<int>(), 1);
+    EXPECT_EQ(ToScalar(1.25f).To<bool>(), true);
+}
+
 }  // namespace tests
 }  // namespace open3d

--- a/cpp/tests/core/Scalar.cpp
+++ b/cpp/tests/core/Scalar.cpp
@@ -43,50 +43,50 @@ static std::vector<core::Scalar> ToVectorOfScalar(
 
 TEST(Scalar, ImplicitConvertConstructor) {
     EXPECT_TRUE(ToScalar(1.25f).IsDouble());
-    EXPECT_EQ(ToScalar(1.25f).ToDouble(), 1.25);
-    EXPECT_ANY_THROW(ToScalar(1.25f).ToInt64());
-    EXPECT_ANY_THROW(ToScalar(1.25f).ToBool());
+    EXPECT_EQ(ToScalar(1.25f).GetDouble(), 1.25);
+    EXPECT_ANY_THROW(ToScalar(1.25f).GetInt64());
+    EXPECT_ANY_THROW(ToScalar(1.25f).GetBool());
 
     EXPECT_TRUE(ToScalar(1.25).IsDouble());
-    EXPECT_EQ(ToScalar(1.25).ToDouble(), 1.25);
-    EXPECT_ANY_THROW(ToScalar(1.25).ToInt64());
-    EXPECT_ANY_THROW(ToScalar(1.25).ToBool());
+    EXPECT_EQ(ToScalar(1.25).GetDouble(), 1.25);
+    EXPECT_ANY_THROW(ToScalar(1.25).GetInt64());
+    EXPECT_ANY_THROW(ToScalar(1.25).GetBool());
 
     EXPECT_TRUE(ToScalar(1).IsInt64());
-    EXPECT_EQ(ToScalar(1).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToScalar(1).ToDouble());
-    EXPECT_ANY_THROW(ToScalar(1).ToBool());
+    EXPECT_EQ(ToScalar(1).GetInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(1).GetDouble());
+    EXPECT_ANY_THROW(ToScalar(1).GetBool());
 
     EXPECT_TRUE(ToScalar(static_cast<int64_t>(1)).IsInt64());
-    EXPECT_EQ(ToScalar(static_cast<int64_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).ToBool());
+    EXPECT_EQ(ToScalar(static_cast<int64_t>(1)).GetInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).GetDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).GetBool());
 
     EXPECT_TRUE(ToScalar(static_cast<uint8_t>(1)).IsInt64());
-    EXPECT_EQ(ToScalar(static_cast<uint8_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).ToBool());
+    EXPECT_EQ(ToScalar(static_cast<uint8_t>(1)).GetInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).GetDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).GetBool());
 
     EXPECT_TRUE(ToScalar(static_cast<uint16_t>(1)).IsInt64());
-    EXPECT_EQ(ToScalar(static_cast<uint16_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).ToBool());
+    EXPECT_EQ(ToScalar(static_cast<uint16_t>(1)).GetInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).GetDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).GetBool());
 
     EXPECT_TRUE(ToScalar(true).IsBool());
-    EXPECT_EQ(ToScalar(true).ToBool(), true);
-    EXPECT_ANY_THROW(ToScalar(true).ToInt64());
-    EXPECT_ANY_THROW(ToScalar(true).ToDouble());
+    EXPECT_EQ(ToScalar(true).GetBool(), true);
+    EXPECT_ANY_THROW(ToScalar(true).GetInt64());
+    EXPECT_ANY_THROW(ToScalar(true).GetDouble());
 }
 
 TEST(Scalar, ImplicitConvertVectorConstructor) {
     std::vector<core::Scalar> ss = ToVectorOfScalar({1, 1.25f, true});
 
     EXPECT_TRUE(ss[0].IsInt64());
-    EXPECT_EQ(ss[0].ToInt64(), 1);
+    EXPECT_EQ(ss[0].GetInt64(), 1);
     EXPECT_TRUE(ss[1].IsDouble());
-    EXPECT_EQ(ss[1].ToDouble(), 1.25);
+    EXPECT_EQ(ss[1].GetDouble(), 1.25);
     EXPECT_TRUE(ss[2].IsBool());
-    EXPECT_EQ(ss[2].ToBool(), true);
+    EXPECT_EQ(ss[2].GetBool(), true);
 }
 
 TEST(Scalar, LiteralEquality) {

--- a/cpp/tests/core/Scalar.cpp
+++ b/cpp/tests/core/Scalar.cpp
@@ -1,0 +1,91 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/Scalar.h"
+
+#include "tests/UnitTest.h"
+
+namespace open3d {
+namespace tests {
+
+static core::Scalar ToImplicitScalar(const core::Scalar& s) { return s; }
+
+TEST(Scalar, ImplicitConvertConstructor) {
+    EXPECT_TRUE(ToImplicitScalar(1.25f).IsDouble());
+    EXPECT_EQ(ToImplicitScalar(1.25f).ToDouble(), 1.25);
+    EXPECT_ANY_THROW(ToImplicitScalar(1.25f).ToInt64());
+    EXPECT_ANY_THROW(ToImplicitScalar(1.25f).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(1.25).IsDouble());
+    EXPECT_EQ(ToImplicitScalar(1.25).ToDouble(), 1.25);
+    EXPECT_ANY_THROW(ToImplicitScalar(1.25).ToInt64());
+    EXPECT_ANY_THROW(ToImplicitScalar(1.25).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(1).IsInt64());
+    EXPECT_EQ(ToImplicitScalar(1).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToImplicitScalar(1).ToDouble());
+    EXPECT_ANY_THROW(ToImplicitScalar(1).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(static_cast<int64_t>(1)).IsInt64());
+    EXPECT_EQ(ToImplicitScalar(static_cast<int64_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<int64_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<int64_t>(1)).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(static_cast<uint8_t>(1)).IsInt64());
+    EXPECT_EQ(ToImplicitScalar(static_cast<uint8_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint8_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint8_t>(1)).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(static_cast<uint16_t>(1)).IsInt64());
+    EXPECT_EQ(ToImplicitScalar(static_cast<uint16_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint16_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint16_t>(1)).ToBool());
+
+    EXPECT_TRUE(ToImplicitScalar(true).IsBool());
+    EXPECT_EQ(ToImplicitScalar(true).ToBool(), true);
+    EXPECT_ANY_THROW(ToImplicitScalar(true).ToInt64());
+    EXPECT_ANY_THROW(ToImplicitScalar(true).ToDouble());
+}
+
+TEST(Scalar, LiteralEquality) {
+    EXPECT_TRUE(core::Scalar(1.25f).Equal(1.25));
+    EXPECT_FALSE(core::Scalar(1.25f).Equal(1));
+    EXPECT_TRUE(core::Scalar(1).Equal(1.0f));
+    EXPECT_TRUE(core::Scalar(1).Equal(1));
+    EXPECT_FALSE(core::Scalar(1).Equal(0));
+
+    EXPECT_FALSE(core::Scalar(true).Equal(1));
+    EXPECT_FALSE(core::Scalar(true).Equal(0));
+    EXPECT_FALSE(core::Scalar(false).Equal(1));
+    EXPECT_FALSE(core::Scalar(false).Equal(0));
+    EXPECT_FALSE(core::Scalar(1).Equal(true));
+    EXPECT_FALSE(core::Scalar(0).Equal(true));
+    EXPECT_FALSE(core::Scalar(1).Equal(false));
+    EXPECT_FALSE(core::Scalar(0).Equal(false));
+}
+
+}  // namespace tests
+}  // namespace open3d

--- a/cpp/tests/core/Scalar.cpp
+++ b/cpp/tests/core/Scalar.cpp
@@ -31,43 +31,62 @@
 namespace open3d {
 namespace tests {
 
-static core::Scalar ToImplicitScalar(const core::Scalar& s) { return s; }
+// Implicit conversion constructor.
+static core::Scalar ToScalar(const core::Scalar& s) { return s; }
+
+// Convert an initializer_list of Scalar. Each element's type can be different.
+static std::vector<core::Scalar> ToVectorOfScalar(
+        const std::initializer_list<core::Scalar>& ss) {
+    std::vector<core::Scalar> ss_vector(ss.begin(), ss.end());
+    return ss_vector;
+}
 
 TEST(Scalar, ImplicitConvertConstructor) {
-    EXPECT_TRUE(ToImplicitScalar(1.25f).IsDouble());
-    EXPECT_EQ(ToImplicitScalar(1.25f).ToDouble(), 1.25);
-    EXPECT_ANY_THROW(ToImplicitScalar(1.25f).ToInt64());
-    EXPECT_ANY_THROW(ToImplicitScalar(1.25f).ToBool());
+    EXPECT_TRUE(ToScalar(1.25f).IsDouble());
+    EXPECT_EQ(ToScalar(1.25f).ToDouble(), 1.25);
+    EXPECT_ANY_THROW(ToScalar(1.25f).ToInt64());
+    EXPECT_ANY_THROW(ToScalar(1.25f).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(1.25).IsDouble());
-    EXPECT_EQ(ToImplicitScalar(1.25).ToDouble(), 1.25);
-    EXPECT_ANY_THROW(ToImplicitScalar(1.25).ToInt64());
-    EXPECT_ANY_THROW(ToImplicitScalar(1.25).ToBool());
+    EXPECT_TRUE(ToScalar(1.25).IsDouble());
+    EXPECT_EQ(ToScalar(1.25).ToDouble(), 1.25);
+    EXPECT_ANY_THROW(ToScalar(1.25).ToInt64());
+    EXPECT_ANY_THROW(ToScalar(1.25).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(1).IsInt64());
-    EXPECT_EQ(ToImplicitScalar(1).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToImplicitScalar(1).ToDouble());
-    EXPECT_ANY_THROW(ToImplicitScalar(1).ToBool());
+    EXPECT_TRUE(ToScalar(1).IsInt64());
+    EXPECT_EQ(ToScalar(1).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(1).ToDouble());
+    EXPECT_ANY_THROW(ToScalar(1).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(static_cast<int64_t>(1)).IsInt64());
-    EXPECT_EQ(ToImplicitScalar(static_cast<int64_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<int64_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<int64_t>(1)).ToBool());
+    EXPECT_TRUE(ToScalar(static_cast<int64_t>(1)).IsInt64());
+    EXPECT_EQ(ToScalar(static_cast<int64_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<int64_t>(1)).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(static_cast<uint8_t>(1)).IsInt64());
-    EXPECT_EQ(ToImplicitScalar(static_cast<uint8_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint8_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint8_t>(1)).ToBool());
+    EXPECT_TRUE(ToScalar(static_cast<uint8_t>(1)).IsInt64());
+    EXPECT_EQ(ToScalar(static_cast<uint8_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint8_t>(1)).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(static_cast<uint16_t>(1)).IsInt64());
-    EXPECT_EQ(ToImplicitScalar(static_cast<uint16_t>(1)).ToInt64(), 1);
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint16_t>(1)).ToDouble());
-    EXPECT_ANY_THROW(ToImplicitScalar(static_cast<uint16_t>(1)).ToBool());
+    EXPECT_TRUE(ToScalar(static_cast<uint16_t>(1)).IsInt64());
+    EXPECT_EQ(ToScalar(static_cast<uint16_t>(1)).ToInt64(), 1);
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).ToDouble());
+    EXPECT_ANY_THROW(ToScalar(static_cast<uint16_t>(1)).ToBool());
 
-    EXPECT_TRUE(ToImplicitScalar(true).IsBool());
-    EXPECT_EQ(ToImplicitScalar(true).ToBool(), true);
-    EXPECT_ANY_THROW(ToImplicitScalar(true).ToInt64());
-    EXPECT_ANY_THROW(ToImplicitScalar(true).ToDouble());
+    EXPECT_TRUE(ToScalar(true).IsBool());
+    EXPECT_EQ(ToScalar(true).ToBool(), true);
+    EXPECT_ANY_THROW(ToScalar(true).ToInt64());
+    EXPECT_ANY_THROW(ToScalar(true).ToDouble());
+}
+
+TEST(Scalar, ImplicitConvertVectorConstructor) {
+    std::vector<core::Scalar> ss = ToVectorOfScalar({1, 1.25f, true});
+
+    EXPECT_TRUE(ss[0].IsInt64());
+    EXPECT_EQ(ss[0].ToInt64(), 1);
+    EXPECT_TRUE(ss[1].IsDouble());
+    EXPECT_EQ(ss[1].ToDouble(), 1.25);
+    EXPECT_TRUE(ss[2].IsBool());
+    EXPECT_EQ(ss[2].ToBool(), true);
 }
 
 TEST(Scalar, LiteralEquality) {

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -212,54 +212,46 @@ TEST_P(TensorPermuteDevices, WithInitValueSizeMismatch) {
 
 TEST_P(TensorPermuteDevices, Arange) {
     core::Device device = GetParam();
+    core::Tensor arange;
 
-    // Test float.
-    std::vector<float> valsf{0, 1, 2, 3, 4};
-    float startf = 0.0;
-    float stopf = 5.0;
-    float stepf = 1.0;
-    core::Tensor arangef =
-            core::Tensor::Arange<float>(startf, stopf, stepf, device);
-    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+    // Double value to float type.
+    arange = core::Tensor::Arange(0.0, 5.0, 1.0, core::Dtype::Float32, device);
+    EXPECT_EQ(arange.GetDtype(), core::Dtype::Float32);
+    EXPECT_EQ(arange.GetShape(), core::SizeVector({5}));
+    EXPECT_EQ(arange.ToFlatVector<float>(),
+              std::vector<float>({0, 1, 2, 3, 4}));
 
-    // Test float with non-one step.
-    valsf = {0.1, 2.1, 4.1};
-    startf = 0.1;
-    stopf = 6.0;
-    stepf = 2.0;
-    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
-    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+    // Double value to int type.
+    arange = core::Tensor::Arange(0.0, 5.0, 1.0, core::Dtype::Int32, device);
+    EXPECT_EQ(arange.GetDtype(), core::Dtype::Int32);
+    EXPECT_EQ(arange.GetShape(), core::SizeVector({5}));
+    EXPECT_EQ(arange.ToFlatVector<int>(), std::vector<int>({0, 1, 2, 3, 4}));
 
-    // Test float with negative step.
-    valsf = {0, -2.0, -4.0};
-    startf = 0.0;
-    stopf = -4.1;
-    stepf = -2.0;
-    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
-    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+    // Int value to float type.
+    arange = core::Tensor::Arange(0, 5, 1, core::Dtype::Float32, device);
+    EXPECT_EQ(arange.GetDtype(), core::Dtype::Float32);
+    EXPECT_EQ(arange.GetShape(), core::SizeVector({5}));
+    EXPECT_EQ(arange.ToFlatVector<float>(),
+              std::vector<float>({0, 1, 2, 3, 4}));
+
+    // Float value with non-integer step.
+    arange = core::Tensor::Arange(0.1, 6.0, 2.0, core::Dtype::Float32, device);
+    EXPECT_EQ(arange.ToFlatVector<float>(),
+              std::vector<float>({0.1, 2.1, 4.1}));
+
+    // Float value with negative step.
+    arange =
+            core::Tensor::Arange(0.0, -4.1, -2.0, core::Dtype::Float32, device);
+    EXPECT_EQ(arange.ToFlatVector<float>(),
+              std::vector<float>({0, -2.0, -4.0}));
 
     // Test empty set -- empty Tensor.
-    startf = 0.0;
-    stopf = 2.0;
-    stepf = -2.0;
-    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
-    EXPECT_EQ(arangef.NumElements(), 0);
+    arange = core::Tensor::Arange(0, 2, -2, core::Dtype::Float32, device);
+    EXPECT_EQ(arange.NumElements(), 0);
 
     // Test zero step -- error.
-    startf = 0.0;
-    stopf = 2.0;
-    stepf = 0.0;
-    EXPECT_THROW(core::Tensor::Arange<float>(startf, stopf, stepf, device),
+    EXPECT_THROW(core::Tensor::Arange(0, 2, 0, core::Dtype::Float32, device),
                  std::runtime_error);
-
-    // Test int.
-    std::vector<int64_t> valsi{0, 1, 2, 3, 4};
-    int64_t starti = 0;
-    int64_t stopi = 5;
-    int64_t stepi = 1;
-    core::Tensor arangei =
-            core::Tensor::Arange<int64_t>(starti, stopi, stepi, device);
-    EXPECT_EQ(arangei.ToFlatVector<int64_t>(), valsi);
 }
 
 TEST_P(TensorPermuteDevices, Fill) {

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -184,13 +184,17 @@ def test_arange(device):
     setups = [(0, 10, 1), (0, 10, 1), (0.0, 10.0, 2.0), (0.0, -10.0, -2.0)]
     for start, stop, step in setups:
         np_t = np.arange(start, stop, step)
-        o3_t = o3d.core.Tensor.arange(start, stop, step, device)
+        o3_t = o3d.core.Tensor.arange(start,
+                                      stop,
+                                      step,
+                                      dtype=None,
+                                      device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Only stop.
     for stop in [1.0, 2.0, 3.0, 1, 2, 3]:
         np_t = np.arange(stop)
-        o3_t = o3d.core.Tensor.arange(stop, device)
+        o3_t = o3d.core.Tensor.arange(stop, dtype=None, device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Only start, stop (step = 1).
@@ -198,8 +202,35 @@ def test_arange(device):
     for start, stop in setups:
         np_t = np.arange(start, stop)
         # Not full parameter list, need to specify device by kw.
-        o3_t = o3d.core.Tensor.arange(start, stop, device=device)
+        o3_t = o3d.core.Tensor.arange(start, stop, dtype=None, device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Type inference: int -> int.
+    o3_t = o3d.core.Tensor.arange(0, 5, dtype=None, device=device)
+    np_t = np.arange(0, 5)
+    assert o3_t.dtype == o3d.core.Dtype.Int64
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Type inference: int, float -> float.
+    o3_t = o3d.core.Tensor.arange(0, 5.0, dtype=None, device=device)
+    np_t = np.arange(0, 5)
+    assert o3_t.dtype == o3d.core.Dtype.Float64
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Type inference: float, float -> float.
+    o3_t = o3d.core.Tensor.arange(0.0, 5.0, dtype=None, device=device)
+    np_t = np.arange(0, 5)
+    assert o3_t.dtype == o3d.core.Dtype.Float64
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Type inference: explicit type.
+    o3_t = o3d.core.Tensor.arange(0.0,
+                                  5.0,
+                                  dtype=o3d.core.Dtype.Int64,
+                                  device=device)
+    np_t = np.arange(0, 5)
+    assert o3_t.dtype == o3d.core.Dtype.Int64
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
 
 def test_tensor_from_to_numpy():


### PR DESCRIPTION
- Add `core::Scalar` class
- Siimplify `Tensor::Arange`
- Future work: `core::Scalar` can potentially be used for `Tensor::Init`, `Tensor::Fill`, etc, where currently templates are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2857)
<!-- Reviewable:end -->
