### PR TITLE
fix index set for 0-D tensor

### DIFF
--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -702,8 +702,34 @@ Tensor Tensor::Slice(int64_t dim,
 }
 
 Tensor Tensor::IndexGet(const std::vector<Tensor>& index_tensors) const {
+    if (NumDims() == 0) {
+        const std::string error_prefix =
+                "A 0-D tensor can only be indexed by a 0-D boolean tensor";
+        if (index_tensors.size() != 1) {
+            utility::LogError("{}, but got {} index tensors.", error_prefix,
+                              index_tensors.size());
+        }
+        Tensor index_tensor = index_tensors[0];
+        index_tensor.AssertShape(
+                {}, fmt::format("{}, but got shape {}.", error_prefix,
+                                index_tensor.GetShape().ToString()));
+        index_tensor.AssertDtype(
+                Dtype::Bool, fmt::format("{}, but got dtype {}.", error_prefix,
+                                         index_tensor.GetDtype().ToString()));
+
+        if (index_tensor.IsNonZero()) {
+            // E.g. np.array(5)[np.array(True)].
+            return *this;
+        } else {
+            // E.g. np.array(5)[np.array(False)].
+            // The output tensor becomes 1D of 0 element.
+            return Tensor(/*shape=*/{0}, GetDtype(), GetDevice());
+        }
+    }
+
     AdvancedIndexPreprocessor aip(*this, index_tensors);
     Tensor dst = Tensor(aip.GetOutputShape(), dtype_, GetDevice());
+
     kernel::IndexGet(aip.GetTensor(), dst, aip.GetIndexTensors(),
                      aip.GetIndexedShape(), aip.GetIndexedStrides());
 
@@ -712,8 +738,59 @@ Tensor Tensor::IndexGet(const std::vector<Tensor>& index_tensors) const {
 
 void Tensor::IndexSet(const std::vector<Tensor>& index_tensors,
                       const Tensor& src_tensor) {
+    if (NumDims() == 0) {
+        const std::string error_prefix =
+                "A 0-D tensor can only be indexed by a 0-D boolean tensor";
+        if (index_tensors.size() != 1) {
+            utility::LogError("{}, but got {} index tensors.", error_prefix,
+                              index_tensors.size());
+        }
+        Tensor index_tensor = index_tensors[0];
+        index_tensor.AssertShape(
+                {}, fmt::format("{}, but got shape {}.", error_prefix,
+                                index_tensor.GetShape().ToString()));
+        index_tensor.AssertDtype(
+                Dtype::Bool, fmt::format("{}, but got dtype {}.", error_prefix,
+                                         index_tensor.GetDtype().ToString()));
+
+        // Example index set
+        // t = np.array(5)
+        // t[np.array(True)]  = 10                 // Works, assigned
+        // t[np.array(True)]  = np.array(10)       // Works, assigned
+        // t[np.array(True)]  = np.array([10])     // Works, assigned
+        // t[np.array(True)]  = np.array([[10]])   // Cannot assign 2D
+        // t[np.array(True)]  = np.array([10, 11]) // Cannot assign 1+ values
+        // t[np.array(False)] = 10                 // Works, unchanged
+        // t[np.array(False)] = np.array(10)       // Works, unchanged
+        // t[np.array(False)] = np.array([10])     // Works, unchanged
+        // t[np.array(False)] = np.array([[10]])   // Cannot assign 2D
+        // t[np.array(False)] = np.array([10, 11]) // Cannot assign 1+ values
+
+        // Assert 0-D or 1-D.
+        if (src_tensor.NumDims() > 1) {
+            utility::LogError(
+                    "Boolean indexing of a 0-D tensor can only be assigned "
+                    "with 0 or 1-dimensional input, but got {} dimensions.",
+                    src_tensor.NumDims());
+        }
+        // Assert single element.
+        if (src_tensor.NumElements() != 1) {
+            utility::LogError(
+                    "Boolean indexing of a 0-D tensor can only be assigned "
+                    "with input containing 1 element, but got {} elements.",
+                    src_tensor.NumElements());
+        }
+        if (index_tensors[0].IsNonZero()) {
+            DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src_tensor.GetDtype(), [&]() {
+                AsRvalue() = src_tensor.Item<scalar_t>();
+            });
+        }
+        return;
+    }
+
     AdvancedIndexPreprocessor aip(*this, index_tensors);
     Tensor pre_processed_dst = aip.GetTensor();
+
     kernel::IndexSet(src_tensor, pre_processed_dst, aip.GetIndexTensors(),
                      aip.GetIndexedShape(), aip.GetIndexedStrides());
 }

--- a/cpp/pybind/core/tensor_accessor.cpp
+++ b/cpp/pybind/core/tensor_accessor.cpp
@@ -134,6 +134,10 @@ static TensorKey PyHandleToTensorKey(const py::handle& item) {
 }
 
 static void pybind_getitem(py::class_<Tensor>& tensor) {
+    tensor.def("__getitem__", [](const Tensor& tensor, bool key) {
+        return tensor.GetItem(ToTensorKey(Tensor::Init(key)));
+    });
+
     tensor.def("__getitem__", [](const Tensor& tensor, int key) {
         return tensor.GetItem(ToTensorKey(key));
     });
@@ -172,6 +176,14 @@ static void pybind_getitem(py::class_<Tensor>& tensor) {
 }
 
 static void pybind_setitem(py::class_<Tensor>& tensor) {
+    tensor.def("__setitem__", [](Tensor& tensor, bool key,
+                                 const py::handle& value) {
+        return tensor.SetItem(
+                ToTensorKey(Tensor::Init(key)),
+                PyHandleToTensor(value, tensor.GetDtype(), tensor.GetDevice(),
+                                 /*force_copy=*/false));
+    });
+
     tensor.def("__setitem__", [](Tensor& tensor, int key,
                                  const py::handle& value) {
         return tensor.SetItem(

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -901,6 +901,20 @@ TEST_P(TensorPermuteDevicePairs, IndexGet) {
     EXPECT_TRUE(dst_t.IsContiguous());
     EXPECT_EQ(dst_t.GetShape(), core::SizeVector({2, 2}));
     EXPECT_EQ(dst_t.ToFlatVector<float>(), std::vector<float>({5, 10, 17, 22}));
+
+    // Check 0-D tensor.
+    src_t = core::Tensor::Init<int>(1, src_device);
+    indices = {core::Tensor::Init<bool>(true, idx_device)};
+    dst_t = src_t.IndexGet(indices);
+    EXPECT_TRUE(dst_t.AllClose(src_t));
+    EXPECT_EQ(src_t.GetDtype(), dst_t.GetDtype());
+
+    src_t = core::Tensor::Init<int>(1, src_device);
+    indices = {core::Tensor::Init<bool>(false, idx_device)};
+    dst_t = src_t.IndexGet(indices);
+    EXPECT_TRUE(
+            dst_t.AllClose(core::Tensor({0}, core::Dtype::Int32, src_device)));
+    EXPECT_EQ(src_t.GetDtype(), dst_t.GetDtype());
 }
 
 TEST_P(TensorPermuteDevicePairs, IndexGetNegative) {
@@ -1088,6 +1102,60 @@ TEST_P(TensorPermuteDevicePairs, IndexSet) {
     EXPECT_EQ(dst_t.ToFlatVector<float>(),
               std::vector<float>({0, 0, 0, 0, 4,  5,  6,  0, 0, 0, 0, 0,
                                   0, 0, 0, 0, 16, 17, 18, 0, 0, 0, 0, 0}));
+
+    // Check 0-D tensor.
+    // dst_t[np.array(True)] = 10 // Works, assigned
+    // dst_t[np.array(True)] = np.array(10) // Works, assigned
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    dst_t.IndexSet({core::Tensor::Init<bool>(true, src_device)},
+                   core::Tensor::Init<float>(10, src_device));
+    EXPECT_TRUE(dst_t.AllClose(core::Tensor::Init<float>(10, dst_device)));
+
+    // dst_t[np.array(True)] = np.array([10]) // Works, assigned
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    dst_t.IndexSet({core::Tensor::Init<bool>(true, src_device)},
+                   core::Tensor::Init<float>({10}, src_device));
+    EXPECT_TRUE(dst_t.AllClose(core::Tensor::Init<float>(10, dst_device)));
+
+    // dst_t[np.array(True)] = np.array([[10]]) // Cannot assign 2D
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    EXPECT_ANY_THROW(
+            dst_t.IndexSet({core::Tensor::Init<bool>(true, src_device)},
+                           core::Tensor::Init<float>({{10}}, src_device)));
+
+    // dst_t[np.array(True)] = np.array([10, 11]) // Cannot assign 1+ values
+    EXPECT_ANY_THROW(
+            dst_t.IndexSet({core::Tensor::Init<bool>(true, src_device)},
+                           core::Tensor::Init<float>({10, 11}, src_device)));
+
+    // dst_t[np.array(False)] = 10 // Works, unchanged
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    dst_t.IndexSet({core::Tensor::Init<bool>(false, src_device)},
+                   core::Tensor::Init<float>(10, src_device));
+    EXPECT_TRUE(dst_t.AllClose(core::Tensor::Init<float>(5, dst_device)));
+
+    // dst_t[np.array(False)] = np.array(10) // Works, unchanged
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    dst_t.IndexSet({core::Tensor::Init<bool>(false, src_device)},
+                   core::Tensor::Init<float>({10}, src_device));
+    EXPECT_TRUE(dst_t.AllClose(core::Tensor::Init<float>(5, dst_device)));
+
+    // dst_t[np.array(False)] = np.array([10]) // Works, unchanged
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    EXPECT_ANY_THROW(
+            dst_t.IndexSet({core::Tensor::Init<bool>(false, src_device)},
+                           core::Tensor::Init<float>({{5}}, src_device)));
+
+    // dst_t[np.array(False)] = np.array([[10]]) // Cannot assign 2D
+    dst_t = core::Tensor::Init<float>(5, dst_device);
+    EXPECT_ANY_THROW(
+            dst_t.IndexSet({core::Tensor::Init<bool>(false, src_device)},
+                           core::Tensor::Init<float>({{10}}, src_device)));
+
+    // dst_t[np.array(False)] = np.array([10, 11]) // Cannot assign 1+ values
+    EXPECT_ANY_THROW(
+            dst_t.IndexSet({core::Tensor::Init<bool>(false, src_device)},
+                           core::Tensor::Init<float>({10, 11}, src_device)));
 }
 
 TEST_P(TensorPermuteDevicePairs, IndexSetBroadcast) {

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -25,6 +25,7 @@
 # ----------------------------------------------------------------------------
 
 import open3d as o3d
+import open3d.core as o3c
 import numpy as np
 import pytest
 import tempfile
@@ -37,48 +38,48 @@ from open3d_test import list_devices
 
 def list_dtypes():
     return [
-        o3d.core.Dtype.Float32,
-        o3d.core.Dtype.Float64,
-        o3d.core.Dtype.Int8,
-        o3d.core.Dtype.Int16,
-        o3d.core.Dtype.Int32,
-        o3d.core.Dtype.Int64,
-        o3d.core.Dtype.UInt8,
-        o3d.core.Dtype.UInt16,
-        o3d.core.Dtype.UInt32,
-        o3d.core.Dtype.UInt64,
-        o3d.core.Dtype.Bool,
+        o3c.Dtype.Float32,
+        o3c.Dtype.Float64,
+        o3c.Dtype.Int8,
+        o3c.Dtype.Int16,
+        o3c.Dtype.Int32,
+        o3c.Dtype.Int64,
+        o3c.Dtype.UInt8,
+        o3c.Dtype.UInt16,
+        o3c.Dtype.UInt32,
+        o3c.Dtype.UInt64,
+        o3c.Dtype.Bool,
     ]
 
 
 def list_non_bool_dtypes():
     return [
-        o3d.core.Dtype.Float32,
-        o3d.core.Dtype.Float64,
-        o3d.core.Dtype.Int8,
-        o3d.core.Dtype.Int16,
-        o3d.core.Dtype.Int32,
-        o3d.core.Dtype.Int64,
-        o3d.core.Dtype.UInt8,
-        o3d.core.Dtype.UInt16,
-        o3d.core.Dtype.UInt32,
-        o3d.core.Dtype.UInt64,
+        o3c.Dtype.Float32,
+        o3c.Dtype.Float64,
+        o3c.Dtype.Int8,
+        o3c.Dtype.Int16,
+        o3c.Dtype.Int32,
+        o3c.Dtype.Int64,
+        o3c.Dtype.UInt8,
+        o3c.Dtype.UInt16,
+        o3c.Dtype.UInt32,
+        o3c.Dtype.UInt64,
     ]
 
 
-def to_numpy_dtype(dtype: o3d.core.Dtype):
+def to_numpy_dtype(dtype: o3c.Dtype):
     conversions = {
-        o3d.core.Dtype.Float32: np.float32,
-        o3d.core.Dtype.Float64: np.float64,
-        o3d.core.Dtype.Int8: np.int8,
-        o3d.core.Dtype.Int16: np.int16,
-        o3d.core.Dtype.Int32: np.int32,
-        o3d.core.Dtype.Int64: np.int64,
-        o3d.core.Dtype.UInt8: np.uint8,
-        o3d.core.Dtype.UInt16: np.uint16,
-        o3d.core.Dtype.UInt32: np.uint32,
-        o3d.core.Dtype.UInt64: np.uint64,
-        o3d.core.Dtype.Bool: np.bool8,  # np.bool deprecated
+        o3c.Dtype.Float32: np.float32,
+        o3c.Dtype.Float64: np.float64,
+        o3c.Dtype.Int8: np.int8,
+        o3c.Dtype.Int16: np.int16,
+        o3c.Dtype.Int32: np.int32,
+        o3c.Dtype.Int64: np.int64,
+        o3c.Dtype.UInt8: np.uint8,
+        o3c.Dtype.UInt16: np.uint16,
+        o3c.Dtype.UInt32: np.uint32,
+        o3c.Dtype.UInt64: np.uint64,
+        o3c.Dtype.Bool: np.bool8,  # np.bool deprecated
     }
     return conversions[dtype]
 
@@ -86,25 +87,25 @@ def to_numpy_dtype(dtype: o3d.core.Dtype):
 @pytest.mark.parametrize("dtype", list_dtypes())
 @pytest.mark.parametrize("device", list_devices())
 def test_creation(dtype, device):
-    # Shape takes tuple, list or o3d.core.SizeVector
-    t = o3d.core.Tensor.empty((2, 3), dtype, device=device)
-    assert t.shape == o3d.core.SizeVector([2, 3])
-    t = o3d.core.Tensor.empty([2, 3], dtype, device=device)
-    assert t.shape == o3d.core.SizeVector([2, 3])
-    t = o3d.core.Tensor.empty(o3d.core.SizeVector([2, 3]), dtype, device=device)
-    assert t.shape == o3d.core.SizeVector([2, 3])
+    # Shape takes tuple, list or o3c.SizeVector
+    t = o3c.Tensor.empty((2, 3), dtype, device=device)
+    assert t.shape == o3c.SizeVector([2, 3])
+    t = o3c.Tensor.empty([2, 3], dtype, device=device)
+    assert t.shape == o3c.SizeVector([2, 3])
+    t = o3c.Tensor.empty(o3c.SizeVector([2, 3]), dtype, device=device)
+    assert t.shape == o3c.SizeVector([2, 3])
 
     # Test zeros and ones
-    t = o3d.core.Tensor.zeros((2, 3), dtype, device=device)
+    t = o3c.Tensor.zeros((2, 3), dtype, device=device)
     np.testing.assert_equal(t.cpu().numpy(), np.zeros((2, 3), dtype=np.float32))
-    t = o3d.core.Tensor.ones((2, 3), dtype, device=device)
+    t = o3c.Tensor.ones((2, 3), dtype, device=device)
     np.testing.assert_equal(t.cpu().numpy(), np.ones((2, 3), dtype=np.float32))
 
     # Automatic casting of dtype.
-    t = o3d.core.Tensor.full((2,), False, o3d.core.Dtype.Float32, device=device)
+    t = o3c.Tensor.full((2,), False, o3c.Dtype.Float32, device=device)
     np.testing.assert_equal(t.cpu().numpy(),
                             np.full((2,), False, dtype=np.float32))
-    t = o3d.core.Tensor.full((2,), 3.5, o3d.core.Dtype.UInt8, device=device)
+    t = o3c.Tensor.full((2,), 3.5, o3c.Dtype.UInt8, device=device)
     np.testing.assert_equal(t.cpu().numpy(), np.full((2,), 3.5, dtype=np.uint8))
 
 
@@ -113,77 +114,77 @@ def test_creation(dtype, device):
 @pytest.mark.parametrize("dtype", list_dtypes())
 @pytest.mark.parametrize("device", list_devices())
 def test_creation_special_shapes(shape, dtype, device):
-    o3_t = o3d.core.Tensor.full(shape, 3.14, dtype, device=device)
+    o3_t = o3c.Tensor.full(shape, 3.14, dtype, device=device)
     np_t = np.full(shape, 3.14, dtype=to_numpy_dtype(dtype))
     np.testing.assert_allclose(o3_t.cpu().numpy(), np_t)
 
 
 def test_dtype():
-    dtype = o3d.core.Dtype.Int32
+    dtype = o3c.Dtype.Int32
     assert dtype.byte_size() == 4
     assert "{}".format(dtype) == "Int32"
 
 
 def test_device():
-    device = o3d.core.Device()
-    assert device.get_type() == o3d.core.Device.DeviceType.CPU
+    device = o3c.Device()
+    assert device.get_type() == o3c.Device.DeviceType.CPU
     assert device.get_id() == 0
 
-    device = o3d.core.Device("CUDA", 1)
-    assert device.get_type() == o3d.core.Device.DeviceType.CUDA
+    device = o3c.Device("CUDA", 1)
+    assert device.get_type() == o3c.Device.DeviceType.CUDA
     assert device.get_id() == 1
 
-    device = o3d.core.Device("CUDA:2")
-    assert device.get_type() == o3d.core.Device.DeviceType.CUDA
+    device = o3c.Device("CUDA:2")
+    assert device.get_type() == o3c.Device.DeviceType.CUDA
     assert device.get_id() == 2
 
-    assert o3d.core.Device("CUDA", 1) == o3d.core.Device("CUDA:1")
-    assert o3d.core.Device("CUDA", 1) != o3d.core.Device("CUDA:0")
+    assert o3c.Device("CUDA", 1) == o3c.Device("CUDA:1")
+    assert o3c.Device("CUDA", 1) != o3c.Device("CUDA:0")
 
-    assert o3d.core.Device("CUDA", 1).__str__() == "CUDA:1"
+    assert o3c.Device("CUDA", 1).__str__() == "CUDA:1"
 
 
 def test_size_vector():
     # List
-    sv = o3d.core.SizeVector([-1, 2, 3])
+    sv = o3c.SizeVector([-1, 2, 3])
     assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
 
     # Tuple
-    sv = o3d.core.SizeVector((-1, 2, 3))
+    sv = o3c.SizeVector((-1, 2, 3))
     assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
 
     # Numpy 1D array
-    sv = o3d.core.SizeVector(np.array([-1, 2, 3]))
+    sv = o3c.SizeVector(np.array([-1, 2, 3]))
     assert "{}".format(sv) == "SizeVector[-1, 2, 3]"
 
     # Empty
-    sv = o3d.core.SizeVector()
+    sv = o3c.SizeVector()
     assert "{}".format(sv) == "SizeVector[]"
-    sv = o3d.core.SizeVector([])
+    sv = o3c.SizeVector([])
     assert "{}".format(sv) == "SizeVector[]"
-    sv = o3d.core.SizeVector(())
+    sv = o3c.SizeVector(())
     assert "{}".format(sv) == "SizeVector[]"
-    sv = o3d.core.SizeVector(np.array([]))
+    sv = o3c.SizeVector(np.array([]))
     assert "{}".format(sv) == "SizeVector[]"
 
     # Not integer: thorws exception
-    with pytest.raises(RuntimeError):
-        sv = o3d.core.SizeVector([1.9, 2, 3])
+    with pytest.raises(Exception):
+        sv = o3c.SizeVector([1.9, 2, 3])
 
-    with pytest.raises(RuntimeError):
-        sv = o3d.core.SizeVector([-1.5, 2, 3])
+    with pytest.raises(Exception):
+        sv = o3c.SizeVector([-1.5, 2, 3])
 
     # 2D list exception
-    with pytest.raises(RuntimeError):
-        sv = o3d.core.SizeVector([[1, 2], [3, 4]])
+    with pytest.raises(Exception):
+        sv = o3c.SizeVector([[1, 2], [3, 4]])
 
     # 2D Numpy array exception
-    with pytest.raises(RuntimeError):
-        sv = o3d.core.SizeVector(np.array([[1, 2], [3, 4]]))
+    with pytest.raises(Exception):
+        sv = o3c.SizeVector(np.array([[1, 2], [3, 4]]))
 
     # Garbage input
-    with pytest.raises(RuntimeError):
-        sv = o3d.core.SizeVector(["foo", "bar"])
+    with pytest.raises(Exception):
+        sv = o3c.SizeVector(["foo", "bar"])
 
 
 @pytest.mark.parametrize("dtype", list_dtypes())
@@ -191,13 +192,13 @@ def test_size_vector():
 def test_tensor_constructor(dtype, device):
     # Numpy array
     np_t = np.array([[0, 1, 2], [3, 4, 5]], dtype=to_numpy_dtype(dtype))
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # 2D list
     li_t = [[0, 1, 2], [3, 4, 5]]
     np_t = np.array(li_t, dtype=to_numpy_dtype(dtype))
-    o3_t = o3d.core.Tensor(li_t, dtype, device)
+    o3_t = o3c.Tensor(li_t, dtype, device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # 2D list, inconsistent length
@@ -208,31 +209,31 @@ def test_tensor_constructor(dtype, device):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
                                     category=VisibleDeprecationWarning)
-            o3_t = o3d.core.Tensor(li_t, dtype, device)
+            o3_t = o3c.Tensor(li_t, dtype, device)
 
     # Automatic casting
     np_t_double = np.array([[0., 1.5, 2.], [3., 4., 5.]])
     np_t_int = np.array([[0, 1, 2], [3, 4, 5]])
-    o3_t = o3d.core.Tensor(np_t_double, o3d.core.Dtype.Int32, device)
+    o3_t = o3c.Tensor(np_t_double, o3c.Dtype.Int32, device)
     np.testing.assert_equal(np_t_int, o3_t.cpu().numpy())
 
     # Special strides
     np_t = np.random.randint(10, size=(10, 10))[1:10:2, 1:10:3].T
-    o3_t = o3d.core.Tensor(np_t, o3d.core.Dtype.Int32, device)
+    o3_t = o3c.Tensor(np_t, o3c.Dtype.Int32, device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Boolean
     np_t = np.array([True, False, True], dtype=np.bool8)
-    o3_t = o3d.core.Tensor([True, False, True], o3d.core.Dtype.Bool, device)
+    o3_t = o3c.Tensor([True, False, True], o3c.Dtype.Bool, device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
-    o3_t = o3d.core.Tensor(np_t, o3d.core.Dtype.Bool, device)
+    o3_t = o3c.Tensor(np_t, o3c.Dtype.Bool, device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Scalar Boolean
     np_t = np.array(True)
-    o3_t = o3d.core.Tensor(True, dtype=None, device=device)
+    o3_t = o3c.Tensor(True, dtype=None, device=device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
-    o3_t = o3d.core.Tensor(True, dtype=o3d.core.Dtype.Bool, device=device)
+    o3_t = o3c.Tensor(True, dtype=o3c.Dtype.Bool, device=device)
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
 
@@ -242,17 +243,13 @@ def test_arange(device):
     setups = [(0, 10, 1), (0, 10, 1), (0.0, 10.0, 2.0), (0.0, -10.0, -2.0)]
     for start, stop, step in setups:
         np_t = np.arange(start, stop, step)
-        o3_t = o3d.core.Tensor.arange(start,
-                                      stop,
-                                      step,
-                                      dtype=None,
-                                      device=device)
+        o3_t = o3c.Tensor.arange(start, stop, step, dtype=None, device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Only stop.
     for stop in [1.0, 2.0, 3.0, 1, 2, 3]:
         np_t = np.arange(stop)
-        o3_t = o3d.core.Tensor.arange(stop, dtype=None, device=device)
+        o3_t = o3c.Tensor.arange(stop, dtype=None, device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Only start, stop (step = 1).
@@ -260,41 +257,38 @@ def test_arange(device):
     for start, stop in setups:
         np_t = np.arange(start, stop)
         # Not full parameter list, need to specify device by kw.
-        o3_t = o3d.core.Tensor.arange(start, stop, dtype=None, device=device)
+        o3_t = o3c.Tensor.arange(start, stop, dtype=None, device=device)
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Type inference: int -> int.
-    o3_t = o3d.core.Tensor.arange(0, 5, dtype=None, device=device)
+    o3_t = o3c.Tensor.arange(0, 5, dtype=None, device=device)
     np_t = np.arange(0, 5)
-    assert o3_t.dtype == o3d.core.Dtype.Int64
+    assert o3_t.dtype == o3c.Dtype.Int64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Type inference: int, float -> float.
-    o3_t = o3d.core.Tensor.arange(0, 5.0, dtype=None, device=device)
+    o3_t = o3c.Tensor.arange(0, 5.0, dtype=None, device=device)
     np_t = np.arange(0, 5)
-    assert o3_t.dtype == o3d.core.Dtype.Float64
+    assert o3_t.dtype == o3c.Dtype.Float64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Type inference: float, float -> float.
-    o3_t = o3d.core.Tensor.arange(0.0, 5.0, dtype=None, device=device)
+    o3_t = o3c.Tensor.arange(0.0, 5.0, dtype=None, device=device)
     np_t = np.arange(0, 5)
-    assert o3_t.dtype == o3d.core.Dtype.Float64
+    assert o3_t.dtype == o3c.Dtype.Float64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
     # Type inference: explicit type.
-    o3_t = o3d.core.Tensor.arange(0.0,
-                                  5.0,
-                                  dtype=o3d.core.Dtype.Int64,
-                                  device=device)
+    o3_t = o3c.Tensor.arange(0.0, 5.0, dtype=o3c.Dtype.Int64, device=device)
     np_t = np.arange(0, 5)
-    assert o3_t.dtype == o3d.core.Dtype.Int64
+    assert o3_t.dtype == o3c.Dtype.Int64
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
 
 def test_tensor_from_to_numpy():
     # a->b copy; b, c share memory
     a = np.ones((2, 2))
-    b = o3d.core.Tensor(a)
+    b = o3c.Tensor(a)
     c = b.numpy()
 
     c[0, 1] = 200
@@ -304,7 +298,7 @@ def test_tensor_from_to_numpy():
 
     # a, b, c share memory
     a = np.array([[1., 1.], [1., 1.]])
-    b = o3d.core.Tensor.from_numpy(a)
+    b = o3c.Tensor.from_numpy(a)
     c = b.numpy()
 
     a[0, 0] = 100
@@ -317,7 +311,7 @@ def test_tensor_from_to_numpy():
     # Special strides
     ran_t = np.random.randint(10, size=(10, 10)).astype(np.int32)
     src_t = ran_t[1:10:2, 1:10:3].T
-    o3d_t = o3d.core.Tensor.from_numpy(src_t)  # Shared memory
+    o3d_t = o3c.Tensor.from_numpy(src_t)  # Shared memory
     dst_t = o3d_t.numpy()
     np.testing.assert_equal(dst_t, src_t)
 
@@ -334,7 +328,7 @@ def test_tensor_to_numpy_scope():
     src_t = np.array([[10., 11., 12.], [13., 14., 15.]])
 
     def get_dst_t():
-        o3d_t = o3d.core.Tensor(src_t)  # Copy
+        o3d_t = o3c.Tensor(src_t)  # Copy
         dst_t = o3d_t.numpy()
         return dst_t
 
@@ -345,12 +339,8 @@ def test_tensor_to_numpy_scope():
 @pytest.mark.parametrize("dtype", list_non_bool_dtypes())
 @pytest.mark.parametrize("device", list_devices())
 def test_binary_ew_ops(dtype, device):
-    a = o3d.core.Tensor(np.array([4, 6, 8, 10, 12, 14]),
-                        dtype=dtype,
-                        device=device)
-    b = o3d.core.Tensor(np.array([2, 3, 4, 5, 6, 7]),
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor(np.array([4, 6, 8, 10, 12, 14]), dtype=dtype, device=device)
+    b = o3c.Tensor(np.array([2, 3, 4, 5, 6, 7]), dtype=dtype, device=device)
     np.testing.assert_equal((a + b).cpu().numpy(),
                             np.array([6, 9, 12, 15, 18, 21]))
     np.testing.assert_equal((a - b).cpu().numpy(), np.array([2, 3, 4, 5, 6, 7]))
@@ -358,48 +348,39 @@ def test_binary_ew_ops(dtype, device):
                             np.array([8, 18, 32, 50, 72, 98]))
     np.testing.assert_equal((a / b).cpu().numpy(), np.array([2, 2, 2, 2, 2, 2]))
 
-    a = o3d.core.Tensor(np.array([4, 6, 8, 10, 12, 14]),
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor(np.array([4, 6, 8, 10, 12, 14]), dtype=dtype, device=device)
     a += b
     np.testing.assert_equal(a.cpu().numpy(), np.array([6, 9, 12, 15, 18, 21]))
 
-    a = o3d.core.Tensor(np.array([4, 6, 8, 10, 12, 14]),
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor(np.array([4, 6, 8, 10, 12, 14]), dtype=dtype, device=device)
     a -= b
     np.testing.assert_equal(a.cpu().numpy(), np.array([2, 3, 4, 5, 6, 7]))
 
-    a = o3d.core.Tensor(np.array([4, 6, 8, 10, 12, 14]),
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor(np.array([4, 6, 8, 10, 12, 14]), dtype=dtype, device=device)
     a *= b
     np.testing.assert_equal(a.cpu().numpy(), np.array([8, 18, 32, 50, 72, 98]))
 
-    a = o3d.core.Tensor(np.array([4, 6, 8, 10, 12, 14]),
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor(np.array([4, 6, 8, 10, 12, 14]), dtype=dtype, device=device)
     a //= b
     np.testing.assert_equal(a.cpu().numpy(), np.array([2, 2, 2, 2, 2, 2]))
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_to(device):
-    a = o3d.core.Tensor(np.array([0.1, 1.2, 2.3, 3.4, 4.5,
-                                  5.6]).astype(np.float32),
-                        device=device)
-    b = a.to(o3d.core.Dtype.Int32)
+    a = o3c.Tensor(np.array([0.1, 1.2, 2.3, 3.4, 4.5, 5.6]).astype(np.float32),
+                   device=device)
+    b = a.to(o3c.Dtype.Int32)
     np.testing.assert_equal(b.cpu().numpy(), np.array([0, 1, 2, 3, 4, 5]))
-    assert b.shape == o3d.core.SizeVector([6])
-    assert b.strides == o3d.core.SizeVector([1])
-    assert b.dtype == o3d.core.Dtype.Int32
+    assert b.shape == o3c.SizeVector([6])
+    assert b.strides == o3c.SizeVector([1])
+    assert b.dtype == o3c.Dtype.Int32
     assert b.device == a.device
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_unary_ew_ops(device):
     src_vals = np.array([0, 1, 2, 3, 4, 5]).astype(np.float32)
-    src = o3d.core.Tensor(src_vals, device=device)
+    src = o3c.Tensor(src_vals, device=device)
 
     rtol = 1e-5
     atol = 0
@@ -428,7 +409,7 @@ def test_unary_ew_ops(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_getitem(device):
     np_t = np.array(range(24)).reshape((2, 3, 4))
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
 
     np.testing.assert_equal(o3_t[:].cpu().numpy(), np_t[:])
     np.testing.assert_equal(o3_t[0].cpu().numpy(), np_t[0])
@@ -464,104 +445,104 @@ def test_setitem(device):
     np_ref = np.array(range(24)).reshape((2, 3, 4))
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[:].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[:] = np_fill_t
     o3_t[:] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0] = np_fill_t
     o3_t[0] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1] = np_fill_t
     o3_t[0, 1] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, :].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, :] = np_fill_t
     o3_t[0, :] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1:3].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1:3] = np_fill_t
     o3_t[0, 1:3] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, :, :-2].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, :, :-2] = np_fill_t
     o3_t[0, :, :-2] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1:3, 2].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1:3, 2] = np_fill_t
     o3_t[0, 1:3, 2] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1:-1, 2].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1:-1, 2] = np_fill_t
     o3_t[0, 1:-1, 2] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1:3, 0:4:2].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1:3, 0:4:2] = np_fill_t
     o3_t[0, 1:3, 0:4:2] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1:3, 0:-1:2].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1:3, 0:-1:2] = np_fill_t
     o3_t[0, 1:3, 0:-1:2] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0, 1, :].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0, 1, :] = np_fill_t
     o3_t[0, 1, :] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     np_t = np_ref.copy()
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
     np_fill_t = np.random.rand(*np_t[0:2, 1:3, 0:4][0:1, 0:2, 2:3].shape)
-    o3_fill_t = o3d.core.Tensor(np_fill_t, device=device)
+    o3_fill_t = o3c.Tensor(np_fill_t, device=device)
     np_t[0:2, 1:3, 0:4][0:1, 0:2, 2:3] = np_fill_t
     o3_t[0:2, 1:3, 0:4][0:1, 0:2, 2:3] = o3_fill_t
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
 
     # Scalar boolean set item
     np_t = np.eye(4, dtype=np.bool8)
-    o3_t = o3d.core.Tensor.eye(4, dtype=o3d.core.Dtype.Bool)
+    o3_t = o3c.Tensor.eye(4, dtype=o3c.Dtype.Bool)
     np_t[2, 2] = False
     o3_t[2, 2] = False
     np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
@@ -574,7 +555,7 @@ def test_setitem(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_reduction_sum(dim, keepdim, device):
     np_src = np.array(range(24)).reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.sum(axis=dim, keepdims=keepdim)
     o3_dst = o3_src.sum(dim=dim, keepdim=keepdim)
@@ -594,7 +575,7 @@ def test_reduction_sum(dim, keepdim, device):
 def test_reduction_special_shapes(shape_and_axis, keepdim, device):
     shape, axis = shape_and_axis
     np_src = np.array(np.random.rand(*shape))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
     np.testing.assert_equal(o3_src.cpu().numpy(), np_src)
 
     np_dst = np_src.sum(axis=axis, keepdims=keepdim)
@@ -609,7 +590,7 @@ def test_reduction_special_shapes(shape_and_axis, keepdim, device):
 @pytest.mark.parametrize("device", list_devices())
 def test_reduction_mean(dim, keepdim, device):
     np_src = np.array(range(24)).reshape((2, 3, 4)).astype(np.float32)
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.mean(axis=dim, keepdims=keepdim)
     o3_dst = o3_src.mean(dim=dim, keepdim=keepdim)
@@ -623,7 +604,7 @@ def test_reduction_mean(dim, keepdim, device):
 @pytest.mark.parametrize("device", list_devices())
 def test_reduction_prod(dim, keepdim, device):
     np_src = np.array(range(24)).reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.prod(axis=dim, keepdims=keepdim)
     o3_dst = o3_src.prod(dim=dim, keepdim=keepdim)
@@ -639,7 +620,7 @@ def test_reduction_min(dim, keepdim, device):
     np_src = np.array(range(24))
     np.random.shuffle(np_src)
     np_src = np_src.reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.min(axis=dim, keepdims=keepdim)
     o3_dst = o3_src.min(dim=dim, keepdim=keepdim)
@@ -655,7 +636,7 @@ def test_reduction_max(dim, keepdim, device):
     np_src = np.array(range(24))
     np.random.shuffle(np_src)
     np_src = np_src.reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.max(axis=dim, keepdims=keepdim)
     o3_dst = o3_src.max(dim=dim, keepdim=keepdim)
@@ -668,7 +649,7 @@ def test_reduction_argmin_argmax(dim, device):
     np_src = np.array(range(24))
     np.random.shuffle(np_src)
     np_src = np_src.reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src.argmin(axis=dim)
     o3_dst = o3_src.argmin(dim=dim)
@@ -682,7 +663,7 @@ def test_reduction_argmin_argmax(dim, device):
 @pytest.mark.parametrize("device", list_devices())
 def test_advanced_index_get_mixed(device):
     np_src = np.array(range(24)).reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_dst = np_src[1, 0:2, [1, 2]]
     o3_dst = o3_src[1, 0:2, [1, 2]]
@@ -690,7 +671,7 @@ def test_advanced_index_get_mixed(device):
 
     # Subtle differences between slice and list
     np_src = np.array([0, 100, 200, 300, 400, 500, 600, 700, 800]).reshape(3, 3)
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
     np.testing.assert_equal(o3_src[1, 2].cpu().numpy(), np_src[1, 2])
     np.testing.assert_equal(o3_src[[1, 2]].cpu().numpy(), np_src[[1, 2]])
     np.testing.assert_equal(o3_src[(1, 2)].cpu().numpy(), np_src[(1, 2)])
@@ -699,7 +680,7 @@ def test_advanced_index_get_mixed(device):
 
     # Complex case: interleaving slice and advanced indexing
     np_src = np.array(range(120)).reshape((2, 3, 4, 5))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
     o3_dst = o3_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]]
     np_dst = np_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]]
     np.testing.assert_equal(o3_dst.cpu().numpy(), np_dst)
