### PR TITLE
Fixed trackpad scrolling to be buttery smooth at slow speeds on macOS

### DIFF
--- a/cpp/open3d/visualization/gui/Events.h
+++ b/cpp/open3d/visualization/gui/Events.h
@@ -65,8 +65,8 @@ struct MouseEvent {
             MouseButton button;
         } button;
         struct {
-            int dx;
-            int dy;
+            float dx;  // macOS gives fractional values, and is required
+            float dy;  //   for the buttery-smooth trackpad scrolling on macOS
             bool isTrackpad;
         } wheel;
     };

--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -367,7 +367,7 @@ public:
                 break;
             }
             case MouseEvent::WHEEL: {
-                interactor_->Dolly(2 * e.wheel.dy,
+                interactor_->Dolly(2.0f * e.wheel.dy,
                                    e.wheel.isTrackpad
                                            ? rendering::MatrixInteractorLogic::
                                                      DragType::TWO_FINGER

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -1105,10 +1105,10 @@ void Window::OnMouseEvent(const MouseEvent& e) {
             ImGuiIO& io = ImGui::GetIO();
             float dx = 0.0, dy = 0.0;
             if (e.wheel.dx != 0) {
-                dx = float(e.wheel.dx / std::abs(e.wheel.dx));  // get sign
+                dx = e.wheel.dx / std::abs(e.wheel.dx);  // get sign
             }
             if (e.wheel.dy != 0) {
-                dy = float(e.wheel.dy / std::abs(e.wheel.dy));  // get sign
+                dy = e.wheel.dy / std::abs(e.wheel.dy);  // get sign
             }
             // Note: ImGUI's documentation says that 1 unit of wheel movement
             //       is about 5 lines of text scrolling.
@@ -1340,9 +1340,14 @@ void Window::MouseScrollCallback(GLFWwindow* window, double dx, double dy) {
     int ix = int(std::ceil(mx * scaling));
     int iy = int(std::ceil(my * scaling));
 
+    // Note that although pixels are integers, the trackpad value needs to
+    // be a float, since macOS trackpads produce fractional values when
+    // scrolling slowly. These fractional values need to be passed all the way
+    // down to the MatrixInteractorLogic::Dolly() in order for dollying to
+    // feel buttery smooth with the trackpad.
     MouseEvent me = {MouseEvent::WHEEL, ix, iy, w->impl_->mouse_mods_};
-    me.wheel.dx = int(std::round(dx));
-    me.wheel.dy = int(std::round(dy));
+    me.wheel.dx = dx;
+    me.wheel.dy = dy;
 
     // GLFW doesn't give us any information about whether this scroll event
     // came from a mousewheel or a trackpad two-finger scroll.

--- a/cpp/open3d/visualization/rendering/CameraInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/CameraInteractorLogic.cpp
@@ -61,7 +61,7 @@ void CameraInteractorLogic::RotateFly(int dx, int dy) {
     camera_->SetModelMatrix(GetMatrix());
 }
 
-void CameraInteractorLogic::Dolly(int dy, DragType type) {
+void CameraInteractorLogic::Dolly(float dy, DragType type) {
     // Parent's matrix_ may not have been set yet
     if (type != DragType::MOUSE) {
         SetMouseDownInfo(camera_->GetModelMatrix(), center_of_rotation_);

--- a/cpp/open3d/visualization/rendering/CameraInteractorLogic.h
+++ b/cpp/open3d/visualization/rendering/CameraInteractorLogic.h
@@ -43,7 +43,7 @@ public:
 
     void Rotate(int dx, int dy) override;
     void RotateZ(int dx, int dy) override;
-    void Dolly(int dy, DragType type) override;
+    void Dolly(float dy, DragType type) override;
     void Dolly(float z_dist, Camera::Transform matrix_in) override;
 
     void Pan(int dx, int dy) override;

--- a/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/MatrixInteractorLogic.cpp
@@ -177,7 +177,7 @@ float MatrixInteractorLogic::CalcRotateZRadians(int dx, int dy) {
     return float(4.0 * M_PI * dy / view_height_);
 }
 
-void MatrixInteractorLogic::Dolly(int dy, DragType drag_type) {
+void MatrixInteractorLogic::Dolly(float dy, DragType drag_type) {
     float dist = CalcDollyDist(dy, drag_type);
     if (drag_type == DragType::MOUSE) {
         Dolly(dist, matrix_at_mouse_down_);  // copies the matrix
@@ -202,7 +202,7 @@ void MatrixInteractorLogic::Dolly(float z_dist, Camera::Transform matrix) {
     matrix_ = matrix;
 }
 
-float MatrixInteractorLogic::CalcDollyDist(int dy, DragType drag_type) {
+float MatrixInteractorLogic::CalcDollyDist(float dy, DragType drag_type) {
     float dist = 0.0f;  // initialize to make GCC happy
     switch (drag_type) {
         case DragType::MOUSE:

--- a/cpp/open3d/visualization/rendering/MatrixInteractorLogic.h
+++ b/cpp/open3d/visualization/rendering/MatrixInteractorLogic.h
@@ -74,7 +74,7 @@ public:
 
     /// Moves the matrix along the forward axis. (This is one type
     /// of zoom.)
-    virtual void Dolly(int dy, DragType drag_type);
+    virtual void Dolly(float dy, DragType drag_type);
     virtual void Dolly(float z_dist, Camera::Transform matrix);
 
 private:
@@ -93,7 +93,7 @@ protected:
     void SetMatrix(const Camera::Transform& matrix);
     float CalcRotateRadians(int dx, int dy);
     float CalcRotateZRadians(int dx, int dy);
-    float CalcDollyDist(int dy, DragType drag_type);
+    float CalcDollyDist(float dy, DragType drag_type);
 };
 
 }  // namespace rendering

--- a/cpp/open3d/visualization/rendering/ModelInteractorLogic.cpp
+++ b/cpp/open3d/visualization/rendering/ModelInteractorLogic.cpp
@@ -94,7 +94,7 @@ void ModelInteractorLogic::RotateZ(int dx, int dy) {
     UpdateBoundingBox(Camera::Transform(rot_matrix));
 }
 
-void ModelInteractorLogic::Dolly(int dy, DragType drag_type) {
+void ModelInteractorLogic::Dolly(float dy, DragType drag_type) {
     float z_dist = CalcDollyDist(dy, drag_type);
     Eigen::Vector3f world_move = -z_dist * camera_->GetForwardVector();
 

--- a/cpp/open3d/visualization/rendering/ModelInteractorLogic.h
+++ b/cpp/open3d/visualization/rendering/ModelInteractorLogic.h
@@ -54,7 +54,7 @@ public:
 
     void Rotate(int dx, int dy) override;
     void RotateZ(int dx, int dy) override;
-    void Dolly(int dy, DragType drag_type) override;
+    void Dolly(float dy, DragType drag_type) override;
     void Pan(int dx, int dy) override;
 
     void StartMouseDrag() override;


### PR DESCRIPTION
To test, two-finger swipe *slowly* to dolly in/out on macOS. You should see it buttery-smooth with this PR, and very discrete (arguably not working) without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2964)
<!-- Reviewable:end -->
