### PR TITLE
Fix incorrect coordinates for mouse events on Linux

### DIFF
--- a/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
@@ -235,9 +235,7 @@ float BitmapWindowSystem::GetWindowScaleFactor(OSWindow w) const {
     return 1.0f;
 }
 
-float BitmapWindowSystem::GetUIScaleFactor(OSWindow w) const {
-    return 1.0f;
-}
+float BitmapWindowSystem::GetUIScaleFactor(OSWindow w) const { return 1.0f; }
 
 void BitmapWindowSystem::SetWindowTitle(OSWindow w, const char *title) {}
 

--- a/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/BitmapWindowSystem.cpp
@@ -235,6 +235,10 @@ float BitmapWindowSystem::GetWindowScaleFactor(OSWindow w) const {
     return 1.0f;
 }
 
+float BitmapWindowSystem::GetUIScaleFactor(OSWindow w) const {
+    return 1.0f;
+}
+
 void BitmapWindowSystem::SetWindowTitle(OSWindow w, const char *title) {}
 
 Point BitmapWindowSystem::GetMousePosInWindow(OSWindow w) const {

--- a/cpp/open3d/visualization/gui/BitmapWindowSystem.h
+++ b/cpp/open3d/visualization/gui/BitmapWindowSystem.h
@@ -93,6 +93,7 @@ public:
     void SetWindowSizePixels(OSWindow w, const Size& size) override;
 
     float GetWindowScaleFactor(OSWindow w) const override;
+    float GetUIScaleFactor(OSWindow w) const override;
 
     void SetWindowTitle(OSWindow w, const char* title) override;
 

--- a/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
@@ -297,7 +297,6 @@ Point GLFWWindowSystem::GetMousePosInWindow(OSWindow w) const {
     glfwGetCursorPos((GLFWwindow*)w, &mx, &my);
     auto scaling = GetWindowScaleFactor((GLFWwindow*)w);
     return Point(int(float(mx) * scaling), int(float(my) * scaling));
-//    return Point(int(mx), int(my));
 }
 
 int GLFWWindowSystem::GetMouseButtons(OSWindow w) const {
@@ -360,7 +359,9 @@ void GLFWWindowSystem::MouseMoveCallback(GLFWwindow* window,
             buttons |= MouseButtonFromGLFW(b);
         }
     }
-    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
+    float scaling =
+            Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(
+                    window);
     int ix = int(std::ceil(x * scaling));
     int iy = int(std::ceil(y * scaling));
 
@@ -381,7 +382,9 @@ void GLFWWindowSystem::MouseButtonCallback(GLFWwindow* window,
                                       : MouseEvent::BUTTON_UP);
     double mx, my;
     glfwGetCursorPos(window, &mx, &my);
-    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
+    float scaling =
+            Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(
+                    window);
     int ix = int(std::ceil(mx * scaling));
     int iy = int(std::ceil(my * scaling));
 
@@ -410,7 +413,9 @@ void GLFWWindowSystem::MouseScrollCallback(GLFWwindow* window,
 
     double mx, my;
     glfwGetCursorPos(window, &mx, &my);
-    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
+    float scaling =
+            Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(
+                    window);
     int ix = int(std::ceil(mx * scaling));
     int iy = int(std::ceil(my * scaling));
 

--- a/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
@@ -276,7 +276,7 @@ float GLFWWindowSystem::GetWindowScaleFactor(OSWindow w) const {
     // in converting to/from OS coordinates (e.g. mouse events), but not for
     // sizing user interface elements like fonts.
 #if __APPLE__
-    return CallGLFWWindowContentScale((GLFWwindow*)w);
+    return CallGLFWGetWindowContentScale((GLFWwindow*)w);
 #else
     return 1.0f;
 #endif  // __APPLE__

--- a/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
@@ -105,6 +105,18 @@ int KeymodsFromGLFW(int glfw_mods) {
     return keymods;
 }
 
+float CallGLFWGetWindowContentScale(GLFWwindow* w) {
+    // Ubuntu 18.04 uses GLFW 3.1, which doesn't have this function
+#if (GLFW_VERSION_MAJOR > 3 || \
+     (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3))
+    float xscale, yscale;
+    glfwGetWindowContentScale(w, &xscale, &yscale);
+    return std::min(xscale, yscale);
+#else
+    return 1.0f;
+#endif  // GLFW version >= 3.3
+}
+
 }  // namespace
 
 GLFWWindowSystem::GLFWWindowSystem() {}
@@ -256,15 +268,24 @@ void GLFWWindowSystem::SetWindowSizePixels(OSWindow w, const Size& size) {
 }
 
 float GLFWWindowSystem::GetWindowScaleFactor(OSWindow w) const {
-// Ubuntu 18.04 uses GLFW 3.1, which doesn't have this function
-#if (GLFW_VERSION_MAJOR > 3 || \
-     (GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3))
-    float xscale, yscale;
-    glfwGetWindowContentScale((GLFWwindow*)w, &xscale, &yscale);
-    return std::min(xscale, yscale);
+    // This function returns the number of device pixels per OS distance-unit.
+    // Windows and Linux keep one pixel equal to one real pixel, whereas
+    // macOS keeps the unit of measurement the same (1 pt = 1/72 inch) and
+    // changes the number pixels in one "virtual pixel". This function returns
+    // the scale factor as macOS thinks of it. This function should be used
+    // in converting to/from OS coordinates (e.g. mouse events), but not for
+    // sizing user interface elements like fonts.
+#if __APPLE__
+    return CallGLFWWindowContentScale((GLFWwindow*)w);
 #else
     return 1.0f;
-#endif  // GLFW version >= 3.3
+#endif  // __APPLE__
+}
+
+float GLFWWindowSystem::GetUIScaleFactor(OSWindow w) const {
+    // This function returns the scale factor needed to have appropriately
+    // sized user interface elements.
+    return CallGLFWGetWindowContentScale((GLFWwindow*)w);
 }
 
 void GLFWWindowSystem::SetWindowTitle(OSWindow w, const char* title) {
@@ -276,6 +297,7 @@ Point GLFWWindowSystem::GetMousePosInWindow(OSWindow w) const {
     glfwGetCursorPos((GLFWwindow*)w, &mx, &my);
     auto scaling = GetWindowScaleFactor((GLFWwindow*)w);
     return Point(int(float(mx) * scaling), int(float(my) * scaling));
+//    return Point(int(mx), int(my));
 }
 
 int GLFWWindowSystem::GetMouseButtons(OSWindow w) const {
@@ -338,7 +360,7 @@ void GLFWWindowSystem::MouseMoveCallback(GLFWwindow* window,
             buttons |= MouseButtonFromGLFW(b);
         }
     }
-    float scaling = w->GetScaling();
+    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
     int ix = int(std::ceil(x * scaling));
     int iy = int(std::ceil(y * scaling));
 
@@ -359,7 +381,7 @@ void GLFWWindowSystem::MouseButtonCallback(GLFWwindow* window,
                                       : MouseEvent::BUTTON_UP);
     double mx, my;
     glfwGetCursorPos(window, &mx, &my);
-    float scaling = w->GetScaling();
+    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
     int ix = int(std::ceil(mx * scaling));
     int iy = int(std::ceil(my * scaling));
 
@@ -388,7 +410,7 @@ void GLFWWindowSystem::MouseScrollCallback(GLFWwindow* window,
 
     double mx, my;
     glfwGetCursorPos(window, &mx, &my);
-    float scaling = w->GetScaling();
+    float scaling = Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(window);
     int ix = int(std::ceil(mx * scaling));
     int iy = int(std::ceil(my * scaling));
 

--- a/cpp/open3d/visualization/gui/GLFWWindowSystem.h
+++ b/cpp/open3d/visualization/gui/GLFWWindowSystem.h
@@ -71,6 +71,7 @@ public:
     void SetWindowSizePixels(OSWindow w, const Size& size) override;
 
     float GetWindowScaleFactor(OSWindow w) const override;
+    float GetUIScaleFactor(OSWindow w) const override;
 
     void SetWindowTitle(OSWindow w, const char* title) override;
 

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -196,7 +196,7 @@ Window::Window(const std::string& title,
     // is the scaling factor. On Linux, there is no scaling of pixels (just
     // like in Open3D's GUI library), and glfwGetWindowContentScale() returns
     // the appropriate scale factor for text and icons and such.
-    float scaling = ws.GetWindowScaleFactor(impl_->window_);
+    float scaling = ws.GetUIScaleFactor(impl_->window_);
     impl_->theme_ = Application::GetInstance().GetTheme();
     impl_->theme_.font_size =
             int(std::round(impl_->theme_.font_size * scaling));
@@ -500,19 +500,8 @@ Rect Window::GetContentRect() const {
 }
 
 float Window::GetScaling() const {
-// macOS unit of measurement is 72 dpi pixels, which on newer displays
-// is a factor of 2 or 3 smaller than the real number of pixels per inch.
-// This means that you can keep your hard-coded 12 pixel font and N pixel
-// sizes and it will be the same size on any disply.
-// On X Windows a pixel is a device pixel, so glfwGetWindowContentScale()
-// returns the scale factor needed so that your fonts and icons and sizes
-// are correct. This is not the same thing as Apple does.
-#if __APPLE__
     return Application::GetInstance().GetWindowSystem().GetWindowScaleFactor(
             impl_->window_);
-#else
-    return 1.0f;
-#endif  // __APPLE__
 }
 
 Point Window::GlobalToWindowCoord(int global_x, int global_y) {

--- a/cpp/open3d/visualization/gui/WindowSystem.h
+++ b/cpp/open3d/visualization/gui/WindowSystem.h
@@ -85,6 +85,7 @@ public:
     virtual void SetWindowSizePixels(OSWindow w, const Size& size) = 0;
 
     virtual float GetWindowScaleFactor(OSWindow w) const = 0;
+    virtual float GetUIScaleFactor(OSWindow w) const = 0;
 
     virtual void SetWindowTitle(OSWindow w, const char* title) = 0;
 


### PR DESCRIPTION
On high-DPI monitors, glfwGetWindowContentScale() returns > 1, which triggers problems with the new Window System code. The result is that text is properly sized, but the mouse coordinates are reduced by half, making clicking on UI elements not working (or, rather, mapped to the upper left quarter of the window).

Tested on Linux, macOS, and Windows. (Windows works for 100%, 150%, 200%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3177)
<!-- Reviewable:end -->