@@ -708,10 +689,10 @@ def test_advanced_index_get_mixed(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_advanced_index_set_mixed(device):
     np_src = np.array(range(24)).reshape((2, 3, 4))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
 
     np_fill = np.array(([[100, 200], [300, 400]]))
-    o3_fill = o3d.core.Tensor(np_fill, device=device)
+    o3_fill = o3c.Tensor(np_fill, device=device)
 
     np_src[1, 0:2, [1, 2]] = np_fill
     o3_src[1, 0:2, [1, 2]] = o3_fill
@@ -719,10 +700,10 @@ def test_advanced_index_set_mixed(device):
 
     # Complex case: interleaving slice and advanced indexing
     np_src = np.array(range(120)).reshape((2, 3, 4, 5))
-    o3_src = o3d.core.Tensor(np_src, device=device)
+    o3_src = o3c.Tensor(np_src, device=device)
     fill_shape = np_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]].shape
     np_fill_val = np.random.randint(5000, size=fill_shape).astype(np_src.dtype)
-    o3_fill_val = o3d.core.Tensor(np_fill_val)
+    o3_fill_val = o3c.Tensor(np_fill_val)
     o3_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]] = o3_fill_val
     np_src[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]] = np_fill_val
     np.testing.assert_equal(o3_src.cpu().numpy(), np_src)
