### PR TITLE
print warning if compiling pytorch ops with torch 1.7 and cuda 11

### DIFF
--- a/3rdparty/CMake/FindPytorch.cmake
+++ b/3rdparty/CMake/FindPytorch.cmake
@@ -61,6 +61,23 @@ if(NOT Pytorch_FOUND)
         set_target_properties( torch PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
         set_target_properties( torch_cuda PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
         set_target_properties( torch_cpu PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
+
+        if( CUDA_VERSION VERSION_GREATER_EQUAL "11.0" AND
+            Pytorch_VERSION GREATER_EQUAL "1.7" AND Pytorch_VERSION VERSION_LESS "1.9")
+            message( WARNING
+                "================================================================================\n"
+                "                                                                                \n"
+                " You are compiling Open3D with CUDA 11 and Pytorch. This configuration may have \n"
+                " stability issues. See https://github.com/intel-isl/Open3D/issues/3324 and      \n"
+                " https://github.com/pytorch/pytorch/issues/52663 for more information on this   \n"
+                " problem.                                                                       \n"
+                "                                                                                \n"
+                " We recommend to compile Pytorch from source with compile flags.                \n"
+                "   '-Xcompiler -fno-gnu-unique'                                                 \n"
+                "                                                                                \n"
+                "================================================================================\n"
+            )
+        endif()
     endif()
 
     # Get Pytorch_CXX11_ABI: True/False

--- a/3rdparty/CMake/FindPytorch.cmake
+++ b/3rdparty/CMake/FindPytorch.cmake
@@ -62,7 +62,7 @@ if(NOT Pytorch_FOUND)
         set_target_properties( torch_cuda PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
         set_target_properties( torch_cpu PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
 
-        if( CUDA_VERSION VERSION_GREATER_EQUAL "11.0" AND
+        if( CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0" AND
             Pytorch_VERSION GREATER_EQUAL "1.7" AND Pytorch_VERSION VERSION_LESS "1.9")
             message( WARNING
                 "================================================================================\n"


### PR DESCRIPTION
Adds a warning if we compile the pytorch ops with torch 1.7 or later and cuda 11.
See https://github.com/intel-isl/Open3D/issues/3324

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3325)
<!-- Reviewable:end -->
