### PR TITLE
GCE CUDA Python tests

### DIFF
--- a/.github/workflows/gce-ubuntu-docker.yml
+++ b/.github/workflows/gce-ubuntu-docker.yml
@@ -59,16 +59,13 @@ jobs:
           project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: GCloud setup for docker
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh gcloud-setup
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh gcloud-setup
 
       - name: Build docker image
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-build
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-build
 
       - name: Push the Docker image to Google Container Registry
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-push
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh docker-push
 
 
   build-install-test:
@@ -80,7 +77,8 @@ jobs:
       fail-fast: false
       max-parallel: 4     # Limit parallel runs to max GPU quota (4)
       matrix:
-        CI_CONFIG_ID: [2, 3, 4, 5]   # See gce-ubuntu-docker-run.sh for details. These need GPU.
+        # See gce-ubuntu-docker-run.sh for details. These need GPU.
+        CI_CONFIG_ID: ['2-bionic', '3-ML-bionic', '4-ML-RPC-bionic', '5-ML-RPC-focal']
 
     env:
       CI_CONFIG_ID: ${{ matrix.CI_CONFIG_ID }}
@@ -103,13 +101,11 @@ jobs:
           ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh create-vm
 
       - name: Config, build and run unit tests
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-ci
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh run-ci
 
       - name: Delete VM
         if: always()
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-vm
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-vm
 
   cleanup:
     name: Clean-up container image
@@ -137,5 +133,4 @@ jobs:
           project_id: ${{ secrets.GCE_PROJECT }}
 
       - name: Delete container image
-        run: |
-          ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-image
+        run: ./util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh delete-image

--- a/python/open3d/ml/torch/__init__.py
+++ b/python/open3d/ml/torch/__init__.py
@@ -73,7 +73,6 @@ for _lp in _lib_path:
         _loaded = True
         break
     except Exception as ex:
