### PR TITLE
Fix camera matrix getting pybinds not returning something that can be converted to a Python object

### DIFF
--- a/cpp/pybind/visualization/rendering/rendering.cpp
+++ b/cpp/pybind/visualization/rendering/rendering.cpp
@@ -214,12 +214,26 @@ void pybind_rendering_classes(py::module &m) {
             .def("get_field_of_view_type", &Camera::GetFieldOfViewType,
                  "Returns the field of view type. Only valid if it was passed "
                  "to set_projection().")
-            .def("get_projection_matrix", &Camera::GetProjectionMatrix,
-                 "Returns the projection matrix of the camera")
-            .def("get_view_matrix", &Camera::GetViewMatrix,
-                 "Returns the view matrix of the camera")
-            .def("get_model_matrix", &Camera::GetModelMatrix,
-                 "Returns the model matrix of the camera");
+            .def(
+                    "get_projection_matrix",
+                    [](const Camera &cam) -> Eigen::Matrix4f {
+                        // GetProjectionMatrix() returns Eigen::Transform which
+                        // doesn't have a conversion to a Python object
+                        return cam.GetProjectionMatrix().matrix();
+                    },
+                    "Returns the projection matrix of the camera")
+            .def(
+                    "get_view_matrix",
+                    [](const Camera &cam) -> Eigen::Matrix4f {
+                        return cam.GetViewMatrix().matrix();
+                    },
+                    "Returns the view matrix of the camera")
+            .def(
+                    "get_model_matrix",
+                    [](const Camera &cam) -> Eigen::Matrix4f {
+                        return cam.GetModelMatrix().matrix();
+                    },
+                    "Returns the model matrix of the camera");
 
     // ---- Gradient ----
     py::class_<Gradient, std::shared_ptr<Gradient>> gradient(


### PR DESCRIPTION
Fixes #3117. The problem is that the camera functions return Eigen::Transform, but there isn't a conversion for that into Python, so we convert into a full-blown Eigen::Matrix instead.

```
import open3d as o3d
import open3d.visualization.gui as gui

gui.Application.instance.initialize()
w = o3d.visualization.O3DVisualizer("03DVisualizer",640, 480)
w.add_geometry("box", o3d.geometry.TriangleMesh.create_box())
w.reset_camera_to_default()
gui.Application.instance.add_window(w)
open3DScene = w.scene
camera = open3DScene.camera
debug = camera.get_model_matrix()
print("model matrix:\n", debug)
debug = camera.get_view_matrix()
print("view matrix:\n", debug)
debug = camera.get_projection_matrix()
print("proj matrix:\n", debug)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3257)
<!-- Reviewable:end -->
