### PR TITLE
Add post_redraw() to O3DVisualizer so that it can be used non-blocking

### DIFF
--- a/cpp/pybind/visualization/o3dvisualizer.cpp
+++ b/cpp/pybind/visualization/o3dvisualizer.cpp
@@ -144,6 +144,8 @@ void pybind_o3dvisualizer(py::module& m) {
                     "and device pixels (read-only)")
             .def_property_readonly("is_visible", &O3DVisualizer::IsVisible,
                                    "True if window is visible (read-only)")
+            .def("post_redraw", &O3DVisualizer::PostRedraw,
+                 "Tells the window to redraw")
             .def("show", &O3DVisualizer::Show, "Shows or hides the window")
             .def("close", &O3DVisualizer::Close,
                  "Closes the window and destroys it, unless an on_close "


### PR DESCRIPTION
Allows this:
```
import numpy as np
import open3d as o3d
import open3d.visualization.gui as gui
import open3d.visualization.rendering as rendering
import time

def make_point_cloud():
    npts = 1000
    center = (0, 0, 0)
    radius = 1.0
    pts = np.random.uniform(-radius, radius, size=[npts, 3]) + center
    cloud = o3d.geometry.PointCloud()
    cloud.points = o3d.utility.Vector3dVector(pts)
    cloud.paint_uniform_color((0, 0, 0))
    return cloud

def main():
    cloud_name = "random"

    app = gui.Application.instance
    app.initialize()

    vis = o3d.visualization.O3DVisualizer("Open3D - non-blocking", 1024, 768)
    vis.add_geometry(cloud_name, make_point_cloud())
    vis.reset_camera_to_default()
    app.add_window(vis)

    last_now = time.perf_counter()
    while app.run_one_tick():
        now = time.perf_counter()
        if now - last_now > 0.1:
            vis.remove_geometry(cloud_name)
            vis.add_geometry(cloud_name, make_point_cloud())
            vis.post_redraw()
            last_now = now

if __name__ == "__main__":
    main()
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3262)
<!-- Reviewable:end -->
