### PR TITLE
fix conditions for showing warning about CUDA 11 and pytorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,8 +658,7 @@ endif()
 open3d_aligned_print("Build TensorFlow Ops" "${BUILD_TENSORFLOW_OPS}")
 open3d_aligned_print("Build PyTorch Ops" "${BUILD_PYTORCH_OPS}")
 if (BUILD_PYTORCH_OPS AND BUILD_CUDA_MODULE AND
-    CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0" AND
-    Pytorch_VERSION GREATER_EQUAL "1.7" AND Pytorch_VERSION VERSION_LESS "1.9")
+    CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0" )
     message( WARNING
         "--------------------------------------------------------------------------------\n"
         "                                                                                \n"
@@ -668,7 +667,7 @@ if (BUILD_PYTORCH_OPS AND BUILD_CUDA_MODULE AND
         " https://github.com/pytorch/pytorch/issues/52663 for more information on this   \n"
         " problem.                                                                       \n"
         "                                                                                \n"
-        " We recommend to compile PyTorch from source with compile flags.                \n"
+        " We recommend to compile PyTorch from source with compile flags                 \n"
         "   '-Xcompiler -fno-gnu-unique'                                                 \n"
         "                                                                                \n"
         " or use the PyTorch wheels at                                                   \n"


### PR DESCRIPTION
Drop the test for Pytorch_VERSION, which was not defined in the current scope.
Further, the warning can be relevant for older versions of Pytorch too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3355)
<!-- Reviewable:end -->
