### PR TITLE
[Draft] Changes rotation to be like PPTK

### DIFF
--- a/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
@@ -93,8 +93,8 @@ void MatrixInteractorLogic::Rotate(int dx, int dy) {
     forward_axis = matrix.rotation() * forward_axis;  // convert to world coords
     Eigen::Vector3f up_axis(0.0f, 1.0f, 0.0f);
     up_axis = matrix.rotation() * up_axis;  // convert to world coords
-    rot_matrix = rot_matrix * Eigen::AngleAxisf(-theta_right, up_axis)
-                            * Eigen::AngleAxisf(theta_y, forward_axis);
+    rot_matrix = rot_matrix * Eigen::AngleAxisf(-theta_right, up_axis) *
+                 Eigen::AngleAxisf(theta_y, forward_axis);
 
     auto pos = matrix * Eigen::Vector3f(0, 0, 0);
     Eigen::Vector3f to_cor = center_of_rotation_ - pos;

--- a/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
@@ -87,12 +87,14 @@ void MatrixInteractorLogic::Rotate(int dx, int dy) {
     // camera's rotation matrix to get the correct world vector.
     dy = -dy;  // up is negative, but the calculations are easiest to
                // imagine up is positive.
-    Eigen::Vector3f axis(float(-dy), float(dx), 0);  // rotate by 90 deg in 2D
-    axis = axis.normalized();
-    float theta = CalcRotateRadians(dx, dy);
-
-    axis = matrix.rotation() * axis;  // convert axis to world coords
-    rot_matrix = rot_matrix * Eigen::AngleAxisf(-theta, axis);
+    float theta_right = float(M_PI) * float(dx) / float(view_width_);
+    float theta_y = float(M_PI) * float(dy) / float(view_height_);
+    Eigen::Vector3f forward_axis(1.0f, 0.0f, 0.0f);
+    forward_axis = matrix.rotation() * forward_axis;  // convert to world coords
+    Eigen::Vector3f up_axis(0.0f, 1.0f, 0.0f);
+    up_axis = matrix.rotation() * up_axis;  // convert to world coords
+    rot_matrix = rot_matrix * Eigen::AngleAxisf(-theta_right, up_axis)
+                            * Eigen::AngleAxisf(theta_y, forward_axis);
 
     auto pos = matrix * Eigen::Vector3f(0, 0, 0);
     Eigen::Vector3f to_cor = center_of_rotation_ - pos;

--- a/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
@@ -74,17 +74,6 @@ void MatrixInteractorLogic::Rotate(int dx, int dy) {
     auto matrix = matrix_at_mouse_down_;  // copy
     Eigen::AngleAxisf rot_matrix(0, Eigen::Vector3f(1, 0, 0));
 
-    // We want to rotate as if we were rotating an imaginary trackball
-    // centered at the point of rotation. To do this we need an axis
-    // of rotation and an angle about the axis. To find the axis, we
-    // imagine that the viewing plane has been translated into the screen
-    // so that it intersects the center of rotation. The axis we want
-    // to rotate around is perpendicular to the vector defined by (dx, dy)
-    // (assuming +x is right and +y is up). (Imagine the situation if the
-    // mouse movement is (100, 0) or (0, 100).) Now it is easy to find
-    // the perpendicular in 2D. Conveniently, (axis.x, axis.y, 0) is the
-    // correct axis in camera-local coordinates. We can multiply by the
-    // camera's rotation matrix to get the correct world vector.
     dy = -dy;  // up is negative, but the calculations are easiest to
                // imagine up is positive.
     float theta_right = float(M_PI) * float(dx) / float(view_width_);


### PR DESCRIPTION
Rotation was rotation(dx * right-axis + dy * up-aixs), is not rotation(right-axis) * rotation(up-axis).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2920)
<!-- Reviewable:end -->
