### PR TITLE
Properly scale UInt8 colors when converting to Legacy Point Cloud

### DIFF
--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -259,8 +259,13 @@ open3d::geometry::PointCloud PointCloud::ToLegacyPointCloud() const {
                 core::eigen_converter::TensorToEigenVector3dVector(GetPoints());
     }
     if (HasPointColors()) {
-        pcd_legacy.colors_ = core::eigen_converter::TensorToEigenVector3dVector(
-                GetPointColors());
+        auto colors = GetPointColors();
+        if (colors.GetDtype() == core::Dtype::UInt8) {
+            colors = colors.To(core::Dtype::Float64) / 255.0;
+        }
+
+        pcd_legacy.colors_ =
+                core::eigen_converter::TensorToEigenVector3dVector(colors);
     }
     if (HasPointNormals()) {
         pcd_legacy.normals_ =

--- a/cpp/open3d/t/geometry/PointCloud.cpp
+++ b/cpp/open3d/t/geometry/PointCloud.cpp
@@ -286,7 +286,7 @@ open3d::geometry::PointCloud PointCloud::ToLegacyPointCloud() const {
         if (dtype_is_supported_for_conversion) {
             if (normalization_factor != 1.0) {
                 core::Tensor rescaled_colors =
-                        GetPointColors().To(core::Dtype::Float64, true) *
+                        GetPointColors().To(core::Dtype::Float64) *
                         normalization_factor;
                 pcd_legacy.colors_ =
                         core::eigen_converter::TensorToEigenVector3dVector(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3350)
<!-- Reviewable:end -->
