### PR TITLE
Sped up RemoveRadiusOutliers

### DIFF
--- a/cpp/open3d/geometry/PointCloud.cpp
+++ b/cpp/open3d/geometry/PointCloud.cpp
@@ -479,8 +479,8 @@ PointCloud::RemoveRadiusOutliers(size_t nb_points, double search_radius) const {
     for (int i = 0; i < int(points_.size()); i++) {
         std::vector<int> tmp_indices;
         std::vector<double> dist;
-        size_t nb_neighbors = kdtree.SearchRadius(points_[i], search_radius,
-                                                  tmp_indices, dist);
+        size_t nb_neighbors = kdtree.SearchHybrid(points_[i], search_radius,
+                                                  nb_points + 1, tmp_indices, dist);
         mask[i] = (nb_neighbors > nb_points);
     }
     std::vector<size_t> indices;


### PR DESCRIPTION
RemoveRadiusOutliers checks if a point has more neighbours in radius than nb_points. Therefore, we only need to find at least nb_points + 1 neighbors to assume that the point is not an outlier. As a result, we can use the SearchHybrid function which is much faster than the SearchRadius.