### PR TITLE
Added pybinds for color grading enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add mouselook for the legacy visualizer (PR #2551)
 * Add function to randomly downsample pointcloud (PR #3050)
 * Allow TriangleMesh with textures to be added (PR #3170)
+* Python property of open3d.visualization.rendering.Open3DScene `get_view` has been renamed to `view`.
 
 ## 0.11
 

--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -308,6 +308,27 @@ void pybind_rendering_classes(py::module &m) {
     // ---- ColorGradingParams ---
     py::class_<ColorGradingParams> color_grading(
             m, "ColorGrading", "Parameters to control color grading options");
+
+    py::enum_<ColorGradingParams::Quality> cgp_quality(
+            color_grading, "Quality",
+            "Quality level of color grading operations");
+    cgp_quality.value("LOW", ColorGradingParams::Quality::kLow)
+            .value("MEDIUM", ColorGradingParams::Quality::kMedium)
+            .value("HIGH", ColorGradingParams::Quality::kHigh)
+            .value("ULTRA", ColorGradingParams::Quality::kUltra);
+
+    py::enum_<ColorGradingParams::ToneMapping> cgp_tone(
+            color_grading, "ToneMapping",
+            "Specifies the tone-mapping algorithm");
+    cgp_tone.value("LINEAR", ColorGradingParams::ToneMapping::kLinear)
+            .value("ACES_LEGACY", ColorGradingParams::ToneMapping::kAcesLegacy)
+            .value("ACES", ColorGradingParams::ToneMapping::kAces)
+            .value("FILMIC", ColorGradingParams::ToneMapping::kFilmic)
+            .value("UCHIMURA", ColorGradingParams::ToneMapping::kUchimura)
+            .value("REINHARD", ColorGradingParams::ToneMapping::kReinhard)
+            .value("DISPLAY_RANGE",
+                   ColorGradingParams::ToneMapping::kDisplayRange);
+
     color_grading
             .def(py::init([](ColorGradingParams::Quality q,
                              ColorGradingParams::ToneMapping algorithm) {
@@ -515,7 +536,7 @@ void pybind_rendering_classes(py::module &m) {
                                    "The bounding box of all the items in the "
                                    "scene, visible and invisible")
             .def_property_readonly(
-                    "get_view", &Open3DScene::GetView,
+                    "view", &Open3DScene::GetView,
                     "The low level view associated with the scene")
             .def_property("downsample_threshold",
                           &Open3DScene::GetDownsampleThreshold,


### PR DESCRIPTION
Also changes open3d.visualization.rendering.Open3DScene.`get_view` to `view` (it is a property, not a function). This should have minor impact on users, since the only thing that can be done with a view is setting the color grading, but that turns out to be impossible because the enums did not exist. Hence, we should have no users using `get_view`.

Resolves #2918.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3193)
<!-- Reviewable:end -->
