### PR TITLE
Replace CMake GLOB and GLOB_RECURSE with file listing

### DIFF
--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -26,6 +26,7 @@ if (WIN32)
         ext_k4a
         PREFIX k4a
         URL https://www.nuget.org/api/v2/package/Microsoft.Azure.Kinect.Sensor/1.4.1
+        URL_HASH MD5=4a6cd4ffcaab8c332d8842c94bc17c35
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -38,6 +39,7 @@ else()
         ext_k4a
         PREFIX k4a
         URL https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/libk/libk4a1.4-dev/libk4a1.4-dev_1.4.1_amd64.deb
+        URL_HASH MD5=0ee7ba01198759dcd148dc15bb7d43e8
         UPDATE_COMMAND ${CMAKE_COMMAND} -E tar xvf data.tar.gz
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/3rdparty/mkl/mkl.cmake
+++ b/3rdparty/mkl/mkl.cmake
@@ -17,12 +17,14 @@ if(WIN32)
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-include-2020.1-intel_216-win-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-include/2020.1/download/win-64/mkl-include-2020.1-intel_216.tar.bz2"
     )
+    set(MKL_INCLUDE_SHA256 65cedb770358721fd834224cd8be1fe1cc10b37ef2a1efcc899fc2fefbeb5b31)
     set_local_or_remote_url(
         MKL_URL
         LOCAL_URL   "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/mkl-static-2020.1-intel_216-win-64.tar.bz2"
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-static-2020.1-intel_216-win-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-static/2020.1/download/win-64/mkl-static-2020.1-intel_216.tar.bz2"
     )
+    set(MKL_SHA256 c6f037aa9e53501d91d5245b6e65020399ebf34174cc4d03637818ebb6e6b6b9)
 elseif(APPLE)
     set_local_or_remote_url(
         MKL_INCLUDE_URL
@@ -30,12 +32,14 @@ elseif(APPLE)
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-include-2020.1-intel_216-osx-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-include/2020.1/download/osx-64/mkl-include-2020.1-intel_216.tar.bz2"
     )
+    set(MKL_INCLUDE_SHA256 d4d025bd17ce75b92c134f70759b93ae1dee07801d33bcc59e40778003f05de5)
     set_local_or_remote_url(
         MKL_URL
         LOCAL_URL   "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/mkl-static-2020.1-intel_216-osx-64.tar.bz2"
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-static-2020.1-intel_216-osx-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-static/2020.1/download/osx-64/mkl-static-2020.1-intel_216.tar.bz2"
     )
+    set(MKL_SHA256 ca94ab8933cf58cbb7b42ac1bdc8671a948490fd1e0e9cea71a5b4d613b21be4)
 else()
     set_local_or_remote_url(
         MKL_INCLUDE_URL
@@ -43,18 +47,21 @@ else()
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-include-2020.1-intel_217-linux-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-include/2020.1/download/linux-64/mkl-include-2020.1-intel_217.tar.bz2"
     )
+    set(MKL_INCLUDE_SHA256 c0c4e7f261aa9182d811b91132c622211e55a5f3dfb8afb65a5377804f39eb61)
     set_local_or_remote_url(
         MKL_URL
         LOCAL_URL   "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/mkl-static-2020.1-intel_217-linux-64.tar.bz2"
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.12.0/mkl-static-2020.1-intel_217-linux-64.tar.bz2"
                     "https://anaconda.org/intel/mkl-static/2020.1/download/linux-64/mkl-static-2020.1-intel_217.tar.bz2"
     )
+    set(MKL_SHA256 44fe60fa895c8967fe7c70fd1b680700f23ecac6ae038b267aa0a0c48dce3d59)
     # URL for merged libmkl_merged.a for Ubuntu.
     set_local_or_remote_url(
         MKL_MERGED_URL
         LOCAL_URL   "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/linux-merged-mkl-static-2020.1-intel_217.zip"
         REMOTE_URLS "https://github.com/intel-isl/Open3D/releases/download/v0.10.0/linux-merged-mkl-static-2020.1-intel_217.zip"
     )
