### PR TITLE
Better error message if you don't initialize gui::Application before creating a window

### DIFF
--- a/cpp/open3d/visualization/gui/Application.cpp
+++ b/cpp/open3d/visualization/gui/Application.cpp
@@ -387,7 +387,9 @@ void Application::VerifyIsInitialized() {
     // It would be nice to make this LogWarning() and then call Initialize(),
     // but Python scripts requires a different heuristic for finding the
     // resource path than C++.
-    utility::LogError("gui::Initialize() must be called before creating a window or UI element.");
+    utility::LogError(
+            "gui::Initialize() must be called before creating a window or UI "
+            "element.");
 }
 
 WindowSystem &Application::GetWindowSystem() const {

--- a/cpp/open3d/visualization/gui/Application.cpp
+++ b/cpp/open3d/visualization/gui/Application.cpp
@@ -375,6 +375,21 @@ void Application::Initialize(const char *resource_path) {
     impl_->is_initialized_ = true;
 }
 
+void Application::VerifyIsInitialized() {
+    if (impl_->is_initialized_) {
+        return;
+    }
+
+    // Call LogWarning() first because it is easier to visually parse than the
+    // error message.
+    utility::LogWarning("gui::Initialize() was not called");
+
+    // It would be nice to make this LogWarning() and then call Initialize(),
+    // but Python scripts requires a different heuristic for finding the
+    // resource path than C++.
+    utility::LogError("gui::Initialize() must be called before creating a window or UI element.");
+}
+
 WindowSystem &Application::GetWindowSystem() const {
     return *impl_->window_system_;
 }

--- a/cpp/open3d/visualization/gui/Application.h
+++ b/cpp/open3d/visualization/gui/Application.h
@@ -182,6 +182,10 @@ public:
     /// before creating any Windows.
     void SetWindowSystem(std::shared_ptr<WindowSystem> ws);
 
+    /// Verifies that Initialize() has been called, printing out an error and
+    /// exiting if not.
+    void VerifyIsInitialized();
+
     /// Returns the scene rendered to an image. This MUST NOT be called while
     /// in Run(). It is intended for use when no windows are shown. If you
     /// need to render from a GUI, use Scene::RenderToImage().

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -152,6 +152,13 @@ Window::Window(const std::string& title,
                int height,
                int flags /*= 0*/)
     : impl_(new Window::Impl()) {
+    // Make sure that the Application instance is initialized before creating
+    // the window. It is easy to call, e.g. O3DVisualizer() and forgetting to
+    // initialize the application. This will cause a crash because the window
+    // system will not exist, nor will the resource directory be located, and
+    // so the renderer will not load properly and give cryptic messages.
+    Application::GetInstance().VerifyIsInitialized();
+
     impl_->wants_auto_center_ = (x == CENTERED_X || y == CENTERED_Y);
     impl_->wants_auto_size_ =
             (width == AUTOSIZE_WIDTH || height == AUTOSIZE_HEIGHT);


### PR DESCRIPTION
It's easy to do something like:
```
import open3d as o3d
vis = o3d.visualization.O3DVisualizer()
...
```
You need to initialize the Application instance before creating anything UI-related, so that we can start up GLFW and find the resources. This spits out an error instead of continuing and crashing or getting unrelated-sounding errors like not being able to load images. (See #2995)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3103)
<!-- Reviewable:end -->
