### PR TITLE
Remove support for USE_SYSTEM_LIBREALSENSE

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -539,43 +539,21 @@ set(TRITRIINTERSECT_TARGET "3rdparty_tritriintersect")
 list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${TRITRIINTERSECT_TARGET}")
 
 # librealsense SDK
+# USE_SYSTEM_LIBREALSENSE is not supported due to a custom bug fix patch
 if (BUILD_LIBREALSENSE)
-    if(USE_SYSTEM_LIBREALSENSE AND NOT GLIBCXX_USE_CXX11_ABI)
-        # Turn off USE_SYSTEM_LIBREALSENSE.
-        # Because it is affected by libraries built with different CXX ABIs.
-        # See details: https://github.com/intel-isl/Open3D/pull/2876
-        message(STATUS "Set USE_SYSTEM_LIBREALSENSE=OFF, because GLIBCXX_USE_CXX11_ABI is OFF.")
-        set(USE_SYSTEM_LIBREALSENSE OFF)
-    endif()
-    if(USE_SYSTEM_LIBREALSENSE)
-        find_package(realsense2)
-        if(TARGET realsense2::realsense2)
-            message(STATUS "Using installed third-party library librealsense")
-            if(NOT BUILD_SHARED_LIBS)
-                list(APPEND Open3D_3RDPARTY_EXTERNAL_MODULES "realsense2")
-            endif()
-            set(LIBREALSENSE_TARGET  "realsense2::realsense2")
-            list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
-        else()
-            message(STATUS "Unable to find installed third-party library librealsense")
-            set(USE_SYSTEM_LIBREALSENSE OFF)
-        endif()
-    endif()
-    if(NOT USE_SYSTEM_LIBREALSENSE)
-        include(${Open3D_3RDPARTY_DIR}/librealsense/librealsense.cmake)
-        import_3rdparty_library(3rdparty_librealsense
-            INCLUDE_DIRS ${LIBREALSENSE_INCLUDE_DIR}
-            LIBRARIES    ${LIBREALSENSE_LIBRARIES}
-            LIB_DIR      ${LIBREALSENSE_LIB_DIR}
-        )
-        add_dependencies(3rdparty_librealsense ext_librealsense)
-        set(LIBREALSENSE_TARGET "3rdparty_librealsense")
-        list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
-        if (UNIX AND NOT APPLE)    # Ubuntu dependency: libudev-dev
-            find_library(UDEV_LIBRARY udev REQUIRED
-                DOC "Library provided by the deb package libudev-dev")
-            target_link_libraries(3rdparty_librealsense INTERFACE ${UDEV_LIBRARY})
-        endif()
+    include(${Open3D_3RDPARTY_DIR}/librealsense/librealsense.cmake)
+    import_3rdparty_library(3rdparty_librealsense
+        INCLUDE_DIRS ${LIBREALSENSE_INCLUDE_DIR}
+        LIBRARIES    ${LIBREALSENSE_LIBRARIES}
+        LIB_DIR      ${LIBREALSENSE_LIB_DIR}
+    )
+    add_dependencies(3rdparty_librealsense ext_librealsense)
+    set(LIBREALSENSE_TARGET "3rdparty_librealsense")
+    list(APPEND Open3D_3RDPARTY_PRIVATE_TARGETS "${LIBREALSENSE_TARGET}")
+    if (UNIX AND NOT APPLE)    # Ubuntu dependency: libudev-dev
+        find_library(UDEV_LIBRARY udev REQUIRED
+            DOC "Library provided by the deb package libudev-dev")
+        target_link_libraries(3rdparty_librealsense INTERFACE ${UDEV_LIBRARY})
     endif()
 endif()
 

