### PR TITLE
Improves progress bar in Open3DViewer app, also fixes unlit material instead of lit

### DIFF
--- a/cpp/open3d/io/ModelIO.cpp
+++ b/cpp/open3d/io/ModelIO.cpp
@@ -36,12 +36,20 @@ namespace io {
 
 bool ReadModelUsingAssimp(const std::string& filename,
                           visualization::rendering::TriangleMeshModel& model,
-                          bool print_progress);
+                          const ReadTriangleModelOptions& params /*={}*/);
 
 bool ReadTriangleModel(const std::string& filename,
                        visualization::rendering::TriangleMeshModel& model,
-                       bool print_progress) {
-    return ReadModelUsingAssimp(filename, model, print_progress);
+                       ReadTriangleModelOptions params /*={}*/) {
+    if (params.print_progress) {
+        auto progress_text = std::string("Reading model file") + filename;
+        auto pbar = utility::ConsoleProgressBar(100, progress_text, true);
+        params.update_progress = [pbar](double percent) mutable -> bool {
+            pbar.SetCurrentCount(size_t(percent));
+            return true;
+        };
+    }
+    return ReadModelUsingAssimp(filename, model, params);
 }
 
 }  // namespace io

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 
 namespace open3d {

--- a/cpp/open3d/io/ModelIO.h
+++ b/cpp/open3d/io/ModelIO.h
@@ -37,9 +37,20 @@ struct TriangleMeshModel;
 
 namespace io {
 
+struct ReadTriangleModelOptions {
+    /// Print progress to stdout about loading progress.
+    /// Also see \p update_progress if you want to have your own progress
+    /// indicators or to be able to cancel loading.
+    bool print_progress = false;
+    /// Callback to invoke as reading is progressing, parameter is percentage
+    /// completion (0.-100.) return true indicates to continue loading, false
+    /// means to try to stop loading and cleanup
+    std::function<bool(double)> update_progress;
+};
+
 bool ReadTriangleModel(const std::string& filename,
                        visualization::rendering::TriangleMeshModel& model,
-                       bool print_progress);
+                       ReadTriangleModelOptions params = {});
 
 }  // namespace io
 }  // namespace open3d

--- a/cpp/open3d/io/TriangleMeshIO.h
+++ b/cpp/open3d/io/TriangleMeshIO.h
@@ -38,13 +38,25 @@ namespace io {
 std::shared_ptr<geometry::TriangleMesh> CreateMeshFromFile(
         const std::string &filename, bool print_progress = false);
 
+struct ReadTriangleMeshOptions {
+    /// Enables post-processing on the mesh
+    bool enable_post_processing = false;
+    /// Print progress to stdout about loading progress.
+    /// Also see \p update_progress if you want to have your own progress
+    /// indicators or to be able to cancel loading.
+    bool print_progress = false;
+    /// Callback to invoke as reading is progressing, parameter is percentage
+    /// completion (0.-100.) return true indicates to continue loading, false
+    /// means to try to stop loading and cleanup
+    std::function<bool(double)> update_progress;
+};
+
 /// The general entrance for reading a TriangleMesh from a file
 /// The function calls read functions based on the extension name of filename.
 /// \return return true if the read function is successful, false otherwise.
 bool ReadTriangleMesh(const std::string &filename,
                       geometry::TriangleMesh &mesh,
-                      bool enable_post_processing = false,
-                      bool print_progress = false);
+                      ReadTriangleMeshOptions params = {});
 
 /// The general entrance for writing a TriangleMesh to a file
 /// The function calls write functions based on the extension name of filename.