@@ -741,7 +722,7 @@ def test_advanced_index_set_mixed(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_unary_elementwise(np_func_name, o3_func_name, device):
     np_t = np.array([-3.4, -2.6, -1.5, 0, 1.4, 2.6, 3.5]).astype(np.float32)
-    o3_t = o3d.core.Tensor(np_t, device=device)
+    o3_t = o3c.Tensor(np_t, device=device)
 
     # Test non-in-place version
     np.seterr(invalid='ignore')  # e.g. sqrt of negative should be -nan
@@ -764,8 +745,8 @@ def test_unary_elementwise(np_func_name, o3_func_name, device):
 def test_logical_ops(device):
     np_a = np.array([True, False, True, False])
     np_b = np.array([True, True, False, False])
-    o3_a = o3d.core.Tensor(np_a, device=device)
-    o3_b = o3d.core.Tensor(np_b, device=device)
+    o3_a = o3c.Tensor(np_a, device=device)
+    o3_b = o3c.Tensor(np_b, device=device)
 
     o3_r = o3_a.logical_and(o3_b)
     np_r = np.logical_and(np_a, np_b)
@@ -784,8 +765,8 @@ def test_logical_ops(device):
 def test_comparision_ops(device):
     np_a = np.array([0, 1, -1])
     np_b = np.array([0, 0, 0])
-    o3_a = o3d.core.Tensor(np_a, device=device)
-    o3_b = o3d.core.Tensor(np_b, device=device)
+    o3_a = o3c.Tensor(np_a, device=device)
+    o3_b = o3c.Tensor(np_b, device=device)
 
     np.testing.assert_equal((o3_a > o3_b).cpu().numpy(), np_a > np_b)
     np.testing.assert_equal((o3_a >= o3_b).cpu().numpy(), np_a >= np_b)
@@ -799,7 +780,7 @@ def test_comparision_ops(device):
 def test_non_zero(device):
     np_x = np.array([[3, 0, 0], [0, 4, 0], [5, 6, 0]])
     np_nonzero_tuple = np.nonzero(np_x)
-    o3_x = o3d.core.Tensor(np_x, device=device)
+    o3_x = o3c.Tensor(np_x, device=device)
     o3_nonzero_tuple = o3_x.nonzero(as_tuple=True)
     for np_t, o3_t in zip(np_nonzero_tuple, o3_nonzero_tuple):
         np.testing.assert_equal(np_t, o3_t.cpu().numpy())
@@ -808,7 +789,7 @@ def test_non_zero(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_boolean_advanced_indexing(device):
     np_a = np.array([1, -1, -2, 3])
-    o3_a = o3d.core.Tensor(np_a, device=device)
+    o3_a = o3c.Tensor(np_a, device=device)
     np_a[np_a < 0] = 0
     o3_a[o3_a < 0] = 0
     np.testing.assert_equal(np_a, o3_a.cpu().numpy())
@@ -816,16 +797,84 @@ def test_boolean_advanced_indexing(device):
     np_x = np.array([[0, 1], [1, 1], [2, 2]])
     np_row_sum = np.array([1, 2, 4])
     np_y = np_x[np_row_sum <= 2, :]
-    o3_x = o3d.core.Tensor(np_x, device=device)
-    o3_row_sum = o3d.core.Tensor(np_row_sum)
+    o3_x = o3c.Tensor(np_x, device=device)
+    o3_row_sum = o3c.Tensor(np_row_sum)
     o3_y = o3_x[o3_row_sum <= 2, :]
     np.testing.assert_equal(np_y, o3_y.cpu().numpy())
+
+    np_t = np.array(5)
+    np_t[np.array(True)] = 10
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(True, device=device)] = 10
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    np_t[np.array(True)] = np.array(10)
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(True, device=device)] = o3c.Tensor(10, device=device)
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    np_t[np.array(True)] = np.array([10])
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(True, device=device)] = o3c.Tensor([10], device=device)
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    with pytest.raises(Exception):
+        np_t[np.array(True)] = np.array([[10]])
+    o3_t = o3c.Tensor(5, device=device)
+    with pytest.raises(Exception):
+        o3_t[o3c.Tensor(True, device=device)] = o3c.Tensor([[10]],
+                                                           device=device)
+
+    np_t = np.array(5)
+    with pytest.raises(Exception):
+        np_t[np.array(True)] = np.array([10, 11])
+    o3_t = o3c.Tensor(5, device=device)
+    with pytest.raises(Exception):
+        o3_t[o3c.Tensor(True, device=device)] = o3c.Tensor([10, 11],
+                                                           device=device)
+
+    np_t = np.array(5)
+    np_t[np.array(False)] = 10
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(False, device=device)] = 10
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    np_t[np.array(False)] = np.array(10)
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(False, device=device)] = o3c.Tensor(10, device=device)
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    np_t[np.array(False)] = np.array([10])
+    o3_t = o3c.Tensor(5, device=device)
+    o3_t[o3c.Tensor(False, device=device)] = o3c.Tensor([10], device=device)
+    np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    np_t = np.array(5)
+    with pytest.raises(Exception):
+        np_t[np.array(False)] = np.array([[10]])
+    o3_t = o3c.Tensor(5, device=device)
+    with pytest.raises(Exception):
+        o3_t[o3c.Tensor(False, device=device)] = o3c.Tensor([[10]],
+                                                            device=device)
+
+    np_t = np.array(5)
+    with pytest.raises(Exception):
+        np_t[np.array(False)] = np.array([10, 11])
+    o3_t = o3c.Tensor(5, device=device)
+    with pytest.raises(Exception):
+        o3_t[o3c.Tensor(False, device=device)] = o3c.Tensor([10, 11],
+                                                            device=device)
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_scalar_op(device):
     # +
