### PR TITLE
Fix memory leak in stdgpu hashmap backend

### DIFF
--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
@@ -258,6 +258,7 @@ void StdGPUHashmap<Key, Hash>::Rehash(int64_t buckets) {
     float avg_capacity_per_bucket =
             float(this->capacity_) / float(GetBucketCount());
 
+    Free();
     int64_t new_capacity =
             int64_t(std::ceil(buckets * avg_capacity_per_bucket));
     Allocate(new_capacity);


### PR DESCRIPTION
The new default hashmap backend based on `stdgpu` can leak memory in its `Rehash` function when re-allocating memory to increase its capacity. Tested internally by intentionally producing a double-free error (calling `Free()` twice) to verify the first call releases the memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3281)
<!-- Reviewable:end -->
