### PR TITLE
SceneWidget works with layouts

### DIFF
--- a/cpp/open3d/visualization/gui/Layout.h
+++ b/cpp/open3d/visualization/gui/Layout.h
@@ -111,6 +111,9 @@ public:
     };
 
 protected:
+    int GetMinorAxisPreferredSize() const;
+    void SetMinorAxisPreferredSize(int size);
+
     Margins& GetMutableMargins();
 
 private:
@@ -132,6 +135,9 @@ public:
          const Margins& margins,
          const std::vector<std::shared_ptr<Widget>>& children);
     virtual ~Vert();
+
+    int GetPreferredWidth() const;
+    void SetPreferredWidth(int w);
 };
 
 /// This is a vertical layout with a twisty + title that can be clicked on
@@ -177,6 +183,9 @@ public:
           const Margins& margins,
           const std::vector<std::shared_ptr<Widget>>& children);
     ~Horiz();
+
+    int GetPreferredHeight() const;
+    void SetPreferredHeight(int h);
 };
 
 /// Lays out widgets in a grid. The widgets are assigned to the next
@@ -191,6 +200,9 @@ public:
 
     int GetSpacing() const;
     const Margins& GetMargins() const;
+
+    int GetPreferredWidth() const;
+    void SetPreferredWidth(int w);
 
     Size CalcPreferredSize(const Theme& theme) const override;
     void Layout(const Theme& theme) override;

--- a/cpp/open3d/visualization/gui/SceneWidget.cpp
+++ b/cpp/open3d/visualization/gui/SceneWidget.cpp
@@ -735,7 +735,12 @@ private:
 };
 
 // ----------------------------------------------------------------------------
+namespace {
+static int g_next_button_id = 1;
+}  // namespace
+
 struct SceneWidget::Impl {
+    std::string id_;
     std::shared_ptr<rendering::Open3DScene> scene_;
     geometry::AxisAlignedBoundingBox bounds_;
     std::shared_ptr<Interactors> controls_;
@@ -773,7 +778,10 @@ struct SceneWidget::Impl {
     }
 };
 
