### PR TITLE
Changed t-registration unit-test to use RegistrationPermuteDevices

### DIFF
--- a/cpp/tests/t/pipelines/registration/Registration.cpp
+++ b/cpp/tests/t/pipelines/registration/Registration.cpp
@@ -46,12 +46,6 @@ INSTANTIATE_TEST_SUITE_P(
         RegistrationPermuteDevicePairs,
         testing::ValuesIn(RegistrationPermuteDevicePairs::TestCases()));
 
-class RegistrationPermuteDevicesWithFaiss : public PermuteDevicesWithFaiss {};
-INSTANTIATE_TEST_SUITE_P(
-        Registration,
-        RegistrationPermuteDevicesWithFaiss,
-        testing::ValuesIn(PermuteDevicesWithFaiss::TestCases()));
-
 TEST_P(RegistrationPermuteDevices, ICPConvergenceCriteriaConstructor) {
     core::Device device = GetParam();
     core::Dtype dtype = core::Dtype::Float32;
@@ -81,7 +75,7 @@ TEST_P(RegistrationPermuteDevices, RegistrationResultConstructor) {
               init_trans_t.ToFlatVector<float>());
 }
 
-TEST_P(RegistrationPermuteDevicesWithFaiss, EvaluateRegistration) {
+TEST_P(RegistrationPermuteDevices, EvaluateRegistration) {
     core::Device device = GetParam();
     core::Dtype dtype = core::Dtype::Float32;
 
@@ -146,7 +140,7 @@ TEST_P(RegistrationPermuteDevicesWithFaiss, EvaluateRegistration) {
     EXPECT_NEAR(evaluation_t.inlier_rmse_, evaluation_l.inlier_rmse_, 0.0005);
 }
 
-TEST_P(RegistrationPermuteDevicesWithFaiss, RegistrationICPPointToPoint) {
+TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPoint) {
     core::Device device = GetParam();
     core::Dtype dtype = core::Dtype::Float32;
 
@@ -212,7 +206,7 @@ TEST_P(RegistrationPermuteDevicesWithFaiss, RegistrationICPPointToPoint) {
     EXPECT_NEAR(reg_p2p_t.inlier_rmse_, reg_p2p_l.inlier_rmse_, 0.0005);
 }
 
-TEST_P(RegistrationPermuteDevicesWithFaiss, RegistrationICPPointToPlane) {
+TEST_P(RegistrationPermuteDevices, RegistrationICPPointToPlane) {
     core::Device device = GetParam();
     core::Dtype dtype = core::Dtype::Float32;
 


### PR DESCRIPTION
In PR #2979, The unit-test for t-registrations that require Faiss were disabled if build with `WITH_FAISS=OFF`. 
However, the updated HybridSearch uses `fixed_radius_search` instead of `knn_search`, so it might not be using FAISS anymore. 
If that's the case we may change the unit test back to run with `RegistrationPermuteDevices` instead of `RegistrationPermuteDevicesWithFaiss`. As for system build with `FAISS=OFF` and `CUDA=ON`, this might be potentially harmful. 

Seeking confirmation from @junha-l.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3095)
<!-- Reviewable:end -->
