### PR TITLE
Increase warning level

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,6 @@ function(open3d_show_and_abort_on_warning trgt)
             )
     set(DISABLE_GNU_CLANG_INTEL_WARNINGS
             -Wno-unused-parameter               # (many places in Open3D code)
-            -Wno-missing-field-initializers     # (visualization/gui/Events.h)
             )
 
     if (BUILD_CUDA_MODULE)
@@ -31,7 +30,7 @@ function(open3d_show_and_abort_on_warning trgt)
                 )
         string(REPLACE ";" "," DISABLE_NVCC_WARNINGS "${DISABLE_NVCC_WARNINGS}")
 
-        set(CUDA_FLAGS "--Werror cross-execution-space-call,deprecated-declarations,reorder")
+        set(CUDA_FLAGS "--Werror cross-execution-space-call,deprecated-declarations")
         if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
             string(APPEND CUDA_FLAGS " --Werror all-warnings")
         endif()
@@ -55,6 +54,9 @@ function(open3d_show_and_abort_on_warning trgt)
 
             string(APPEND CUDA_FLAGS " -Xcompiler /W4,/WX,${CUDA_DISABLE_MSVC_WARNINGS}")
         else()
+            # reorder breaks builds on Windows, so only enable for other platforms
+            string(APPEND CUDA_FLAGS " --Werror reorder")
+
             set(CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS ${DISABLE_GNU_CLANG_INTEL_WARNINGS})
             string(REPLACE ";" "," CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS "${CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS}")
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -17,44 +17,48 @@ function(open3d_show_and_abort_on_warning trgt)
             /wd4267        # conversion from size_t to smaller type (FixedRadiusSearchCUDA, tests)
             /wd4305        # conversion to smaller type in initialization or constructor argument (examples, tests)
             )
+    set(DISABLE_GNU_CLANG_INTEL_WARNINGS
+            -Wno-unused-parameter               # (many places in Open3D code)
+            -Wno-missing-field-initializers     # (visualization/gui/Events.h)
+            )
 
     if (BUILD_CUDA_MODULE)
-        set(CUDA_FLAGS "--Werror cross-execution-space-call,deprecated-declarations")
+        # General NVCC flags
+        set(DISABLE_NVCC_WARNINGS
+                550            # variable was set but never used (Eigen)
+                940            # missing return statement at end of non-void function (Eigen)
+                2809           # ignoring return value from routine declared with "nodiscard" attribute (Eigen)
+                )
+        string(REPLACE ";" "," DISABLE_NVCC_WARNINGS "${DISABLE_NVCC_WARNINGS}")
 
-        if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.2")
-            if (MSVC)
-                string(APPEND CUDA_FLAGS " -Xcompiler /W4,/WX")
-            else()
-                string(APPEND CUDA_FLAGS " -Xcompiler -Wall,-Werror")
-            endif()
-        else()
+        set(CUDA_FLAGS "--Werror cross-execution-space-call,deprecated-declarations,reorder")
+        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "10.2")
             string(APPEND CUDA_FLAGS " --Werror all-warnings")
-            if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0")
-                string(APPEND CUDA_FLAGS " --Werror ext-lambda-captures-this")
-            endif()
+        endif()
+        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0")
+            string(APPEND CUDA_FLAGS " --Werror ext-lambda-captures-this")
+        endif()
+        string(APPEND CUDA_FLAGS " --expt-relaxed-constexpr")
+        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.2")
+            string(APPEND CUDA_FLAGS " --diag-suppress ${DISABLE_NVCC_WARNINGS}")
+        else()
+            string(APPEND CUDA_FLAGS " -Xcudafe --diag_suppress=[${DISABLE_NVCC_WARNINGS}]")
         endif()
 
+        # Host compiler flags
         if (MSVC)
             set(CUDA_DISABLE_MSVC_WARNINGS ${DISABLE_MSVC_WARNINGS})
-            set(DISABLE_NVCC_WARNINGS
-                    550            # variable was set but never used (Eigen)
-                    940            # missing return statement at end of non-void function (Eigen)
-                    2809           # ignoring return value from routine declared with "nodiscard" attribute (Eigen)
-                    )
             if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.1")
                 list(APPEND CUDA_DISABLE_MSVC_WARNINGS /wd4515) # namespace uses itself (thrust)
             endif()
             string(REPLACE ";" "," CUDA_DISABLE_MSVC_WARNINGS "${CUDA_DISABLE_MSVC_WARNINGS}")