--- a/3rdparty/librealsense/librealsense.cmake
+++ b/3rdparty/librealsense/librealsense.cmake
@@ -4,10 +4,10 @@ ExternalProject_Add(
     ext_librealsense
     PREFIX librealsense
     GIT_REPOSITORY https://github.com/IntelRealSense/librealsense.git
-    GIT_TAG v2.40.0 # 18 Nov 2020
+    GIT_TAG v2.42.0 #  2020 Feb 14
     UPDATE_COMMAND ""
     # Patch for libusb static build failure on Linux
-    PATCH_COMMAND git -C <SOURCE_DIR> reset --hard v2.40.0
+    PATCH_COMMAND git -C <SOURCE_DIR> reset --hard v2.42.0
     COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/librealsense/libusb-CMakeLists.txt
     <SOURCE_DIR>/third-party/libusb/CMakeLists.txt
@@ -28,7 +28,6 @@ ExternalProject_Add(
         -DBUILD_GRAPHICAL_EXAMPLES=OFF
         -DBUILD_PYTHON_BINDINGS=OFF
         -DBUILD_WITH_CUDA=${BUILD_CUDA_MODULE}
-        -DFORCE_RSUSB_BACKEND=$<IF:$<PLATFORM_ID:Linux>,ON,OFF>      # https://github.com/IntelRealSense/librealsense/wiki/Release-Notes#release-2400
         -DUSE_EXTERNAL_USB=ON
         $<$<PLATFORM_ID:Darwin>:-DBUILD_WITH_OPENMP=OFF>
         $<$<PLATFORM_ID:Darwin>:-DHWM_OVER_XU=OFF>

--- a/cpp/pybind/make_install_pip_package.cmake
+++ b/cpp/pybind/make_install_pip_package.cmake
@@ -4,4 +4,4 @@
 # Note: Since `make python-package` clears PYTHON_COMPILED_MODULE_DIR every time,
 #       it is guaranteed that there is only one wheel in ${PYTHON_PACKAGE_DST_DIR}/pip_package/*.whl
 file(GLOB WHEEL_FILE "${PYTHON_PACKAGE_DST_DIR}/pip_package/*.whl")
-execute_process(COMMAND pip install ${WHEEL_FILE} -U)
+execute_process(COMMAND pip install --force-reinstall --upgrade ${WHEEL_FILE})

--- a/python/test/t/io/test_realsense.py
+++ b/python/test/t/io/test_realsense.py
@@ -37,8 +37,10 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../..")
 from open3d_test import test_data_dir
 
 
-# @pytest.mark.skipif(not hasattr(o3d.t.io, 'RSBagReader'))
-@pytest.mark.skip(reason="Hangs in Github Actions, but succeeds locally")
+@pytest.mark.skipif(os.getenv('GITHUB_SHA') or
+                    not hasattr(o3d.t.io, 'RSBagReader'),
+                    reason="Hangs in Github Actions, but succeeds locally or "
+                    "not built with librealsense")
 def test_RSBagReader():
 
     shutil.unpack_archive(test_data_dir +
@@ -102,7 +104,8 @@ def test_RSBagReader():
     }.issubset(os.listdir('L515_test_s/color'))
 
     shutil.rmtree("L515_test_s")
-    # os.remove("L515_test_s.bag")  # Permission error in Windows
+    if os.name != 'nt':  # Permission error in Windows
+        os.remove("L515_test_s.bag")
 
 
 # Test recording from a RealSense camera, if one is connected
@@ -118,8 +121,9 @@ def test_RealSenseSensor():
         rs_cam.start_capture(True)  # true: start recording with capture
         im_rgbd = rs_cam.capture_frame(True,
                                        True)  # wait for frames and align them
-        assert im_rgbd.depth.rows == im_rgbd.color.rows
-        assert im_rgbd.depth.columns == im_rgbd.color.columns
+        print(im_rgbd)
+        assert im_rgbd.depth.rows == im_rgbd.color.rows > 0
+        assert im_rgbd.depth.columns == im_rgbd.color.columns > 0
         rs_cam.stop_capture()
         assert os.path.exists(bag_filename)
         os.remove(bag_filename)


### PR DESCRIPTION
Revert PR #3057 by @NobuoTsukamoto since system `librealsense` does not contain custom patches and causes bug #2837 

- Upgrade `librealsense` to v2.42
- `RSUSB_BACKEND` is no longer required in Linux
- add --force-reinstall to make install-pip-package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3191)
<!-- Reviewable:end -->
