### PR TITLE
Don't allow empty geometry to be added to scene

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentScene.cpp
@@ -318,6 +318,14 @@ bool FilamentScene::AddGeometry(const std::string& object_name,
         return false;
     }
 
+    // Basic sanity checks
+    if (geometry.IsEmpty()) {
+        utility::LogDebug(
+                "Geometry for object {} is empty. Not adding geometry to scene",
+                object_name);
+        return false;
+    }
+
     auto tris = dynamic_cast<const geometry::TriangleMesh*>(&geometry);
     if (tris && tris->vertex_normals_.empty() &&
         tris->triangle_normals_.empty() &&


### PR DESCRIPTION
Prevents panic asserts from Filament when vertex buffers with 0 vertices are created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3203)
<!-- Reviewable:end -->
