### PR TITLE
Expose outlier threshold parameter to users

### DIFF
--- a/cpp/open3d/t/geometry/TSDFVoxelGrid.cpp
+++ b/cpp/open3d/t/geometry/TSDFVoxelGrid.cpp
@@ -187,7 +187,7 @@ void TSDFVoxelGrid::Integrate(const Image &depth,
                             sdf_trunc_, depth_scale, depth_max);
 }
 
-PointCloud TSDFVoxelGrid::ExtractSurfacePoints() {
+PointCloud TSDFVoxelGrid::ExtractSurfacePoints(float weight_threshold) {
     // Extract active voxel blocks from the hashmap.
     core::Tensor active_addrs;
     block_hashmap_->GetActiveIndices(active_addrs);
@@ -201,7 +201,8 @@ PointCloud TSDFVoxelGrid::ExtractSurfacePoints() {
             active_addrs.To(core::Dtype::Int64),
             active_nb_addrs.To(core::Dtype::Int64), active_nb_masks,
             block_hashmap_->GetKeyTensor(), block_hashmap_->GetValueTensor(),
-            points, normals, colors, block_resolution_, voxel_size_);
+            points, normals, colors, block_resolution_, voxel_size_,
+            weight_threshold);
     auto pcd = PointCloud(points);
     pcd.SetPointNormals(normals);
     if (colors.NumElements() != 0) {
@@ -211,7 +212,7 @@ PointCloud TSDFVoxelGrid::ExtractSurfacePoints() {
     return pcd;
 }
 
-TriangleMesh TSDFVoxelGrid::ExtractSurfaceMesh() {
+TriangleMesh TSDFVoxelGrid::ExtractSurfaceMesh(float weight_threshold) {
     // Query active blocks and their nearest neighbors to handle boundary cases.
     core::Tensor active_addrs;
     block_hashmap_->GetActiveIndices(active_addrs);
@@ -235,7 +236,7 @@ TriangleMesh TSDFVoxelGrid::ExtractSurfaceMesh() {
             active_nb_addrs.To(core::Dtype::Int64), active_nb_masks,
             block_hashmap_->GetKeyTensor(), block_hashmap_->GetValueTensor(),
             vertices, triangles, vertex_normals, vertex_colors,
-            block_resolution_, voxel_size_);
+            block_resolution_, voxel_size_, weight_threshold);
 
     TriangleMesh mesh(vertices, triangles);
     mesh.SetVertexNormals(vertex_normals);

--- a/cpp/open3d/t/geometry/TSDFVoxelGrid.h
+++ b/cpp/open3d/t/geometry/TSDFVoxelGrid.h
@@ -85,10 +85,18 @@ public:
                    float depth_max = 3.0f);
 
     /// Extract point cloud near iso-surfaces.
-    PointCloud ExtractSurfacePoints();
+    /// Weight threshold is used to filter outliers. By default we use 3.0,
+    /// where we assume a reliable surface point comes from the fusion of at
+    /// least 3 viewpoints. Use as low as 0.0 to accept all the possible
+    /// observations.
+    PointCloud ExtractSurfacePoints(float weight_threshold = 3.0f);
 
     /// Extract mesh near iso-surfaces with Marching Cubes.
-    TriangleMesh ExtractSurfaceMesh();
+    /// Weight threshold is used to filter outliers. By default we use 3.0,
+    /// where we assume a reliable surface point comes from the fusion of at
+    /// least 3 viewpoints. Use as low as 0.0 to accept all the possible
+    /// observations.
+    TriangleMesh ExtractSurfaceMesh(float weight_threshold = 3.0f);
 
     /// Convert TSDFVoxelGrid to the target device.
     /// \param device The targeted device to convert to.

--- a/cpp/open3d/t/geometry/kernel/GeometryMacros.h
+++ b/cpp/open3d/t/geometry/kernel/GeometryMacros.h
@@ -367,6 +367,4 @@ OPEN3D_DEVICE const int edge_to_vert[12][2] = {
         {0, 1}, {1, 2}, {3, 2}, {0, 3}, {4, 5}, {5, 6},
         {7, 6}, {4, 7}, {0, 4}, {1, 5}, {2, 6}, {3, 7},
 };
-
-OPEN3D_DEVICE const float kWeightThreshold = 3.0;
 }  // unnamed namespace

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGrid.cpp
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGrid.cpp
@@ -116,20 +116,22 @@ void ExtractSurfacePoints(const core::Tensor& block_indices,
                           core::Tensor& normals,
                           core::Tensor& colors,
                           int64_t block_resolution,
-                          float voxel_size) {
+                          float voxel_size,
+                          float weight_threshold) {
     core::Device device = block_keys.GetDevice();
 
     core::Device::DeviceType device_type = device.GetType();
     if (device_type == core::Device::DeviceType::CPU) {
         ExtractSurfacePointsCPU(block_indices, nb_block_indices, nb_block_masks,
                                 block_keys, block_values, points, normals,
-                                colors, block_resolution, voxel_size);
+                                colors, block_resolution, voxel_size,
+                                weight_threshold);
     } else if (device_type == core::Device::DeviceType::CUDA) {
 #ifdef BUILD_CUDA_MODULE
         ExtractSurfacePointsCUDA(block_indices, nb_block_indices,
                                  nb_block_masks, block_keys, block_values,
                                  points, normals, colors, block_resolution,
-                                 voxel_size);
+                                 voxel_size, weight_threshold);
 #else
         utility::LogError("Not compiled with CUDA, but CUDA device is used.");
 #endif
@@ -149,7 +151,8 @@ void ExtractSurfaceMesh(const core::Tensor& block_indices,
                         core::Tensor& vertex_normals,
                         core::Tensor& vertex_colors,
                         int64_t block_resolution,
-                        float voxel_size) {
+                        float voxel_size,
+                        float weight_threshold) {
     core::Device device = block_keys.GetDevice();
 
     core::Device::DeviceType device_type = device.GetType();
@@ -157,13 +160,15 @@ void ExtractSurfaceMesh(const core::Tensor& block_indices,
         ExtractSurfaceMeshCPU(block_indices, inv_block_indices,
                               nb_block_indices, nb_block_masks, block_keys,
                               block_values, vertices, triangles, vertex_normals,
-                              vertex_colors, block_resolution, voxel_size);
+                              vertex_colors, block_resolution, voxel_size,
+                              weight_threshold);
     } else if (device_type == core::Device::DeviceType::CUDA) {
 #ifdef BUILD_CUDA_MODULE
-        ExtractSurfaceMeshCUDA(
-                block_indices, inv_block_indices, nb_block_indices,
-                nb_block_masks, block_keys, block_values, vertices, triangles,
-                vertex_normals, vertex_colors, block_resolution, voxel_size);
+        ExtractSurfaceMeshCUDA(block_indices, inv_block_indices,
+                               nb_block_indices, nb_block_masks, block_keys,
+                               block_values, vertices, triangles,
+                               vertex_normals, vertex_colors, block_resolution,
+                               voxel_size, weight_threshold);
 #else
         utility::LogError("Not compiled with CUDA, but CUDA device is used.");
 #endif

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGrid.h
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGrid.h
@@ -63,7 +63,8 @@ void ExtractSurfacePoints(const core::Tensor& block_indices,
                           core::Tensor& normals,
                           core::Tensor& colors,
                           int64_t block_resolution,
-                          float voxel_size);
+                          float voxel_size,
+                          float weight_threshold);
 
 void ExtractSurfaceMesh(const core::Tensor& block_indices,
                         const core::Tensor& inv_block_indices,
@@ -76,7 +77,8 @@ void ExtractSurfaceMesh(const core::Tensor& block_indices,
                         core::Tensor& vertex_normals,
                         core::Tensor& vertex_colors,
                         int64_t block_resolution,
-                        float voxel_size);
+                        float voxel_size,
+                        float weight_threshold);
 
 void TouchCPU(const core::Tensor& points,
               core::Tensor& voxel_block_coords,
@@ -106,7 +108,8 @@ void ExtractSurfacePointsCPU(const core::Tensor& block_indices,
                              core::Tensor& normals,
                              core::Tensor& colors,
                              int64_t block_resolution,
-                             float voxel_size);
+                             float voxel_size,
+                             float weight_threshold);
 
 void ExtractSurfaceMeshCPU(const core::Tensor& block_indices,
                            const core::Tensor& inv_block_indices,
@@ -119,7 +122,8 @@ void ExtractSurfaceMeshCPU(const core::Tensor& block_indices,
                            core::Tensor& vertex_normals,
                            core::Tensor& vertex_colors,
                            int64_t block_resolution,
-                           float voxel_size);
+                           float voxel_size,
+                           float weight_threshold);
 
 #ifdef BUILD_CUDA_MODULE
 void TouchCUDA(const core::Tensor& points,
@@ -150,7 +154,8 @@ void ExtractSurfacePointsCUDA(const core::Tensor& block_indices,
                               core::Tensor& normals,
                               core::Tensor& colors,
                               int64_t block_resolution,
-                              float voxel_size);
+                              float voxel_size,
+                              float weight_threshold);
 
 void ExtractSurfaceMeshCUDA(const core::Tensor& block_indices,
                             const core::Tensor& inv_block_indices,
@@ -163,7 +168,8 @@ void ExtractSurfaceMeshCUDA(const core::Tensor& block_indices,
                             core::Tensor& vertex_normals,
                             core::Tensor& vertex_colors,
                             int64_t block_resolution,
-                            float voxel_size);
+                            float voxel_size,
+                            float weight_threshold);
 
 #endif
 }  // namespace tsdf

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridShared.h
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridShared.h
@@ -373,7 +373,8 @@ void ExtractSurfacePointsCPU
          core::Tensor& normals,
          core::Tensor& colors,
          int64_t resolution,
