### PR TITLE
Fix window resize when Scene caching is enabled.

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentResourceManager.cpp
@@ -691,6 +691,10 @@ void FilamentResourceManager::Destroy(const REHandle_abstract& id) {
         case EntityType::IndirectLight:
             DestroyResource(id, ibls_);
             break;
+        case EntityType::RenderTarget:
+            DestroyResource(id, render_targets_);
+            break;
+
         default:
             utility::LogWarning(
                     "Resource {} is not suited for destruction by "

--- a/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentView.cpp
@@ -294,7 +294,16 @@ void FilamentView::ConfigureForColorPicking() {
 void FilamentView::EnableViewCaching(bool enable) {
     caching_enabled_ = enable;
 
-    if (caching_enabled_ && !render_target_) {
+    if (caching_enabled_) {
+        if (render_target_) {
+            resource_mgr_.Destroy(render_target_);
+            resource_mgr_.Destroy(color_buffer_);
+            resource_mgr_.Destroy(depth_buffer_);
+            render_target_ = RenderTargetHandle();
+            color_buffer_ = TextureHandle();
+            depth_buffer_ = TextureHandle();
+        }
+
         // Create RenderTarget
         auto vp = view_->getViewport();
         color_buffer_ =


### PR DESCRIPTION
Fixes resize bug caused by switch to Render Targets for scene caching

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3107)
<!-- Reviewable:end -->