@@ -65,8 +77,7 @@ bool WriteTriangleMesh(const std::string &filename,
 // Currently enable_post_processing not used in ReadTriangleMeshFromPLY.
 bool ReadTriangleMeshFromPLY(const std::string &filename,
                              geometry::TriangleMesh &mesh,
-                             bool enable_post_processing,
-                             bool print_progress);
+                             const ReadTriangleMeshOptions &params);
 
 bool WriteTriangleMeshToPLY(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
@@ -86,9 +97,10 @@ bool WriteTriangleMeshToSTL(const std::string &filename,
                             bool write_triangle_uvs,
                             bool print_progress);
 
+// Currently enable_post_processing not used in ReadTriangleMeshFromOBJ.
 bool ReadTriangleMeshFromOBJ(const std::string &filename,
                              geometry::TriangleMesh &mesh,
-                             bool print_progress);
+                             const ReadTriangleMeshOptions &params);
 
 bool WriteTriangleMeshToOBJ(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
@@ -101,14 +113,12 @@ bool WriteTriangleMeshToOBJ(const std::string &filename,
 
 bool ReadTriangleMeshUsingASSIMP(const std::string &filename,
                                  geometry::TriangleMesh &mesh,
-                                 bool enable_post_processing,
-                                 bool print_progress);
+                                 const ReadTriangleMeshOptions &params);
 
 // Currently enable_post_processing not used in ReadTriangleMeshFromOFF.
 bool ReadTriangleMeshFromOFF(const std::string &filename,
                              geometry::TriangleMesh &mesh,
-                             bool enable_post_processing,
-                             bool print_progress);
+                             const ReadTriangleMeshOptions &params);
 
 bool WriteTriangleMeshToOFF(const std::string &filename,
                             const geometry::TriangleMesh &mesh,
@@ -119,9 +129,10 @@ bool WriteTriangleMeshToOFF(const std::string &filename,
                             bool write_triangle_uvs,
                             bool print_progress);
 
+// Currently enable_post_processing not used in ReadTriangleMeshFromGLTF.
 bool ReadTriangleMeshFromGLTF(const std::string &filename,
                               geometry::TriangleMesh &mesh,
-                              bool print_progress);
+                              const ReadTriangleMeshOptions &params);
 
 bool WriteTriangleMeshToGLTF(const std::string &filename,
                              const geometry::TriangleMesh &mesh,

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -29,14 +29,17 @@
 #include <vector>
 
 #include "assimp/Importer.hpp"
+#include "assimp/ProgressHandler.hpp"
 #include "assimp/pbrmaterial.h"
 #include "assimp/postprocess.h"
 #include "assimp/scene.h"
 #include "open3d/io/FileFormatIO.h"
 #include "open3d/io/ImageIO.h"
+#include "open3d/io/ModelIO.h"
 #include "open3d/io/TriangleMeshIO.h"
 #include "open3d/utility/Console.h"
 #include "open3d/utility/FileSystem.h"
+#include "open3d/utility/ProgressReporters.h"
 #include "open3d/visualization/rendering/Material.h"
 #include "open3d/visualization/rendering/Model.h"
 
@@ -136,15 +139,15 @@ void LoadTextures(const std::string& filename,
     // anisotropy
 }
 
-bool ReadTriangleMeshUsingASSIMP(const std::string& filename,
-                                 geometry::TriangleMesh& mesh,
-                                 bool enable_post_processing,
-                                 bool print_progress) {
+bool ReadTriangleMeshUsingASSIMP(
+        const std::string& filename,
+        geometry::TriangleMesh& mesh,
+        const ReadTriangleMeshOptions& params /*={}*/) {
     Assimp::Importer importer;
 
     unsigned int post_process_flags = 0;
 
-    if (enable_post_processing) {
+    if (params.enable_post_processing) {
         post_process_flags = kPostProcessFlags;
     }
 
@@ -273,13 +276,45 @@ bool ReadTriangleMeshUsingASSIMP(const std::string& filename,
 
 bool ReadModelUsingAssimp(const std::string& filename,
                           visualization::rendering::TriangleMeshModel& model,
-                          bool print_progress) {
+                          const ReadTriangleModelOptions& params /*={}*/) {
+    int64_t progress_total = 100;  // 70: ReadFile(), 10: mesh, 20: textures
+    float readfile_total = 70.0f;
+    float mesh_total = 10.0f;
+    float textures_total = 20.0f;
+    int64_t progress = 0;
+    utility::CountingProgressReporter reporter(params.update_progress);
+    reporter.SetTotal(progress_total);
+    class AssimpProgress : public Assimp::ProgressHandler {
+    public:
+        AssimpProgress(const ReadTriangleModelOptions& params, float scaling)
+            : params_(params), scaling_(scaling) {}
+
+        bool Update(float percentage = -1.0f) override {
+            if (params_.update_progress) {
+                params_.update_progress(
+                        std::max(0.0f, 100.0f * scaling_ * percentage));
+            }
+            return true;
+        }
+
+    private:
+        const ReadTriangleModelOptions& params_;
+        float scaling_;
+    };
+
     Assimp::Importer importer;
+    // The ASSIMP documentation does not say who owns the progress handler
+    // pointer, but empirically it the importer seems to take ownership.
+    importer.SetProgressHandler(
+            new AssimpProgress(params, readfile_total / progress_total));
     const auto* scene = importer.ReadFile(filename.c_str(), kPostProcessFlags);
     if (!scene) {
         utility::LogWarning("Unable to load file {} with ASSIMP", filename);
         return false;
     }
+
+    progress = int64_t(readfile_total);
+    reporter.Update(progress);
 
     // Process each Assimp mesh into a geometry::TriangleMesh
     for (size_t midx = 0; midx < scene->mNumMeshes; ++midx) {
@@ -344,6 +379,9 @@ bool ReadModelUsingAssimp(const std::string& filename,
                                  assimp_mesh->mMaterialIndex});
     }
 
+    progress = int64_t(readfile_total + mesh_total);
+    reporter.Update(progress);
+
     // Load materials
     for (size_t i = 0; i < scene->mNumMaterials; ++i) {
         auto* mat = scene->mMaterials[i];
@@ -393,7 +431,14 @@ bool ReadModelUsingAssimp(const std::string& filename,
         }
 
         model.materials_.push_back(o3d_mat);
+
+        progress = int64_t(readfile_total + mesh_total +
+                           textures_total * float(i + 1) /
+                                   float(scene->mNumMaterials));
+        reporter.Update(progress);
     }
+
+    reporter.Update(progress_total);
 
     return true;
 }

--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -303,8 +303,8 @@ bool ReadModelUsingAssimp(const std::string& filename,
     };
 
     Assimp::Importer importer;
-    // The ASSIMP documentation does not say who owns the progress handler
-    // pointer, but empirically it the importer seems to take ownership.
+    // The importer takes ownership of the pointer (the documentation
+    // is silent on this salient point).
     importer.SetProgressHandler(
             new AssimpProgress(params, readfile_total / progress_total));
     const auto* scene = importer.ReadFile(filename.c_str(), kPostProcessFlags);

--- a/cpp/open3d/io/file_format/FileGLTF.cpp
+++ b/cpp/open3d/io/file_format/FileGLTF.cpp
@@ -93,7 +93,7 @@ FileGeometry ReadFileGeometryTypeGLTF(const std::string& path) {
 
 bool ReadTriangleMeshFromGLTF(const std::string& filename,
                               geometry::TriangleMesh& mesh,
-                              bool print_progress) {
+                              const ReadTriangleMeshOptions& params /*={}*/) {
     tinygltf::Model model;
     tinygltf::TinyGLTF loader;
     std::string warn;

--- a/cpp/open3d/io/file_format/FileOBJ.cpp
+++ b/cpp/open3d/io/file_format/FileOBJ.cpp
@@ -45,7 +45,7 @@ FileGeometry ReadFileGeometryTypeOBJ(const std::string& path) {
 
 bool ReadTriangleMeshFromOBJ(const std::string& filename,
                              geometry::TriangleMesh& mesh,
-                             bool print_progress) {
+                             const ReadTriangleMeshOptions& /*={}*/) {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
     std::vector<tinyobj::material_t> materials;

--- a/cpp/open3d/io/file_format/FileOFF.cpp
+++ b/cpp/open3d/io/file_format/FileOFF.cpp
@@ -30,6 +30,7 @@
 #include "open3d/io/FileFormatIO.h"
 #include "open3d/io/TriangleMeshIO.h"
 #include "open3d/utility/Console.h"
+#include "open3d/utility/ProgressReporters.h"
 
 namespace open3d {
 namespace io {
@@ -40,8 +41,7 @@ FileGeometry ReadFileGeometryTypeOFF(const std::string &path) {
 
 bool ReadTriangleMeshFromOFF(const std::string &filename,
                              geometry::TriangleMesh &mesh,
-                             bool enable_post_processing,
-                             bool print_progress) {
+                             const ReadTriangleMeshOptions &params) {
     std::ifstream file(filename.c_str(), std::ios::in);
     if (!file) {
         utility::LogWarning("Read OFF failed: unable to open file: {}",
@@ -93,8 +93,8 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
         mesh.vertex_colors_.resize(num_of_vertices);
     }
 
-    utility::ConsoleProgressBar progress_bar(num_of_vertices + num_of_faces,
-                                             "Reading OFF: ", print_progress);
+    utility::CountingProgressReporter reporter(params.update_progress);
+    reporter.SetTotal(num_of_vertices + num_of_faces);
 
     float vx, vy, vz;
     float nx, ny, nz;
@@ -131,7 +131,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
                     Eigen::Vector3d(r / 255, g / 255, b / 255);
         }
 
-        ++progress_bar;
+        ++reporter;
     }
 
     unsigned int n, vertex_index;
@@ -157,7 +157,7 @@ bool ReadTriangleMeshFromOFF(const std::string &filename,
                     indices);
             return false;
         }
-        ++progress_bar;
+        ++reporter;
     }
 
     file.close();

--- a/cpp/open3d/io/file_format/FilePLY.cpp
+++ b/cpp/open3d/io/file_format/FilePLY.cpp
@@ -114,7 +114,7 @@ int ReadColorCallback(p_ply_argument argument) {
 namespace ply_trianglemesh_reader {
 
 struct PLYReaderState {
-    utility::ConsoleProgressBar *progress_bar;
+    utility::CountingProgressReporter *progress_bar;
     geometry::TriangleMesh *mesh_ptr;
     long vertex_index;
     long vertex_num;
@@ -538,8 +538,7 @@ bool WritePointCloudToPLY(const std::string &filename,
 
 bool ReadTriangleMeshFromPLY(const std::string &filename,
                              geometry::TriangleMesh &mesh,
-                             bool enable_post_processing,
-                             bool print_progress) {
+                             const ReadTriangleMeshOptions &params /*={}*/) {
     using namespace ply_trianglemesh_reader;
 
     p_ply ply_file = ply_open(filename.c_str(), NULL, 0, NULL);
@@ -594,9 +593,9 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
     mesh.vertex_normals_.resize(state.normal_num);
     mesh.vertex_colors_.resize(state.color_num);
 
-    utility::ConsoleProgressBar progress_bar(state.vertex_num + state.face_num,
-                                             "Reading PLY: ", print_progress);
-    state.progress_bar = &progress_bar;
+    utility::CountingProgressReporter reporter(params.update_progress);
+    reporter.SetTotal(state.vertex_num + state.face_num);
+    state.progress_bar = &reporter;
 
     if (!ply_read(ply_file)) {
         utility::LogWarning("Read PLY failed: unable to read file: {}",
@@ -606,6 +605,7 @@ bool ReadTriangleMeshFromPLY(const std::string &filename,
     }
 
     ply_close(ply_file);
+    reporter.Finish();
     return true;
 }
 

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -270,9 +270,14 @@ public:
     }
 
     ConsoleProgressBar &operator++() {
-        current_count_++;
+        SetCurrentCount(current_count_ + 1);
+        return *this;
+    }
+
+    void SetCurrentCount(size_t n) {
+        current_count_ = n;
         if (!active_) {
-            return *this;
+            return;
         }
         if (current_count_ >= expected_count_) {
             fmt::print("{}[{}] 100%\n", progress_info_,
@@ -290,7 +295,6 @@ public:
                 fflush(stdout);
             }
         }
-        return *this;
     }
 
 private:

--- a/cpp/open3d/visualization/visualizer/GuiSettingsModel.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiSettingsModel.cpp
@@ -201,6 +201,7 @@ const GuiSettingsModel::LitMaterial& GuiSettingsModel::GetDefaultLitMaterial() {
 GuiSettingsModel::GuiSettingsModel() {
     lighting_ = GetDefaultLightingProfile();
     current_materials_.lit = GetDefaultLitMaterial();
+    current_materials_.lit_name = DEFAULT_MATERIAL_NAME;
 }
 
 bool GuiSettingsModel::GetShowSkybox() const { return show_skybox_; }

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -215,8 +215,10 @@ void pybind_class_io(py::module &m_io) {
                bool print_progress) {
                 py::gil_scoped_release release;
                 geometry::TriangleMesh mesh;
-                ReadTriangleMesh(filename, mesh, enable_post_processing,
-                                 print_progress);
+                ReadTriangleMeshOptions opt;
+                opt.enable_post_processing = enable_post_processing;
+                opt.print_progress = print_progress;
+                ReadTriangleMesh(filename, mesh, opt);
                 return mesh;
             },
             "Function to read TriangleMesh from file", "filename"_a,
@@ -249,7 +251,9 @@ void pybind_class_io(py::module &m_io) {
             [](const std::string &filename, bool print_progress) {
                 py::gil_scoped_release release;
                 visualization::rendering::TriangleMeshModel model;
-                ReadTriangleModel(filename, model, print_progress);
+                ReadTriangleModelOptions opt;
+                opt.print_progress = print_progress;
+                ReadTriangleModel(filename, model, opt);
                 return model;
             },
             "Function to read visualization.rendering.TriangleMeshModel from "

--- a/cpp/tests/io/file_format/FileGLTF.cpp
+++ b/cpp/tests/io/file_format/FileGLTF.cpp
@@ -40,7 +40,9 @@ TEST(FileGLTF, WriteReadTriangleMeshFromGLTF) {
     io::WriteTriangleMesh("tmp.gltf", tm_gt);
 
     geometry::TriangleMesh tm_test;
-    io::ReadTriangleMesh("tmp.gltf", tm_test, false);
+    io::ReadTriangleMeshOptions opt;
+    opt.print_progress = false;
+    io::ReadTriangleMesh("tmp.gltf", tm_test, opt);
 
     ExpectEQ(tm_gt.vertices_, tm_test.vertices_);
     ExpectEQ(tm_gt.triangles_, tm_test.triangles_);

--- a/cpp/tests/io/file_format/FileSTL.cpp
+++ b/cpp/tests/io/file_format/FileSTL.cpp
@@ -40,7 +40,9 @@ TEST(FileSTL, WriteReadTriangleMeshFromSTL) {
     io::WriteTriangleMesh("tmp.stl", tm_gt);
 
     geometry::TriangleMesh tm_test;
-    io::ReadTriangleMesh("tmp.stl", tm_test, false);
+    io::ReadTriangleMeshOptions opt;
+    opt.print_progress = false;
+    io::ReadTriangleMesh("tmp.stl", tm_test, opt);
 
     ExpectEQ(tm_gt.vertices_, tm_test.vertices_);
     ExpectEQ(tm_gt.triangles_, tm_test.triangles_);


### PR DESCRIPTION
Progress bar isn't perfect, ASSIMP doesn't quantize internal computations of normals, but it is better than what we had before (the progress bar did not work at all). Progress feedback is also added to ReadTriangleMesh() subfunctions, but most of them did not work with print_progress=True, so not much change there.

Fixed Open3DViewer using unlit material for triangle meshes instead of lit material (regression due to changing the default shader for Material).

Fixed some console warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3238)
<!-- Reviewable:end -->