-SceneWidget::SceneWidget() : impl_(new Impl()) {}
+SceneWidget::SceneWidget() : impl_(new Impl()) {
+    impl_->id_ = std::string("SceneWidget##widget3d_") +
+                 std::to_string(g_next_button_id++);
+}
 
 SceneWidget::~SceneWidget() {
     SetScene(nullptr);  // will do any necessary cleanup
@@ -1026,13 +1034,14 @@ void SceneWidget::RemoveLabel(std::shared_ptr<Label3D> label) {
 void SceneWidget::Layout(const Theme& theme) { Super::Layout(theme); }
 
 Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
+    const auto f = GetFrame();
+
     // If the widget has changed size we need to update the viewport and the
     // camera. We can't do it in SetFrame() because we need to know the height
     // of the window to convert to OpenGL coordinates for the viewport.
     if (impl_->frame_rect_changed_) {
         impl_->frame_rect_changed_ = false;
 
-        auto f = GetFrame();
         impl_->controls_->SetViewSize(Size(f.width, f.height));
         // GUI has origin of Y axis at top, but renderer has it at bottom
         // so we need to convert coordinates.
@@ -1052,16 +1061,22 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
         impl_->controls_->SetPickNeedsRedraw();
     }
 
-    if (!impl_->labels_3d_.empty()) {
-        const auto f = GetFrame();
-        // Setup ImGUI
-        ImGui::SetNextWindowPos(ImVec2(float(f.x), float(f.y)));
-        ImGui::SetNextWindowSize(ImVec2(float(f.width), float(f.height)));
-        ImGui::Begin("3D Labels", nullptr,
-                     ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
-                             ImGuiWindowFlags_NoNav |
-                             ImGuiWindowFlags_NoBackground);
+    // The scene will be rendered to texture, so all we need to do is
+    // draw the image. This is just a pass-through, and the ImGuiFilamentBridge
+    // will blit the texture.
+    ImGui::SetNextWindowPos(ImVec2(float(f.x), float(f.y)));
+    ImGui::SetNextWindowSize(ImVec2(float(f.width), float(f.height)));
+    ImGui::Begin(impl_->id_.c_str(), nullptr,
+                 ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                         ImGuiWindowFlags_NoNav |
+                         ImGuiWindowFlags_NoBackground);
 
+    auto render_tex = impl_->scene_->GetView()->GetColorBuffer();
+    ImTextureID image_id = reinterpret_cast<ImTextureID>(render_tex.GetId());
+    ImGui::Image(image_id, ImVec2(f.width, f.height), ImVec2(0.0f, 1.0f),
+                 ImVec2(1.0f, 0.0f));
+
+    if (!impl_->labels_3d_.empty()) {
         // Draw each text label
         for (const auto& l : impl_->labels_3d_) {
             auto ndc = GetCamera()->GetNDC(l->GetPosition());
@@ -1076,14 +1091,10 @@ Widget::DrawResult SceneWidget::Draw(const DrawContext& context) {
                                 color.GetBlue(), color.GetAlpha()},
                                "%s", l->GetText());
         }
-
-        ImGui::End();
     }
 
-    // The actual drawing is done later, at the end of drawing in
-    // Window::OnDraw(), in FilamentRenderer::Draw(). We can always
-    // return NONE because any changes this frame will automatically
-    // be rendered (unlike the ImGUI parts).
+    ImGui::End();
+
     return Widget::DrawResult::NONE;
 }
 

--- a/cpp/open3d/visualization/rendering/Open3DScene.cpp
+++ b/cpp/open3d/visualization/rendering/Open3DScene.cpp
@@ -125,11 +125,6 @@ Open3DScene::Open3DScene(Renderer& renderer) : renderer_(renderer) {
     SetLighting(LightingProfile::MED_SHADOWS, {0.577f, -0.577f, -0.577f});
 
     RecreateAxis(scene, bounds_, false);
-
-    window_scene_ = renderer_.CreateScene();
-    auto window_scene = renderer_.GetScene(window_scene_);
-    window_view_ = window_scene->AddView(0, 0, 1, 1);
-    window_scene->SetBackground({0.f, 1.f, 0.f, 1.f});
 }
 
 Open3DScene::~Open3DScene() {
@@ -144,23 +139,17 @@ View* Open3DScene::GetView() const {
     return scene->GetView(view_);
 }
 
-View* Open3DScene::GetWindowView() const {
-    auto scene = renderer_.GetScene(window_scene_);
-    return scene->GetView(window_view_);
-}
-
 void Open3DScene::SetViewport(std::int32_t x,
                               std::int32_t y,
                               std::uint32_t width,
                               std::uint32_t height) {
     auto view = GetView();
-    view->SetViewport(x, y, width, height);
+    // Since we are rendering into a texture (EnableViewCaching(true) below),
+    // we need to use the entire texture; the viewport passed in is the viewport
+    // with respect to the window, and we are setting the viewport with respect
+    // to the render target here.
+    view->SetViewport(0, 0, width, height);
     view->EnableViewCaching(true);
-    auto window_view = GetWindowView();
-    window_view->SetViewport(x, y, width, height);
-    window_view->ConfigureForColorPicking();
-    auto window_scene = renderer_.GetScene(window_scene_);
-    window_scene->SetBackground(view->GetColorBuffer());
 }
 
 void Open3DScene::ShowSkybox(bool enable) {

--- a/cpp/open3d/visualization/rendering/Open3DScene.h
+++ b/cpp/open3d/visualization/rendering/Open3DScene.h
@@ -144,8 +144,6 @@ private:
 
     void SetGeometryToLOD(const GeometryData&, LOD lod);
 
-    View* GetWindowView() const;
-
 private:
     Renderer& renderer_;
     SceneHandle scene_;

--- a/cpp/open3d/visualization/rendering/filament/FilamentRenderer.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentRenderer.cpp
@@ -192,10 +192,14 @@ void FilamentRenderer::BeginFrame() {
 
 void FilamentRenderer::Draw() {
     if (frame_started_) {
+        // Draw 3D scenes into textures
         for (const auto& pair : scenes_) {
             pair.second->Draw(*renderer_);
         }
 
+        // Draw the UI. This should come after the 3D scene(s), as SceneWidget
+        // will draw the textures as an image, and this way we will have the
+        // current frame's content from above.
         if (gui_scene_) {
             gui_scene_->Draw(*renderer_);
         }

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -1370,7 +1370,10 @@ void pybind_gui_classes(py::module &m) {
                  "Creates a layout that arranges widgets vertically, top to "
                  "bottom, making their width equal to the layout's width. "
                  "First argument is the spacing between widgets, the second "
-                 "is the margins. Both default to 0.");
+                 "is the margins. Both default to 0.")
+            .def_property("preferred_width", &Vert::GetPreferredWidth,
+                          &Vert::SetPreferredWidth,
+                          "Sets the preferred width of the layout");
 
     // ---- CollapsableVert ----
     py::class_<CollapsableVert, UnownedPointer<CollapsableVert>, Vert>
@@ -1424,7 +1427,10 @@ void pybind_gui_classes(py::module &m) {
                  "right, making their height equal to the layout's height "
                  "(which will generally be the largest height of the items). "
                  "First argument is the spacing between widgets, the second "
-                 "is the margins. Both default to 0.");
+                 "is the margins. Both default to 0.")
+            .def_property("preferred_height", &Horiz::GetPreferredHeight,
+                          &Horiz::SetPreferredHeight,
+                          "Sets the preferred height of the layout");
 
     // ---- VGrid ----
     py::class_<VGrid, UnownedPointer<VGrid>, Widget> vgrid(m, "VGrid",
@@ -1456,7 +1462,10 @@ void pybind_gui_classes(py::module &m) {
                     "spacing", &VGrid::GetSpacing,
                     "Returns the spacing between rows and columns")
             .def_property_readonly("margins", &VGrid::GetMargins,
-                                   "Returns the margins");
+                                   "Returns the margins")
+            .def_property("preferred_width", &VGrid::GetPreferredWidth,
+                          &VGrid::SetPreferredWidth,
+                          "Sets the preferred width of the layout");
 
     // ---- Dialog ----
     py::class_<Dialog, UnownedPointer<Dialog>, Widget> dialog(m, "Dialog",


### PR DESCRIPTION
Moves drawing render targets from Open3DScene into SceneWidget, where they get drawn as an ImGUI image. (There is no overhead for this, ImGUI just takes an opaque ID and the ImguiFilamentBridge needs to make sure that the ID identifies the proper texture; in our case the ID is simply Filament's texture ID.) Because the image is incorporated into the UI, the painting order will be correct and SceneWidgets can now be used in a layout.

```
#!/usr/bin/env python
import open3d as o3d
import open3d.visualization.gui as gui

app = gui.Application.instance
app.initialize()

w = app.create_window("SceneWidget and Layout", 1024, 768)
em = w.theme.font_size
left = gui.VGrid(2, 0.5 * em)
widget3d = gui.SceneWidget()
right = gui.Vert(0.5 * em)
horiz = gui.Horiz()
horiz.add_child(left)
horiz.add_child(widget3d)
horiz.add_child(right)
w.add_child(horiz)

left.preferred_width = 10 * em
left.add_child(gui.Label("Double"))
left.add_child(gui.Slider(gui.Slider.Type.DOUBLE))
left.add_child(gui.Label("Options"))
cb = gui.Combobox()
cb.add_item("Item 1")
cb.add_item("Item 2")
cb.add_item("Item 3")
left.add_child(cb)

right.preferred_width = 15 * em
right.add_child(gui.Label("Lorem ipsum dolor"))

widget3d.scene = o3d.visualization.rendering.Open3DScene(w.renderer)
torus = o3d.geometry.TriangleMesh.create_torus()
torus.compute_vertex_normals()
mat = o3d.visualization.rendering.Material()
mat.shader = "defaultLit"
widget3d.scene.add_geometry("Torus", torus, mat)
bbox = widget3d.scene.bounding_box
widget3d.setup_camera(60, bbox, bbox.get_center())

app.run()
```

(If you apply the changes to Layout.h, Layout.cpp, and gui.cpp in a fresh branch, you can see that the script does not show the 3D scene, which is under the horiz layout)

This also turns out to fix scene not being redrawn in Open3DViewer when model is loaded (until a mouse event or something else causes a redraw), especially when a model is specified on the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3212)
<!-- Reviewable:end -->