-         float voxel_size) {
+         float voxel_size,
+         float weight_threshold) {
     // Parameters
     int64_t resolution3 = resolution * resolution * resolution;
 
@@ -439,7 +440,7 @@ void ExtractSurfacePointsCPU
                                                          xv, yv, zv, block_idx);
                     float tsdf_o = voxel_ptr->GetTSDF();
                     float weight_o = voxel_ptr->GetWeight();
-                    if (weight_o <= kWeightThreshold) return;
+                    if (weight_o <= weight_threshold) return;
 
                     // Enumerate x-y-z directions
                     for (int i = 0; i < 3; ++i) {
@@ -453,7 +454,7 @@ void ExtractSurfacePointsCPU
                         float tsdf_i = ptr->GetTSDF();
                         float weight_i = ptr->GetWeight();
 
-                        if (weight_i > kWeightThreshold &&
+                        if (weight_i > weight_threshold &&
                             tsdf_i * tsdf_o < 0) {
                             OPEN3D_ATOMIC_ADD(count_ptr, 1);
                         }
@@ -544,7 +545,7 @@ void ExtractSurfacePointsCPU
                     float tsdf_o = voxel_ptr->GetTSDF();
                     float weight_o = voxel_ptr->GetWeight();
 
-                    if (weight_o <= kWeightThreshold) return;
+                    if (weight_o <= weight_threshold) return;
 
                     int64_t x = xb * resolution + xv;
                     int64_t y = yb * resolution + yv;
@@ -567,7 +568,7 @@ void ExtractSurfacePointsCPU
                         float tsdf_i = ptr->GetTSDF();
                         float weight_i = ptr->GetWeight();
 
-                        if (weight_i > kWeightThreshold &&
+                        if (weight_i > weight_threshold &&
                             tsdf_i * tsdf_o < 0) {
                             float ratio = (0 - tsdf_o) / (tsdf_i - tsdf_o);
 
@@ -646,7 +647,8 @@ void ExtractSurfaceMeshCPU
          core::Tensor& normals,
          core::Tensor& colors,
          int64_t resolution,
-         float voxel_size) {
+         float voxel_size,
+         float weight_threshold) {
 
     int64_t resolution3 = resolution * resolution * resolution;
 
@@ -734,7 +736,7 @@ void ExtractSurfaceMeshCPU
 
                         float tsdf_i = voxel_ptr_i->GetTSDF();
                         float weight_i = voxel_ptr_i->GetWeight();
-                        if (weight_i <= kWeightThreshold) return;
+                        if (weight_i <= weight_threshold) return;
 
                         table_idx |= ((tsdf_i < 0) ? (1 << i) : 0);
                     }

--- a/cpp/pybind/t/geometry/tsdf_voxelgrid.cpp
+++ b/cpp/pybind/t/geometry/tsdf_voxelgrid.cpp
@@ -64,9 +64,11 @@ void pybind_tsdf_voxelgrid(py::module& m) {
                     &TSDFVoxelGrid::Integrate));
 
     tsdf_voxelgrid.def("extract_surface_points",
-                       &TSDFVoxelGrid::ExtractSurfacePoints);
+                       &TSDFVoxelGrid::ExtractSurfacePoints,
+                       "weight_threshold"_a = 3.0f);
     tsdf_voxelgrid.def("extract_surface_mesh",
-                       &TSDFVoxelGrid::ExtractSurfaceMesh);
+                       &TSDFVoxelGrid::ExtractSurfaceMesh,
+                       "weight_threshold"_a = 3.0f);
 
     tsdf_voxelgrid.def("to", &TSDFVoxelGrid::To, "device"_a, "copy"_a = false);
     tsdf_voxelgrid.def("clone", &TSDFVoxelGrid::Clone);


### PR DESCRIPTION
Fixes #2927 by exposing the weight filter ratio to users. By changing the parameter to 0.0 the user can generate relatively noisy mesh from a single frame / multiple frames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2931)
<!-- Reviewable:end -->
