### PR TITLE
Added an example for line width

### DIFF
--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -262,7 +262,8 @@ void pybind_rendering_classes(py::module &m) {
             .def_readwrite("absorption_distance",
                            &Material::absorption_distance)
             .def_readwrite("point_size", &Material::point_size)
-            .def_readwrite("line_width", &Material::line_width)
+            .def_readwrite("line_width", &Material::line_width,
+                           "Requires 'shader' to be 'unlitLine'")
             .def_readwrite("albedo_img", &Material::albedo_img)
             .def_readwrite("normal_img", &Material::normal_img)
             .def_readwrite("ao_img", &Material::ao_img)

--- a/examples/python/gui/line-width.py
+++ b/examples/python/gui/line-width.py
@@ -4,8 +4,10 @@ import random
 
 NUM_LINES = 10
 
+
 def random_point():
     return [5 * random.random(), 5 * random.random(), 5 * random.random()]
+
 
 def main():
     pts = [random_point() for _ in range(0, 2 * NUM_LINES)]
@@ -27,11 +29,14 @@ def main():
     mat = o3d.visualization.rendering.Material()
     mat.shader = "unlitLine"
     mat.line_width = 10  # note that this is scaled with respect to pixels,
-                         # so will give different results depending on the
-                         # scaling values of your system
-    o3d.visualization.draw({"name": "lines",
-                            "geometry": lines,
-                            "material": mat})
- 
+    # so will give different results depending on the
+    # scaling values of your system
+    o3d.visualization.draw({
+        "name": "lines",
+        "geometry": lines,
+        "material": mat
+    })
+
+
 if __name__ == "__main__":
     main()

--- a/examples/python/gui/line-width.py
+++ b/examples/python/gui/line-width.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import open3d as o3d
+import random
+
+NUM_LINES = 10
+
+def random_point():
+    return [5 * random.random(), 5 * random.random(), 5 * random.random()]
+
+def main():
+    pts = [random_point() for _ in range(0, 2 * NUM_LINES)]
+    line_indices = [[2 * i, 2 * i + 1] for i in range(0, NUM_LINES)]
+    colors = [[0.0, 0.0, 0.0] for _ in range(0, NUM_LINES)]
+
+    lines = o3d.geometry.LineSet()
+    lines.points = o3d.utility.Vector3dVector(pts)
+    lines.lines = o3d.utility.Vector2iVector(line_indices)
+    # The default color of the lines is white, which will be invisible on the
+    # default white background. So we either need to set the color of the lines
+    # or the base_color of the material.
+    lines.colors = o3d.utility.Vector3dVector(colors)
+
+    # Some platforms do not require OpenGL implementations to support wide lines,
+    # so the renderer requires a custom shader to implement this: "unlitLine".
+    # The line_width field is only used by this shader; all other shaders ignore
+    # it.
+    mat = o3d.visualization.rendering.Material()
+    mat.shader = "unlitLine"
+    mat.line_width = 10  # note that this is scaled with respect to pixels,
+                         # so will give different results depending on the
+                         # scaling values of your system
+    o3d.visualization.draw({"name": "lines",
+                            "geometry": lines,
+                            "material": mat})
+ 
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It's not obvious that `Material::line_width` requires `shader` to be set to "unlitLine"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3194)
<!-- Reviewable:end -->
