### PR TITLE
Support USE_SYSTEM_LIBREALSENSE flag.

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -540,20 +540,42 @@ list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${TRITRIINTERSECT_TARGET}")
 
 # librealsense SDK
 if (BUILD_LIBREALSENSE)
-    include(${Open3D_3RDPARTY_DIR}/librealsense/librealsense.cmake)
-    import_3rdparty_library(3rdparty_librealsense
-        INCLUDE_DIRS ${LIBREALSENSE_INCLUDE_DIR}
-        LIBRARIES    ${LIBREALSENSE_LIBRARIES}
-        LIB_DIR      ${LIBREALSENSE_LIB_DIR}
-    )
-    add_dependencies(3rdparty_librealsense ext_librealsense)
-    set(LIBREALSENSE_TARGET "3rdparty_librealsense")
-    list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
-
-    if (UNIX AND NOT APPLE)    # Ubuntu dependency: libudev-dev
-        find_library(UDEV_LIBRARY udev REQUIRED
-            DOC "Library provided by the deb package libudev-dev")
-        target_link_libraries(3rdparty_librealsense INTERFACE ${UDEV_LIBRARY})
+    if(USE_SYSTEM_LIBREALSENSE AND NOT GLIBCXX_USE_CXX11_ABI)
+        # Turn off USE_SYSTEM_LIBREALSENSE.
+        # Because it is affected by libraries built with different CXX ABIs.
+        # See details: https://github.com/intel-isl/Open3D/pull/2876
+        message(STATUS "Set USE_SYSTEM_LIBREALSENSE=OFF, because GLIBCXX_USE_CXX11_ABI is OFF.")
+        set(USE_SYSTEM_LIBREALSENSE OFF)
+    endif()
+    if(USE_SYSTEM_LIBREALSENSE)
+        find_package(realsense2)
+        if(TARGET realsense2::realsense2)
+            message(STATUS "Using installed third-party library librealsense")
+            if(NOT BUILD_SHARED_LIBS)
+                list(APPEND Open3D_3RDPARTY_EXTERNAL_MODULES "realsense2")
+            endif()
+            set(LIBREALSENSE_TARGET  "realsense2::realsense2")
+            list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
+        else()
+            message(STATUS "Unable to find installed third-party library librealsense")
+            set(USE_SYSTEM_LIBREALSENSE OFF)
+        endif()
+    endif()
+    if(NOT USE_SYSTEM_LIBREALSENSE)
+        include(${Open3D_3RDPARTY_DIR}/librealsense/librealsense.cmake)
+        import_3rdparty_library(3rdparty_librealsense
+            INCLUDE_DIRS ${LIBREALSENSE_INCLUDE_DIR}
+            LIBRARIES    ${LIBREALSENSE_LIBRARIES}
+            LIB_DIR      ${LIBREALSENSE_LIB_DIR}
+        )
+        add_dependencies(3rdparty_librealsense ext_librealsense)
+        set(LIBREALSENSE_TARGET "3rdparty_librealsense")
+        list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
+        if (UNIX AND NOT APPLE)    # Ubuntu dependency: libudev-dev
+            find_library(UDEV_LIBRARY udev REQUIRED
+                DOC "Library provided by the deb package libudev-dev")
+            target_link_libraries(3rdparty_librealsense INTERFACE ${UDEV_LIBRARY})
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Resolves #3056

- Support USE_SYSTEM_LIBREALSENSE flag.
- If USE_SYSTEM_LIBREALSENSE=ON and BUILD_LIBREALSENSE=ON, build using pre-install librealsense.
- If GLIBCXX_USE_CXX11_ABI=ON, USE_SYSTEM_LIBREALSENSE turn OFF. This is to avoid problems with different ABIs (#2876).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3057)
<!-- Reviewable:end -->
