### PR TITLE
handle the invalid tetra warning - fix #1829

### DIFF
--- a/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionAlphaShape.cpp
@@ -113,22 +113,23 @@ std::shared_ptr<TriangleMesh> TriangleMesh::CreateFromPointCloudAlphaShape(
         double dz = tmp.determinant();
         // clang-format on
         if (a == 0) {
-            utility::LogError(
+            utility::LogWarning(
                     "[CreateFromPointCloudAlphaShape] invalid tetra in "
                     "TetraMesh");
-        }
-        double r = std::sqrt(dx * dx + dy * dy + dz * dz - 4 * a * c) /
-                   (2 * std::abs(a));
+        } else {
+            double r = std::sqrt(dx * dx + dy * dy + dz * dz - 4 * a * c) /
+                       (2 * std::abs(a));
 
-        if (r <= alpha) {
-            mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
-                    tetra(0), tetra(1), tetra(2)));
-            mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
-                    tetra(0), tetra(1), tetra(3)));
-            mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
-                    tetra(0), tetra(2), tetra(3)));
-            mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
-                    tetra(1), tetra(2), tetra(3)));
+            if (r <= alpha) {
+                mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
+                        tetra(0), tetra(1), tetra(2)));
+                mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
+                        tetra(0), tetra(1), tetra(3)));
+                mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
+                        tetra(0), tetra(2), tetra(3)));
+                mesh->triangles_.push_back(TriangleMesh::GetOrderedTriangle(
+                        tetra(1), tetra(2), tetra(3)));
+            }
         }
     }
     utility::LogDebug(


### PR DESCRIPTION
fixes #1829 

Change the handling of "invalid tetra" from error to warning. If the tetra is invalid - do not perform the calculation on the tetra but cycle to the next tetra to continue building the mesh.

This does not prevent the original incorrect Tetra but does mean that the mesh is created although there may be a missing vertex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3201)
<!-- Reviewable:end -->
