### PR TITLE
add missing ops to python api doc

### DIFF
--- a/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOps.cpp
@@ -56,10 +56,14 @@ REGISTER_OP("Open3DNms")
             return Status::OK();
         })
         .Doc(R"doc(
-Performs non-maximum suppression of bounding boxes and returns the selected box
-indices.
+Performs non-maximum suppression of bounding boxes. 
 
-  # TensorFlow example.
+This function performs non-maximum suppression for the input bounding boxes
+considering the the per-box score and overlaps. It returns the indices of the
+selected boxes.
+
+Minimal example::
+
   import open3d.ml.tf as ml3d
   import numpy as np
 
@@ -98,5 +102,5 @@ nms_overlap_thresh: float value between 0 and 1. When a high-score box is
   selected, other remaining boxes with IoU > nms_overlap_thresh will be discarded.
   A higher nms_overlap_thresh means more boxes will be kept.
 
-returns (M,) int64 tensor. The selected box indices.
+keep_indices: (M,) int64 tensor. The selected box indices.
 )doc");

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -453,7 +453,8 @@ if __name__ == "__main__":
     # Build docs for release (version number will be used instead of git hash).
     $ python make_docs.py --is_release --sphinx --doxygen
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "--clean_notebooks",
         action="store_true",

--- a/docs/python_api_in/open3d.ml.tf.ops.rst
+++ b/docs/python_api_in/open3d.ml.tf.ops.rst
@@ -17,10 +17,12 @@ open3d.ml.tf.ops
     fixed_radius_search
     invert_neighbors_list
     knn_search
+    nms
     radius_search
     reduce_subarrays_sum
     voxel_pooling
     voxel_pooling_grad
+    voxelize
 
 
 .. toctree::
@@ -34,7 +36,9 @@ open3d.ml.tf.ops
     fixed_radius_search <open3d.ml.tf.ops.fixed_radius_search>
     invert_neighbors_list <open3d.ml.tf.ops.invert_neighbors_list>
     knn_search <open3d.ml.tf.ops.knn_search>
+    nms <open3d.ml.tf.ops.nms>
     radius_search <open3d.ml.tf.ops.radius_search>
     reduce_subarrays_sum <open3d.ml.tf.ops.reduce_subarrays_sum>
     voxel_pooling <open3d.ml.tf.ops.voxel_pooling>
     voxel_pooling_grad <open3d.ml.tf.ops.voxel_pooling_grad>
+    voxelize <open3d.ml.tf.ops.voxelize>

--- a/docs/python_api_in/open3d.ml.torch.ops.rst
+++ b/docs/python_api_in/open3d.ml.torch.ops.rst
@@ -15,9 +15,11 @@ open3d.ml.torch.ops
     fixed_radius_search
     invert_neighbors_list
     knn_search
+    nms
     radius_search
     reduce_subarrays_sum
     voxel_pooling
+    voxelize
 
 
 .. toctree::
@@ -29,6 +31,8 @@ open3d.ml.torch.ops
     fixed_radius_search <open3d.ml.torch.ops.fixed_radius_search>
     invert_neighbors_list <open3d.ml.torch.ops.invert_neighbors_list>
     knn_search <open3d.ml.torch.ops.knn_search>
+    nms <open3d.ml.torch.ops.nms>
     radius_search <open3d.ml.torch.ops.radius_search>
     reduce_subarrays_sum <open3d.ml.torch.ops.reduce_subarrays_sum>
     voxel_pooling <open3d.ml.torch.ops.voxel_pooling>
+    voxelize <open3d.ml.torch.ops.voxelize>


### PR DESCRIPTION
This PR
- adds the nms and voxelize ops to the python api documentation
- fixes some formatting problem with the nms op doc
- adds default values to the help message of make_docs.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3425)
<!-- Reviewable:end -->
