### PR TITLE
Improve performance of stdgpu hashmap backend

### DIFF
--- a/3rdparty/stdgpu/stdgpu.cmake
+++ b/3rdparty/stdgpu/stdgpu.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(
     ext_stdgpu
     PREFIX stdgpu
     GIT_REPOSITORY https://github.com/stotko/stdgpu.git
-    GIT_TAG 0d306f767ec6d395f5a9cb275fc441bab7a67eea
+    GIT_TAG bfb66261b75ebadccd0060448d9ed9290eccc76e
     UPDATE_COMMAND ""
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/cpp/benchmarks/core/Hashmap.cpp
+++ b/cpp/benchmarks/core/Hashmap.cpp
@@ -105,6 +105,46 @@ void HashInsertInt(benchmark::State& state,
     }
 }
 
+void HashEraseInt(benchmark::State& state,
+                  int capacity,
+                  int duplicate_factor,
+                  const Device& device,
+                  const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<int, int> data(capacity, slots);
+
+#ifdef BUILD_CUDA_MODULE
+    CUDACachedMemoryManager::ReleaseCache();
+#endif
+    Tensor keys(data.keys_, {capacity}, Dtype::Int32, device);
+    Tensor values(data.vals_, {capacity}, Dtype::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, Dtype::Int32, Dtype::Int32, {1}, {1},
+                           device, backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, Dtype::Int32, Dtype::Int32, {1}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+        hashmap.Insert(keys, values, addrs, masks);
+        state.ResumeTiming();
+
+        hashmap.Erase(keys, masks);
+
+        state.PauseTiming();
+        int64_t s = hashmap.Size();
+        if (s != 0) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.", 0,
+                    s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 void HashFindInt(benchmark::State& state,
                  int capacity,
                  int duplicate_factor,
@@ -184,6 +224,49 @@ void HashInsertInt3(benchmark::State& state,
     }
 }
 
+void HashEraseInt3(benchmark::State& state,
+                   int capacity,
+                   int duplicate_factor,
+                   const Device& device,
+                   const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<Int3, int> data(capacity, slots);
+
+    std::vector<int> keys_Int3;
+    keys_Int3.assign(reinterpret_cast<int*>(data.keys_.data()),
+                     reinterpret_cast<int*>(data.keys_.data()) + 3 * capacity);
+#ifdef BUILD_CUDA_MODULE
+    CUDACachedMemoryManager::ReleaseCache();
+#endif
+    Tensor keys(keys_Int3, {capacity, 3}, Dtype::Int32, device);
+    Tensor values(data.vals_, {capacity}, Dtype::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, Dtype::Int32, Dtype::Int32, {3}, {1},
+                           device, backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, Dtype::Int32, Dtype::Int32, {3}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+        hashmap.Insert(keys, values, addrs, masks);
+        state.ResumeTiming();
+
+        hashmap.Erase(keys, masks);
+
+        state.PauseTiming();
+        int64_t s = hashmap.Size();
+        if (s != 0) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.", 0,
+                    s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 void HashFindInt3(benchmark::State& state,
                   int capacity,
                   int duplicate_factor,
@@ -250,6 +333,8 @@ void HashFindInt3(benchmark::State& state,
 
 ENUM_BM_BACKEND(HashInsertInt)
 ENUM_BM_BACKEND(HashInsertInt3)
+ENUM_BM_BACKEND(HashEraseInt)
+ENUM_BM_BACKEND(HashEraseInt3)
 ENUM_BM_BACKEND(HashFindInt)
 ENUM_BM_BACKEND(HashFindInt3)
 

--- a/cpp/benchmarks/core/Hashmap.cpp
+++ b/cpp/benchmarks/core/Hashmap.cpp
@@ -170,6 +170,54 @@ void HashFindInt(benchmark::State& state,
     }
 }
 
+void HashClearInt(benchmark::State& state,
+                  int capacity,
+                  int duplicate_factor,
+                  const Device& device,
+                  const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<int, int> data(capacity, slots);
+
+#ifdef BUILD_CUDA_MODULE
+    CUDACachedMemoryManager::ReleaseCache();
+#endif
+    Tensor keys(data.keys_, {capacity}, Dtype::Int32, device);
+    Tensor values(data.vals_, {capacity}, Dtype::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, Dtype::Int32, Dtype::Int32, {1}, {1},
+                           device, backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, Dtype::Int32, Dtype::Int32, {1}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+
+        hashmap.Insert(keys, values, addrs, masks);
+
+        int64_t s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+        state.ResumeTiming();
+
+        hashmap.Clear();
+
+        state.PauseTiming();
+        s = hashmap.Size();
+        if (s != 0) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.", 0,
+                    s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 class Int3 {
 public:
     Int3() : x_(0), y_(0), z_(0){};
@@ -294,6 +342,57 @@ void HashFindInt3(benchmark::State& state,
     }
 }
 
+void HashClearInt3(benchmark::State& state,
+                   int capacity,
+                   int duplicate_factor,
+                   const Device& device,
+                   const HashmapBackend& backend) {
+    int slots = std::max(1, capacity / duplicate_factor);
+    HashData<Int3, int> data(capacity, slots);
+
+    std::vector<int> keys_Int3;
+    keys_Int3.assign(reinterpret_cast<int*>(data.keys_.data()),
+                     reinterpret_cast<int*>(data.keys_.data()) + 3 * capacity);
+#ifdef BUILD_CUDA_MODULE
+    CUDACachedMemoryManager::ReleaseCache();
+#endif
+    Tensor keys(keys_Int3, {capacity, 3}, Dtype::Int32, device);
+    Tensor values(data.vals_, {capacity}, Dtype::Int32, device);
+
+    Hashmap hashmap_warmup(capacity, Dtype::Int32, Dtype::Int32, {3}, {1},
+                           device, backend);
+    Tensor addrs, masks;
+    hashmap_warmup.Insert(keys, values, addrs, masks);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        Hashmap hashmap(capacity, Dtype::Int32, Dtype::Int32, {3}, {1}, device,
+                        backend);
+        Tensor addrs, masks;
+
+        hashmap.Insert(keys, values, addrs, masks);
+
+        int64_t s = hashmap.Size();
+        if (s != slots) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.",
+                    slots, s);
+        }
+        state.ResumeTiming();
+
+        hashmap.Clear();
+
+        state.PauseTiming();
+        s = hashmap.Size();
+        if (s != 0) {
+            utility::LogError(
+                    "Error returning hashmap size, expected {}, but got {}.", 0,
+                    s);
+        }
+        state.ResumeTiming();
+    }
+}
+
 // Note: to enable large scale insertion (> 1M entries), change
 // default_max_load_factor() in stdgpu from 1.0 to 1.2~1.4.
 #define ENUM_BM_CAPACITY(FN, FACTOR, DEVICE, BACKEND)                          \
@@ -337,6 +436,8 @@ ENUM_BM_BACKEND(HashEraseInt)
 ENUM_BM_BACKEND(HashEraseInt3)
 ENUM_BM_BACKEND(HashFindInt)
 ENUM_BM_BACKEND(HashFindInt3)
+ENUM_BM_BACKEND(HashClearInt)
+ENUM_BM_BACKEND(HashClearInt3)
 
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/hashmap/CUDA/CUDAHashmapBufferAccessor.h
+++ b/cpp/open3d/core/hashmap/CUDA/CUDAHashmapBufferAccessor.h
@@ -60,6 +60,8 @@ public:
         values_ = values.GetDataPtr<uint8_t>();
         heap_ = static_cast<addr_t *>(heap.GetDataPtr());
         OPEN3D_CUDA_CHECK(cudaMemset(values_, 0, capacity_ * dsize_value_));
+        OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+        OPEN3D_CUDA_CHECK(cudaGetLastError());
     }
 
     __host__ void Reset(const Device &device) {

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
@@ -186,6 +186,8 @@ void SlabHashmap<Key, Hash>::Find(const void* input_keys,
     if (count == 0) return;
 
     OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
+    OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+    OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
@@ -202,6 +204,8 @@ void SlabHashmap<Key, Hash>::Erase(const void* input_keys,
     if (count == 0) return;
 
     OPEN3D_CUDA_CHECK(cudaMemset(output_masks, 0, sizeof(bool) * count));
+    OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+    OPEN3D_CUDA_CHECK(cudaGetLastError());
     auto iterator_addrs = static_cast<addr_t*>(
             MemoryManager::Malloc(sizeof(addr_t) * count, this->device_));
 
@@ -221,7 +225,9 @@ template <typename Key, typename Hash>
 int64_t SlabHashmap<Key, Hash>::GetActiveIndices(addr_t* output_addrs) {
     uint32_t* iterator_count = static_cast<uint32_t*>(
             MemoryManager::Malloc(sizeof(uint32_t), this->device_));
-    cudaMemset(iterator_count, 0, sizeof(uint32_t));
+    OPEN3D_CUDA_CHECK(cudaMemset(iterator_count, 0, sizeof(uint32_t)));
+    OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+    OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     const int64_t num_blocks =
             (impl_.bucket_count_ * kWarpSize + kThreadsPerBlock - 1) /
@@ -335,6 +341,8 @@ void SlabHashmap<Key, Hash>::Allocate(int64_t bucket_count, int64_t capacity) {
             sizeof(Slab) * this->bucket_count_, this->device_));
     OPEN3D_CUDA_CHECK(cudaMemset(impl_.bucket_list_head_, 0xFF,
                                  sizeof(Slab) * this->bucket_count_));
+    OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+    OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     impl_.Setup(this->bucket_count_, this->capacity_, this->dsize_key_,
                 this->dsize_value_, node_mgr_->impl_, buffer_accessor_);

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
@@ -253,6 +253,8 @@ void SlabHashmap<Key, Hash>::Clear() {
     // Clear the linked list heads
     OPEN3D_CUDA_CHECK(cudaMemset(impl_.bucket_list_head_, 0xFF,
                                  sizeof(Slab) * this->bucket_count_));
+    OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+    OPEN3D_CUDA_CHECK(cudaGetLastError());
 
     // Clear the linked list nodes
     node_mgr_->Reset();

--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -263,6 +263,8 @@ public:
                     impl_.super_blocks_ + i * kUIntsPerSuperBlock, 0x00,
                     kBlocksPerSuperBlock * kSlabsPerBlock * sizeof(uint32_t)));
         }
+        OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
+        OPEN3D_CUDA_CHECK(cudaGetLastError());
     }
 
     std::vector<int> CountSlabsPerSuperblock() {

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
@@ -171,8 +171,8 @@ void StdGPUHashmap<Key, Hash>::Find(const void* input_keys,
                                     addr_t* output_addrs,
                                     bool* output_masks,
                                     int64_t count) {
-    int threads = 32;
-    int blocks = (count + threads - 1) / threads;
+    uint32_t threads = 128;
+    uint32_t blocks = (count + threads - 1) / threads;
 
     STDGPUFindKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
                                           static_cast<const Key*>(input_keys),
@@ -192,6 +192,11 @@ __global__ void STDGPUEraseKernel(stdgpu::unordered_map<Key, addr_t, Hash> map,
     if (tid >= count) return;
 
     Key key = input_keys[tid];
+    auto iter = map.find(key);
+    bool flag = (iter != map.end());
+    output_masks[tid] = flag;
+    output_addrs[tid] = flag ? iter->second : 0;
+
     if (output_masks[tid]) {
         output_masks[tid] = map.erase(key);
         if (output_masks[tid]) {
@@ -204,19 +209,13 @@ template <typename Key, typename Hash>
 void StdGPUHashmap<Key, Hash>::Erase(const void* input_keys,
                                      bool* output_masks,
                                      int64_t count) {
-    stdgpu::index_t threads = 32;
-    stdgpu::index_t blocks = (count + threads - 1) / threads;
+    uint32_t threads = 128;
+    uint32_t blocks = (count + threads - 1) / threads;
 
-    // Erase has to go in two passes -- find the iterator, then erase and free
-    // Not frequently used, may not be fully optimized due to the tricky
-    // iterator change in the erase operation
     core::Tensor toutput_addrs =
             core::Tensor({count}, Dtype::Int32, this->device_);
     addr_t* output_addrs = static_cast<addr_t*>(toutput_addrs.GetDataPtr());
 
-    STDGPUFindKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
-                                          static_cast<const Key*>(input_keys),
-                                          output_addrs, output_masks, count);
     STDGPUEraseKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
                                            static_cast<const Key*>(input_keys),
                                            output_addrs, output_masks, count);
@@ -351,8 +350,8 @@ void StdGPUHashmap<Key, Hash>::InsertImpl(const void* input_keys,
                                           addr_t* output_addrs,
                                           bool* output_masks,
                                           int64_t count) {
-    stdgpu::index_t threads = 32;
-    stdgpu::index_t blocks = (count + threads - 1) / threads;
+    uint32_t threads = 128;
+    uint32_t blocks = (count + threads - 1) / threads;
 
     STDGPUInsertKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
                                             static_cast<const Key*>(input_keys),


### PR DESCRIPTION
- Update to most recent upstream version of `stdgpu` which includes significant performance improvements for `clear()`
- Fix asynchronous `cudaMemset` calls leading to wrong benchmark results
- Increase threads per block in `stdgpu` backend to `128` for better performance
- Fuse erase kernels for better performance which is safe because `stdgpu` only invalidates the iterator in `erase()` that gets removed while keeping all other valid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3346)
<!-- Reviewable:end -->
