### PR TITLE
Enable RSUSB backend only on Linux.

### DIFF
--- a/3rdparty/librealsense/librealsense.cmake
+++ b/3rdparty/librealsense/librealsense.cmake
@@ -7,7 +7,8 @@ ExternalProject_Add(
     GIT_TAG v2.40.0 # 18 Nov 2020
     UPDATE_COMMAND ""
     # Patch for libusb static build failure on Linux
-    PATCH_COMMAND  ${CMAKE_COMMAND} -E copy
+    PATCH_COMMAND git -C <SOURCE_DIR> reset --hard v2.40.0
+    COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/librealsense/libusb-CMakeLists.txt
     <SOURCE_DIR>/third-party/libusb/CMakeLists.txt
     # Patch for libstdc++ regex bug
@@ -25,7 +26,7 @@ ExternalProject_Add(
         -D BUILD_GRAPHICAL_EXAMPLES=OFF
         -D BUILD_PYTHON_BINDINGS=OFF
         -D BUILD_WITH_CUDA=${BUILD_CUDA_MODULE}
-        -D FORCE_RSUSB_BACKEND=ON      # https://github.com/IntelRealSense/librealsense/wiki/Release-Notes#release-2400
+        -D FORCE_RSUSB_BACKEND=$<IF:$<PLATFORM_ID:Linux>,ON,OFF>      # https://github.com/IntelRealSense/librealsense/wiki/Release-Notes#release-2400
         -D USE_EXTERNAL_USB=ON
         $<$<PLATFORM_ID:Darwin>:-DBUILD_WITH_OPENMP=OFF>
         $<$<PLATFORM_ID:Darwin>:-DHWM_OVER_XU=OFF>
@@ -39,9 +40,9 @@ set(LIBREALSENSE_LIB_DIR "${INSTALL_DIR}/lib")
 set(LIBREALSENSE_LIBRARIES realsense2 fw realsense-file usb) # The order is critical.
 if(MSVC)    # Rename debug libs to ${LIBREALSENSE_LIBRARIES}. rem (comment) is no-op
     ExternalProject_Add_Step(ext_librealsense rename_debug_libs
-        COMMAND $<IF:$<CONFIG:Debug>,rename,rem> realsense2d.lib realsense2.lib
-        COMMAND $<IF:$<CONFIG:Debug>,rename,rem> fwd.lib fw.lib
-        COMMAND $<IF:$<CONFIG:Debug>,rename,rem> realsense-filed.lib realsense-file.lib
+        COMMAND $<IF:$<CONFIG:Debug>,move,rem> /Y realsense2d.lib realsense2.lib
+        COMMAND $<IF:$<CONFIG:Debug>,move,rem> /Y fwd.lib fw.lib
+        COMMAND $<IF:$<CONFIG:Debug>,move,rem> /Y realsense-filed.lib realsense-file.lib
         WORKING_DIRECTORY "${LIBREALSENSE_LIB_DIR}"
         DEPENDEES install
     )

--- a/examples/cpp/RealSenseRecorder.cpp
+++ b/examples/cpp/RealSenseRecorder.cpp
@@ -73,10 +73,6 @@ int main(int argc, char **argv) {
         config_file = utility::GetProgramOptionAsString(argc, argv, "-c");
     } else if (utility::ProgramOptionExists(argc, argv, "--config")) {
         config_file = utility::GetProgramOptionAsString(argc, argv, "--config");
-    } else {
-        utility::LogError("config json file required.");
-        PrintUsage();
-        return 1;
     }
     if (utility::ProgramOptionExists(argc, argv, "--align")) {
         align_streams = true;
@@ -87,7 +83,9 @@ int main(int argc, char **argv) {
 
     // Read in camera configuration.
     tio::RealSenseSensorConfig rs_cfg;
-    open3d::io::ReadIJsonConvertible(config_file, rs_cfg);
+    if (!config_file.empty()) {
+        open3d::io::ReadIJsonConvertible(config_file, rs_cfg);
+    }
 
     // Initialize camera.
     tio::RealSenseSensor rs;

--- a/python/test/t/io/test_realsense.py
+++ b/python/test/t/io/test_realsense.py
@@ -124,5 +124,5 @@ def test_RealSenseSensor():
         assert os.path.exists(bag_filename)
         os.remove(bag_filename)
     except RuntimeError as err:
-        assert "[Open3D ERROR] Invalid RealSense camera configuration, or camera not connected" in str(
+        assert "Invalid RealSense camera configuration, or camera not connected" in str(
             err)

--- a/python/test/t/io/test_realsense.py
+++ b/python/test/t/io/test_realsense.py
@@ -37,8 +37,9 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../..")
 from open3d_test import test_data_dir
 
 
+# @pytest.mark.skipif(not hasattr(o3d.t.io, 'RSBagReader'))
 @pytest.mark.skip(reason="Hangs in Github Actions, but succeeds locally")
-def test_RSBagReader(suspend_capture):
+def test_RSBagReader():
 
     shutil.unpack_archive(test_data_dir +
                           "/RGBD/other_formats/L515_test_s.bag.tar.xz")
@@ -101,4 +102,27 @@ def test_RSBagReader(suspend_capture):
     }.issubset(os.listdir('L515_test_s/color'))
 
     shutil.rmtree("L515_test_s")
-    # shutil.rmtree("L515_test_s.bag")  # Permission error in Windows
+    # os.remove("L515_test_s.bag")  # Permission error in Windows
+
+
+# Test recording from a RealSense camera, if one is connected
+@pytest.mark.skipif(not hasattr(o3d.t.io, 'RealSenseSensor'),
+                    reason="Not built with librealsense")
+def test_RealSenseSensor():
+
+    o3d.t.io.RealSenseSensor.list_devices()
+    rs_cam = o3d.t.io.RealSenseSensor()
+    bag_filename = "test_record.bag"
+    try:
+        rs_cam.init_sensor(o3d.t.io.RealSenseSensorConfig(), 0, bag_filename)
+        rs_cam.start_capture(True)  # true: start recording with capture
+        im_rgbd = rs_cam.capture_frame(True,
+                                       True)  # wait for frames and align them
+        assert im_rgbd.depth.rows == im_rgbd.color.rows
+        assert im_rgbd.depth.columns == im_rgbd.color.columns
+        rs_cam.stop_capture()
+        assert os.path.exists(bag_filename)
+        os.remove(bag_filename)
+    except RuntimeError as err:
+        assert "[Open3D ERROR] Invalid RealSense camera configuration, or camera not connected" in str(
+            err)


### PR DESCRIPTION
- RSUSB backend cannot detect devices correctly on Windows.
- More robust patching command for librealsense repo - succeeds on rebuild.
- Add Python unit test for `RealSenseSensor`

fixes #2861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2923)
<!-- Reviewable:end -->
