### PR TITLE
Refactored RPC interface to be more amenable to variation in visualizers (fixes add not updating)

### DIFF
--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -863,8 +863,18 @@ void GuiVisualizer::Layout(const gui::Theme &theme) {
 
 void GuiVisualizer::StartRPCInterface(const std::string &address, int timeout) {
 #ifdef BUILD_RPC_INTERFACE
-    impl_->receiver_ = std::make_shared<Receiver>(
-            this, impl_->scene_wgt_->GetScene(), address, timeout);
+    auto on_geometry = [this](std::shared_ptr<geometry::Geometry3D> geom,
+                              const std::string &path, int time,
+                              const std::string &layer) {
+        // Rather than duplicating the logic to figure out the correct material,
+        // just add with the default material and pretend the user changed the
+        // current material and update everyone's material.
+        impl_->scene_wgt_->GetScene()->AddGeometry(path, geom.get(),
+                                                   rendering::Material());
+        impl_->UpdateFromModel(GetRenderer(), true);
+    };
+    impl_->receiver_ =
+            std::make_shared<Receiver>(address, timeout, this, on_geometry);
     try {
         utility::LogInfo("Starting to listen on {}", address);
         impl_->receiver_->Start();

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1687,8 +1687,17 @@ Open3DScene *O3DVisualizer::GetScene() const {
 
 void O3DVisualizer::StartRPCInterface(const std::string &address, int timeout) {
 #ifdef BUILD_RPC_INTERFACE
-    impl_->receiver_ = std::make_shared<Receiver>(
-            this, impl_->scene_->GetScene(), address, timeout);
+    auto on_geometry = [this](std::shared_ptr<geometry::Geometry3D> geom,
+                              const std::string &path, int time,
+                              const std::string &layer) {
+        impl_->AddGeometry(path, geom, nullptr, nullptr, layer, time, true);
+        if (impl_->objects_.size() == 1) {
+            impl_->ResetCameraToDefault();
+        }
+    };
+
+    impl_->receiver_ =
+            std::make_shared<Receiver>(address, timeout, this, on_geometry);
     try {
         utility::LogInfo("Starting to listen on {}", address);
         impl_->receiver_->Start();

--- a/cpp/open3d/visualization/visualizer/Receiver.cpp
+++ b/cpp/open3d/visualization/visualizer/Receiver.cpp
@@ -195,7 +195,7 @@ std::shared_ptr<zmq::message_t> Receiver::ProcessMessage(
             }
         }
 
-        HandleGeometry(mesh, msg.path, msg.time, msg.layer);
+        SetGeometry(mesh, msg.path, msg.time, msg.layer);
 
     } else {
         // create a PointCloud
@@ -301,16 +301,16 @@ std::shared_ptr<zmq::message_t> Receiver::ProcessMessage(
                 }
             }
         }
-        HandleGeometry(pcd, msg.path, msg.time, msg.layer);
+        SetGeometry(pcd, msg.path, msg.time, msg.layer);
     }
 
     return CreateStatusOKMsg();
 }
 
-void Receiver::HandleGeometry(std::shared_ptr<geometry::Geometry3D> geom,
-                              const std::string& path,
-                              int time,
-                              const std::string& layer) {
+void Receiver::SetGeometry(std::shared_ptr<geometry::Geometry3D> geom,
+                           const std::string& path,
+                           int time,
+                           const std::string& layer) {
     gui::Application::GetInstance().PostToMainThread(
             window_, [this, geom, path, time, layer]() {
                 on_geometry_(geom, path, time, layer);

--- a/cpp/open3d/visualization/visualizer/Receiver.h
+++ b/cpp/open3d/visualization/visualizer/Receiver.h
@@ -28,23 +28,34 @@
 #pragma once
 
 #include "open3d/io/rpc/ReceiverBase.h"
-#include "open3d/visualization/rendering/Open3DScene.h"
 
 namespace open3d {
+
+namespace geometry {
+class Geometry3D;
+}  // namespace geometry
+
 namespace visualization {
 
 namespace gui {
 class Window;
-}
+}  // namespace gui
 
 /// Receiver implementation which interfaces with the Open3DScene and a Window.
 class Receiver : public io::rpc::ReceiverBase {
 public:
-    Receiver(gui::Window* window,
-             std::shared_ptr<rendering::Open3DScene> scene,
-             const std::string& address,
-             int timeout)
-        : ReceiverBase(address, timeout), window_(window), scene_(scene) {}
+    using OnGeometryFunc = std::function<void(
+            std::shared_ptr<geometry::Geometry3D>,  // geometry
+            const std::string&,                     // path
+            int,                                    // time
+            const std::string&)>;                   // layer
+    Receiver(const std::string& address,
+             int timeout,
+             gui::Window* window,
+             OnGeometryFunc on_geometry)
+        : ReceiverBase(address, timeout),
+          window_(window),
+          on_geometry_(on_geometry) {}
 
     std::shared_ptr<zmq::message_t> ProcessMessage(
             const io::rpc::messages::Request& req,
@@ -52,13 +63,13 @@ public:
             const MsgpackObject& obj) override;
 
 private:
-    void SetGeometry(std::shared_ptr<geometry::Geometry3D> geom,
-                     const std::string& path,
-                     int time,
-                     const std::string& layer);
-
     gui::Window* window_;
-    std::shared_ptr<rendering::Open3DScene> scene_;
+    OnGeometryFunc on_geometry_;
+
+    void HandleGeometry(std::shared_ptr<geometry::Geometry3D> geom,
+                        const std::string& path,
+                        int time,
+                        const std::string& layer);
 };
 
 }  // namespace visualization

--- a/cpp/open3d/visualization/visualizer/Receiver.h
+++ b/cpp/open3d/visualization/visualizer/Receiver.h
@@ -66,10 +66,10 @@ private:
     gui::Window* window_;
     OnGeometryFunc on_geometry_;
 
-    void HandleGeometry(std::shared_ptr<geometry::Geometry3D> geom,
-                        const std::string& path,
-                        int time,
-                        const std::string& layer);
+    void SetGeometry(std::shared_ptr<geometry::Geometry3D> geom,
+                     const std::string& path,
+                     int time,
+                     const std::string& layer);
 };
 
 }  // namespace visualization

--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -26,6 +26,7 @@
 
 #include <open3d/geometry/Geometry3D.h>
 #include <open3d/t/geometry/Geometry.h>
+#include <open3d/visualization/gui/Dialog.h>
 #include <open3d/visualization/gui/Window.h>
 #include <open3d/visualization/rendering/Open3DScene.h>
 #include <open3d/visualization/visualizer/O3DVisualizer.h>
@@ -119,6 +120,51 @@ void pybind_o3dvisualizer(py::module& m) {
     o3dvis.def(py::init<const std::string, int, int>(), "title"_a = "Open3D",
                "width"_a = 1024, "height"_a = 768,
                "Creates a O3DVisualizer object")
+            // selected functions inherited from Window
+            .def_property("os_frame", &O3DVisualizer::GetOSFrame,
+                          &O3DVisualizer::SetOSFrame,
+                          "Window rect in OS coords, not device pixels")
+            .def_property("title", &O3DVisualizer::GetTitle,
+                          &O3DVisualizer::SetTitle,
+                          "Returns the title of the window")
+            .def("size_to_fit", &O3DVisualizer::SizeToFit,
+                 "Sets the width and height of window to its preferred size")
+            .def_property("size", &O3DVisualizer::GetSize,
+                          &O3DVisualizer::SetSize,
+                          "The size of the window in device pixels, including "
+                          "menubar (except on macOS)")
+            .def_property_readonly(
+                    "content_rect", &O3DVisualizer::GetContentRect,
+                    "Returns the frame in device pixels, relative "
+                    " to the window, which is available for widgets "
+                    "(read-only)")
+            .def_property_readonly(
+                    "scaling", &O3DVisualizer::GetScaling,
+                    "Returns the scaling factor between OS pixels "
+                    "and device pixels (read-only)")
+            .def_property_readonly("is_visible", &O3DVisualizer::IsVisible,
+                                   "True if window is visible (read-only)")
+            .def("show", &O3DVisualizer::Show, "Shows or hides the window")
+            .def("close", &O3DVisualizer::Close,
+                 "Closes the window and destroys it, unless an on_close "
+                 "callback cancels the close.")
+            .def(
+                    "show_dialog",
+                    [](O3DVisualizer& w, UnownedPointer<gui::Dialog> dlg) {
+                        w.ShowDialog(TakeOwnership<gui::Dialog>(dlg));
+                    },
+                    "Displays the dialog")
+            .def("close_dialog", &O3DVisualizer::CloseDialog,
+                 "Closes the current dialog")
+            .def("show_message_box", &O3DVisualizer::ShowMessageBox,
+                 "Displays a simple dialog with a title and message and okay "
+                 "button")
+            .def("set_on_close", &O3DVisualizer::SetOnClose,
+                 "Sets a callback that will be called when the window is "
+                 "closed. The callback is given no arguments and should return "
+                 "True to continue closing the window or False to cancel the "
+                 "close")
+            // from O3DVisualizer
             .def("add_action", &O3DVisualizer::AddAction,
                  "Adds a button to the custom actions section of the UI "
                  "and a corresponding menu item in the \"Actions\" menu. "

--- a/python/open3d/visualization/draw.py
+++ b/python/open3d/visualization/draw.py
@@ -61,6 +61,12 @@ def draw(
     if rpc_interface:
         w.start_rpc_interface(address="tcp://127.0.0.1:51454", timeout=10000)
 
+        def stop_rpc():
+            w.stop_rpc_interface()
+            return True
+
+        w.set_on_close(stop_rpc)
+
     if on_init is not None:
         on_init(w)
     if on_animation_frame is not None:
@@ -70,6 +76,3 @@ def draw(
 
     gui.Application.instance.add_window(w)
     gui.Application.instance.run()
-
-    if rpc_interface:
-        w.stop_rpc_interface()


### PR DESCRIPTION
The initial problem was to get RPC add-geometry to redraw the scene in response to an update. However, this is a little troublesome because a) the scene doesn't know about the SceneWidget (which needs to note that it needs to actually redraw the scene for the next redraw and not just copy a bitmap) and the widgets don't know about their owning window (which is what requests a redraw from the OS), and b) different visualizers need to do different things even on adding geometry: O3DVisualizer needs to add to the scene using a lit material if it has normals or unlit otherwise, and to the list of geometries, but GuiVisualizer needs to add to the scene using the current material (or maybe replace the current object). So it seemed like it would be more flexible for the RPC Receiver to have a callback function so that the owner can process the add request appropriately, rather than the Receiver adding to the scene and expecting the higher level objects to figure out what happened.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2970)
<!-- Reviewable:end -->
