### PR TITLE
refactor logging, add option to log to console

### DIFF
--- a/cpp/open3d/geometry/PointCloudCluster.cpp
+++ b/cpp/open3d/geometry/PointCloudCluster.cpp
@@ -39,10 +39,10 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
                                            bool print_progress) const {
     KDTreeFlann kdtree(*this);
 
-    // precompute all neighbours
-    utility::LogDebug("Precompute Neighbours");
+    // Precompute all neighbors.
+    utility::LogDebug("Precompute neighbors.");
     utility::ConsoleProgressBar progress_bar(
-            points_.size(), "Precompute Neighbours", print_progress);
+            points_.size(), "Precompute neighbors.", print_progress);
     std::vector<std::vector<int>> nbs(points_.size());
 #pragma omp parallel for schedule(static)
     for (int idx = 0; idx < int(points_.size()); ++idx) {
@@ -52,19 +52,20 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
 #pragma omp critical
         { ++progress_bar; }
     }
-    utility::LogDebug("Done Precompute Neighbours");
+    utility::LogDebug("Done Precompute neighbors.");
 
-    // set all labels to undefined (-2)
+    // Set all labels to undefined (-2).
     utility::LogDebug("Compute Clusters");
-    progress_bar.reset(points_.size(), "Clustering", print_progress);
+    progress_bar.Reset(points_.size(), "Clustering", print_progress);
     std::vector<int> labels(points_.size(), -2);
     int cluster_label = 0;
     for (size_t idx = 0; idx < points_.size(); ++idx) {
-        if (labels[idx] != -2) {  // label is not undefined
+        // Label is not undefined.
+        if (labels[idx] != -2) {
             continue;
         }
 
-        // check density
+        // Check density.
         if (nbs[idx].size() < min_points) {
             labels[idx] = -1;
             continue;
@@ -81,11 +82,13 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
             nbs_next.erase(nbs_next.begin());
             nbs_visited.insert(nb);
 
-            if (labels[nb] == -1) {  // noise label
+            // Noise label.
+            if (labels[nb] == -1) {
                 labels[nb] = cluster_label;
                 ++progress_bar;
             }
-            if (labels[nb] != -2) {  // not undefined label
+            // Not undefined label.
+            if (labels[nb] != -2) {
                 continue;
             }
             labels[nb] = cluster_label;

--- a/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionPoisson.cpp
@@ -673,9 +673,9 @@ void Execute(const open3d::geometry::PointCloud& pcd,
             typename FEMTree<Dim, Real>::SolverInfo sInfo;
             sInfo.cgDepth = 0, sInfo.cascadic = true, sInfo.vCycles = 1,
             sInfo.iters = iters, sInfo.cgAccuracy = cg_solver_accuracy,
-            sInfo.verbose = utility::Logger::i().verbosity_level_ ==
+            sInfo.verbose = utility::GetVerbosityLevel() ==
                             utility::VerbosityLevel::Debug,
-            sInfo.showResidual = utility::Logger::i().verbosity_level_ ==
+            sInfo.showResidual = utility::GetVerbosityLevel() ==
                                  utility::VerbosityLevel::Debug,
             sInfo.showGlobalResidual = SHOW_GLOBAL_RESIDUAL_NONE,
             sInfo.sliceBlockSize = 1;

--- a/cpp/open3d/utility/Console.cpp
+++ b/cpp/open3d/utility/Console.cpp
@@ -47,53 +47,189 @@
 #include "open3d/utility/Helper.h"
 
 namespace open3d {
-
 namespace utility {
 
-void Logger::ChangeConsoleColor(TextColor text_color,
-                                int highlight_text) const {
-#ifdef _WIN32
-    const WORD EMPHASIS_MASK[2] = {0, FOREGROUND_INTENSITY};
-    const WORD COLOR_MASK[8] = {
-            0,
-            FOREGROUND_RED,
-            FOREGROUND_GREEN,
-            FOREGROUND_GREEN | FOREGROUND_RED,
-            FOREGROUND_BLUE,
-            FOREGROUND_RED | FOREGROUND_BLUE,
-            FOREGROUND_GREEN | FOREGROUND_BLUE,
-            FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_RED};
-    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-    SetConsoleTextAttribute(
-            h, EMPHASIS_MASK[highlight_text] | COLOR_MASK[(int)text_color]);
-#else
-    printf("%c[%d;%dm", 0x1B, highlight_text, (int)text_color + 30);
+enum class TextColor {
+    Black = 0,
+    Red = 1,
+    Green = 2,
+    Yellow = 3,
+    Blue = 4,
+    Magenta = 5,
+    Cyan = 6,
+    White = 7
+};
+
+struct Logger::Impl {
+    // The current print function.
+    std::function<void(const std::string &)> print_fcn_;
+
+    // The default print function (that prints to console).
+    static std::function<void(const std::string &)> console_print_fcn_;
+
+    // Verbosity level.
+    VerbosityLevel verbosity_level_;
+
+    // Colorize and reset the color of a string, does not work on Windows,
+    std::string ColorString(const std::string &text,
+                            TextColor text_color,
+                            int highlight_text) const {
+        std::ostringstream msg;
+#ifndef _WIN32
+        msg << fmt::sprintf("%c[%d;%dm", 0x1B, highlight_text,
+                            (int)text_color + 30);
 #endif
+        msg << text;
+#ifndef _WIN32
+        msg << fmt::sprintf("%c[0;m", 0x1B);
+#endif
+        return msg.str();
+    }
+};
+
+std::function<void(const std::string &)> Logger::Impl::console_print_fcn_ =
+        [](const std::string &msg) { std::cout << msg << std::endl; };
+
+Logger::Logger() : impl_(new Logger::Impl()) {
+    impl_->print_fcn_ = Logger::Impl::console_print_fcn_;
+    impl_->verbosity_level_ = VerbosityLevel::Info;
 }
 
-void Logger::ResetConsoleColor() const {
-#ifdef _WIN32
-    HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
-    SetConsoleTextAttribute(
-            h, FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_RED);
-#else
-    printf("%c[0;m", 0x1B);
-#endif
+Logger &Logger::GetInstance() {
+    static Logger instance;
+    return instance;
 }
 
-std::string Logger::ColorString(const std::string &text,
-                                TextColor text_color,
-                                int highlight_text) const {
-    std::ostringstream msg;
-#ifndef _WIN32
-    msg << fmt::sprintf("%c[%d;%dm", 0x1B, highlight_text,
-                        (int)text_color + 30);
-#endif
-    msg << text;
-#ifndef _WIN32
-    msg << fmt::sprintf("%c[0;m", 0x1B);
-#endif
-    return msg.str();
+void Logger::VError [[noreturn]] (const char *file_name,
+                                  int line_number,
+                                  const char *function_name,
+                                  bool force_console_log,
+                                  const char *format,
+                                  fmt::format_args args) const {
+    std::string err_msg = fmt::vformat(format, args);
+    err_msg = fmt::format("[Open3D Error] ({}) {}:{}: {}\n", function_name,
+                          file_name, line_number, err_msg);
+    err_msg = impl_->ColorString(err_msg, TextColor::Red, 1);
+
+    throw std::runtime_error(err_msg);
+}
+
+void Logger::VWarning(const char *file_name,
+                      int line_number,
+                      const char *function_name,
+                      bool force_console_log,
+                      const char *format,
+                      fmt::format_args args) const {
+    if (impl_->verbosity_level_ >= VerbosityLevel::Warning) {
+        std::string err_msg = fmt::vformat(format, args);
+        err_msg = fmt::format("[Open3D WARNING] {}", err_msg);
+        err_msg = impl_->ColorString(err_msg, TextColor::Yellow, 1);
+        if (force_console_log) {
+            Logger::Impl::console_print_fcn_(err_msg);
+        } else {
+            impl_->print_fcn_(err_msg);
+        }
+    }
+}
+
+void Logger::VInfo(const char *file_name,
+                   int line_number,
+                   const char *function_name,
+                   bool force_console_log,
+                   const char *format,
+                   fmt::format_args args) const {
+    if (impl_->verbosity_level_ >= VerbosityLevel::Info) {
+        std::string err_msg = fmt::vformat(format, args);
+        err_msg = fmt::format("[Open3D INFO] {}", err_msg);
+        if (force_console_log) {
+            Logger::Impl::console_print_fcn_(err_msg);
+        } else {
+            impl_->print_fcn_(err_msg);
+        }
+    }
+}
+
+void Logger::VDebug(const char *file_name,
+                    int line_number,
+                    const char *function_name,
+                    bool force_console_log,
+                    const char *format,
+                    fmt::format_args args) const {
+    if (impl_->verbosity_level_ >= VerbosityLevel::Debug) {
+        std::string err_msg = fmt::vformat(format, args);
+        err_msg = fmt::format("[Open3D DEBUG] {}", err_msg);
+        if (force_console_log) {
+            Logger::Impl::console_print_fcn_(err_msg);
+        } else {
+            impl_->print_fcn_(err_msg);
+        }
+    }
+}
+
+void Logger::SetPrintFunction(
+        std::function<void(const std::string &)> print_fcn) {
+    impl_->print_fcn_ = print_fcn;
+}
+
+void Logger::SetVerbosityLevel(VerbosityLevel verbosity_level) {
+    impl_->verbosity_level_ = verbosity_level;
+}
+
+VerbosityLevel Logger::GetVerbosityLevel() const {
+    return impl_->verbosity_level_;
+}
+
+ConsoleProgressBar::ConsoleProgressBar(size_t expected_count,
+                                       const std::string &progress_info,
+                                       bool active) {
+    Reset(expected_count, progress_info, active);
+}
+
+void ConsoleProgressBar::Reset(size_t expected_count,
+                               const std::string &progress_info,
+                               bool active) {
+    expected_count_ = expected_count;
+    current_count_ = static_cast<size_t>(-1);  // Guaranteed to wraparound
+    progress_info_ = progress_info;
+    progress_pixel_ = 0;
+    active_ = active;
+    operator++();
+}
+
+ConsoleProgressBar &ConsoleProgressBar::operator++() {
+    SetCurrentCount(current_count_ + 1);
+    return *this;
+}
+
+void ConsoleProgressBar::SetCurrentCount(size_t n) {
+    current_count_ = n;
+    if (!active_) {
+        return;
+    }
+    if (current_count_ >= expected_count_) {
+        fmt::print("{}[{}] 100%\n", progress_info_,
+                   std::string(resolution_, '='));
+    } else {
+        size_t new_progress_pixel =
+                int(current_count_ * resolution_ / expected_count_);
+        if (new_progress_pixel > progress_pixel_) {
+            progress_pixel_ = new_progress_pixel;
+            int percent = int(current_count_ * 100 / expected_count_);
+            fmt::print("{}[{}>{}] {:d}%\r", progress_info_,
+                       std::string(progress_pixel_, '='),
+                       std::string(resolution_ - 1 - progress_pixel_, ' '),
+                       percent);
+            fflush(stdout);
+        }
+    }
+}
+
+void SetVerbosityLevel(VerbosityLevel level) {
+    Logger::GetInstance().SetVerbosityLevel(level);
+}
+
+VerbosityLevel GetVerbosityLevel() {
+    return Logger::GetInstance().GetVerbosityLevel();
 }
 
 std::string GetCurrentTimeStamp() {

--- a/cpp/open3d/utility/Console.h
+++ b/cpp/open3d/utility/Console.h
@@ -57,17 +57,74 @@
 #define __FN__ __PRETTY_FUNCTION__
 #endif
 
-// Mimic 'macro in namespace' by concatenating utility:: and _LogError.
+// Mimic "macro in namespace" by concatenating `utility::` and a macro.
 // Ref: https://stackoverflow.com/a/11791202
+//
 // We avoid using (format, ...) since in this case __VA_ARGS__ can be
 // empty, and the behavior of pruning trailing comma with ##__VA_ARGS__ is not
 // officially standard.
 // Ref: https://stackoverflow.com/a/28074198
+//
 // __PRETTY_FUNCTION__ has to be converted, otherwise a bug regarding [noreturn]
 // will be triggered.
 // Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94742
-#define LogError(...) \
-    _LogError(__FILE__, __LINE__, (const char *)__FN__, __VA_ARGS__)
+
+// LogError throws now a runtime_error with the given error message. This
+// should be used if there is no point in continuing the given algorithm at
+// some point and the error is not returned in another way (e.g., via a
+// bool/int as return value).
+//
+// Usage  : utility::LogError(format_string, arg0, arg1, ...);
+// Example: utility::LogError("name: {}, age: {}", "dog", 5);
+#define LogError(...)                                                  \
+    Logger::_LogError(__FILE__, __LINE__, (const char *)__FN__, false, \
+                      __VA_ARGS__)
+// Same as LogError but enforce printing the message in the console.
+#define LogErrorConsole(...)                                          \
+    Logger::_LogError(__FILE__, __LINE__, (const char *)__FN__, true, \
+                      __VA_ARGS__)
+
+// LogWarning is used if an error occurs, but the error is also signaled
+// via a return value (i.e., there is no need to throw an exception). This
+// warning should further be used, if the algorithms encounters a state
+// that does not break its continuation, but the output is likely not to be
+// what the user expected.
+//
+// Usage  : utility::LogWarning(format_string, arg0, arg1, ...);
+// Example: utility::LogWarning("name: {}, age: {}", "dog", 5);
+#define LogWarning(...)                                                  \
+    Logger::_LogWarning(__FILE__, __LINE__, (const char *)__FN__, false, \
+                        __VA_ARGS__)
+// Same as LogWarning but enforce printing the message in the console.
+#define LogWarningConsole(...)                                          \
+    Logger::_LogWarning(__FILE__, __LINE__, (const char *)__FN__, true, \
+                        __VA_ARGS__)
+
+// LogInfo is used to inform the user with expected output, e.g, pressed a
+// key in the visualizer prints helping information.
+//
+// Usage  : utility::LogInfo(format_string, arg0, arg1, ...);
+// Example: utility::LogInfo("name: {}, age: {}", "dog", 5);
+#define LogInfo(...)                                                  \
+    Logger::_LogInfo(__FILE__, __LINE__, (const char *)__FN__, false, \
+                     __VA_ARGS__)
+// Same as LogInfo but enforce printing the message in the console.
+#define LogInfoConsole(...)                                          \
+    Logger::_LogInfo(__FILE__, __LINE__, (const char *)__FN__, true, \
+                     __VA_ARGS__)
+
+// LogDebug is used to print debug/additional information on the state of
+// the algorithm.
+//
+// Usage  : utility::LogDebug(format_string, arg0, arg1, ...);
+// Example: utility::LogDebug("name: {}, age: {}", "dog", 5);
+#define LogDebug(...)                                                  \
+    Logger::_LogDebug(__FILE__, __LINE__, (const char *)__FN__, false, \
+                      __VA_ARGS__)
+// Same as LogDebug but enforce printing the message in the console.
+#define LogDebugConsole(...)                                          \
+    Logger::_LogDebug(__FILE__, __LINE__, (const char *)__FN__, true, \
+                      __VA_ARGS__)
 
 namespace open3d {
 namespace utility {
@@ -78,7 +135,7 @@ enum class VerbosityLevel {
     /// some point and the error is not returned in another way (e.g., via a
     /// bool/int as return value).
     Error = 0,
-    /// LogWarning is used if an error occured, but the error is also signaled
+    /// LogWarning is used if an error occurs, but the error is also signaled
     /// via a return value (i.e., there is no need to throw an exception). This
     /// warning should further be used, if the algorithms encounters a state
     /// that does not break its continuation, but the output is likely not to be
@@ -92,158 +149,128 @@ enum class VerbosityLevel {
     Debug = 3,
 };
 
+/// Logger class should be used as a global singleton object (GetInstance()).
 class Logger {
 public:
-    enum class TextColor {
-        Black = 0,
-        Red = 1,
-        Green = 2,
-        Yellow = 3,
-        Blue = 4,
-        Magenta = 5,
-        Cyan = 6,
-        White = 7
-    };
-
-    Logger() : verbosity_level_(VerbosityLevel::Info) {}
     Logger(Logger const &) = delete;
     void operator=(Logger const &) = delete;
 
-    static Logger &i() {
-        static Logger instance;
-        return instance;
+    /// Get Logger global singleton instance.
+    static Logger &GetInstance();
+
+    /// Overwrite the default print function, this is useful when you want to
+    /// redirect prints rather than printing to stdout. For example, in Open3D's
+    /// python binding, the default print function is replaced with py::print().
+    ///
+    /// \param print_fcn The function for printing. It should take a string
+    /// input and returns nothing.
+    void SetPrintFunction(std::function<void(const std::string &)> print_fcn);
+
+    /// Set global verbosity level of Open3D.
+    ///
+    /// \param level Messages with equal or less than verbosity_level verbosity
+    /// will be printed.
+    void SetVerbosityLevel(VerbosityLevel verbosity_level);
+
+    /// Get global verbosity level of Open3D.
+    VerbosityLevel GetVerbosityLevel() const;
+
+    template <typename... Args>
+    static void _LogError [[noreturn]] (const char *file_name,
+                                        int line_number,
+                                        const char *function_name,
+                                        bool force_console_log,
+                                        const char *format,
+                                        Args &&... args) {
+        Logger::GetInstance().VError(file_name, line_number, function_name,
+                                     force_console_log, format,
+                                     fmt::make_format_args(args...));
+    }
+    template <typename... Args>
+    static void _LogWarning(const char *file_name,
+                            int line_number,
+                            const char *function_name,
+                            bool force_console_log,
+                            const char *format,
+                            Args &&... args) {
+        Logger::GetInstance().VWarning(file_name, line_number, function_name,
+                                       force_console_log, format,
+                                       fmt::make_format_args(args...));
+    }
+    template <typename... Args>
+    static void _LogInfo(const char *file_name,
+                         int line_number,
+                         const char *function_name,
+                         bool force_console_log,
+                         const char *format,
+                         Args &&... args) {
+        Logger::GetInstance().VInfo(file_name, line_number, function_name,
+                                    force_console_log, format,
+                                    fmt::make_format_args(args...));
+    }
+    template <typename... Args>
+    static void _LogDebug(const char *file_name,
+                          int line_number,
+                          const char *function_name,
+                          bool force_console_log,
+                          const char *format,
+                          Args &&... args) {
+        Logger::GetInstance().VDebug(file_name, line_number, function_name,
+                                     force_console_log, format,
+                                     fmt::make_format_args(args...));
     }
 
-    void VError [[noreturn]] (const char *fname,
-                              int linenum,
-                              const char *fn_name,
+private:
+    Logger();
+    void VError [[noreturn]] (const char *file_name,
+                              int line_number,
+                              const char *function_name,
+                              bool force_console_log,
                               const char *format,
-                              fmt::format_args args) const {
-        std::string err_msg = fmt::vformat(format, args);
-        err_msg = fmt::format(
-                "In function {}:\n"
-                "{}:{} [Open3D Error] {}",
-                fn_name, fname, linenum, err_msg);
-        err_msg = ColorString(err_msg, TextColor::Red, 1);
-        throw std::runtime_error(err_msg);
-    }
+                              fmt::format_args args) const;
+    void VWarning(const char *file_name,
+                  int line_number,
+                  const char *function_name,
+                  bool force_console_log,
+                  const char *format,
+                  fmt::format_args args) const;
+    void VInfo(const char *file_name,
+               int line_number,
+               const char *function_name,
+               bool force_console_log,
+               const char *format,
+               fmt::format_args args) const;
+    void VDebug(const char *file_name,
+                int line_number,
+                const char *function_name,
+                bool force_console_log,
+                const char *format,
+                fmt::format_args args) const;
 
-    void VWarning(const char *format, fmt::format_args args) const {
-        if (verbosity_level_ >= VerbosityLevel::Warning) {
-            std::string err_msg = fmt::vformat(format, args);
-            err_msg = fmt::format("[Open3D WARNING] {}", err_msg);
-            err_msg = ColorString(err_msg, TextColor::Yellow, 1);
-            print_fcn_(err_msg);
-        }
-    }
-
-    void VInfo(const char *format, fmt::format_args args) const {
-        if (verbosity_level_ >= VerbosityLevel::Info) {
-            std::string err_msg = fmt::vformat(format, args);
-            err_msg = fmt::format("[Open3D INFO] {}", err_msg);
-            print_fcn_(err_msg);
-        }
-    }
-
-    void VDebug(const char *format, fmt::format_args args) const {
-        if (verbosity_level_ >= VerbosityLevel::Debug) {
-            std::string err_msg = fmt::vformat(format, args);
-            err_msg = fmt::format("[Open3D DEBUG] {}", err_msg);
-            print_fcn_(err_msg);
-        }
-    }
-
-    template <typename... Args>
-    void Error [[noreturn]] (const char *fname,
-                             int linenum,
-                             const char *fn_name,
-                             const char *format,
-                             const Args &... args) const {
-        VError(fname, linenum, fn_name, format, fmt::make_format_args(args...));
-    }
-
-    template <typename... Args>
-    void Warning(const char *format, const Args &... args) const {
-        VWarning(format, fmt::make_format_args(args...));
-    }
-
-    template <typename... Args>
-    void Info(const char *format, const Args &... args) const {
-        VInfo(format, fmt::make_format_args(args...));
-    }
-
-    template <typename... Args>
-    void Debug(const char *format, const Args &... args) const {
-        VDebug(format, fmt::make_format_args(args...));
-    }
-
-protected:
-    /// Internal function to change text color for the console
-    /// Note there is no safety check for parameters.
-    /// \param text_color from 0 to 7, they are black, red, green, yellow,
-    /// blue, magenta, cyan, white
-    /// \param highlight_text is 0 or 1
-    void ChangeConsoleColor(TextColor text_color, int highlight_text) const;
-    void ResetConsoleColor() const;
-    /// Colorize and reset the color of a string, does not work on Windows
-    std::string ColorString(const std::string &text,
-                            TextColor text_color,
-                            int highlight_text) const;
-
-public:
-    VerbosityLevel verbosity_level_;
-    std::function<void(const std::string &)> print_fcn_ =
-            [](const std::string &msg) { std::cout << msg << std::endl; };
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 /// Set global verbosity level of Open3D
 ///
 /// \param level Messages with equal or less than verbosity_level verbosity will
 /// be printed.
-inline void SetVerbosityLevel(VerbosityLevel level) {
-    Logger::i().verbosity_level_ = level;
-}
+void SetVerbosityLevel(VerbosityLevel level);
 
 /// Get global verbosity level of Open3D.
-inline VerbosityLevel GetVerbosityLevel() {
-    return Logger::i().verbosity_level_;
-}
-
-template <typename... Args>
-inline void _LogError [[noreturn]] (const char *fname,
-                                    int linenum,
-                                    const char *fn_name,
-                                    const char *format,
-                                    Args &&... args) {
-    Logger::i().VError(fname, linenum, fn_name, format,
-                       fmt::make_format_args(args...));
-}
-
-template <typename... Args>
-inline void LogWarning(const char *format, const Args &... args) {
-    Logger::i().VWarning(format, fmt::make_format_args(args...));
-}
-
-template <typename... Args>
-inline void LogInfo(const char *format, const Args &... args) {
-    Logger::i().VInfo(format, fmt::make_format_args(args...));
-}
-
-template <typename... Args>
-inline void LogDebug(const char *format, const Args &... args) {
-    Logger::i().VDebug(format, fmt::make_format_args(args...));
-}
+VerbosityLevel GetVerbosityLevel();
 
 class VerbosityContextManager {
 public:
     VerbosityContextManager(VerbosityLevel level) : level_(level) {}
 
-    void enter() {
-        level_backup_ = Logger::i().verbosity_level_;
-        Logger::i().verbosity_level_ = level_;
+    void Enter() {
+        level_backup_ = Logger::GetInstance().GetVerbosityLevel();
+        Logger::GetInstance().SetVerbosityLevel(level_);
     }
 
-    void exit() { Logger::i().verbosity_level_ = level_backup_; }
+    void Exit() { Logger::GetInstance().SetVerbosityLevel(level_backup_); }
 
 private:
     VerbosityLevel level_;
@@ -254,48 +281,15 @@ class ConsoleProgressBar {
 public:
     ConsoleProgressBar(size_t expected_count,
                        const std::string &progress_info,
-                       bool active = false) {
-        reset(expected_count, progress_info, active);
-    }
+                       bool active = false);
 
-    void reset(size_t expected_count,
+    void Reset(size_t expected_count,
                const std::string &progress_info,
-               bool active) {
-        expected_count_ = expected_count;
-        current_count_ = static_cast<size_t>(-1);  // Guaranteed to wraparound
-        progress_info_ = progress_info;
-        progress_pixel_ = 0;
-        active_ = active;
-        operator++();
-    }
+               bool active);
 
-    ConsoleProgressBar &operator++() {
-        SetCurrentCount(current_count_ + 1);
-        return *this;
-    }
+    ConsoleProgressBar &operator++();
 
-    void SetCurrentCount(size_t n) {
-        current_count_ = n;
-        if (!active_) {
-            return;
-        }
-        if (current_count_ >= expected_count_) {
-            fmt::print("{}[{}] 100%\n", progress_info_,
-                       std::string(resolution_, '='));
-        } else {
-            size_t new_progress_pixel =
-                    int(current_count_ * resolution_ / expected_count_);
-            if (new_progress_pixel > progress_pixel_) {
-                progress_pixel_ = new_progress_pixel;
-                int percent = int(current_count_ * 100 / expected_count_);
-                fmt::print("{}[{}>{}] {:d}%\r", progress_info_,
-                           std::string(progress_pixel_, '='),
-                           std::string(resolution_ - 1 - progress_pixel_, ' '),
-                           percent);
-                fflush(stdout);
-            }
-        }
-    }
+    void SetCurrentCount(size_t n);
 
 private:
     const size_t resolution_ = 40;

--- a/cpp/pybind/open3d_pybind.cpp
+++ b/cpp/pybind/open3d_pybind.cpp
@@ -40,10 +40,10 @@
 namespace open3d {
 
 PYBIND11_MODULE(pybind, m) {
-    open3d::utility::Logger::i().print_fcn_ = [](const std::string& msg) {
+    utility::Logger::GetInstance().SetPrintFunction([](const std::string& msg) {
         py::gil_scoped_acquire acquire;
         py::print(msg);
-    };
+    });
 
     m.doc() = "Python binding of Open3D";
 

--- a/cpp/pybind/utility/console.cpp
+++ b/cpp/pybind/utility/console.cpp
@@ -68,13 +68,13 @@ void pybind_console(py::module& m) {
                  "level"_a)
             .def(
                     "__enter__",
-                    [&](VerbosityContextManager& cm) { cm.enter(); },
+                    [&](VerbosityContextManager& cm) { cm.Enter(); },
                     "Enter the context manager")
             .def(
                     "__exit__",
                     [&](VerbosityContextManager& cm, pybind11::object exc_type,
                         pybind11::object exc_value,
-                        pybind11::object traceback) { cm.exit(); },
+                        pybind11::object traceback) { cm.Exit(); },
                     "Exit the context manager");
 }
 


### PR DESCRIPTION
In Jupyter (python), the default logging function `std::cout` is replaced by `py::print`, where the logging displays in the Jupyter cell. This PR:

### Changes
1. Adds `LogInfoConsole`, `LogDebugConsole`, ... to allow logging to console even in Jupyter environment. This is useful for debugging and make the front end appear less verbose.
2. Some tweaks of the `Logger` class, making some variables/functions private.
3. Hide `Logger` class and unnecessary APIs in the `.cpp` (with pimpl). This drastically reduces the binary size of Open3D.

### Binary size
Build with:
```bash
cmake -DCMAKE_BUILD_TYPE=Release ..
```

Current `master`:
```bash
➜  ~/repo/Open3D/build (master) ls -alh lib/Release/libOpen3D.a
-rw-rw-r-- 1 yixing yixing 52M Apr  4 14:23 lib/Release/libOpen3D.a
```

This PR:
```bash
➜  ~/repo/Open3D/build (yixing/console-logger) ls -alh lib/Release/libOpen3D.a
-rw-rw-r-- 1 yixing yixing 30M Apr  4 14:26 lib/Release/libOpen3D.a
```
The static `libOpen3D.a` library is 58% of the original size. When we add more components (e.g. CUDA), the relative improvement won't be as substantial as this, but it is still considerable.

### Future PR
The `Logger` class needs more refactoring. In future PR:
- Rename `Console.h/cpp` to `Logger.h/cpp`. `Logger.h` is for logging only, `Console.h` is reserved for console-argument parsing helper functions. You should include `Logger.h` for logging.
Since these will cause major disruptions to a lot of files, it will be done in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3241)
<!-- Reviewable:end -->
