### PR TITLE
Spelling error within documentation

### DIFF
--- a/docs/contribute/contribution_recipes.rst
+++ b/docs/contribute/contribution_recipes.rst
@@ -237,7 +237,7 @@ Case 2: When documenting Python bindings
                    ":meth:`open3d.Calculator.add` is "
                    "commutative.",
                                 "a"_a, "b"_a);
-    calculator.def("sub", &Calculator::Add, "Substracts ``b`` from ``a``", "a"_a,
+    calculator.def("sub", &Calculator::Add, "Subtracts ``b`` from ``a``", "a"_a,
                                 "b"_a);
     docstring::ClassMethodDocInject(m, "Calculator", "add",
                                     {{"a", "LHS operand for summation."},


### PR DESCRIPTION
Reading through the documentation and noticed a small spelling error in the documentation for contributions so I have amended it fo you in an effort to practice with GitHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3088)
<!-- Reviewable:end -->
