### PR TITLE
Suppress warnings in python unit tests

### DIFF
--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -203,7 +203,12 @@ def test_tensor_constructor(dtype, device):
     # 2D list, inconsistent length
     li_t = [[0, 1, 2], [3, 4]]
     with pytest.raises(Exception):
-        o3_t = o3d.core.Tensor(li_t, dtype, device)
+        # Suppress inconsistent length warning as this check is intentional
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    category=VisibleDeprecationWarning)
+            o3_t = o3d.core.Tensor(li_t, dtype, device)
 
     # Automatic casting
     np_t_double = np.array([[0., 1.5, 2.], [3., 4., 5.]])

--- a/python/test/ml_ops/mltest.py
+++ b/python/test/ml_ops/mltest.py
@@ -21,7 +21,12 @@ MLModules = namedtuple(
 # define the list of frameworks and devices for running the ops
 _ml_modules = {}
 try:
-    tf = importlib.import_module('tensorflow')
+    # Suppress deprecated imp module warnings caused by tensorflow,
+    # see https://github.com/tensorflow/tensorflow/issues/31412
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        tf = importlib.import_module('tensorflow')
     ml3d_ops = importlib.import_module('open3d.ml.tf.ops')
     ml3d_layers = importlib.import_module('open3d.ml.tf.layers')
     _ml_modules['tf'] = MLModules(tf, ml3d_ops, ml3d_layers, 'CPU:0', 'CPU:0',


### PR DESCRIPTION
Before:
```
...

============================================================================================================= warnings summary ==============================================================================================================
<...>/lib/python3.8/site-packages/tensorflow/python/autograph/impl/api.py:22
  <...>/lib/python3.8/site-packages/tensorflow/python/autograph/impl/api.py:22: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

test/core/test_core.py: 22 warnings
  <...>/Open3D/python/test/core/test_core.py:206: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
    o3_t = o3d.core.Tensor(li_t, dtype, device)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================================================= 5690 passed, 4 skipped, 23 warnings in 279.32s (0:04:39) ==========================================================================================
```

After:
```
...

================================================================================================ 5690 passed, 4 skipped in 278.87s (0:04:38) ================================================================================================
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3421)
<!-- Reviewable:end -->