-    a = o3d.core.Tensor.ones((2, 3), o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.ones((2, 3), o3c.Dtype.Float32, device=device)
     b = a.add(1)
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 2))
     b = a + 1
@@ -836,7 +885,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 2))
 
     # +=
-    a = o3d.core.Tensor.ones((2, 3), o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.ones((2, 3), o3c.Dtype.Float32, device=device)
     a.add_(1)
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 2))
     a += 1
@@ -845,7 +894,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 4))
 
     # -
-    a = o3d.core.Tensor.ones((2, 3), o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.ones((2, 3), o3c.Dtype.Float32, device=device)
     b = a.sub(1)
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 0))
     b = a - 1
@@ -856,7 +905,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 0))
 
     # -=
-    a = o3d.core.Tensor.ones((2, 3), o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.ones((2, 3), o3c.Dtype.Float32, device=device)
     a.sub_(1)
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 0))
     a -= 1
@@ -865,7 +914,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), -2))
 
     # *
-    a = o3d.core.Tensor.full((2, 3), 2, o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.full((2, 3), 2, o3c.Dtype.Float32, device=device)
     b = a.mul(10)
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 20))
     b = a * 10
@@ -876,7 +925,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 2))
 
     # *=
-    a = o3d.core.Tensor.full((2, 3), 2, o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.full((2, 3), 2, o3c.Dtype.Float32, device=device)
     a.mul_(10)
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 20))
     a *= 10
@@ -885,7 +934,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 200))
 
     # /
-    a = o3d.core.Tensor.full((2, 3), 20, o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.full((2, 3), 20, o3c.Dtype.Float32, device=device)
     b = a.div(2)
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 10))
     b = a / 2
@@ -900,7 +949,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(b.cpu().numpy(), np.full((2, 3), 20))
 
     # /=
-    a = o3d.core.Tensor.full((2, 3), 20, o3d.core.Dtype.Float32, device=device)
+    a = o3c.Tensor.full((2, 3), 20, o3c.Dtype.Float32, device=device)
     a.div_(2)
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 10))
     a /= 2