+    set(MKL_MERGED_SHA256 027c2b0d89c554479edbe5faecb93c26528877c1b682f939f8e1764d96860064)
 endif()
 
 # Where MKL and TBB headers and libs will be installed.
@@ -68,6 +75,7 @@ if(WIN32)
         ext_mkl_include
         PREFIX mkl_include
         URL ${MKL_INCLUDE_URL}
+        URL_HASH SHA256=${MKL_INCLUDE_SHA256}
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -77,6 +85,7 @@ if(WIN32)
         ext_mkl
         PREFIX mkl
         URL ${MKL_URL}
+        URL_HASH SHA256=${MKL_SHA256}
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -100,6 +109,7 @@ elseif(APPLE)
         ext_mkl_include
         PREFIX mkl_include
         URL ${MKL_INCLUDE_URL}
+        URL_HASH SHA256=${MKL_INCLUDE_SHA256}
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -109,6 +119,7 @@ elseif(APPLE)
         ext_mkl
         PREFIX mkl
         URL ${MKL_URL}
+        URL_HASH SHA256=${MKL_SHA256}
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -120,6 +131,7 @@ else()
         ext_mkl_include
         PREFIX mkl_include
         URL ${MKL_INCLUDE_URL}
+        URL_HASH SHA256=${MKL_INCLUDE_SHA256}
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -145,6 +157,7 @@ else()
             ext_mkl
             PREFIX mkl
             URL ${MKL_URL}
+            URL_HASH SHA256=${MKL_SHA256}
             UPDATE_COMMAND ""
             CONFIGURE_COMMAND ""
             BUILD_IN_SOURCE ON
@@ -164,6 +177,7 @@ else()
             ext_mkl
             PREFIX mkl
             URL ${MKL_MERGED_URL}
+            URL_HASH SHA256=${MKL_MERGED_SHA256}
             UPDATE_COMMAND ""
             CONFIGURE_COMMAND ""
             BUILD_IN_SOURCE ON

--- a/cpp/open3d/camera/CMakeLists.txt
+++ b/cpp/open3d/camera/CMakeLists.txt
@@ -1,5 +1,9 @@
 # build
-file(GLOB_RECURSE ALL_SOURCE_FILES "*.cpp")
+set(ALL_SOURCE_FILES
+    PinholeCameraTrajectory.cpp
+    PinholeCameraParameters.cpp
+    PinholeCameraIntrinsic.cpp
+    )
 
 # create object library
 add_library(camera OBJECT ${ALL_SOURCE_FILES})

--- a/cpp/open3d/geometry/CMakeLists.txt
+++ b/cpp/open3d/geometry/CMakeLists.txt
@@ -1,5 +1,39 @@
 # build
-file(GLOB_RECURSE ALL_SOURCE_FILES "*.cpp")
+set(ALL_SOURCE_FILES
+    BoundingVolume.cpp
+    EstimateNormals.cpp
+    Geometry3D.cpp
+    HalfEdgeTriangleMesh.cpp
+    ISSKeypoints.cpp
+    Image.cpp
+    ImageFactory.cpp
+    IntersectionTest.cpp
+    KDTreeFlann.cpp
+    Line3D.cpp
+    LineSet.cpp
+    LineSetFactory.cpp
+    MeshBase.cpp
+    Octree.cpp
+    PointCloud.cpp
+    PointCloudCluster.cpp
+    PointCloudFactory.cpp
+    PointCloudSegmentation.cpp
+    Qhull.cpp
+    RGBDImage.cpp
+    RGBDImageFactory.cpp
+    SurfaceReconstructionAlphaShape.cpp
+    SurfaceReconstructionBallPivoting.cpp
+    SurfaceReconstructionPoisson.cpp
+    TetraMesh.cpp
+    TetraMeshFactory.cpp
+    TriangleMesh.cpp
+    TriangleMeshDeformation.cpp
+    TriangleMeshFactory.cpp
+    TriangleMeshSimplification.cpp
+    TriangleMeshSubdivide.cpp
+    VoxelGrid.cpp
+    VoxelGridFactory.cpp
+    )
 
 # create object library
 add_library(geometry OBJECT ${ALL_SOURCE_FILES})

