### PR TITLE
Fix ModuleNotFoundError when build with GCC10.

### DIFF
--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
@@ -42,6 +42,8 @@ namespace open3d {
 namespace t {
 namespace io {
 
+const size_t RSBagReader::DEFAULT_BUFFER_SIZE;
+
 RSBagReader::RSBagReader(size_t buffer_size)
     : frame_buffer_(buffer_size),
       frame_position_us_(buffer_size),

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
@@ -42,7 +42,10 @@ namespace open3d {
 namespace t {
 namespace io {
 
-constexpr size_t RSBagReader::DEFAULT_BUFFER_SIZE;
+// If DEFAULT_BUFFER_SIZE is odr-uses, a definition is required.
+// For Fedora33, GCC10, CUDA11.2, fix undefined symble error in pybind-*-linux-gnu.so.
+// See: https://github.com/intel-isl/Open3D/issues/3141
+const size_t RSBagReader::DEFAULT_BUFFER_SIZE;
 
 RSBagReader::RSBagReader(size_t buffer_size)
     : frame_buffer_(buffer_size),

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
@@ -43,7 +43,8 @@ namespace t {
 namespace io {
 
 // If DEFAULT_BUFFER_SIZE is odr-uses, a definition is required.
-// For Fedora33, GCC10, CUDA11.2, fix undefined symble error in pybind-*-linux-gnu.so.
+// For Fedora33, GCC10, CUDA11.2:
+// Fix undefined symble error in pybind-*-linux-gnu.so.
 // See: https://github.com/intel-isl/Open3D/issues/3141
 const size_t RSBagReader::DEFAULT_BUFFER_SIZE;
 

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.cpp
@@ -42,7 +42,7 @@ namespace open3d {
 namespace t {
 namespace io {
 
-const size_t RSBagReader::DEFAULT_BUFFER_SIZE;
+constexpr size_t RSBagReader::DEFAULT_BUFFER_SIZE;
 
 RSBagReader::RSBagReader(size_t buffer_size)
     : frame_buffer_(buffer_size),

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
@@ -66,7 +66,7 @@ namespace io {
 ///
 class RSBagReader : public RGBDVideoReader {
 public:
-    static const size_t DEFAULT_BUFFER_SIZE = 32;
+    static constexpr size_t DEFAULT_BUFFER_SIZE{32};
 
     /// Constructor
     ///

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
@@ -66,7 +66,7 @@ namespace io {
 ///
 class RSBagReader : public RGBDVideoReader {
 public:
-    static constexpr size_t DEFAULT_BUFFER_SIZE{32};
+    static constexpr size_t DEFAULT_BUFFER_SIZE = 32;
 
     /// Constructor
     ///

--- a/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
+++ b/cpp/open3d/t/io/sensor/realsense/RSBagReader.h
@@ -66,7 +66,7 @@ namespace io {
 ///
 class RSBagReader : public RGBDVideoReader {
 public:
-    static constexpr size_t DEFAULT_BUFFER_SIZE = 32;
+    static const size_t DEFAULT_BUFFER_SIZE = 32;
 
     /// Constructor
     ///


### PR DESCRIPTION
Resolves #3141

- Resolves undefined symbol error (`RSBagReader::DEFAULT_BUFFER_SIZE`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3142)
<!-- Reviewable:end -->
