### PR TITLE
Minor typo in __repr__ for OBB

### DIFF
--- a/cpp/pybind/geometry/boundingvolume.cpp
+++ b/cpp/pybind/geometry/boundingvolume.cpp
@@ -58,7 +58,7 @@ void pybind_boundingvolume(py::module &m) {
                      auto e = box.extent_;
                      s << "OrientedBoundingBox: center: (" << c.x() << ", "
                        << c.y() << ", " << c.z() << "), extent: " << e.x()
-                       << ", " << e.y() << e.z() << ")";
+                       << ", " << e.y() << ", " << e.z() << ")";
                      return s.str();
                  })
             .def("get_point_indices_within_bounding_box",


### PR DESCRIPTION
Typo in __repr__ for OBB in boundingvolume.cpp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/2987)
<!-- Reviewable:end -->