--- a/cpp/open3d/io/CMakeLists.txt
+++ b/cpp/open3d/io/CMakeLists.txt
@@ -1,15 +1,63 @@
 # Build
-file(GLOB CLASS_IO_SOURCE_FILES "*.cpp")
-file(GLOB_RECURSE FILE_FORMAT_SOURCE_FILES "file_format/*.cpp")
+set(CLASS_IO_SOURCE_FILES
+    FeatureIO.cpp
+    FileFormatIO.cpp
+    IJsonConvertibleIO.cpp
+    ImageIO.cpp
+    ImageWarpingFieldIO.cpp
+    LineSetIO.cpp
+    ModelIO.cpp
+    OctreeIO.cpp
+    PinholeCameraTrajectoryIO.cpp
+    PointCloudIO.cpp
+    PoseGraphIO.cpp
+    TriangleMeshIO.cpp
+    VoxelGridIO.cpp
+    )
+set(FILE_FORMAT_SOURCE_FILES
+    file_format/FileASSIMP.cpp
+    file_format/FileBIN.cpp
+    file_format/FileGLTF.cpp
+    file_format/FileJPG.cpp
+    file_format/FileJSON.cpp
+    file_format/FileLOG.cpp
+    file_format/FileOBJ.cpp
+    file_format/FileOFF.cpp
+    file_format/FilePCD.cpp
+    file_format/FilePLY.cpp
+    file_format/FilePNG.cpp
+    file_format/FilePTS.cpp
+    file_format/FileSTL.cpp
+    file_format/FileTUM.cpp
+    file_format/FileXYZ.cpp
+    file_format/FileXYZN.cpp
+    file_format/FileXYZRGB.cpp
+    )
 set(IO_ALL_SOURCE_FILES ${CLASS_IO_SOURCE_FILES} ${FILE_FORMAT_SOURCE_FILES})
 
 if (BUILD_AZURE_KINECT)
-    file(GLOB_RECURSE SENSOR_SOURCE_FILES "sensor/*.cpp")
+    set(SENSOR_SOURCE_FILES
+        sensor/azure_kinect/AzureKinectRecorder.cpp
+        sensor/azure_kinect/MKVMetadata.cpp
+        sensor/azure_kinect/AzureKinectSensorConfig.cpp
+        sensor/azure_kinect/MKVReader.cpp
+        sensor/azure_kinect/AzureKinectSensor.cpp
+        sensor/azure_kinect/MKVWriter.cpp
+        sensor/azure_kinect/K4aPlugin.cpp
+        )
     set(IO_ALL_SOURCE_FILES ${IO_ALL_SOURCE_FILES} ${SENSOR_SOURCE_FILES})
 endif ()
 
 if (BUILD_RPC_INTERFACE)
-    file(GLOB      RPC_SOURCE_FILES "rpc/*.cpp")
+    set(RPC_SOURCE_FILES
+        rpc/BufferConnection.cpp
+        rpc/Connection.cpp
+        rpc/DummyReceiver.cpp
+        rpc/MessageUtils.cpp
+        rpc/ReceiverBase.cpp
+        rpc/RemoteFunctions.cpp
+        rpc/ZMQContext.cpp
+        )
     set(IO_ALL_SOURCE_FILES ${IO_ALL_SOURCE_FILES} ${RPC_SOURCE_FILES})
 endif()
 

--- a/cpp/open3d/pipelines/CMakeLists.txt
+++ b/cpp/open3d/pipelines/CMakeLists.txt
@@ -1,5 +1,22 @@
-file(GLOB_RECURSE ALL_SOURCE_FILES "*.cpp")
-
+set(ALL_SOURCE_FILES
+    color_map/NonRigidOptimizer.cpp
+    color_map/ImageWarpingField.cpp
+    color_map/ColorMapUtils.cpp
+    color_map/RigidOptimizer.cpp
+    integration/UniformTSDFVolume.cpp
+    integration/ScalableTSDFVolume.cpp
+    odometry/Odometry.cpp
+    odometry/RGBDOdometryJacobian.cpp
+    registration/GlobalOptimization.cpp
+    registration/RobustKernel.cpp
+    registration/Registration.cpp
+    registration/FastGlobalRegistration.cpp
+    registration/ColoredICP.cpp
+    registration/PoseGraph.cpp
+    registration/TransformationEstimation.cpp
+    registration/CorrespondenceChecker.cpp
+    registration/Feature.cpp
+    )
 add_library(pipelines OBJECT ${ALL_SOURCE_FILES})
 open3d_show_and_abort_on_warning(pipelines)
 open3d_set_global_properties(pipelines)

