### PR TITLE
Add support for textures in TriangleMesh::operator+=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * RealSense sensor configuration, live capture and recording (with example and tutorial) (PR #2748)
 * Add mouselook for the legacy visualizer (PR #2551)
 * Add function to randomly downsample pointcloud (PR #3050)
+* Allow TriangleMesh with textures to be added (PR #3170)
 
 ## 0.11
 

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -113,7 +113,7 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
                                       mesh.triangle_material_ids_.size());
         for (size_t i = 0; i < mesh.triangle_material_ids_.size(); i++) {
             triangle_material_ids_[old_mat_id_num + i] =
-                    mesh.triangle_material_ids_[i] + old_tex_num;
+                    mesh.triangle_material_ids_[i] + (int)old_tex_num;
         }
     } else {
         triangle_uvs_.clear();

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -92,11 +92,37 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (HasAdjacencyList()) {
         ComputeAdjacencyList();
     }
-    if (HasTriangleUvs() || HasTextures() || HasTriangleMaterialIds()) {
-        utility::LogError(
-                "[TriangleMesh] copy of uvs and texture and per-triangle "
-                "material ids is not implemented "
-                "yet");
+    if (HasTriangleUvs() && HasTextures() && HasTriangleMaterialIds() &&
+        mesh.HasTriangleUvs() && mesh.HasTextures() &&
+        mesh.HasTriangleMaterialIds()) {
+        size_t old_tri_uv_num = triangle_uvs_.size();
+        size_t add_tri_uv_num = mesh.triangle_uvs_.size();
+        size_t new_tri_uv_num = old_tri_uv_num + add_tri_uv_num;
+        triangle_uvs_.resize(new_tri_uv_num);
+        for (size_t i = 0; i < add_tri_uv_num; i++) {
+            triangle_uvs_[old_tri_uv_num + i] = mesh.triangle_uvs_[i];
+        }
+
+        size_t old_tex_num = textures_.size();
+        size_t add_tex_num = mesh.textures_.size();
+        size_t new_tex_num = old_tex_num + add_tex_num;
+        textures_.resize(new_tex_num);
+        for (size_t i = 0; i < add_tex_num; i++) {
+            textures_[old_tex_num + i] = mesh.textures_[i];
+        }
+
+        size_t old_mat_id_num = triangle_material_ids_.size();
+        size_t add_mat_id_num = mesh.triangle_material_ids_.size();
+        size_t new_mat_id_num = old_mat_id_num + add_mat_id_num;
+        triangle_material_ids_.resize(new_mat_id_num);
+        for (size_t i = 0; i < add_mat_id_num; i++) {
+            triangle_material_ids_[old_mat_id_num + i] =
+                    mesh.triangle_material_ids_[i] + old_tex_num;
+        }
+    } else {
+        triangle_uvs_.clear();
+        textures_.clear();
+        triangle_material_ids_.clear();
     }
     return (*this);
 }

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -70,6 +70,9 @@ TriangleMesh &TriangleMesh::Rotate(const Eigen::Matrix3d &R,
 
 TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (mesh.IsEmpty()) return (*this);
+    bool add_textures = HasTriangleUvs() && HasTextures() &&
+                        HasTriangleMaterialIds() && mesh.HasTriangleUvs() &&
+                        mesh.HasTextures() && mesh.HasTriangleMaterialIds();
     size_t old_vert_num = vertices_.size();
     MeshBase::operator+=(mesh);
     size_t old_tri_num = triangles_.size();
@@ -92,9 +95,7 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     if (HasAdjacencyList()) {
         ComputeAdjacencyList();
     }
-    if (HasTriangleUvs() && HasTextures() && HasTriangleMaterialIds() &&
-        mesh.HasTriangleUvs() && mesh.HasTextures() &&
-        mesh.HasTriangleMaterialIds()) {
+    if (add_textures) {
         size_t old_tri_uv_num = triangle_uvs_.size();
         size_t add_tri_uv_num = mesh.triangle_uvs_.size();
         size_t new_tri_uv_num = old_tri_uv_num + add_tri_uv_num;

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -97,26 +97,21 @@ TriangleMesh &TriangleMesh::operator+=(const TriangleMesh &mesh) {
     }
     if (add_textures) {
         size_t old_tri_uv_num = triangle_uvs_.size();
-        size_t add_tri_uv_num = mesh.triangle_uvs_.size();
-        size_t new_tri_uv_num = old_tri_uv_num + add_tri_uv_num;
-        triangle_uvs_.resize(new_tri_uv_num);
-        for (size_t i = 0; i < add_tri_uv_num; i++) {
+        triangle_uvs_.resize(old_tri_uv_num + mesh.triangle_uvs_.size());
+        for (size_t i = 0; i < mesh.triangle_uvs_.size(); i++) {
             triangle_uvs_[old_tri_uv_num + i] = mesh.triangle_uvs_[i];
         }
 
         size_t old_tex_num = textures_.size();
-        size_t add_tex_num = mesh.textures_.size();
-        size_t new_tex_num = old_tex_num + add_tex_num;
-        textures_.resize(new_tex_num);
-        for (size_t i = 0; i < add_tex_num; i++) {
+        textures_.resize(old_tex_num + mesh.textures_.size());
+        for (size_t i = 0; i < mesh.textures_.size(); i++) {
             textures_[old_tex_num + i] = mesh.textures_[i];
         }
 
         size_t old_mat_id_num = triangle_material_ids_.size();
-        size_t add_mat_id_num = mesh.triangle_material_ids_.size();
-        size_t new_mat_id_num = old_mat_id_num + add_mat_id_num;
-        triangle_material_ids_.resize(new_mat_id_num);
-        for (size_t i = 0; i < add_mat_id_num; i++) {
+        triangle_material_ids_.resize(old_mat_id_num +
+                                      mesh.triangle_material_ids_.size());
+        for (size_t i = 0; i < mesh.triangle_material_ids_.size(); i++) {
             triangle_material_ids_[old_mat_id_num + i] =
                     mesh.triangle_material_ids_[i] + old_tex_num;
         }


### PR DESCRIPTION
Add support for textures in TriangleMesh::operator+=

`TriangleMesh::operator+=` previously didn't support adding meshes with textures. This PR fixes that. Note that if either one of the meshes doesn't have texture, the resulting mesh won't have textures.

Tested and verified compliance with `WriteTriangleMeshToOBJ` as well. Let me know if anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3170)
<!-- Reviewable:end -->
