### PR TITLE
Add disconnection function to AzureKinectSensor (#3044)

### DIFF
--- a/cpp/open3d/io/sensor/azure_kinect/AzureKinectSensor.cpp
+++ b/cpp/open3d/io/sensor/azure_kinect/AzureKinectSensor.cpp
@@ -42,10 +42,7 @@ AzureKinectSensor::AzureKinectSensor(
         const AzureKinectSensorConfig &sensor_config)
     : RGBDSensor(), sensor_config_(sensor_config) {}
 
-AzureKinectSensor::~AzureKinectSensor() {
-    k4a_plugin::k4a_device_stop_cameras(device_);
-    k4a_plugin::k4a_device_close(device_);
-}
+AzureKinectSensor::~AzureKinectSensor() { Disconnect(); }
 
 bool AzureKinectSensor::Connect(size_t sensor_index) {
     utility::LogInfo("AzureKinectSensor::Connect");
@@ -100,7 +97,7 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
     if (K4A_FAILED(k4a_plugin::k4a_device_start_cameras(device_,
                                                         &device_config))) {
         utility::LogWarning(
-                "Runtime error: k4a_plugin::k4a_device_set_color_control() "
+                "Runtime error: k4a_plugin::k4a_device_start_cameras() "
                 "failed");
         k4a_plugin::k4a_device_close(device_);
         return false;
@@ -126,6 +123,11 @@ bool AzureKinectSensor::Connect(size_t sensor_index) {
             k4a_plugin::k4a_transformation_create(&calibration);
 
     return true;
+}
+
+void AzureKinectSensor::Disconnect() {
+    k4a_plugin::k4a_device_stop_cameras(device_);
+    k4a_plugin::k4a_device_close(device_);
 }
 
 k4a_capture_t AzureKinectSensor::CaptureRawFrame() const {

--- a/cpp/open3d/io/sensor/azure_kinect/AzureKinectSensor.h
+++ b/cpp/open3d/io/sensor/azure_kinect/AzureKinectSensor.h
@@ -57,6 +57,7 @@ public:
     ~AzureKinectSensor();
 
     bool Connect(size_t sensor_index) override;
+    void Disconnect();
     std::shared_ptr<geometry::RGBDImage> CaptureFrame(
             bool enable_align_depth_to_color) const override;
 

--- a/cpp/pybind/io/sensor.cpp
+++ b/cpp/pybind/io/sensor.cpp
@@ -83,6 +83,8 @@ void pybind_sensor(py::module &m) {
     azure_kinect_sensor
             .def("connect", &AzureKinectSensor::Connect, "sensor_index"_a,
                  "Connect to specified device.")
+            .def("disconnect", &AzureKinectSensor::Disconnect,
+                 "Disconnect from the connected device.")
             .def("capture_frame", &AzureKinectSensor::CaptureFrame,
                  "enable_align_depth_to_color"_a, "Capture an RGBD frame.")
             .def_static("list_devices", &AzureKinectSensor::ListDevices,


### PR DESCRIPTION
This PR add `disconnect` method to AzureKinectSensor class. (required by #3044).
The method give user more flexible control to disconnect sensor.

For the test procedure. I prepared manual test.
For the test, please connect azure kinect to your PC, run this script for the manual test,
and check if all the assertion passed.

```py
import open3d as o3d

config = o3d.io.AzureKinectSensorConfig()
sensor = o3d.io.AzureKinectSensor(config)

assert(sensor.connect(0))
assert(not sensor.connect(0))
sensor.disconnect()
assert(sensor.connect(0))
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3082)
<!-- Reviewable:end -->