-            string(REPLACE ";" "," DISABLE_NVCC_WARNINGS "${DISABLE_NVCC_WARNINGS}")
-            string(APPEND CUDA_FLAGS " -Xcompiler ${CUDA_DISABLE_MSVC_WARNINGS}")
-            string(APPEND CUDA_FLAGS " --expt-relaxed-constexpr")
-            if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.2")
-                string(APPEND CUDA_FLAGS " -Xcudafe --diag_suppress=[${DISABLE_NVCC_WARNINGS}]")
-            else()
-                string(APPEND CUDA_FLAGS " --diag-suppress ${DISABLE_NVCC_WARNINGS}")
-            endif()
+
+            string(APPEND CUDA_FLAGS " -Xcompiler /W4,/WX,${CUDA_DISABLE_MSVC_WARNINGS}")
         else()
-            string(APPEND CUDA_FLAGS " --Werror reorder")
+            set(CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS ${DISABLE_GNU_CLANG_INTEL_WARNINGS})
+            string(REPLACE ";" "," CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS "${CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS}")
+
+            string(APPEND CUDA_FLAGS " -Xcompiler -Wall,-Wextra,-Werror,${CUDA_DISABLE_GNU_CLANG_INTEL_WARNINGS}")
         endif()
     else()
         set(CUDA_FLAGS "")
@@ -62,9 +66,9 @@ function(open3d_show_and_abort_on_warning trgt)
 
     target_compile_options(${trgt} PRIVATE
         $<$<COMPILE_LANG_AND_ID:C,MSVC>:/W4 /WX ${DISABLE_MSVC_WARNINGS}>
-        $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang,Intel>:-Wall -Werror>
+        $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang,Intel>:-Wall -Wextra -Werror ${DISABLE_GNU_CLANG_INTEL_WARNINGS}>
         $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4 /WX ${DISABLE_MSVC_WARNINGS}>
-        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,Intel>:-Wall -Werror>
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang,Intel>:-Wall -Wextra -Werror ${DISABLE_GNU_CLANG_INTEL_WARNINGS}>
         $<$<COMPILE_LANGUAGE:CUDA>:SHELL:${CUDA_FLAGS}>
     )
 endfunction()

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
@@ -277,7 +277,7 @@ std::vector<int64_t> SlabHashmap<Key, Hash>::BucketSizes() const {
     std::vector<int64_t> result(impl_.bucket_count_);
     thrust::copy(elems_per_bucket.begin(), elems_per_bucket.end(),
                  result.begin());
-    return std::move(result);
+    return result;
 }
 
 template <typename Key, typename Hash>

--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -285,7 +285,7 @@ public:
         thrust::copy(slabs_per_superblock.begin(), slabs_per_superblock.end(),
                      result.begin());
 
