### PR TITLE
Expose rendering to a depth image to Python

### DIFF
--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -479,12 +479,12 @@ private:
                                 int y) {
         const int radius_px = 2;  // should be even;  total size is 2*r+1
         float far_z = 0.999999f;  // 1.0 - epsilon
-        float win_z = (1.0 - *depth_img->PointerAt<float>(x, y));
+        float win_z = *depth_img->PointerAt<float>(x, y);
         if (win_z >= far_z) {
             for (int v = y - radius_px; v < y + radius_px; ++v) {
                 for (int u = x - radius_px; u < x + radius_px; ++u) {
                     float z = *depth_img->PointerAt<float>(x, y);
-                    win_z = (1.0 - std::min(win_z, z));
+                    win_z = std::min(win_z, z);
                 }
             }
         }

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -706,8 +706,8 @@ Widget::DrawResult DrawChild(DrawContext& dc,
     }
     auto frame = child->GetFrame();
     bool bg_color_not_default = !child->IsDefaultBackgroundColor();
-    auto is_container = !child->GetChildren().empty();
-    if (is_container) {
+    auto is_3d = (std::dynamic_pointer_cast<SceneWidget>(child) != nullptr);
+    if (!is_3d) {
         dc.uiOffsetX = frame.x;
         dc.uiOffsetY = frame.y;
         ImGui::SetNextWindowPos(ImVec2(float(frame.x), float(frame.y)));
@@ -726,7 +726,7 @@ Widget::DrawResult DrawChild(DrawContext& dc,
     Widget::DrawResult result;
     result = child->Draw(dc);
 
-    if (is_container) {
+    if (!is_3d) {
         ImGui::End();
         if (bg_color_not_default) {
             ImGui::PopStyleColor();

--- a/cpp/open3d/visualization/rendering/Renderer.cpp
+++ b/cpp/open3d/visualization/rendering/Renderer.cpp
@@ -126,6 +126,16 @@ void Renderer::RenderToDepthImage(
                                     image->num_of_channels_ *
                                     image->bytes_per_channel_);
                 memcpy(image->data_.data(), buffer.bytes, buffer.size);
+                // Filament's shaders calculate depth ranging from 1 (near)
+                // to 0 (far), which is reversed from what is normally done,
+                // so convert here so that users do not need to rediscover
+                // Filament internals. (And so we can change it back if Filament
+                // decides to swap how they do it again.)
+                float* pixels = (float*)image->data_.data();
+                int n_pixels = image->width_ * image->height_;
+                for (int i = 0; i < n_pixels; ++i) {
+                    pixels[i] = 1.0f - pixels[i];
+                }
                 cb(image);
                 render = nullptr;
             });

--- a/cpp/open3d/visualization/rendering/Scene.h
+++ b/cpp/open3d/visualization/rendering/Scene.h
@@ -203,6 +203,10 @@ public:
     virtual void RenderToImage(
             std::function<void(std::shared_ptr<geometry::Image>)> callback) = 0;
 
+    /// Size of image is the size of the window.
+    virtual void RenderToDepthImage(
+            std::function<void(std::shared_ptr<geometry::Image>)> callback) = 0;
+
 protected:
     Renderer& renderer_;
 };

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -1756,6 +1756,12 @@ void FilamentScene::RenderToImage(
     renderer_.RenderToImage(view, this, callback);
 }
 
+void FilamentScene::RenderToDepthImage(
+        std::function<void(std::shared_ptr<geometry::Image>)> callback) {
+    auto view = views_.begin()->second.view.get();
+    renderer_.RenderToDepthImage(view, this, callback);
+}
+
 std::vector<FilamentScene::RenderableGeometry*> FilamentScene::GetGeometry(
         const std::string& object_name, bool warn_if_not_found) {
     std::vector<RenderableGeometry*> geoms;

--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.h
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.h
@@ -222,6 +222,9 @@ public:
 
     void RenderToImage(std::function<void(std::shared_ptr<geometry::Image>)>
                                callback) override;
+    void RenderToDepthImage(
+            std::function<void(std::shared_ptr<geometry::Image>)> callback)
+            override;
 
     void Draw(filament::Renderer& renderer);
 

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -611,6 +611,9 @@ void pybind_gui_classes(py::module &m) {
                           "True if widget is visible, False otherwise")
             .def_property("enabled", &Widget::IsEnabled, &Widget::SetEnabled,
                           "True if widget is enabled, False if disabled")
+            .def_property("background_color", &Widget::GetBackgroundColor,
+                          &Widget::SetBackgroundColor,
+                          "Background color of the widget")
             .def("calc_preferred_size", &Widget::CalcPreferredSize,
                  "Returns the preferred size of the widget. This is intended "
                  "to be called only during layout, although it will also work "

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -418,7 +418,12 @@ void pybind_rendering_classes(py::module &m) {
             .def("render_to_image", &Scene::RenderToImage,
                  "Renders the scene to an image. This can only be used in a "
                  "GUI app. To render without a window, use "
-                 "Application.render_to_image");
+                 "Application.render_to_image")
+            .def("render_to_depth_image", &Scene::RenderToDepthImage,
+                 "Renders the scene to a depth image. This can only be used in "
+                 "GUI app. To render without a window, use "
+                 "Application.render_to_depth_image. Pixels range from "
+                 "0.0 (near plane) to 1.0 (far plane)");
 
     scene.attr("UPDATE_POINTS_FLAG") = py::int_(Scene::kUpdatePointsFlag);
     scene.attr("UPDATE_NORMALS_FLAG") = py::int_(Scene::kUpdateNormalsFlag);


### PR DESCRIPTION
Also:
- makes resulting depth iage range from 0 (near plane) to 1 (far plane) instead of simply returning the raw values from Filament's buffer (which are reversed)
- fixes widgets that aren't SceneWidget or a Layout not working if they are a top-level child. (If you created a window and then called `window->AddChild(a_label)` (and properly sized it) the label would not draw, but if you put it in a layout and made the layout top-level, it worked fine.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3178)
<!-- Reviewable:end -->
