### PR TITLE
TransformConverter supports Float32 and Float64 

### DIFF
--- a/cpp/open3d/core/CoreUtil.h
+++ b/cpp/open3d/core/CoreUtil.h
@@ -33,10 +33,10 @@ namespace core {
 
 #define DISPATCH_FLOAT32_FLOAT64_DTYPE(DTYPE, ...)       \
     [&] {                                                \
-        if (DTYPE == Dtype::Float32) {                   \
+        if (DTYPE == core::Dtype::Float32) {             \
             using scalar_t = float;                      \
             return __VA_ARGS__();                        \
-        } else if (DTYPE == Dtype::Float64) {            \
+        } else if (DTYPE == core::Dtype::Float64) {      \
             using scalar_t = double;                     \
             return __VA_ARGS__();                        \
         } else {                                         \

--- a/cpp/open3d/core/CoreUtil.h
+++ b/cpp/open3d/core/CoreUtil.h
@@ -28,21 +28,15 @@
 
 #include "open3d/utility/Console.h"
 
-namespace open3d {
-namespace core {
-
-#define DISPATCH_FLOAT32_FLOAT64_DTYPE(DTYPE, ...)       \
-    [&] {                                                \
-        if (DTYPE == core::Dtype::Float32) {             \
-            using scalar_t = float;                      \
-            return __VA_ARGS__();                        \
-        } else if (DTYPE == core::Dtype::Float64) {      \
-            using scalar_t = double;                     \
-            return __VA_ARGS__();                        \
-        } else {                                         \
-            utility::LogError("Unsupported data type."); \
-        }                                                \
+#define DISPATCH_FLOAT32_FLOAT64_DTYPE(DTYPE, ...)          \
+    [&] {                                                   \
+        if (DTYPE == open3d::core::Dtype::Float32) {        \
+            using scalar_t = float;                         \
+            return __VA_ARGS__();                           \
+        } else if (DTYPE == open3d::core::Dtype::Float64) { \
+            using scalar_t = double;                        \
+            return __VA_ARGS__();                           \
+        } else {                                            \
+            utility::LogError("Unsupported data type.");    \
+        }                                                   \
     }()
-
-}  // namespace core
-}  // namespace open3d

--- a/cpp/open3d/core/linalg/LU.cpp
+++ b/cpp/open3d/core/linalg/LU.cpp
@@ -34,7 +34,7 @@ namespace open3d {
 namespace core {
 
 // Get column permutation tensor from ipiv (swaping index array).
-inline core::Tensor GetColPermutation(const Tensor& ipiv,
+static core::Tensor GetColPermutation(const Tensor& ipiv,
                                       int number_of_indices,
                                       int number_of_rows) {
     Tensor full_ipiv = Tensor::Arange(0, number_of_rows, 1, core::Dtype::Int32,
@@ -54,7 +54,7 @@ inline core::Tensor GetColPermutation(const Tensor& ipiv,
 }
 
 // Decompose output in P, L, U matrix form.
-inline void OutputToPLU(const Tensor& output,
+static void OutputToPLU(const Tensor& output,
                         Tensor& permutation,
                         Tensor& lower,
                         Tensor& upper,

--- a/cpp/open3d/core/linalg/Tri.cpp
+++ b/cpp/open3d/core/linalg/Tri.cpp
@@ -32,7 +32,7 @@
 namespace open3d {
 namespace core {
 
-inline void CheckInput(const Tensor& A, const int diagonal) {
+static void CheckInput(const Tensor& A, const int diagonal) {
     // Check dimensions.
     SizeVector A_shape = A.GetShape();
     if (A_shape.size() != 2) {

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverter.cpp
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverter.cpp
@@ -28,8 +28,10 @@
 
 #include <cmath>
 
+#include "open3d/core/CoreUtil.h"
 #include "open3d/core/Tensor.h"
 #include "open3d/t/pipelines/kernel/TransformationConverterImpl.h"
+#include "open3d/utility/Console.h"
 
 namespace open3d {
 namespace t {
@@ -37,8 +39,16 @@ namespace pipelines {
 namespace kernel {
 
 core::Tensor RtToTransformation(const core::Tensor &R, const core::Tensor &t) {
-    core::Dtype dtype = core::Dtype::Float32;
     core::Device device = R.GetDevice();
+    core::Dtype dtype = R.GetDtype();
+
+    if (dtype != core::Dtype::Float32 && dtype != core::Dtype::Float64) {
+        utility::LogError(
+                " [RtToTransformation]: Only Float32 abd Float64 supported, "
+                "but got {} ",
+                dtype.ToString());
+    }
+
     core::Tensor transformation = core::Tensor::Zeros({4, 4}, dtype, device);
     R.AssertShape({3, 3});
     R.AssertDtype(dtype);
@@ -60,29 +70,39 @@ core::Tensor RtToTransformation(const core::Tensor &R, const core::Tensor &t) {
 }
 
 core::Tensor PoseToTransformation(const core::Tensor &pose) {
-    core::Dtype dtype = core::Dtype::Float32;
-    pose.AssertShape({6});
-    pose.AssertDtype(dtype);
     core::Device device = pose.GetDevice();
+    core::Dtype dtype = pose.GetDtype();
+
+    if (dtype != core::Dtype::Float32 && dtype != core::Dtype::Float64) {
+        utility::LogError(
+                " [PoseToTransformation]: Only Float32 abd Float64 supported, "
+                "but got {} ",
+                dtype.ToString());
+    }
+
+    pose.AssertShape({6});
     core::Tensor transformation = core::Tensor::Zeros({4, 4}, dtype, device);
     transformation = transformation.Contiguous();
     core::Tensor pose_ = pose.Contiguous();
-    float *transformation_ptr = transformation.GetDataPtr<float>();
-    const float *pose_ptr = pose_.GetDataPtr<float>();
 
-    // Rotation from pose.
-    core::Device::DeviceType device_type = device.GetType();
-    if (device_type == core::Device::DeviceType::CPU) {
-        PoseToTransformationImpl(transformation_ptr, pose_ptr);
-    } else if (device_type == core::Device::DeviceType::CUDA) {
+    DISPATCH_FLOAT32_FLOAT64_DTYPE(dtype, [&]() {
+        scalar_t *transformation_ptr = transformation.GetDataPtr<scalar_t>();
+        const scalar_t *pose_ptr = pose_.GetDataPtr<scalar_t>();
+
+        // Rotation from pose.
+        core::Device::DeviceType device_type = device.GetType();
+        if (device_type == core::Device::DeviceType::CPU) {
+            PoseToTransformationImpl<scalar_t>(transformation_ptr, pose_ptr);
+        } else if (device_type == core::Device::DeviceType::CUDA) {
 #ifdef BUILD_CUDA_MODULE
-        PoseToTransformationCUDA(transformation_ptr, pose_ptr);
+            PoseToTransformationCUDA<scalar_t>(transformation_ptr, pose_ptr);
 #else
-        utility::LogError("Not compiled with CUDA, but CUDA device is used.");
+            utility::LogError("Not compiled with CUDA, but CUDA device is used.");
 #endif
-    } else {
-        utility::LogError("Unimplemented device.");
-    }
+        } else {
+            utility::LogError("Unimplemented device.");
+        }
+    });
     // Translation from pose.
     transformation.SetItem(
             {core::TensorKey::Slice(0, 3, 1), core::TensorKey::Slice(3, 4, 1)},

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
@@ -34,13 +34,28 @@ namespace t {
 namespace pipelines {
 namespace kernel {
 
-__global__ void PoseToTransformationKernel(float *transformation_ptr,
-                                           const float *X_ptr) {
+template <typename scalar_t>
+__global__ void PoseToTransformationKernel(scalar_t *transformation_ptr,
+                                           const scalar_t *X_ptr) {
     PoseToTransformationImpl(transformation_ptr, X_ptr);
 }
 
-void PoseToTransformationCUDA(float *transformation_ptr, const float *X_ptr) {
-    PoseToTransformationKernel<<<1, 1>>>(transformation_ptr, X_ptr);
+template <typename scalar_t>
+void PoseToTransformationCUDA(scalar_t *transformation_ptr,
+                              const scalar_t *X_ptr) {
+    utility::LogError("Unsupported data type.");
+}
+
+template <>
+void PoseToTransformationCUDA<float>(float *transformation_ptr,
+                                     const float *X_ptr) {
+    PoseToTransformationKernel<float><<<1, 1>>>(transformation_ptr, X_ptr);
+}
+
+template <>
+void PoseToTransformationCUDA<double>(double *transformation_ptr,
+                                      const double *X_ptr) {
+    PoseToTransformationKernel<double><<<1, 1>>>(transformation_ptr, X_ptr);
 }
 
 }  // namespace kernel

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverterImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverterImpl.h
@@ -31,6 +31,7 @@
 #include <cmath>
 
 #include "open3d/core/CUDAUtils.h"
+#include "open3d/core/CoreUtil.h"
 
 namespace open3d {
 namespace t {
@@ -38,8 +39,9 @@ namespace pipelines {
 namespace kernel {
 
 /// Shared implementation for PoseToTransformation function.
+template <typename scalar_t>
 OPEN3D_HOST_DEVICE inline void PoseToTransformationImpl(
-        float *transformation_ptr, const float *pose_ptr) {
+        scalar_t *transformation_ptr, const scalar_t *pose_ptr) {
     transformation_ptr[0] = cos(pose_ptr[2]) * cos(pose_ptr[1]);
     transformation_ptr[1] =
             -1 * sin(pose_ptr[2]) * cos(pose_ptr[0]) +
@@ -64,7 +66,9 @@ OPEN3D_HOST_DEVICE inline void PoseToTransformationImpl(
 /// Do not call this independently, as it only sets the transformation part
 /// in transformation matrix, using the Pose, the rest is set in
 /// the parent function PoseToTransformation.
-void PoseToTransformationCUDA(float *transformation_ptr, const float *pose_ptr);
+template <typename scalar_t>
+void PoseToTransformationCUDA(scalar_t *transformation_ptr,
+                              const scalar_t *pose_ptr);
 #endif
 
 }  // namespace kernel

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -43,6 +43,26 @@
 
 #define DEFAULT_IO_BUFFER_SIZE 1024
 
+// Compiler-specific function macro.
+// Ref: https://stackoverflow.com/a/4384825
+#ifdef _WIN32
+#define __FN__ __FUNCSIG__
+#else
+#define __FN__ __PRETTY_FUNCTION__
+#endif
+
+// Mimic 'macro in namespace' by concatenating utility:: and _LogError.
+// Ref: https://stackoverflow.com/a/11791202
+// We avoid using (format, ...) since in this case __VA_ARGS__ can be
+// empty, and the behavior of pruning trailing comma with ##__VA_ARGS__ is not
+// officially standard.
+// Ref: https://stackoverflow.com/a/28074198
+// __PRETTY_FUNCTION__ has to be converted, otherwise a bug regarding [noreturn]
+// will be triggered.
+// Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
+#define LogError(...) \
+    _LogError(__FILE__, __LINE__, (const char *)__FN__, __VA_ARGS__)
+
 namespace open3d {
 namespace utility {
 
@@ -192,26 +212,6 @@ inline void _LogError [[noreturn]] (const char *fname,
     Logger::i().VError(fname, linenum, fn_name, format,
                        fmt::make_format_args(args...));
 }
-
-// Compiler-specific function macro.
-// Ref: https://stackoverflow.com/a/4384825
-#ifdef _WIN32
-#define __FN__ __FUNCSIG__
-#else
-#define __FN__ __PRETTY_FUNCTION__
-#endif
-
-// Mimic 'macro in namespace' by concatenating utility:: and _LogError.
-// Ref: https://stackoverflow.com/a/11791202
-// We avoid using (format, ...) since in this case __VA_ARGS__ can be
-// empty, and the behavior of pruning trailing comma with ##__VA_ARGS__ is not
-// officially standard.
-// Ref: https://stackoverflow.com/a/28074198
-// __PRETTY_FUNCTION__ has to be converted, otherwise a bug regarding [noreturn]
-// will be triggered.
-// Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
-#define LogError(...) \
-    _LogError(__FILE__, __LINE__, (const char *)__FN__, __VA_ARGS__)
 
 template <typename... Args>
 inline void LogWarning(const char *format, const Args &... args) {

--- a/cpp/tests/t/pipelines/TransformationConverter.cpp
+++ b/cpp/tests/t/pipelines/TransformationConverter.cpp
@@ -48,17 +48,14 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(TransformationConverterPermuteDevices, RtToTransformation) {
     core::Device device = GetParam();
 
-    core::Dtype dtype[2];
-    dtype[0] = core::Dtype::Float32;
-    dtype[1] = core::Dtype::Float64;
-
-    for (int i = 0; i < 2; i++) {
-        core::Tensor rotation = core::Tensor::Eye(3, dtype[i], device);
-        core::Tensor translation = core::Tensor::Zeros({3}, dtype[i], device);
+    for (const core::Dtype& dtype :
+         {core::Dtype::Float32, core::Dtype::Float64}) {
+        core::Tensor rotation = core::Tensor::Eye(3, dtype, device);
+        core::Tensor translation = core::Tensor::Zeros({3}, dtype, device);
         core::Tensor transformation_ =
                 t::pipelines::kernel::RtToTransformation(rotation, translation);
 
-        core::Tensor transformation = core::Tensor::Eye(4, dtype[i], device);
+        core::Tensor transformation = core::Tensor::Eye(4, dtype, device);
         EXPECT_TRUE(transformation_.AllClose(transformation));
     }
 }
@@ -66,16 +63,13 @@ TEST_P(TransformationConverterPermuteDevices, RtToTransformation) {
 TEST_P(TransformationConverterPermuteDevices, PoseToTransformation) {
     core::Device device = GetParam();
 
-    core::Dtype dtype[2];
-    dtype[0] = core::Dtype::Float32;
-    dtype[1] = core::Dtype::Float64;
-
-    for (int i = 0; i < 2; i++) {
-        core::Tensor pose = core::Tensor::Zeros({6}, dtype[i], device);
+    for (const core::Dtype& dtype :
+         {core::Dtype::Float32, core::Dtype::Float64}) {
+        core::Tensor pose = core::Tensor::Zeros({6}, dtype, device);
         core::Tensor transformation_ =
                 t::pipelines::kernel::PoseToTransformation(pose);
 
-        core::Tensor transformation = core::Tensor::Eye(4, dtype[i], device);
+        core::Tensor transformation = core::Tensor::Eye(4, dtype, device);
         EXPECT_TRUE(transformation_.AllClose(transformation));
     }
 }

--- a/cpp/tests/t/pipelines/TransformationConverter.cpp
+++ b/cpp/tests/t/pipelines/TransformationConverter.cpp
@@ -47,41 +47,37 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(TransformationConverterPermuteDevices, RtToTransformation) {
     core::Device device = GetParam();
-    core::Dtype dtype = core::Dtype::Float32;
 
-    std::vector<float> rotation_vec{1, 0, 0, 0, 1, 0, 0, 0, 1};
-    core::Tensor rotation(rotation_vec, {3, 3}, dtype, device);
+    core::Dtype dtype[2];
+    dtype[0] = core::Dtype::Float32;
+    dtype[1] = core::Dtype::Float64;
 
-    std::vector<float> translation_vec{0, 0, 0};
-    core::Tensor translation(translation_vec, {3}, dtype, device);
+    for (int i = 0; i < 2; i++) {
+        core::Tensor rotation = core::Tensor::Eye(3, dtype[i], device);
+        core::Tensor translation = core::Tensor::Zeros({3}, dtype[i], device);
+        core::Tensor transformation_ =
+                t::pipelines::kernel::RtToTransformation(rotation, translation);
 
-    std::vector<float> transformation_vec{1, 0, 0, 0, 0, 1, 0, 0,
-                                          0, 0, 1, 0, 0, 0, 0, 1};
-    core::Tensor transformation(transformation_vec, {4, 4}, dtype, device);
-
-    core::Tensor transformation_ =
-            t::pipelines::kernel::RtToTransformation(rotation, translation);
-
-    EXPECT_EQ(transformation.ToFlatVector<float>(),
-              transformation_.ToFlatVector<float>());
+        core::Tensor transformation = core::Tensor::Eye(4, dtype[i], device);
+        EXPECT_TRUE(transformation_.AllClose(transformation));
+    }
 }
 
 TEST_P(TransformationConverterPermuteDevices, PoseToTransformation) {
     core::Device device = GetParam();
-    core::Dtype dtype = core::Dtype::Float32;
 
-    std::vector<float> pose_vec{0, 0, 0, 0, 0, 0};
-    core::Tensor pose(pose_vec, {6}, dtype, device);
+    core::Dtype dtype[2];
+    dtype[0] = core::Dtype::Float32;
+    dtype[1] = core::Dtype::Float64;
 
-    std::vector<float> transformation_vec{1, 0, 0, 0, 0, 1, 0, 0,
-                                          0, 0, 1, 0, 0, 0, 0, 1};
-    core::Tensor transformation(transformation_vec, {4, 4}, dtype, device);
+    for (int i = 0; i < 2; i++) {
+        core::Tensor pose = core::Tensor::Zeros({6}, dtype[i], device);
+        core::Tensor transformation_ =
+                t::pipelines::kernel::PoseToTransformation(pose);
 
-    core::Tensor transformation_ =
-            t::pipelines::kernel::PoseToTransformation(pose);
-
-    EXPECT_EQ(transformation.ToFlatVector<float>(),
-              transformation_.ToFlatVector<float>());
+        core::Tensor transformation = core::Tensor::Eye(4, dtype[i], device);
+        EXPECT_TRUE(transformation_.AllClose(transformation));
+    }
 }
 
 }  // namespace tests


### PR DESCRIPTION
Changes:
-  Float32 and Float64 support added for PoseToTransformation and RtToTransformation.
-  Changed `DTYPE == Dtype...` to `DTYPE == core::Dtype...`  `DISPATCH_FLOAT32_FLOAT64_DTYPE`, in core/CoreUtil.h, as for t:: modules. not inside core namespace, dispatching the code to just Dtype::... throws error. 
-  Modified Unit Tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3098)
<!-- Reviewable:end -->