@@ -911,7 +960,7 @@ def test_scalar_op(device):
     np.testing.assert_equal(a.cpu().numpy(), np.full((2, 3), 2.5))
 
     # logical_and
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     np.testing.assert_equal(
         a.logical_and(True).cpu().numpy(), np.array([True, False]))
     np.testing.assert_equal(
@@ -922,20 +971,20 @@ def test_scalar_op(device):
         a.logical_and(0).cpu().numpy(), np.array([False, False]))
 
     # logical_and_
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_and_(True)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_and_(5)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_and_(False)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, False]))
     a.logical_and_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, False]))
 
     # logical_or
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     np.testing.assert_equal(
         a.logical_or(True).cpu().numpy(), np.array([True, True]))
     np.testing.assert_equal(
@@ -946,20 +995,20 @@ def test_scalar_op(device):
         a.logical_or(0).cpu().numpy(), np.array([True, False]))
 
     # logical_or_
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_or_(True)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, True]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_or_(5)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, True]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_or_(False)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
     a.logical_or_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
 
     # logical_xor
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     np.testing.assert_equal(
         a.logical_xor(True).cpu().numpy(), np.array([False, True]))
     np.testing.assert_equal(
@@ -970,131 +1019,131 @@ def test_scalar_op(device):
         a.logical_xor(0).cpu().numpy(), np.array([True, False]))
 
     # logical_xor_
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_xor_(True)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, True]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_xor_(5)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, True]))
-    a = o3d.core.Tensor([True, False], device=device)
+    a = o3c.Tensor([True, False], device=device)
     a.logical_xor_(False)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
     a.logical_xor_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False]))
 
     # gt
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.gt(0)).cpu().numpy(),
                             np.array([False, False, True]))
     np.testing.assert_equal((a > 0).cpu().numpy(),
                             np.array([False, False, True]))
 
     # gt_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.gt_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, False, True]))
 
     # lt
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.lt(0)).cpu().numpy(),
                             np.array([True, False, False]))
     np.testing.assert_equal((a < 0).cpu().numpy(),
                             np.array([True, False, False]))
 
     # lt_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.lt_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False, False]))
 
     # ge
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.ge(0)).cpu().numpy(),
                             np.array([False, True, True]))
     np.testing.assert_equal((a >= 0).cpu().numpy(),
                             np.array([False, True, True]))
 
     # ge_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.ge_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, True, True]))
 
     # le
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.le(0)).cpu().numpy(),
                             np.array([True, True, False]))
     np.testing.assert_equal((a <= 0).cpu().numpy(),
                             np.array([True, True, False]))
 
     # le_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.le_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, True, False]))
 
     # eq
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.eq(0)).cpu().numpy(),
                             np.array([False, True, False]))
     np.testing.assert_equal((a == 0).cpu().numpy(),
                             np.array([False, True, False]))
 
     # eq_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.eq_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([False, True, False]))
 
     # ne
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     np.testing.assert_equal((a.ne(0)).cpu().numpy(),
                             np.array([True, False, True]))
     np.testing.assert_equal((a != 0).cpu().numpy(),
                             np.array([True, False, True]))
 
     # ne_
