### PR TITLE
Fix crash if posted Window callback executes after Window is destroyed

### DIFF
--- a/cpp/open3d/visualization/gui/Application.cpp
+++ b/cpp/open3d/visualization/gui/Application.cpp
@@ -588,6 +588,19 @@ Application::RunStatus Application::ProcessQueuedEvents(EnvUnlocker &unlocker) {
         unlocker.relock();
 
         for (auto &p : impl_->posted_) {
+            // Make sure this window still exists. Unfortunately, p.window
+            // is a pointer but impl_->windows_ is a shared_ptr, so we can't
+            // use find.
+            if (p.window) {
+                bool found = false;
+                for (auto w : impl_->windows_) {
+                    if (w.get() == p.window) {
+                        found = true;
+                    }
+                }
+                if (!found) { continue; }
+            }
+
             void *old = nullptr;
             if (p.window) {
                 old = p.window->MakeDrawContextCurrent();

--- a/cpp/open3d/visualization/gui/Application.cpp
+++ b/cpp/open3d/visualization/gui/Application.cpp
@@ -598,7 +598,9 @@ Application::RunStatus Application::ProcessQueuedEvents(EnvUnlocker &unlocker) {
                         found = true;
                     }
                 }
-                if (!found) { continue; }
+                if (!found) {
+                    continue;
+                }
             }
 
             void *old = nullptr;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3084)
<!-- Reviewable:end -->
