### PR TITLE
Update stdgpu dependency to latest upstream

### DIFF
--- a/3rdparty/stdgpu/stdgpu.cmake
+++ b/3rdparty/stdgpu/stdgpu.cmake
@@ -7,9 +7,8 @@ include(ExternalProject)
 ExternalProject_Add(
     ext_stdgpu
     PREFIX stdgpu
-    GIT_REPOSITORY https://github.com/intel-isl/stdgpu.git
-    GIT_TAG build-without-gpu
-    GIT_SHALLOW ON  # Do not download the history.
+    GIT_REPOSITORY https://github.com/stotko/stdgpu.git
+    GIT_TAG e14be8e1386359c0f6dea11aa6feb0aff15a5425
     UPDATE_COMMAND ""
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>


### PR DESCRIPTION
Currently, a patched version of stdgpu is used since its CUDA backend automatically detects the machine's GPU and sets the architecture flags accordingly. In case no GPU can be found, an error is thrown. The latest upstream version of stdgpu relaxes this constraint such that the patched version is not needed anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3265)
<!-- Reviewable:end -->