-    a = o3d.core.Tensor([-1, 0, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([-1, 0, 1], dtype=dtype, device=device)
     a.ne_(0)
     np.testing.assert_equal(a.cpu().numpy(), np.array([True, False, True]))
 
     # clip
-    dtype = o3d.core.Dtype.Int64
-    a = o3d.core.Tensor([2, -1, 1], dtype=dtype, device=device)
+    dtype = o3c.Dtype.Int64
+    a = o3c.Tensor([2, -1, 1], dtype=dtype, device=device)
     np.testing.assert_equal(a.clip(0, 1).cpu().numpy(), np.array([1, 0, 1]))
     np.testing.assert_equal(a.clip(0.5, 1.2).cpu().numpy(), np.array([1, 0, 1]))
 
     # clip_
-    a = o3d.core.Tensor([2, -1, 1], dtype=dtype, device=device)
+    a = o3c.Tensor([2, -1, 1], dtype=dtype, device=device)
     a.clip_(0, 1)
     np.testing.assert_equal(a.cpu().numpy(), np.array([1, 0, 1]))
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_all_any(device):
-    a = o3d.core.Tensor([False, True, True, True],
-                        dtype=o3d.core.Dtype.Bool,
-                        device=device)
+    a = o3c.Tensor([False, True, True, True],
+                   dtype=o3c.Dtype.Bool,
+                   device=device)
     assert not a.all()
     assert a.any()
 
-    a = o3d.core.Tensor([True, True, True, True],
-                        dtype=o3d.core.Dtype.Bool,
-                        device=device)
+    a = o3c.Tensor([True, True, True, True],
+                   dtype=o3c.Dtype.Bool,
+                   device=device)
     assert a.all()
 
     # Empty
-    a = o3d.core.Tensor([], dtype=o3d.core.Dtype.Bool, device=device)
+    a = o3c.Tensor([], dtype=o3c.Dtype.Bool, device=device)
     assert a.all()
     assert not a.any()
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_allclose_isclose(device):
-    a = o3d.core.Tensor([1, 2], device=device)
-    b = o3d.core.Tensor([1, 3], device=device)
+    a = o3c.Tensor([1, 2], device=device)
+    b = o3c.Tensor([1, 3], device=device)
     assert not a.allclose(b)
     np.testing.assert_allclose(
         a.isclose(b).cpu().numpy(), np.array([True, False]))
@@ -1105,22 +1154,22 @@ def test_allclose_isclose(device):
 
     # Test cases from
     # https://numpy.org/doc/stable/reference/generated/numpy.allclose.html
-    a = o3d.core.Tensor([1e10, 1e-7], device=device)
-    b = o3d.core.Tensor([1.00001e10, 1e-8], device=device)
+    a = o3c.Tensor([1e10, 1e-7], device=device)
+    b = o3c.Tensor([1.00001e10, 1e-8], device=device)
     assert not a.allclose(b)
-    a = o3d.core.Tensor([1e10, 1e-8], device=device)
-    b = o3d.core.Tensor([1.00001e10, 1e-9], device=device)
+    a = o3c.Tensor([1e10, 1e-8], device=device)
+    b = o3c.Tensor([1.00001e10, 1e-9], device=device)
     assert a.allclose(b)
-    a = o3d.core.Tensor([1e10, 1e-8], device=device)
-    b = o3d.core.Tensor([1.0001e10, 1e-9], device=device)
+    a = o3c.Tensor([1e10, 1e-8], device=device)
+    b = o3c.Tensor([1.0001e10, 1e-9], device=device)
     assert not a.allclose(b)
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_issame(device):
-    dtype = o3d.core.Dtype.Float32
-    a = o3d.core.Tensor.ones((2, 3), dtype, device=device)
-    b = o3d.core.Tensor.ones((2, 3), dtype, device=device)
+    dtype = o3c.Dtype.Float32
+    a = o3c.Tensor.ones((2, 3), dtype, device=device)
+    b = o3c.Tensor.ones((2, 3), dtype, device=device)
     assert a.allclose(b)
     assert not a.issame(b)
 
@@ -1136,29 +1185,23 @@ def test_issame(device):
 
 @pytest.mark.parametrize("device", list_devices())
 def test_item(device):
-    o3_t = o3d.core.Tensor.ones(
-        (2, 3), dtype=o3d.core.Dtype.Float32, device=device) * 1.5
+    o3_t = o3c.Tensor.ones((2, 3), dtype=o3c.Dtype.Float32, device=device) * 1.5
     assert o3_t[0, 0].item() == 1.5
     assert isinstance(o3_t[0, 0].item(), float)
 
-    o3_t = o3d.core.Tensor.ones(
-        (2, 3), dtype=o3d.core.Dtype.Float64, device=device) * 1.5
+    o3_t = o3c.Tensor.ones((2, 3), dtype=o3c.Dtype.Float64, device=device) * 1.5
     assert o3_t[0, 0].item() == 1.5
     assert isinstance(o3_t[0, 0].item(), float)
 
-    o3_t = o3d.core.Tensor.ones(
-        (2, 3), dtype=o3d.core.Dtype.Int32, device=device) * 1.5
+    o3_t = o3c.Tensor.ones((2, 3), dtype=o3c.Dtype.Int32, device=device) * 1.5
     assert o3_t[0, 0].item() == 1
     assert isinstance(o3_t[0, 0].item(), int)
 
-    o3_t = o3d.core.Tensor.ones(
-        (2, 3), dtype=o3d.core.Dtype.Int64, device=device) * 1.5
+    o3_t = o3c.Tensor.ones((2, 3), dtype=o3c.Dtype.Int64, device=device) * 1.5
     assert o3_t[0, 0].item() == 1
     assert isinstance(o3_t[0, 0].item(), int)
 
-    o3_t = o3d.core.Tensor.ones((2, 3),
-                                dtype=o3d.core.Dtype.Bool,
-                                device=device)
+    o3_t = o3c.Tensor.ones((2, 3), dtype=o3c.Dtype.Bool, device=device)
     assert o3_t[0, 0].item() == True
     assert isinstance(o3_t[0, 0].item(), bool)
 
@@ -1169,19 +1212,12 @@ def test_save_load(device):
         file_name = f"{temp_dir}/tensor.npy"
 
         o3_tensors = [
-            o3d.core.Tensor([[1, 2], [3, 4]],
-                            dtype=o3d.core.Dtype.Float32,
-                            device=device),
-            o3d.core.Tensor(3.14, dtype=o3d.core.Dtype.Float32, device=device),
-            o3d.core.Tensor.ones((0,),
-                                 dtype=o3d.core.Dtype.Float32,
-                                 device=device),
-            o3d.core.Tensor.ones((0, 0),
-                                 dtype=o3d.core.Dtype.Float32,
-                                 device=device),
-            o3d.core.Tensor.ones((0, 1, 0),
-                                 dtype=o3d.core.Dtype.Float32,
-                                 device=device)
+            o3c.Tensor([[1, 2], [3, 4]], dtype=o3c.Dtype.Float32,
+                       device=device),
+            o3c.Tensor(3.14, dtype=o3c.Dtype.Float32, device=device),
+            o3c.Tensor.ones((0,), dtype=o3c.Dtype.Float32, device=device),
+            o3c.Tensor.ones((0, 0), dtype=o3c.Dtype.Float32, device=device),
+            o3c.Tensor.ones((0, 1, 0), dtype=o3c.Dtype.Float32, device=device)
         ]
         np_tensors = [
             np.array([[1, 2], [3, 4]], dtype=np.float32),
@@ -1193,7 +1229,7 @@ def test_save_load(device):
         for o3_t, np_t in zip(o3_tensors, np_tensors):
             # Open3D -> Numpy.
             o3_t.save(file_name)
-            o3_t_load = o3d.core.Tensor.load(file_name)
+            o3_t_load = o3c.Tensor.load(file_name)
             np.testing.assert_equal(o3_t_load.cpu().numpy(), np_t)
 
             # Open3D -> Numpy.
@@ -1202,27 +1238,27 @@ def test_save_load(device):
 
             # Numpy -> Open3D.
             np.save(file_name, np_t)
-            o3_t_load = o3d.core.Tensor.load(file_name)
+            o3_t_load = o3c.Tensor.load(file_name)
             np.testing.assert_equal(o3_t_load.cpu().numpy(), np_t)
 
         # Ragged tensor: exception.
         np_t = np.array([[1, 2, 3], [4, 5]], dtype=np.dtype(object))
         np.save(file_name, np_t)
-        with pytest.raises(RuntimeError):
-            o3_t_load = o3d.core.Tensor.load(file_name)
+        with pytest.raises(Exception):
+            o3_t_load = o3c.Tensor.load(file_name)
 
         # Fortran order: exception.
         np_t = np.array([[1, 2, 3], [4, 5, 6]])
         np_t = np.asfortranarray(np_t)
         np.save(file_name, np_t)
-        with pytest.raises(RuntimeError):
-            o3_t_load = o3d.core.Tensor.load(file_name)
+        with pytest.raises(Exception):
+            o3_t_load = o3c.Tensor.load(file_name)
 
         # Unsupported dtype: exception.
         np_t = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.complex64)
         np.save(file_name, np_t)
-        with pytest.raises(RuntimeError):
-            o3_t_load = o3d.core.Tensor.load(file_name)
+        with pytest.raises(Exception):
+            o3_t_load = o3c.Tensor.load(file_name)
 
         # Non-contiguous numpy array.
         np_t = np.arange(24).reshape(2, 3, 4)
@@ -1230,6 +1266,6 @@ def test_save_load(device):
         np_t = np_t[0:2:1, 0:3:2, 0:4:2]
         assert not np_t.flags['C_CONTIGUOUS']
         np.save(file_name, np_t)
-        o3_t_load = o3d.core.Tensor.load(file_name)
+        o3_t_load = o3c.Tensor.load(file_name)
         assert o3_t_load.is_contiguous()
         np.testing.assert_equal(o3_t_load.cpu().numpy(), np_t)

--- a/python/test/core/test_hashmap.py
+++ b/python/test/core/test_hashmap.py
@@ -25,6 +25,7 @@
 # ----------------------------------------------------------------------------
 
 import open3d as o3d
+import open3d.core as o3c
 import numpy as np
 import pytest
 
@@ -35,26 +36,26 @@ from open3d_test import list_devices
 
 @pytest.mark.parametrize("device", list_devices())
 def test_creation(device):
-    hashmap = o3d.core.Hashmap(10, o3d.core.Dtype.Int64, o3d.core.Dtype.Int64,
-                               [1], [1], device)
+    hashmap = o3c.Hashmap(10, o3c.Dtype.Int64, o3c.Dtype.Int64, [1], [1],
+                          device)
     assert hashmap.size() == 0
 
 
 @pytest.mark.parametrize("device", list_devices())
 def test_insertion(device):
     capacity = 10
-    hashmap = o3d.core.Hashmap(capacity, o3d.core.Dtype.Int64,
-                               o3d.core.Dtype.Int64, [1], [1], device)
-    keys = o3d.core.Tensor([100, 300, 500, 700, 900, 900],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
-    values = o3d.core.Tensor([1, 3, 5, 7, 9, 9],
-                             dtype=o3d.core.Dtype.Int64,
-                             device=device)
+    hashmap = o3c.Hashmap(capacity, o3c.Dtype.Int64, o3c.Dtype.Int64, [1], [1],
+                          device)
+    keys = o3c.Tensor([100, 300, 500, 700, 900, 900],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
+    values = o3c.Tensor([1, 3, 5, 7, 9, 9],
+                        dtype=o3c.Dtype.Int64,
+                        device=device)
     addrs, masks = hashmap.insert(keys, values)
-    assert masks.to(o3d.core.Dtype.Int64).sum() == 5
+    assert masks.to(o3c.Dtype.Int64).sum() == 5
 
-    valid_indices = addrs[masks].to(o3d.core.Dtype.Int64)
+    valid_indices = addrs[masks].to(o3c.Dtype.Int64)
     valid_keys = hashmap.get_key_tensor()[valid_indices]
     valid_values = hashmap.get_value_tensor()[valid_indices]
     np.testing.assert_equal(valid_keys.cpu().numpy(),
@@ -64,15 +65,15 @@ def test_insertion(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_activate(device):
     capacity = 10
-    hashmap = o3d.core.Hashmap(capacity, o3d.core.Dtype.Int64,
-                               o3d.core.Dtype.Int64, [1], [1], device)
-    keys = o3d.core.Tensor([100, 300, 500, 700, 900, 900],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
+    hashmap = o3c.Hashmap(capacity, o3c.Dtype.Int64, o3c.Dtype.Int64, [1], [1],
+                          device)
+    keys = o3c.Tensor([100, 300, 500, 700, 900, 900],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
     addrs, masks = hashmap.activate(keys)
-    assert masks.to(o3d.core.Dtype.Int64).sum() == 5
+    assert masks.to(o3c.Dtype.Int64).sum() == 5
 
-    valid_indices = addrs[masks].to(o3d.core.Dtype.Int64)
+    valid_indices = addrs[masks].to(o3c.Dtype.Int64)
     valid_keys = hashmap.get_key_tensor()[valid_indices]
     np.testing.assert_equal(np.sort(valid_keys.cpu().numpy().flatten()),
                             np.array([100, 300, 500, 700, 900]))
@@ -81,23 +82,19 @@ def test_activate(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_find(device):
     capacity = 10
-    hashmap = o3d.core.Hashmap(capacity, o3d.core.Dtype.Int64,
-                               o3d.core.Dtype.Int64, [1], [1], device)
-    keys = o3d.core.Tensor([100, 300, 500, 700, 900],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
-    values = o3d.core.Tensor([1, 3, 5, 7, 9],
-                             dtype=o3d.core.Dtype.Int64,
-                             device=device)
+    hashmap = o3c.Hashmap(capacity, o3c.Dtype.Int64, o3c.Dtype.Int64, [1], [1],
+                          device)
+    keys = o3c.Tensor([100, 300, 500, 700, 900],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
+    values = o3c.Tensor([1, 3, 5, 7, 9], dtype=o3c.Dtype.Int64, device=device)
     hashmap.insert(keys, values)
 
-    keys = o3d.core.Tensor([100, 200, 500],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
+    keys = o3c.Tensor([100, 200, 500], dtype=o3c.Dtype.Int64, device=device)
     addrs, masks = hashmap.find(keys)
     np.testing.assert_equal(masks.cpu().numpy(), np.array([True, False, True]))
 
-    valid_indices = addrs[masks].to(o3d.core.Dtype.Int64)
+    valid_indices = addrs[masks].to(o3c.Dtype.Int64)
     valid_keys = hashmap.get_key_tensor()[valid_indices]
     valid_values = hashmap.get_value_tensor()[valid_indices]
     assert valid_keys.shape[0] == 2
@@ -111,26 +108,22 @@ def test_find(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_erase(device):
     capacity = 10
-    hashmap = o3d.core.Hashmap(capacity, o3d.core.Dtype.Int64,
-                               o3d.core.Dtype.Int64, [1], [1], device)
-    keys = o3d.core.Tensor([100, 300, 500, 700, 900],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
-    values = o3d.core.Tensor([1, 3, 5, 7, 9],
-                             dtype=o3d.core.Dtype.Int64,
-                             device=device)
+    hashmap = o3c.Hashmap(capacity, o3c.Dtype.Int64, o3c.Dtype.Int64, [1], [1],
+                          device)
+    keys = o3c.Tensor([100, 300, 500, 700, 900],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
+    values = o3c.Tensor([1, 3, 5, 7, 9], dtype=o3c.Dtype.Int64, device=device)
     hashmap.insert(keys, values)
 
-    keys = o3d.core.Tensor([100, 200, 500],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
+    keys = o3c.Tensor([100, 200, 500], dtype=o3c.Dtype.Int64, device=device)
     masks = hashmap.erase(keys)
 
     np.testing.assert_equal(masks.cpu().numpy(), np.array([True, False, True]))
 
     assert hashmap.size() == 3
     active_addrs = hashmap.get_active_addrs()
-    active_indices = active_addrs.to(o3d.core.Dtype.Int64)
+    active_indices = active_addrs.to(o3c.Dtype.Int64)
 
     active_keys = hashmap.get_key_tensor()[active_indices]
     active_values = hashmap.get_value_tensor()[active_indices]
@@ -145,18 +138,16 @@ def test_erase(device):
 @pytest.mark.parametrize("device", list_devices())
 def test_complex_shape(device):
     capacity = 10
-    hashmap = o3d.core.Hashmap(capacity, o3d.core.Dtype.Int64,
-                               o3d.core.Dtype.Int64, [3], [1], device)
-    keys = o3d.core.Tensor([[1, 2, 3], [2, 3, 4], [3, 4, 5]],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
-    values = o3d.core.Tensor([1, 2, 3],
-                             dtype=o3d.core.Dtype.Int64,
-                             device=device)
+    hashmap = o3c.Hashmap(capacity, o3c.Dtype.Int64, o3c.Dtype.Int64, [3], [1],
+                          device)
+    keys = o3c.Tensor([[1, 2, 3], [2, 3, 4], [3, 4, 5]],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
+    values = o3c.Tensor([1, 2, 3], dtype=o3c.Dtype.Int64, device=device)
     addrs, masks = hashmap.insert(keys, values)
-    assert masks.to(o3d.core.Dtype.Int64).sum() == 3
+    assert masks.to(o3c.Dtype.Int64).sum() == 3
 
-    valid_indices = addrs[masks].to(o3d.core.Dtype.Int64)
+    valid_indices = addrs[masks].to(o3c.Dtype.Int64)
     valid_keys = hashmap.get_key_tensor()[valid_indices, :]
 
     valid_values = hashmap.get_value_tensor()[valid_indices]
@@ -167,9 +158,9 @@ def test_complex_shape(device):
     np.testing.assert_equal(valid_values.cpu().numpy().flatten(),
                             np.array([1, 2, 3]))
 
-    keys = o3d.core.Tensor([[1, 2, 3], [4, 5, 6]],
-                           dtype=o3d.core.Dtype.Int64,
-                           device=device)
+    keys = o3c.Tensor([[1, 2, 3], [4, 5, 6]],
+                      dtype=o3c.Dtype.Int64,
+                      device=device)
     masks = hashmap.erase(keys)
 
     np.testing.assert_equal(masks.cpu().numpy().flatten(),

--- a/python/test/core/test_linalg.py
+++ b/python/test/core/test_linalg.py
@@ -25,6 +25,7 @@
 # ----------------------------------------------------------------------------
 
 import open3d as o3d
+import open3d.core as o3c
 import numpy as np
 import pytest
 
@@ -35,18 +36,17 @@ from open3d_test import list_devices
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_matmul(device, dtype):
-    # Shape takes tuple, list or o3d.core.SizeVector
-    a = o3d.core.Tensor([[1, 2.5, 3], [4, 5, 6.2]], dtype=dtype, device=device)
-    b = o3d.core.Tensor([[7.5, 8, 9, 10], [11, 12, 13, 14], [15, 16, 17.8, 18]],
-                        dtype=dtype,
-                        device=device)
-    c = o3d.core.matmul(a, b)
-    assert c.shape == o3d.core.SizeVector([2, 4])
+    # Shape takes tuple, list or o3c.SizeVector
+    a = o3c.Tensor([[1, 2.5, 3], [4, 5, 6.2]], dtype=dtype, device=device)
+    b = o3c.Tensor([[7.5, 8, 9, 10], [11, 12, 13, 14], [15, 16, 17.8, 18]],
+                   dtype=dtype,
+                   device=device)
+    c = o3c.matmul(a, b)
+    assert c.shape == o3c.SizeVector([2, 4])
 
     c_numpy = a.cpu().numpy() @ b.cpu().numpy()
     np.testing.assert_allclose(c.cpu().numpy(), c_numpy, 1e-6)
@@ -55,28 +55,28 @@ def test_matmul(device, dtype):
     a = a[:, 1:]
     b = b[[0, 2], :]
     c = a.matmul(b)
-    assert c.shape == o3d.core.SizeVector([2, 4])
+    assert c.shape == o3c.SizeVector([2, 4])
 
     c_numpy = a.cpu().numpy() @ b.cpu().numpy()
     np.testing.assert_allclose(c.cpu().numpy(), c_numpy, 1e-6)
 
     # Incompatible shape test
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((3, 4, 5), dtype=dtype)
-        b = o3d.core.Tensor.zeros((4, 5), dtype=dtype)
+        a = o3c.Tensor.zeros((3, 4, 5), dtype=dtype)
+        b = o3c.Tensor.zeros((4, 5), dtype=dtype)
         c = a @ b
         assert 'Tensor A must be 2D' in str(excinfo.value)
 
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((3, 4), dtype=dtype)
-        b = o3d.core.Tensor.zeros((4, 5, 6), dtype=dtype)
+        a = o3c.Tensor.zeros((3, 4), dtype=dtype)
+        b = o3c.Tensor.zeros((4, 5, 6), dtype=dtype)
         c = a @ b
         assert 'Tensor B must be 1D (vector) or 2D (matrix)' in str(
             excinfo.value)
 
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((3, 4), dtype=dtype)
-        b = o3d.core.Tensor.zeros((3, 7), dtype=dtype)
+        a = o3c.Tensor.zeros((3, 4), dtype=dtype)
+        b = o3c.Tensor.zeros((3, 7), dtype=dtype)
         c = a @ b
         assert 'mismatch with' in str(excinfo.value)
 
@@ -84,23 +84,22 @@ def test_matmul(device, dtype):
                    ((2, 0), (0, 0))]:
         with pytest.raises(RuntimeError) as excinfo:
             a_shape, b_shape = shapes
-            a = o3d.core.Tensor.zeros(a_shape, dtype=dtype, device=device)
-            b = o3d.core.Tensor.zeros(b_shape, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(a_shape, dtype=dtype, device=device)
+            b = o3c.Tensor.zeros(b_shape, dtype=dtype, device=device)
             c = a @ b
             assert 'dimensions with zero' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_det(device, dtype):
-    a = o3d.core.Tensor([[-5, 0, -1], [1, 2, -1], [-3, 4, 1]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[-5, 0, -1], [1, 2, -1], [-3, 4, 1]],
+                   dtype=dtype,
+                   device=device)
 
-    if dtype in [o3d.core.Dtype.Int32, o3d.core.Dtype.Int64]:
+    if dtype in [o3c.Dtype.Int32, o3c.Dtype.Int64]:
         with pytest.raises(RuntimeError) as excinfo:
             a.det()
             assert 'Only tensors with Float32 or Float64 are supported' in str(
@@ -112,71 +111,69 @@ def test_det(device, dtype):
     # Non-2D
     for shape in [(), [1], (3, 4, 5)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a = o3d.core.Tensor.zeros(shape, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(shape, dtype=dtype, device=device)
             a.det()
             assert 'must be 2D' in str(excinfo.value)
 
     # Non-square
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((2, 3), dtype=dtype, device=device)
+        a = o3c.Tensor.zeros((2, 3), dtype=dtype, device=device)
         a.det()
         assert 'must be square' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_lu(device, dtype):
-    a = o3d.core.Tensor([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+                   dtype=dtype,
+                   device=device)
 
-    if dtype in [o3d.core.Dtype.Int32, o3d.core.Dtype.Int64]:
+    if dtype in [o3c.Dtype.Int32, o3c.Dtype.Int64]:
         with pytest.raises(RuntimeError) as excinfo:
-            o3d.core.lu(a)
+            o3c.lu(a)
             assert 'Only tensors with Float32 or Float64 are supported' in str(
                 excinfo.value)
         return
 
-    p, l, u = o3d.core.lu(a)
+    p, l, u = o3c.lu(a)
     np.testing.assert_allclose(a.cpu().numpy(), (p @ l @ u).cpu().numpy(),
                                rtol=1e-5,
                                atol=1e-5)
-    p, l2, u2 = o3d.core.lu(a, True)
+    p, l2, u2 = o3c.lu(a, True)
     np.testing.assert_allclose(a.cpu().numpy(), (l2 @ u2).cpu().numpy(),
                                rtol=1e-5,
                                atol=1e-5)
     # Non-2D
     for shape in [(), [1], (3, 4, 5)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a_ = o3d.core.Tensor.zeros(shape, dtype=dtype, device=device)
-            o3d.core.lu(a_)
+            a_ = o3c.Tensor.zeros(shape, dtype=dtype, device=device)
+            o3c.lu(a_)
             assert 'must be 2D' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_lu_ipiv(device, dtype):
-    a = o3d.core.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
-                        dtype=dtype,
-                        device=device)
-    if dtype in [o3d.core.Dtype.Int32, o3d.core.Dtype.Int64]:
+    a = o3c.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
+                   dtype=dtype,
+                   device=device)
+    if dtype in [o3c.Dtype.Int32, o3c.Dtype.Int64]:
         with pytest.raises(RuntimeError) as excinfo:
-            o3d.core.lu_ipiv(a)
+            o3c.lu_ipiv(a)
             assert 'Only tensors with Float32 or Float64 are supported' in str(
                 excinfo.value)
         return
-    ipiv, a_lu = o3d.core.lu_ipiv(a)
+    ipiv, a_lu = o3c.lu_ipiv(a)
 
-    a_lu_ = o3d.core.Tensor(
+    a_lu_ = o3c.Tensor(
         [[3.0, 3.0, 1.0], [0.666667, 2.0, 0.333333], [0.666667, 0.5, 0.166667]],
         dtype=dtype)
-    ipiv_ = o3d.core.Tensor([2, 3, 3], dtype=dtype)
+    ipiv_ = o3c.Tensor([2, 3, 3], dtype=dtype)
 
     np.testing.assert_allclose(a_lu.cpu().numpy(),
                                a_lu_.numpy(),
@@ -187,29 +184,28 @@ def test_lu_ipiv(device, dtype):
     # Non-2D
     for shape in [(), [1], (3, 4, 5)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a_ = o3d.core.Tensor.zeros(shape, dtype=dtype, device=device)
-            o3d.core.lu_ipiv(a_)
+            a_ = o3c.Tensor.zeros(shape, dtype=dtype, device=device)
+            o3c.lu_ipiv(a_)
             assert 'must be 2D' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_inverse(device, dtype):
-    a = o3d.core.Tensor([[7, 2, 1], [0, 3, -1], [-3, 4, 2]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[7, 2, 1], [0, 3, -1], [-3, 4, 2]],
+                   dtype=dtype,
+                   device=device)
 
-    if dtype in [o3d.core.Dtype.Int32, o3d.core.Dtype.Int64]:
+    if dtype in [o3c.Dtype.Int32, o3c.Dtype.Int64]:
         with pytest.raises(RuntimeError) as excinfo:
-            o3d.core.inv(a)
+            o3c.inv(a)
             assert 'Only tensors with Float32 or Float64 are supported' in str(
                 excinfo.value)
         return
 
-    a_inv = o3d.core.inv(a)
+    a_inv = o3c.inv(a)
     a_inv_numpy = np.linalg.inv(a.cpu().numpy())
     np.testing.assert_allclose(a_inv.cpu().numpy(),
                                a_inv_numpy,
@@ -219,23 +215,23 @@ def test_inverse(device, dtype):
     # Non-2D
     for shape in [(), [1], (3, 4, 5)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a = o3d.core.Tensor.zeros(shape, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(shape, dtype=dtype, device=device)
             a.inv()
             assert 'must be 2D' in str(excinfo.value)
 
     # Non-square
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((2, 3), dtype=dtype, device=device)
+        a = o3c.Tensor.zeros((2, 3), dtype=dtype, device=device)
         a.inv()
         assert 'must be square' in str(excinfo.value)
 
-    a = o3d.core.Tensor([[1]], dtype=dtype, device=device)
+    a = o3c.Tensor([[1]], dtype=dtype, device=device)
     np.testing.assert_allclose(a.cpu().numpy(), a.inv().cpu().numpy(), 1e-6)
 
     # Singular condition
     for a in [
-            o3d.core.Tensor([[0, 0], [0, 1]], dtype=dtype, device=device),
-            o3d.core.Tensor([[0]], dtype=dtype, device=device)
+            o3c.Tensor([[0, 0], [0, 1]], dtype=dtype, device=device),
+            o3c.Tensor([[0]], dtype=dtype, device=device)
     ]:
         with pytest.raises(RuntimeError) as excinfo:
             a_inv = a.inv()
@@ -247,40 +243,37 @@ def test_inverse(device, dtype):
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_svd(device, dtype):
-    a = o3d.core.Tensor([[2, 4], [1, 3], [0, 0], [0, 0]],
-                        dtype=dtype,
-                        device=device)
-    if dtype in [o3d.core.Dtype.Int32, o3d.core.Dtype.Int64]:
+    a = o3c.Tensor([[2, 4], [1, 3], [0, 0], [0, 0]], dtype=dtype, device=device)
+    if dtype in [o3c.Dtype.Int32, o3c.Dtype.Int64]:
         with pytest.raises(RuntimeError) as excinfo:
-            o3d.core.svd(a)
+            o3c.svd(a)
             assert 'Only tensors with Float32 or Float64 are supported' in str(
                 excinfo.value)
         return
 
-    u, s, vt = o3d.core.svd(a)
-    assert u.shape == o3d.core.SizeVector([4, 4])
-    assert s.shape == o3d.core.SizeVector([2])
-    assert vt.shape == o3d.core.SizeVector([2, 2])
+    u, s, vt = o3c.svd(a)
+    assert u.shape == o3c.SizeVector([4, 4])
+    assert s.shape == o3c.SizeVector([2])
+    assert vt.shape == o3c.SizeVector([2, 2])
 
     # u and vt are orthogonal matrices
     uut = u @ u.T()
-    eye_uut = o3d.core.Tensor.eye(4, dtype=dtype)
+    eye_uut = o3c.Tensor.eye(4, dtype=dtype)
     np.testing.assert_allclose(uut.cpu().numpy(),
                                eye_uut.cpu().numpy(),
                                atol=1e-6)
 
     vvt = vt.T() @ vt
-    eye_vvt = o3d.core.Tensor.eye(2, dtype=dtype)
+    eye_vvt = o3c.Tensor.eye(2, dtype=dtype)
     np.testing.assert_allclose(vvt.cpu().numpy(),
                                eye_vvt.cpu().numpy(),
                                atol=1e-6)
 
-    usvt = u[:, :2] @ o3d.core.Tensor.diag(s) @ vt
+    usvt = u[:, :2] @ o3c.Tensor.diag(s) @ vt
     # The accuracy of svd over Float32 is very low...
     np.testing.assert_allclose(a.cpu().numpy(), usvt.cpu().numpy(), atol=1e-5)
 
@@ -297,48 +290,46 @@ def test_svd(device, dtype):
 
     for shapes in [(0, 0), (0, 2)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a = o3d.core.Tensor.zeros(shapes, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(shapes, dtype=dtype, device=device)
             a.svd()
             assert 'dimensions with zero' in str(excinfo.value)
     for shapes in [(), [1], (1, 2, 4)]:
         with pytest.raises(RuntimeError) as excinfo:
-            a = o3d.core.Tensor.zeros(shapes, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(shapes, dtype=dtype, device=device)
             a.svd()
             assert 'must be 2D' in str(excinfo.value)
 
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor(shapes, dtype=dtype, device=device)
+        a = o3c.Tensor(shapes, dtype=dtype, device=device)
         a.svd()
         assert 'must be 2D' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype",
-                         [o3d.core.Dtype.Float32, o3d.core.Dtype.Float64])
+@pytest.mark.parametrize("dtype", [o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_solve(device, dtype):
     # Test square
-    a = o3d.core.Tensor([[3, 1], [1, 2]], dtype=dtype, device=device)
-    b = o3d.core.Tensor([9, 8], dtype=dtype, device=device)
-    x = o3d.core.solve(a, b)
+    a = o3c.Tensor([[3, 1], [1, 2]], dtype=dtype, device=device)
+    b = o3c.Tensor([9, 8], dtype=dtype, device=device)
+    x = o3c.solve(a, b)
 
     x_numpy = np.linalg.solve(a.cpu().numpy(), b.cpu().numpy())
     np.testing.assert_allclose(x.cpu().numpy(), x_numpy, atol=1e-6)
 
     with pytest.raises(RuntimeError) as excinfo:
-        a = o3d.core.Tensor.zeros((3, 3), dtype=dtype, device=device)
-        b = o3d.core.Tensor.ones((3,), dtype=dtype, device=device)
-        x = o3d.core.solve(a, b)
+        a = o3c.Tensor.zeros((3, 3), dtype=dtype, device=device)
+        b = o3c.Tensor.ones((3,), dtype=dtype, device=device)
+        x = o3c.solve(a, b)
         assert 'singular' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype",
-                         [o3d.core.Dtype.Float32, o3d.core.Dtype.Float64])
+@pytest.mark.parametrize("dtype", [o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_lstsq(device, dtype):
     # Test square
-    a = o3d.core.Tensor([[3, 1], [1, 2]], dtype=dtype, device=device)
-    b = o3d.core.Tensor([9, 8], dtype=dtype, device=device)
-    x = o3d.core.lstsq(a, b)
+    a = o3c.Tensor([[3, 1], [1, 2]], dtype=dtype, device=device)
+    b = o3c.Tensor([9, 8], dtype=dtype, device=device)
+    x = o3c.lstsq(a, b)
 
     x_numpy, _, _, _ = np.linalg.lstsq(a.cpu().numpy(),
                                        b.cpu().numpy(),
@@ -346,16 +337,15 @@ def test_lstsq(device, dtype):
     np.testing.assert_allclose(x.cpu().numpy(), x_numpy, atol=1e-6)
 
     # Test non-square
-    a = o3d.core.Tensor(
-        [[1.44, -7.84, -4.39, 4.53], [-9.96, -0.28, -3.24, 3.83],
-         [-7.55, 3.24, 6.27, -6.64], [8.34, 8.09, 5.28, 2.06],
-         [7.08, 2.52, 0.74, -2.47], [-5.45, -5.70, -1.19, 4.70]],
-        dtype=dtype,
-        device=device)
-    b = o3d.core.Tensor([[8.58, 9.35], [8.26, -4.43], [8.48, -0.70],
-                         [-5.28, -0.26], [5.72, -7.36], [8.93, -2.52]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[1.44, -7.84, -4.39, 4.53], [-9.96, -0.28, -3.24, 3.83],
+                    [-7.55, 3.24, 6.27, -6.64], [8.34, 8.09, 5.28, 2.06],
+                    [7.08, 2.52, 0.74, -2.47], [-5.45, -5.70, -1.19, 4.70]],
+                   dtype=dtype,
+                   device=device)
+    b = o3c.Tensor([[8.58, 9.35], [8.26, -4.43], [8.48, -0.70], [-5.28, -0.26],
+                    [5.72, -7.36], [8.93, -2.52]],
+                   dtype=dtype,
+                   device=device)
     x = a.lstsq(b)
     x_numpy, _, _, _ = np.linalg.lstsq(a.cpu().numpy(),
                                        b.cpu().numpy(),
@@ -365,90 +355,87 @@ def test_lstsq(device, dtype):
     for shapes in [((0, 0), (0, 0)), ((2, 0), (2, 3)), ((2, 0), (2, 0))]:
         with pytest.raises(RuntimeError) as excinfo:
             a_shape, b_shape = shapes
-            a = o3d.core.Tensor.zeros(a_shape, dtype=dtype, device=device)
-            b = o3d.core.Tensor.zeros(b_shape, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(a_shape, dtype=dtype, device=device)
+            b = o3c.Tensor.zeros(b_shape, dtype=dtype, device=device)
             a.lstsq(b)
             assert 'dimensions with zero' in str(excinfo.value)
 
     for shapes in [((2, 3), (2, 2))]:
         with pytest.raises(RuntimeError) as excinfo:
             a_shape, b_shape = shapes
-            a = o3d.core.Tensor.zeros(a_shape, dtype=dtype, device=device)
-            b = o3d.core.Tensor.zeros(b_shape, dtype=dtype, device=device)
+            a = o3c.Tensor.zeros(a_shape, dtype=dtype, device=device)
+            b = o3c.Tensor.zeros(b_shape, dtype=dtype, device=device)
             a.lstsq(b)
             assert 'must satisfy rows({}) > cols({})'.format(
                 a_shape[0], a_shape[1]) in str(excinfo.value)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_thiu(device, dtype):
-    a = o3d.core.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
+                   dtype=dtype,
+                   device=device)
     # Test default diagonal value (= 0).
-    np.testing.assert_allclose(o3d.core.triu(a).cpu().numpy(),
+    np.testing.assert_allclose(o3c.triu(a).cpu().numpy(),
                                np.triu(a.cpu().numpy()),
                                rtol=1e-5,
                                atol=1e-5)
     # Test positive diagonal value (= 1).
-    np.testing.assert_allclose(o3d.core.triu(a, 1).cpu().numpy(),
+    np.testing.assert_allclose(o3c.triu(a, 1).cpu().numpy(),
                                np.triu(a.cpu().numpy(), 1),
                                rtol=1e-5,
                                atol=1e-5)
     # Test negative diagonal value (= -1).
-    np.testing.assert_allclose(o3d.core.triu(a, -1).cpu().numpy(),
+    np.testing.assert_allclose(o3c.triu(a, -1).cpu().numpy(),
                                np.triu(a.cpu().numpy(), -1),
                                rtol=1e-5,
                                atol=1e-5)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_thil(device, dtype):
-    a = o3d.core.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
+                   dtype=dtype,
+                   device=device)
     # Test default diagonal value (= 0).
-    np.testing.assert_allclose(o3d.core.tril(a).cpu().numpy(),
+    np.testing.assert_allclose(o3c.tril(a).cpu().numpy(),
                                np.tril(a.cpu().numpy()),
                                rtol=1e-5,
                                atol=1e-5)
     # Test positive diagonal value (= 1).
-    np.testing.assert_allclose(o3d.core.tril(a, 1).cpu().numpy(),
+    np.testing.assert_allclose(o3c.tril(a, 1).cpu().numpy(),
                                np.tril(a.cpu().numpy(), 1),
                                rtol=1e-5,
                                atol=1e-5)
     # Test negative diagonal value (= -1).
-    np.testing.assert_allclose(o3d.core.tril(a, -1).cpu().numpy(),
+    np.testing.assert_allclose(o3c.tril(a, -1).cpu().numpy(),
                                np.tril(a.cpu().numpy(), -1),
                                rtol=1e-5,
                                atol=1e-5)
 
 
 @pytest.mark.parametrize("device", list_devices())
-@pytest.mark.parametrize("dtype", [
-    o3d.core.Dtype.Int32, o3d.core.Dtype.Int64, o3d.core.Dtype.Float32,
-    o3d.core.Dtype.Float64
-])
+@pytest.mark.parametrize(
+    "dtype",
+    [o3c.Dtype.Int32, o3c.Dtype.Int64, o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_thiul(device, dtype):
-    a = o3d.core.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
-                        dtype=dtype,
-                        device=device)
+    a = o3c.Tensor([[2, 3, 1], [3, 3, 1], [2, 4, 1]],
+                   dtype=dtype,
+                   device=device)
     # Test default diagounal value (= 0).
-    u0, l0 = o3d.core.triul(a)
-    l0_ = o3d.core.Tensor([[1, 0, 0], [3, 1, 0], [2, 4, 1]],
-                          dtype=dtype,
-                          device=device)
-    u0_ = o3d.core.Tensor([[2, 3, 1], [0, 3, 1], [0, 0, 1]],
-                          dtype=dtype,
-                          device=device)
+    u0, l0 = o3c.triul(a)
+    l0_ = o3c.Tensor([[1, 0, 0], [3, 1, 0], [2, 4, 1]],
+                     dtype=dtype,
+                     device=device)
+    u0_ = o3c.Tensor([[2, 3, 1], [0, 3, 1], [0, 0, 1]],
+                     dtype=dtype,
+                     device=device)
     np.testing.assert_allclose(l0.cpu().numpy(),
                                l0_.cpu().numpy(),
                                rtol=1e-5,
@@ -459,13 +446,13 @@ def test_thiul(device, dtype):
                                atol=1e-5)
 
     # Test positive diagounal value (= 0).
-    u1, l1 = o3d.core.triul(a, 1)
-    l1_ = o3d.core.Tensor([[2, 1, 0], [3, 3, 1], [2, 4, 1]],
-                          dtype=dtype,
-                          device=device)
-    u1_ = o3d.core.Tensor([[0, 3, 1], [0, 0, 1], [0, 0, 0]],
-                          dtype=dtype,
-                          device=device)
+    u1, l1 = o3c.triul(a, 1)
+    l1_ = o3c.Tensor([[2, 1, 0], [3, 3, 1], [2, 4, 1]],
+                     dtype=dtype,
+                     device=device)
+    u1_ = o3c.Tensor([[0, 3, 1], [0, 0, 1], [0, 0, 0]],
+                     dtype=dtype,
+                     device=device)
     np.testing.assert_allclose(l1.cpu().numpy(),
                                l1_.cpu().numpy(),
                                rtol=1e-5,

--- a/python/test/core/test_nn.py
+++ b/python/test/core/test_nn.py
@@ -49,7 +49,7 @@ def test_knn_index(device):
     assert nns.hybrid_index(0.1)
 
     # Multi radii search is only supported on CPU.
-    if device.get_type() == o3d.core.Device.DeviceType.CPU:
+    if device.get_type() == o3c.Device.DeviceType.CPU:
         assert nns.multi_radius_index()
 
 
@@ -146,7 +146,7 @@ def test_fixed_radius_search(device, dtype):
 
 @pytest.mark.parametrize("dtype", [o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_hybrid_search_random(dtype):
-    if o3d.core.cuda.device_count() > 0:
+    if o3c.cuda.device_count() > 0:
         dataset_size, query_size = 1000, 100
         radius, k = 0.1, 10
 
@@ -181,7 +181,7 @@ def test_hybrid_search_random(dtype):
 
 @pytest.mark.parametrize("dtype", [o3c.Dtype.Float32, o3c.Dtype.Float64])
 def test_fixed_radius_search_random(dtype):
-    if o3d.core.cuda.device_count() > 0:
+    if o3c.cuda.device_count() > 0:
         dataset_size, query_size = 1000, 100
         radius = 0.1
 

--- a/python/test/core/test_torch_integration.py
+++ b/python/test/core/test_torch_integration.py
@@ -25,6 +25,7 @@
 # ----------------------------------------------------------------------------
 
 import open3d as o3d
+import open3d.core as o3c
 import numpy as np
 import pytest
 
@@ -46,7 +47,7 @@ def test_tensor_to_pytorch_scope(device):
     src_t = np.array([[10, 11, 12.], [13., 14., 15.]])
 
     def get_dst_t():
-        o3d_t = o3d.core.Tensor(src_t, device=device)  # Copy
+        o3d_t = o3c.Tensor(src_t, device=device)  # Copy
         dst_t = torch.utils.dlpack.from_dlpack(o3d_t.to_dlpack())
         return dst_t
 
@@ -64,9 +65,9 @@ def test_tensor_from_to_pytorch(device):
 
     # a, b, c share memory.
     a = torch.ones((2, 2))
-    if device_type == o3d.core.Device.DeviceType.CUDA:
+    if device_type == o3c.Device.DeviceType.CUDA:
         a = a.cuda(device_id)
-    b = o3d.core.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(a))
+    b = o3c.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(a))
     c = torch.utils.dlpack.from_dlpack(b.to_dlpack())
 
     a[0, 0] = 100
@@ -80,10 +81,10 @@ def test_tensor_from_to_pytorch(device):
     np_r = np.random.randint(10, size=(10, 10)).astype(np.int32)
     th_r = torch.Tensor(np_r)
     th_t = th_r[1:10:2, 1:10:3].T
-    if device_type == o3d.core.Device.DeviceType.CUDA:
+    if device_type == o3c.Device.DeviceType.CUDA:
         th_t = th_t.cuda(device_id)
 
-    o3_t = o3d.core.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(th_t))
+    o3_t = o3c.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(th_t))
     np.testing.assert_equal(th_t.cpu().numpy(), o3_t.cpu().numpy())
 
     th_t[0, 0] = 100
@@ -93,7 +94,7 @@ def test_tensor_from_to_pytorch(device):
     for shape in [(), (0), (0, 0), (0, 3)]:
         np_t = np.ones(shape)
         th_t = torch.Tensor(np_t)
-        o3_t = o3d.core.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(th_t))
+        o3_t = o3c.Tensor.from_dlpack(torch.utils.dlpack.to_dlpack(th_t))
         th_t_v2 = torch.utils.dlpack.from_dlpack(o3_t.to_dlpack())
         np.testing.assert_equal(o3_t.cpu().numpy(), np_t)
         np.testing.assert_equal(th_t_v2.cpu().numpy(), np_t)
@@ -105,7 +106,7 @@ def test_tensor_numpy_to_open3d_to_pytorch():
 
     # Numpy -> Open3D -> PyTorch all share the same memory
     a = np.ones((2, 2))
-    b = o3d.core.Tensor.from_numpy(a)
+    b = o3c.Tensor.from_numpy(a)
     c = torch.utils.dlpack.from_dlpack(b.to_dlpack())
 
     a[0, 0] = 100


### PR DESCRIPTION
Fixed IndexSet() for 0-D tensor (Advanced indexing cannot handle 0-D tensor).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3389)
<!-- Reviewable:end -->