--- a/cpp/open3d/utility/CMakeLists.txt
+++ b/cpp/open3d/utility/CMakeLists.txt
@@ -1,5 +1,12 @@
 # build
-file(GLOB ALL_SOURCE_FILES "*.cpp")
+set(ALL_SOURCE_FILES
+    Console.cpp
+    Eigen.cpp
+    FileSystem.cpp
+    Helper.cpp
+    IJsonConvertible.cpp
+    Timer.cpp
+    )
 
 # create object library
 add_library(utility OBJECT ${ALL_SOURCE_FILES})

--- a/cpp/open3d/visualization/gui/CMakeLists.txt
+++ b/cpp/open3d/visualization/gui/CMakeLists.txt
@@ -1,17 +1,82 @@
 # build
-file(GLOB_RECURSE GUI_SOURCE_FILES "*.cpp")
-file(GLOB_RECURSE GUI_HEADER_FILES "*.h")
+set(GUI_SOURCE_FILES
+    Application.cpp
+    Button.cpp
+    Checkbox.cpp
+    Color.cpp
+    ColorEdit.cpp
+    Combobox.cpp
+    Dialog.cpp
+    FileDialog.cpp
+    FileDialogNative.cpp
+    Gui.cpp
+    ImageLabel.cpp
+    ImguiFilamentBridge.cpp
+    Label.cpp
+    Label3D.cpp
+    Layout.cpp
+    ListView.cpp
+    Menu.cpp
+    NumberEdit.cpp
+    PickPointsInteractor.cpp
+    ProgressBar.cpp
+    SceneWidget.cpp
+    Slider.cpp
+    StackedWidget.cpp
+    TabControl.cpp
+    Task.cpp
+    TextEdit.cpp
+    Theme.cpp
+    TreeView.cpp
+    UIImage.cpp
+    Util.cpp
+    VectorEdit.cpp
+    Widget.cpp
+    Window.cpp
+    )
+set(GUI_HEADER_FILES
+    Application.h
+    Button.h
+    Checkbox.h
+    Color.h
+    ColorEdit.h
+    Combobox.h
+    Dialog.h
+    Events.h
+    FileDialog.h
+    Gui.h
+    ImageLabel.h
+    ImguiFilamentBridge.h
+    Label.h
+    Label3D.h
+    Layout.h
+    ListView.h
+    Menu.h
+    NumberEdit.h
+    PickPointsInteractor.h
+    ProgressBar.h
+    SceneWidget.h
+    Slider.h
+    StackedWidget.h
+    TabControl.h
+    Task.h
+    TextEdit.h
+    Theme.h
+    TreeView.h
+    UIImage.h
+    Util.h
+    VectorEdit.h
+    Widget.h
+    Window.h
+    )
 
-list(REMOVE_ITEM GUI_HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Native.h)
 if (WIN32)
-    list(REMOVE_ITEM GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/NativeLinux.cpp)
+    list(APPEND GUI_SOURCE_FILES NativeWin32.cpp)
 elseif (APPLE)
-    list(REMOVE_ITEM GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/NativeWin32.cpp)
-    list(REMOVE_ITEM GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/NativeLinux.cpp)
-    list(APPEND GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/NativeMacOS.mm)
-    list(APPEND GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/MenuMacOS.mm)
+    list(APPEND GUI_SOURCE_FILES NativeMacOS.mm)
+    list(APPEND GUI_SOURCE_FILES MenuMacOS.mm)
 else ()
-    list(REMOVE_ITEM GUI_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/NativeWin32.cpp)
+    list(APPEND GUI_SOURCE_FILES NativeLinux.cpp)
 endif()
 
 # create object library
