### PR TITLE
Fix for CreateFromRGBDImage test

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -223,7 +223,7 @@ jobs:
             make -j$(nproc)
             make tests -j$(nproc)
             make install-pip-package -j$(nproc)
-            ./bin/tests --gtest_filter="-*CreateFromRGBDImage*"
+            ./bin/tests
             pytest ../python/test/ --ignore ../python/test/ml_ops/ --ignore ../python/test/test_color_map.py
             ccache -s
 

--- a/cpp/open3d/t/geometry/Image.cpp
+++ b/cpp/open3d/t/geometry/Image.cpp
@@ -93,6 +93,9 @@ Image Image::To(core::Dtype dtype,
                 bool copy /*= false*/,
                 utility::optional<double> scale_ /* = utility::nullopt */,
                 double offset /* = 0.0 */) const {
+    if (dtype == GetDtype() && !scale_.has_value() && offset == 0.0) {
+        return copy ? Image(data_.Clone()) : *this;
+    }
     // Check IPP datatype support for each function in IPP documentation:
     // https://software.intel.com/content/www/us/en/develop/documentation/ipp-dev-reference/top/volume-2-image-processing.html
     // IPP supports all pairs of conversions for these data types


### PR DESCRIPTION
Add special case for Image::To when there is no dtype conversion / scaling / offset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3207)
<!-- Reviewable:end -->