-        return std::move(result);
+        return result;
     }
 
 public:

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -1495,7 +1495,7 @@ void TriangleMesh::RemoveTrianglesByIndex(
         const std::vector<size_t> &triangle_indices) {
     std::vector<bool> triangle_mask(triangles_.size(), false);
     for (auto tidx : triangle_indices) {
-        if (tidx >= 0 && tidx < triangles_.size()) {
+        if (/*tidx >= 0 &&*/ tidx < triangles_.size()) {
             triangle_mask[tidx] = true;
         } else {
             utility::LogWarning(
@@ -1535,7 +1535,7 @@ void TriangleMesh::RemoveVerticesByIndex(
         const std::vector<size_t> &vertex_indices) {
     std::vector<bool> vertex_mask(vertices_.size(), false);
     for (auto vidx : vertex_indices) {
-        if (vidx >= 0 && vidx < vertices_.size()) {
+        if (/*vidx >= 0 &&*/ vidx < vertices_.size()) {
             vertex_mask[vidx] = true;
         } else {
             utility::LogWarning(
@@ -1606,7 +1606,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectByIndex(
 
     std::vector<int> new_vert_ind(vertices_.size(), -1);
     for (const auto &sel_vidx : indices) {
-        if (sel_vidx < 0 || sel_vidx >= vertices_.size()) {
+        if (/*sel_vidx < 0 ||*/ sel_vidx >= vertices_.size()) {
             utility::LogWarning(
                     "[SelectByIndex] indices contains index {} out of range. "
                     "It is ignored.",

--- a/cpp/open3d/geometry/TriangleMesh.cpp
+++ b/cpp/open3d/geometry/TriangleMesh.cpp
@@ -1495,7 +1495,7 @@ void TriangleMesh::RemoveTrianglesByIndex(
         const std::vector<size_t> &triangle_indices) {
     std::vector<bool> triangle_mask(triangles_.size(), false);
     for (auto tidx : triangle_indices) {
-        if (/*tidx >= 0 &&*/ tidx < triangles_.size()) {
+        if (tidx < triangles_.size()) {
             triangle_mask[tidx] = true;
         } else {
             utility::LogWarning(
@@ -1535,7 +1535,7 @@ void TriangleMesh::RemoveVerticesByIndex(
         const std::vector<size_t> &vertex_indices) {
     std::vector<bool> vertex_mask(vertices_.size(), false);
     for (auto vidx : vertex_indices) {
-        if (/*vidx >= 0 &&*/ vidx < vertices_.size()) {
+        if (vidx < vertices_.size()) {
             vertex_mask[vidx] = true;
         } else {
             utility::LogWarning(
@@ -1606,7 +1606,7 @@ std::shared_ptr<TriangleMesh> TriangleMesh::SelectByIndex(
 
     std::vector<int> new_vert_ind(vertices_.size(), -1);
     for (const auto &sel_vidx : indices) {
-        if (/*sel_vidx < 0 ||*/ sel_vidx >= vertices_.size()) {
+        if (sel_vidx >= vertices_.size()) {
             utility::LogWarning(
                     "[SelectByIndex] indices contains index {} out of range. "
                     "It is ignored.",

--- a/cpp/open3d/visualization/gui/CMakeLists.txt
+++ b/cpp/open3d/visualization/gui/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GUI_SOURCE_FILES
     ColorEdit.cpp
     Combobox.cpp
     Dialog.cpp
+    Events.cpp
     FileDialog.cpp
     FileDialogNative.cpp
     GLFWWindowSystem.cpp

--- a/cpp/open3d/visualization/gui/Events.cpp
+++ b/cpp/open3d/visualization/gui/Events.cpp
@@ -1,0 +1,83 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/visualization/gui/Events.h"
+
+namespace open3d {
+namespace visualization {
+namespace gui {
+
+MouseEvent MouseEvent::MakeMoveEvent(const Type type,
+                                     const int x,
+                                     const int y,
+                                     const int modifiers,
+                                     const int buttons) {
+    MouseEvent me;
+    me.type = type;
+    me.x = x;
+    me.y = y;
+    me.modifiers = modifiers;
+    me.move.buttons = buttons;
+    return me;
+}
+
+MouseEvent MouseEvent::MakeButtonEvent(const Type type,
+                                       const int x,
+                                       const int y,
+                                       const int modifiers,
+                                       const MouseButton button,
+                                       const int count) {
+    MouseEvent me;
+    me.type = type;
+    me.x = x;
+    me.y = y;
+    me.modifiers = modifiers;
+    me.button.button = button;
+    me.button.count = count;
+    return me;
+}
+
+MouseEvent MouseEvent::MakeWheelEvent(const Type type,
+                                      const int x,
+                                      const int y,
+                                      const int modifiers,
+                                      const float dx,
+                                      const float dy,
+                                      const bool isTrackpad) {
+    MouseEvent me;
+    me.type = type;
+    me.x = x;
+    me.y = y;
+    me.modifiers = modifiers;
+    me.wheel.dx = dx;
+    me.wheel.dy = dy;
+    me.wheel.isTrackpad = isTrackpad;
+    return me;
+}
+
+}  // namespace gui
+}  // namespace visualization
+}  // namespace open3d

--- a/cpp/open3d/visualization/gui/Events.h
+++ b/cpp/open3d/visualization/gui/Events.h
@@ -53,6 +53,28 @@ enum class KeyModifier {
 
 struct MouseEvent {
     enum Type { MOVE, BUTTON_DOWN, DRAG, BUTTON_UP, WHEEL };
+
+    static MouseEvent MakeMoveEvent(const Type type,
+                                    const int x,
+                                    const int y,
+                                    const int modifiers,
+                                    const int buttons);
+
+    static MouseEvent MakeButtonEvent(const Type type,
+                                      const int x,
+                                      const int y,
+                                      const int modifiers,
+                                      const MouseButton button,
+                                      const int count);
+
+    static MouseEvent MakeWheelEvent(const Type type,
+                                     const int x,
+                                     const int y,
+                                     const int modifiers,
+                                     const float dx,
+                                     const float dy,
+                                     const bool isTrackpad);
+
     Type type;
     int x;
     int y;

--- a/cpp/open3d/visualization/rendering/filament/FilamentRenderer.cpp
+++ b/cpp/open3d/visualization/rendering/filament/FilamentRenderer.cpp
@@ -373,7 +373,7 @@ void FilamentRenderer::RemoveSkybox(const SkyboxHandle& id) {
 std::shared_ptr<RenderToBuffer> FilamentRenderer::CreateBufferRenderer() {
     auto renderer = std::make_shared<FilamentRenderToBuffer>(engine_);
     buffer_renderers_.insert(renderer);
-    return std::move(renderer);
+    return renderer;
 }
 
 void FilamentRenderer::ConvertToGuiScene(const SceneHandle& id) {

--- a/cpp/open3d/visualization/shader/PhongShader.cpp
+++ b/cpp/open3d/visualization/shader/PhongShader.cpp
@@ -348,6 +348,7 @@ bool PhongShaderForTriangleMesh::PrepareBinding(
                         color = mesh.vertex_colors_[vi];
                         break;
                     }
+                    // fallthrough
                 case RenderOption::MeshColorOption::Default:
                 default:
                     color = option.default_mesh_color_;

--- a/cpp/open3d/visualization/shader/SimpleShader.cpp
+++ b/cpp/open3d/visualization/shader/SimpleShader.cpp
@@ -503,6 +503,7 @@ bool SimpleShaderForTriangleMesh::PrepareBinding(
                         color = mesh.vertex_colors_[vi];
                         break;
                     }
+                    // fallthrough
                 case RenderOption::MeshColorOption::Default:
                 default:
                     color = option.default_mesh_color_;
@@ -584,6 +585,7 @@ bool SimpleShaderForVoxelGridLine::PrepareBinding(
                     voxel_color = voxel.color_;
                     break;
                 }
+                // fallthrough
             case RenderOption::MeshColorOption::Default:
             default:
                 voxel_color = option.default_mesh_color_;
@@ -674,6 +676,7 @@ bool SimpleShaderForVoxelGridFace::PrepareBinding(
                     voxel_color = voxel.color_;
                     break;
                 }
+                // fallthrough
             case RenderOption::MeshColorOption::Default:
             default:
                 voxel_color = option.default_mesh_color_;

--- a/cpp/open3d/visualization/visualizer/O3DVisualizerSelections.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizerSelections.cpp
@@ -56,7 +56,7 @@ O3DVisualizerSelections::~O3DVisualizerSelections() {}
 
 void O3DVisualizerSelections::NewSet() {
     auto name = std::string("__selection_") + std::to_string(next_id_++);
-    sets_.push_back({name});
+    sets_.push_back({name, {}});
     if (current_set_index_ < 0) {
         current_set_index_ = int(sets_.size()) - 1;
     }

--- a/cpp/open3d/visualization/visualizer/VisualizerWithVertexSelection.cpp
+++ b/cpp/open3d/visualization/visualizer/VisualizerWithVertexSelection.cpp
@@ -517,21 +517,21 @@ void VisualizerWithVertexSelection::KeyPressCallback(
             if (action == GLFW_PRESS) {
                 SetPointSize(pick_point_opts_.point_size_ - 1.0);
                 is_redraw_required_ = true;
-                break;
             } else {
                 Visualizer::KeyPressCallback(window, key, scancode, action,
                                              mods);
             }
+            break;
         }
         case GLFW_KEY_EQUAL: {
             if (action == GLFW_PRESS) {
                 SetPointSize(pick_point_opts_.point_size_ + 1.0);
                 is_redraw_required_ = true;
-                break;
             } else {
                 Visualizer::KeyPressCallback(window, key, scancode, action,
                                              mods);
             }
+            break;
         }
         default:
             Visualizer::KeyPressCallback(window, key, scancode, action, mods);

--- a/cpp/tests/test_utility/Print.h
+++ b/cpp/tests/test_utility/Print.h
@@ -146,7 +146,7 @@ void Print(const T* const v, const size_t& size, const int& width = 12) {
         std::cout << std::setw(TAB_SIZE) << "";
 
         for (size_t c = 0; c < cols; c++) {
-            int i = r * cols + c;
+            size_t i = r * cols + c;
 
             std::cout << std::setw(width) << v[i];
 


### PR DESCRIPTION
- Increase warning level for GNU/Clang/Intel compilers by `-Wextra`, but disable noisy `-Wunused-parameter` warning for now
- Make CUDA flags consistent with C++ flags
- Fix newly introduced warnings by the above bump

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3357)
<!-- Reviewable:end -->