@@ -56,4 +121,3 @@ set(GUI_RESOURCE_FILES
     ${GUI_RESOURCE_SOURCE_FILES} ${GUI_MATERIAL_COMPILED_FILES}
     PARENT_SCOPE)
 set(GUI_RESOURCE_DIR ${GUI_RESOURCE_DIR} PARENT_SCOPE)
-

--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -41,26 +41,87 @@ endif()
 
 set(PACKAGE_NAME pybind)
 
-file(GLOB_RECURSE PY_ALL_SOURCE_FILES "*.cpp")
+set(PY_ALL_SOURCE_FILES
+    camera/camera.cpp
+    core/hashmap.cpp
+    core/tensor_converter.cpp
+    core/linalg.cpp
+    core/kernel.cpp
+    core/core.cpp
+    core/tensor_accessor.cpp
+    core/blob.cpp
+    core/device.cpp
+    core/size_vector.cpp
+    core/cuda_utils.cpp
+    core/tensor.cpp
+    core/nns/nearest_neighbor_search.cpp
+    core/dtype.cpp
+    docstring.cpp
+    geometry/pointcloud.cpp
+    geometry/trianglemesh.cpp
+    geometry/voxelgrid.cpp
+    geometry/tetramesh.cpp
+    geometry/geometry.cpp
+    geometry/image.cpp
+    geometry/keypoint.cpp
+    geometry/kdtreeflann.cpp
+    geometry/lineset.cpp
+    geometry/boundingvolume.cpp
+    geometry/octree.cpp
+    geometry/meshbase.cpp
+    geometry/halfedgetrianglemesh.cpp
+    io/io.cpp
+    io/class_io.cpp
+    ml/ml.cpp
+    ml/contrib/contrib.cpp
+    ml/contrib/iou.cpp
+    ml/contrib/contrib_subsample.cpp
+    ml/contrib/contrib_nns.cpp
+    open3d_pybind.cpp
+    pipelines/registration/registration.cpp
+    pipelines/registration/global_optimization.cpp
+    pipelines/registration/robust_kernels.cpp
+    pipelines/registration/feature.cpp
+    pipelines/pipelines.cpp
+    pipelines/integration/integration.cpp
+    pipelines/color_map/color_map.cpp
+    pipelines/odometry/odometry.cpp
+    pybind_utils.cpp
+    t/t.cpp
+    t/io/io.cpp
+    t/io/sensor.cpp
+    t/io/class_io.cpp
+    t/geometry/pointcloud.cpp
+    t/geometry/trianglemesh.cpp
+    t/geometry/geometry.cpp
+    t/geometry/image.cpp
+    t/geometry/tensormap.cpp
+    t/geometry/tsdf_voxelgrid.cpp
+    utility/console.cpp
+    utility/eigen.cpp
+    utility/utility.cpp
+    visualization/visualizer.cpp
+    visualization/visualization.cpp
+    visualization/renderoption.cpp
+    visualization/viewcontrol.cpp
+    visualization/utility.cpp
+    )
 
