### PR TITLE
Set post-processing configuration when copying View settings

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
@@ -288,6 +288,7 @@ void FilamentView::ConfigureForColorPicking() {
     SetPostProcessing(false);
     SetAmbientOcclusion(false, false);
     SetShadowing(false, ShadowType::kPCF);
+    configured_for_picking_ = true;
 }
 
 void FilamentView::EnableViewCaching(bool enable) {
@@ -335,10 +336,12 @@ Camera* FilamentView::GetCamera() const { return camera_.get(); }
 void FilamentView::CopySettingsFrom(const FilamentView& other) {
     SetMode(other.mode_);
     view_->setRenderTarget(nullptr);
-
     auto vp = other.view_->getViewport();
     SetViewport(0, 0, vp.width, vp.height);
     camera_->CopyFrom(other.camera_.get());
+    if (other.configured_for_picking_) {
+        ConfigureForColorPicking();
+    }
 }
 
 void FilamentView::SetScene(FilamentScene& scene) {

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.h
@@ -107,6 +107,7 @@ private:
     Mode mode_ = Mode::Color;
     TargetBuffers discard_buffers_;
     bool caching_enabled_ = false;
+    bool configured_for_picking_ = false;
     TextureHandle color_buffer_;
     TextureHandle depth_buffer_;
     RenderTargetHandle render_target_;


### PR DESCRIPTION
Fixes issue with picking and new render targets based scene caching

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3083)
<!-- Reviewable:end -->
