### PR TITLE
Use more sensible default color for point clouds with no per-vertex color

### DIFF
--- a/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
+++ b/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
@@ -60,7 +60,7 @@ namespace rendering {
 namespace {
 struct ColoredVertex {
     math::float3 position = {0.f, 0.f, 0.f};
-    math::float4 color = {1.0f, 1.0f, 1.0f, 1.f};
+    math::float4 color = {0.5f, 0.5f, 0.5f, 1.f};
     math::quatf tangent = {0.f, 0.f, 0.f, 1.f};
     math::float2 uv = {0.f, 0.f};
 

--- a/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
+++ b/cpp/open3d/visualization/rendering/filament/PointCloudBuffers.cpp
@@ -60,6 +60,10 @@ namespace rendering {
 namespace {
 struct ColoredVertex {
     math::float3 position = {0.f, 0.f, 0.f};
+    // Default to mid-gray which provides good separation from the two most
+    // common background colors: white and black. Otherwise, point clouds
+    // without per-vertex colors may appear is if they are not rendering because
+    // they blend with the background.
     math::float4 color = {0.5f, 0.5f, 0.5f, 1.f};
     math::quatf tangent = {0.f, 0.f, 0.f, 1.f};
     math::float2 uv = {0.f, 0.f};


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3278)
<!-- Reviewable:end -->