-if (NOT BUILD_GUI)
-    list(REMOVE_ITEM PY_ALL_SOURCE_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/visualization/gui/gui.cpp")
-    list(REMOVE_ITEM PY_ALL_SOURCE_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/visualization/rendering/rendering.cpp")
-    list(REMOVE_ITEM PY_ALL_SOURCE_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/visualization/o3dvisualizer.cpp")
-endif()
-
-if (NOT BUILD_AZURE_KINECT)
-    list(REMOVE_ITEM PY_ALL_SOURCE_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/io/sensor.cpp")
-endif()
-
-if (NOT BUILD_RPC_INTERFACE)
-    list(REMOVE_ITEM PY_ALL_SOURCE_FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/io/rpc.cpp"
+if (BUILD_GUI)
+    list(APPEND PY_ALL_SOURCE_FILES
+        visualization/gui/gui.cpp
+        visualization/gui/events.cpp
+        visualization/rendering/rendering.cpp
+        visualization/o3dvisualizer.cpp
         )
+endif()
+
+if (BUILD_AZURE_KINECT)
+    list(APPEND PY_ALL_SOURCE_FILES io/sensor.cpp)
+endif()
+
+if (BUILD_RPC_INTERFACE)
+    list(APPEND PY_ALL_SOURCE_FILES io/rpc.cpp)
 endif()
 
 # NO_EXTRAS disables LTO which causes problems during link with nvcc 9.x

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -8,33 +8,123 @@ endif()
 include_directories(".")
 
 file(GLOB_RECURSE UNIT_TEST_SOURCE_FILES "*.cpp")
+set(UNIT_TEST_SOURCE_FILES
+    Main.cpp
+    camera/PinholeCameraTrajectory.cpp
+    camera/PinholeCameraParameters.cpp
+    camera/PinholeCameraIntrinsic.cpp
+    core/Indexer.cpp
+    core/Hashmap.cpp
+    core/Linalg.cpp
+    core/NearestNeighborSearch.cpp
+    core/CUDAState.cpp
+    core/Blob.cpp
+    core/Scalar.cpp
+    core/TensorList.cpp
+    core/Device.cpp
+    core/TensorObject.cpp
+    core/NanoFlannIndex.cpp
+    core/ShapeUtil.cpp
+    core/MemoryManager.cpp
+    core/Tensor.cpp
+    core/SizeVector.cpp
+    geometry/PointCloud.cpp
+    geometry/TriangleMesh.cpp
+    geometry/VoxelGrid.cpp
+    geometry/TetraMesh.cpp
+    geometry/Image.cpp
+    geometry/KDTreeFlann.cpp
+    geometry/LineSet.cpp
+    geometry/RGBDImage.cpp
+    geometry/IntersectionTest.cpp
+    geometry/EstimateNormals.cpp
+    geometry/Line3D.cpp
+    geometry/Octree.cpp
+    geometry/HalfEdgeTriangleMesh.cpp
+    geometry/AccumulatedPoint.cpp
+    io/TriangleMeshIO.cpp
+    io/IJsonConvertibleIO.cpp
+    io/PointCloudIO.cpp
+    io/file_format/FileSTL.cpp
+    io/file_format/FileJSON.cpp
+    io/file_format/FileLOG.cpp
+    io/file_format/FileBIN.cpp
+    io/file_format/FilePCD.cpp
+    io/file_format/FileJPG.cpp
+    io/file_format/FilePNG.cpp
+    io/file_format/FilePLY.cpp
+    io/file_format/FileXYZRGB.cpp
+    io/file_format/FilePTS.cpp
+    io/file_format/FileGLTF.cpp
+    io/file_format/FileXYZ.cpp
+    io/file_format/FileXYZN.cpp
+    io/PinholeCameraTrajectoryIO.cpp
+    io/PoseGraphIO.cpp
+    io/ImageIO.cpp
+    io/OctreeIO.cpp
+    io/VoxelGridIO.cpp
+    io/FeatureIO.cpp
+    ml/ShapeChecking.cpp
+    pipelines/registration/GlobalOptimization.cpp
+    pipelines/registration/Registration.cpp
+    pipelines/registration/FastGlobalRegistration.cpp
+    pipelines/registration/ColoredICP.cpp
+    pipelines/registration/PoseGraph.cpp
+    pipelines/registration/TransformationEstimation.cpp
+    pipelines/registration/CorrespondenceChecker.cpp
+    pipelines/registration/GlobalOptimizationConvergenceCriteria.cpp
+    pipelines/registration/Feature.cpp
+    pipelines/integration/UniformTSDFVolume.cpp
+    pipelines/integration/ScalableTSDFVolume.cpp
+    pipelines/odometry/OdometryTools.cpp
+    pipelines/odometry/RGBDOdometryJacobianFromColorTerm.cpp
+    pipelines/odometry/RGBDOdometryJacobianFromHybridTerm.cpp
+    pipelines/odometry/Odometry.cpp
+    pipelines/odometry/OdometryOption.cpp
+    t/io/PointCloudIO.cpp
+    t/io/ImageIO.cpp
+    t/pipelines/registration/Registration.cpp
+    t/pipelines/registration/TransformationEstimation.cpp
+    t/pipelines/TransformationConverter.cpp
+    t/geometry/PointCloud.cpp
+    t/geometry/TriangleMesh.cpp
+    t/geometry/Image.cpp
+    t/geometry/TensorMap.cpp
+    t/geometry/TSDFVoxelGrid.cpp
+    test_utility/Compare.cpp
+    test_utility/Sort.cpp
+    test_utility/Raw.cpp
+    test_utility/Rand.cpp
+    utility/Console.cpp
+    utility/Timer.cpp
+    utility/Helper.cpp
+    utility/FileSystem.cpp
+    utility/Eigen.cpp
+    utility/IJsonConvertible.cpp
+    )
 
-# TODO: consider explicitly listing the files
-if (NOT BUILD_AZURE_KINECT)
-    set (EXCLUDE_DIR "io/sensor")
-    foreach (TMP_PATH ${UNIT_TEST_SOURCE_FILES})
-        string (FIND ${TMP_PATH} ${EXCLUDE_DIR} EXCLUDE_DIR_FOUND)
-        if (NOT ${EXCLUDE_DIR_FOUND} EQUAL -1)
-            list (REMOVE_ITEM UNIT_TEST_SOURCE_FILES ${TMP_PATH})
-        endif ()
-    endforeach(TMP_PATH)
+if (BUILD_AZURE_KINECT)
+    list(APPEND UNIT_TEST_SOURCE_FILES
+        io/sensor/AzureKinect/AzureKinectSensorConfig.cpp
+        )
 endif()
 
-# TODO: handle conditional compilation more systematically
-if (NOT BUILD_GUI)
-    list(FILTER UNIT_TEST_SOURCE_FILES EXCLUDE REGEX .*/visualization/rendering/.*cpp)
+if (BUILD_GUI)
+    list(APPEND UNIT_TEST_SOURCE_FILES
+        visualization/rendering/MaterialModifier.cpp
+    )
 endif()
 
-if (NOT BUILD_RPC_INTERFACE)
-    list(FILTER UNIT_TEST_SOURCE_FILES EXCLUDE REGEX .*/io/rpc/RemoteFunctions.cpp)
+if (BUILD_RPC_INTERFACE)
+    list(APPEND UNIT_TEST_SOURCE_FILES io/rpc/RemoteFunctions.cpp)
 endif()
 
-if (NOT BUILD_CUDA_MODULE)
-    list(FILTER UNIT_TEST_SOURCE_FILES EXCLUDE REGEX .*/core/FixedRadiusIndex.cpp)
+if (BUILD_CUDA_MODULE)
+    list(APPEND UNIT_TEST_SOURCE_FILES core/FixedRadiusIndex.cpp)
 endif()
 
-if (NOT WITH_FAISS)
-    list(FILTER UNIT_TEST_SOURCE_FILES EXCLUDE REGEX .*/core/FaissIndex.cpp)
+if (WITH_FAISS)
+    list(APPEND UNIT_TEST_SOURCE_FILES core/FaissIndex.cpp)
 endif()
 
 add_executable(tests ${UNIT_TEST_SOURCE_FILES})

--- a/cpp/tools/ManuallyAlignPointCloud/CMakeLists.txt
+++ b/cpp/tools/ManuallyAlignPointCloud/CMakeLists.txt
@@ -1,5 +1,12 @@
-file(GLOB HEADER_FILES "*.h")
-file(GLOB SOURCE_FILES "*.cpp")
+set(HEADER_FILES
+    AlignmentSession.h
+    VisualizerForAlignment.h
+    )
+set(SOURCE_FILES
+    AlignmentSession.cpp
+    ManuallyAlignPointCloud.cpp
+    VisualizerForAlignment.cpp
+    )
 
 include_directories(".")
 


### PR DESCRIPTION
- Simplifies logic => less chance of errors for conditional compilation.
- Explicitly listing files to be built reduces accidental exclusion of files from the build.

[StackOverflow discussion](https://stackoverflow.com/questions/1027247/is-it-better-to-specify-source-files-with-glob-or-each-file-individually-in-cmak)

GLOBS for macros, GUI resources and style checks are unchanged.

Contributors: Please list unit test files, pybind files, other source files explicitly in CMakeLists.txt from now onwards.

Added URL hashes for MKL and AzureKinect downloads to prevent re-download during rebuild.  Fixes #2989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3059)
<!-- Reviewable:end -->
