### PR TITLE
Fix one frame blinking in Open3DViewer when layout changed or dialog box was closed

### DIFF
--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -634,16 +634,6 @@ void Window::CloseDialog() {
     }
     impl_->active_dialog_.reset();
 
-    ForceRedrawSceneWidget();
-
-    // Closing a dialog does not change the layout of widgets so the following
-    // is not necessary. However, on Apple, ForceRedrawSceneWidget isn't
-    // sufficent to force a SceneWidget to redraw and therefore flickering of
-    // the now closed dialog may occur. SetNeedsLayout ensures that
-    // SceneWidget::Layout gets called which will guarantee proper redraw of the
-    // SceneWidget.
-    SetNeedsLayout();
-
     // The dialog might not be closing from within a draw call, such as when
     // a native file dialog closes, so we need to post a redraw, just in case.
     // If it is from within a draw call, then any redraw request from that will

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -861,9 +861,6 @@ Widget::DrawResult Window::DrawOnce(bool is_layout_pass) {
             OnMenuItemSelected(id);
             needs_redraw = true;
         }
-        if (menubar->CheckVisibilityChange()) {
-            ForceRedrawSceneWidget();
-        }
     }
 
     // Draw any active dialog

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -276,8 +276,6 @@ void FilamentScene::SetRenderOnce(const ViewHandle& view_id) {
     auto found = views_.find(view_id);
     if (found != views_.end()) {
         found->second.is_active = true;
-        // NOTE: This value should match the value of render_count_ in
-        // FilamentRenderer::EnableCaching
         found->second.render_count = 1;
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3121)
<!-- Reviewable:end -->
