### PR TITLE
Add Docker minimal example to getting_started docs. Fix #3388

### DIFF
--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -114,7 +114,8 @@ A minimal ``Dockerfile`` looks like this:
     # Install Open3D from the pypi repositories
     RUN python3 -m pip install --no-cache-dir --upgrade open3d
 
-.. note:: If you need ``CUDA`` support you will need to use nvidia-docker instead.
+.. note:: If you need ``CUDA`` support, follow these directions
+    <https://docs.docker.com/config/containers/resource_constraints/#gpu>__
 
 Try it
 ------

--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -114,8 +114,8 @@ A minimal ``Dockerfile`` looks like this:
     # Install Open3D from the pypi repositories
     RUN python3 -m pip install --no-cache-dir --upgrade open3d
 
-.. note:: If you need ``CUDA`` support, follow these directions
-    <https://docs.docker.com/config/containers/resource_constraints/#gpu>__
+.. note:: If you need ``CUDA`` support, follow these `directions.
+    <https://docs.docker.com/config/containers/resource_constraints/#gpu>`__
 
 Try it
 ------

--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -90,6 +90,32 @@ Conda
     `the official documentation <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_.
 
 
+Docker
+------
+
+If you want to install the Open3D Python packages in a docker conatiner you will
+need to install a minimum set of dependencies. For more details please see `this issue <https://github.com/intel-isl/Open3D/issues/3388>`__.
+
+A minimal ``Dockerfile`` looks like this:
+
+.. code-block:: dockerfile
+
+    # This could also be another ubuntu or debian based distributions
+    FROM ubuntu:20.04
+
+    # Install Open3D system dependencies and pip
+    RUN apt-get update && apt-get install --no-install-recommends -y \
+        libgl1 \
+        libgomp1 \
+        libusb-1.0-0 \
+        python3-pip \
+        && rm -rf /var/lib/apt/lists/*
+
+    # Install Open3D from the pypi repositories
+    RUN python3 -m pip install --no-cache-dir --upgrade open3d
+
+.. note:: If you need ``CUDA`` support you will need to use nvidia-docker instead.
+
 Try it
 ------
 


### PR DESCRIPTION
# Description

Add a minimal `Dockerfile` example as requested in #3388. I've decided to leave out the `docker build` and `docker run` commands out intentionally to keep the document short.

## Results
![image](https://user-images.githubusercontent.com/21349875/117262035-1e5e1b80-ae51-11eb-80ea-0aac75590b53.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3396)
<!-- Reviewable:end -->