-        print(repr(ex))  # Debug
         _load_except = ex
         if not _os.path.isfile(_lp):
             print('The op library at "{}" was not found. Make sure that '

--- a/python/open3d/ml/torch/__init__.py
+++ b/python/open3d/ml/torch/__init__.py
@@ -73,6 +73,7 @@ for _lp in _lib_path:
         _loaded = True
         break
     except Exception as ex:
+        print(repr(ex))  # Debug
         _load_except = ex
         if not _os.path.isfile(_lp):
             print('The op library at "{}" was not found. Make sure that '

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -321,6 +321,7 @@ build_pip_conda_package() {
 # Test wheel in blank virtual environment
 # Usage: test_wheel wheel_path
 test_wheel() {
+    set -x
     wheel_path="$1"
     python -m venv open3d_test.venv
     source open3d_test.venv/bin/activate
@@ -339,6 +340,10 @@ test_wheel() {
     #     find "$DLL_PATH"/cpu/ -type f -execdir otool -L {} \;
     # fi
     echo
+    # Get 3DML requirements from github if Open3D-ML repo is not available
+    set +u
+    OPEN3D_ML_ROOT=${OPEN3D_ML_ROOT:-"https://raw.githubusercontent.com/intel-isl/Open3D-ML/master"}
+    set -u
     if [ "$BUILD_PYTORCH_OPS" == ON ]; then
         python -m pip install -r "$OPEN3D_ML_ROOT/requirements-torch.txt"
         python -c \

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -346,7 +346,11 @@ test_wheel() {
     set -u
     ls -R $(dirname $(python -c "import open3d as o3d; print(o3d.__file__)")) # debug
     if [ "$BUILD_PYTORCH_OPS" == ON ]; then
-        python -m pip install -r "$OPEN3D_ML_ROOT/requirements-torch.txt"
+        if [ "$BUILD_CUDA_MODULE" == ON ]; then
+            python -m pip install -r "$OPEN3D_ML_ROOT/requirements-torch-cuda.txt"
+        else
+            python -m pip install -r "$OPEN3D_ML_ROOT/requirements-torch.txt"
+        fi
         python -c \
             "import open3d.ml.torch; print('PyTorch Ops library loaded:', open3d.ml.torch._loaded)"
     fi

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -344,6 +344,7 @@ test_wheel() {
     set +u
     OPEN3D_ML_ROOT=${OPEN3D_ML_ROOT:-"https://raw.githubusercontent.com/intel-isl/Open3D-ML/master"}
     set -u
+    ls -R $(dirname $(python -c "import open3d as o3d; print(o3d.__file__)")) # debug
     if [ "$BUILD_PYTORCH_OPS" == ON ]; then
         python -m pip install -r "$OPEN3D_ML_ROOT/requirements-torch.txt"
         python -c \
@@ -360,7 +361,9 @@ test_wheel() {
         echo "importing in the normal order"
         python -c "import open3d.ml.torch as o3d; import tensorflow as tf"
     fi
+    set +u
     deactivate
+    set -u
 }
 
 # Run in virtual environment
@@ -374,7 +377,9 @@ run_python_tests() {
         pytest_args+=(--ignore "$OPEN3D_SOURCE_ROOT"/python/test/ml_ops/)
     fi
     python -m pytest "${pytest_args[@]}"
+    set +u
     deactivate
+    set -u
 }
 
 # Use: run_unit_tests

--- a/util/docker/open3d-gpu/scripts/env-setup.sh
+++ b/util/docker/open3d-gpu/scripts/env-setup.sh
@@ -12,7 +12,8 @@ UBUNTU_VERSION=${UBUNTU_VERSION:="$(lsb_release -cs)"} # Empty in macOS
 $SUDO apt-get update
 $SUDO apt-get --yes install git software-properties-common
 echo "Installing Python3 and setting as default python"
-$SUDO apt-get --yes --no-install-recommends install python3 python3-pip python3-setuptools
+$SUDO apt-get --yes --no-install-recommends install python3 python3-pip \
+    python3-setuptools python3-venv
 if ! which python || python -V 2>/dev/null | grep -q ' 2.'; then
     echo 'Making python3 the default python'
     $SUDO ln -s /usr/bin/python3 /usr/local/bin/python

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -13,6 +13,7 @@ set -e
 # GITHUB_SHA
 ## CI test matrix:
 CI_CONFIG_ID=${CI_CONFIG_ID:=0}
+CI_CONFIG_ID=${CI_CONFIG_ID%%-*} # '3-ML-bionic' -> '3'
 
 # CI configuration specification
 SHARED=(OFF ON OFF ON OFF OFF)

--- a/util/run_ci.sh
+++ b/util/run_ci.sh
@@ -19,29 +19,20 @@ else
     install_python_dependencies with-unit-test purge-cache
 fi
 
-echo "using python: $(which python)"
-python --version
-echo -n "Using pip: "
-python -m pip --version
-echo -n "Using pytest:"
-python -m pytest --version
-echo "using cmake: $(which cmake)"
-cmake --version
-
 build_all
 
 echo "Building examples iteratively..."
 make VERBOSE=1 -j"$NPROC" build-examples-iteratively
 echo
 
-echo "running Open3D C++ unit tests..."
+echo "Running Open3D C++ unit tests..."
 run_cpp_unit_tests
 
 # Run on GPU only. CPU versions run on Github already
 if nvidia-smi 2>&1 >/dev/null; then
-    echo "try importing Open3D Python package"
+    echo "Try importing Open3D Python package"
     test_wheel lib/python_package/pip_package/open3d*.whl
-    echo "running Open3D Python tests..."
+    echo "Running Open3D Python tests..."
     run_python_tests
     echo
 fi
@@ -50,5 +41,5 @@ echo "Test building a C++ example with installed Open3D..."
 test_cpp_example "${runExample:=ON}"
 echo
 
-echo "test uninstalling Open3D..."
+echo "Test uninstalling Open3D..."
 make uninstall


### PR DESCRIPTION
Python unit tests were failing in GCE. Issues identified and fixed:
- Change in Nvidia driver version in the host VM image to prepare for upgrade to CUDA-11.0.
- CPU version of PyTorch during Python tests -> CUDA PyTorch.
- Python unit tests now run in virtual env, as in Github.
- The CI config IDs now have meaningful names instead of just numbers.
- Minor formatting fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3063)
<!-- Reviewable:end -->
