### PR TITLE
fix docs build: NotebookNode object has no attribute 'tags'

### DIFF
--- a/docs/builddocs.rst
+++ b/docs/builddocs.rst
@@ -41,7 +41,7 @@ First, install a TeX distribution such as `MacTeX <http://www.tug.org/mactex/>`_
 .. code-block:: bash
 
     # Install deps
-    pip install -U sphinx==3.5.4 sphinx-rtd-theme==0.5.1 nbsphinx==0.8.3 matplotlib==3.3.3
+    pip install -U sphinx==3.5.4 sphinx-rtd-theme==0.5.1 nbsphinx==0.8.3 matplotlib==3.3.3 jinja2==2.11.3
 
     # Patched m2r: https://github.com/sphinx-doc/sphinx/issues/7420#issuecomment-657160798
     pip install -U m2r2==0.2.7

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -406,7 +406,7 @@ class JupyterDocsBuilder:
 
         # Execute Jupyter notebooks
         for nb_path in nb_paths:
-            if nb_out_path.name in nb_direct_copy:
+            if nb_path.name in nb_direct_copy:
                 print("[Processing notebook {}, directly copied]".format(
                     nb_path.name))
                 continue

--- a/examples/python/core/tensor.ipynb
+++ b/examples/python/core/tensor.ipynb
@@ -35,23 +35,23 @@
      "text": [
       "Created from list:\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324b70a580]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d0575a48f0]\n",
       "\n",
       "Created from numpy array:\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324b70a910]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d056caa8d0]\n",
       "\n",
       "Default dtype and device:\n",
       "[0.0 1.0 2.0]\n",
-      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x56324b6f9b40]\n",
+      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x55d05759c330]\n",
       "\n",
       "Specified data type:\n",
       "[0.0 1.0 2.0]\n",
-      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x56324b70aaa0]\n",
+      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x55d057568ca0]\n",
       "\n",
       "Specified device:\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f7733c00000]\n"
+      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f40ff000000]\n"
      ]
     }
    ],
@@ -95,11 +95,11 @@
      "text": [
       "Source tensor:\n",
       "[11 2 3]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324c5a1440]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d057b157a0]\n",
       "\n",
       "Target tensor:\n",
       "[11 2 3]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324c5a1440]\n"
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d057b157a0]\n"
      ]
     }
    ],
@@ -131,9 +131,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "a.shape: {2, 3, 4}\n",
-      "a.strides: {12, 4, 1}\n",
-      "a.dtype: Dtype.Float64\n",
+      "a.shape: SizeVector[2, 3, 4]\n",
+      "a.strides: SizeVector[12, 4, 1]\n",
+      "a.dtype: Float64\n",
       "a.device: CUDA:0\n",
       "a.ndim: 3\n"
      ]
@@ -167,11 +167,11 @@
      "output_type": "stream",
      "text": [
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f7733c00000]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f40ff000000]\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324e54e410]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d05c254780]\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f7733c00600]\n"
+      "Tensor[shape={3}, stride={1}, Int64, CUDA:0, 0x7f40ff000000]\n"
      ]
     }
    ],
@@ -229,9 +229,9 @@
      "output_type": "stream",
      "text": [
       "[0.1 1.5 2.7]\n",
-      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x56324be46b60]\n",
+      "Tensor[shape={3}, stride={1}, Float64, CPU:0, 0x55d056510450]\n",
       "[0 1 2]\n",
-      "Tensor[shape={3}, stride={1}, Int32, CPU:0, 0x56324e54f440]\n"
+      "Tensor[shape={3}, stride={1}, Int32, CPU:0, 0x55d0565104d0]\n"
      ]
     }
    ],
@@ -253,9 +253,9 @@
      "output_type": "stream",
      "text": [
       "[1 2 3]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324be46b40]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d0565103c0]\n",
       "[1.0 2.0 3.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x56324b6ff3d0]\n"
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05c9cddd0]\n"
      ]
     }
    ],
@@ -287,11 +287,11 @@
      "text": [
       "np_a: [1 1 1 1 1]\n",
       "o3_a: [1 1 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x56324e4eb680]\n",
+      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x55d057b15480]\n",
       "\n",
       "np_a: [101   1   1   1   1]\n",
       "o3_a: [1 201 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x56324e4eb680]\n"
+      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x55d057b15480]\n"
      ]
     }
    ],
@@ -321,7 +321,7 @@
      "text": [
       "np_a: [101 201   1   1   1]\n",
       "o3_a: [101 201 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x56324e54edd0]\n"
+      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x55d057b15a60]\n"
      ]
     }
    ],
@@ -348,7 +348,7 @@
      "text": [
       "np_a: [101 201   1   1   1]\n",
       "o3_a: [101 201 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x56324e54ff30]\n",
+      "Tensor[shape={5}, stride={1}, Int32, CPU:0, 0x55d056cc3d30]\n",
       "\n",
       "o3_a.cpu().numpy(): [1 1 1 1 1]\n"
      ]
@@ -389,11 +389,11 @@
      "text": [
       "th_a: tensor([1., 1., 1., 1., 1.], device='cuda:0')\n",
       "o3_a: [1.0 1.0 1.0 1.0 1.0]\n",
-      "Tensor[shape={5}, stride={1}, Float32, CUDA:0, 0x7f768aa00000]\n",
+      "Tensor[shape={5}, stride={1}, Float32, CUDA:0, 0x7f409be00000]\n",
       "\n",
       "th_a: tensor([100., 200.,   1.,   1.,   1.], device='cuda:0')\n",
       "o3_a: [100.0 200.0 1.0 1.0 1.0]\n",
-      "Tensor[shape={5}, stride={1}, Float32, CUDA:0, 0x7f768aa00000]\n"
+      "Tensor[shape={5}, stride={1}, Float32, CUDA:0, 0x7f409be00000]\n"
      ]
     }
    ],
@@ -426,11 +426,11 @@
      "text": [
       "th_a: tensor([1, 1, 1, 1, 1], device='cuda:0')\n",
       "o3_a: [1 1 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int64, CUDA:0, 0x7f7733c00200]\n",
+      "Tensor[shape={5}, stride={1}, Int64, CUDA:0, 0x7f40ff000200]\n",
       "\n",
       "th_a: tensor([100, 200,   1,   1,   1], device='cuda:0')\n",
       "o3_a: [100 200 1 1 1]\n",
-      "Tensor[shape={5}, stride={1}, Int64, CUDA:0, 0x7f7733c00200]\n"
+      "Tensor[shape={5}, stride={1}, Int64, CUDA:0, 0x7f40ff000200]\n"
      ]
     }
    ],
@@ -479,13 +479,13 @@
      "output_type": "stream",
      "text": [
       "a + b = [3.0 3.0 3.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1b2cf0]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d0573a0ed0]\n",
       "a - b = [-1.0 -1.0 -1.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae161590]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed01410]\n",
       "a * b = [2.0 2.0 2.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x56324fc38320]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed0a180]\n",
       "a / b = [0.5 0.5 0.5]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x56324fc8e1c0]\n"
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed013f0]\n"
      ]
     }
    ],
@@ -518,14 +518,14 @@
       "a + b = \n",
       "[[2.0 2.0 2.0],\n",
       " [2.0 2.0 2.0]]\n",
-      "Tensor[shape={2, 3}, stride={3, 1}, Float32, CPU:0, 0x5632ae181cf0]\n",
+      "Tensor[shape={2, 3}, stride={3, 1}, Float32, CPU:0, 0x55d05ed0a440]\n",
       "\n",
       "a + 1 = [2.0 2.0 2.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1568a0]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed0baa0]\n",
       "a + True = [2.0 2.0 2.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1f1070]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d0565103e0]\n",
       "a = [0.0 0.0 0.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x56324d3a1420]\n"
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05c2547a0]\n"
      ]
     }
    ],
@@ -569,19 +569,19 @@
      "output_type": "stream",
      "text": [
       "a = [4.0 9.0 16.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1c8730]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed01410]\n",
       "\n",
       "a.sqrt = [2.0 3.0 4.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1d5fa0]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d0beec40a0]\n",
       "\n",
       "a.sin = [-0.756802 0.412118 -0.287903]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae176fd0]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d056510330]\n",
       "\n",
       "a.cos = [-0.653644 -0.91113 -0.957659]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1ad660]\n",
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed013d0]\n",
       "\n",
       "[2.0 3.0 4.0]\n",
-      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x5632ae1c8730]\n"
+      "Tensor[shape={3}, stride={1}, Float32, CPU:0, 0x55d05ed01410]\n"
      ]
     }
    ],
@@ -623,13 +623,13 @@
      "output_type": "stream",
      "text": [
       "a.sum = 276\n",
-      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x5632ae1640d0]\n",
+      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x55d056cc3d50]\n",
       "\n",
       "a.min = 0\n",
-      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x5632ae201e20]\n",
+      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x55d0beec4080]\n",
       "\n",
       "a.ArgMax = 23\n",
-      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x5632ae17f1a0]\n",
+      "Tensor[shape={}, stride={}, Int64, CPU:0, 0x55d05ed0a440]\n",
       "\n"
      ]
     }
@@ -655,13 +655,13 @@
       "[[12 14 16 18],\n",
       " [20 22 24 26],\n",
       " [28 30 32 34]]\n",
-      "Tensor[shape={3, 4}, stride={4, 1}, Int64, CPU:0, 0x5632accdb2b0]\n",
+      "Tensor[shape={3, 4}, stride={4, 1}, Int64, CPU:0, 0x55d08bffade0]\n",
       "Along dim=(0, 2)\n",
       "[60 92 124]\n",
-      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x56324fcde960]\n",
+      "Tensor[shape={3}, stride={1}, Int64, CPU:0, 0x55d0583dd120]\n",
       "\n",
-      "Shape without retention : {3}\n",
-      "Shape with retention : {1, 3, 1}\n"
+      "Shape without retention : SizeVector[3]\n",
+      "Shape with retention : SizeVector[1, 3, 1]\n"
      ]
     }
    ],
@@ -703,27 +703,27 @@
       " [[12 13 14 15],\n",
       "  [16 17 18 19],\n",
       "  [20 21 22 23]]]\n",
-      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x56324fd0d920]\n",
+      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x55d05ed03150]\n",
       "\n",
       "a[1, 2] = [20 21 22 23]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x56324fd0d9c0]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d05ed031f0]\n",
       "\n",
       "a[1:] = \n",
       "[[[12 13 14 15],\n",
       "  [16 17 18 19],\n",
       "  [20 21 22 23]]]\n",
-      "Tensor[shape={1, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x56324fd0d980]\n",
+      "Tensor[shape={1, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x55d05ed031b0]\n",
       "\n",
       "a[:, 0:3:2, :] = \n",
       "[[[0 1 2 3],\n",
       "  [8 9 10 11]],\n",
       " [[12 13 14 15],\n",
       "  [20 21 22 23]]]\n",
-      "Tensor[shape={2, 2, 4}, stride={12, 8, 1}, Int64, CPU:0, 0x56324fd0d920]\n",
+      "Tensor[shape={2, 2, 4}, stride={12, 8, 1}, Int64, CPU:0, 0x55d05ed03150]\n",
       "\n",
       "a[:-1, 0:3:2, 2] = \n",
       "[[2 10]]\n",
-      "Tensor[shape={1, 2}, stride={12, 8}, Int64, CPU:0, 0x56324fd0d930]\n",
+      "Tensor[shape={1, 2}, stride={12, 8}, Int64, CPU:0, 0x55d05ed03160]\n",
       "\n"
      ]
     }
@@ -756,7 +756,7 @@
      "output_type": "stream",
      "text": [
       "b = [[102 110]]\n",
-      "Tensor[shape={1, 2}, stride={12, 8}, Int64, CPU:0, 0x56324fd0da00]\n",
+      "Tensor[shape={1, 2}, stride={12, 8}, Int64, CPU:0, 0x55d05ed01160]\n",
       "\n",
       "a = \n",
       "[[[0 1 102 3],\n",
@@ -765,7 +765,7 @@
       " [[12 13 14 15],\n",
       "  [16 17 18 19],\n",
       "  [20 21 22 23]]]\n",
-      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x56324fd0d9f0]\n"
+      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x55d05ed01150]\n"
      ]
     }
    ],
@@ -795,7 +795,7 @@
       " [[12 13 114 15],\n",
       "  [16 17 118 19],\n",
       "  [20 21 122 23]]]\n",
-      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x56324fc3ec00]\n"
+      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x55d0573a0ed0]\n"
      ]
     }
    ],
@@ -829,13 +829,13 @@
      "output_type": "stream",
      "text": [
       "a[[0, 1], [1, 2], [1, 0]] = [5 20]\n",
-      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x5632ae171940]\n",
+      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x55d05ed06570]\n",
       "\n",
       "b = [101 5]\n",
-      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x56324fcd7d40]\n",
+      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x55d05ed093e0]\n",
       "\n",
       "a[[0, 0], [0, 1], [1, 1]] = [1 5]\n",
-      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x5632ae1f1070]\n"
+      "Tensor[shape={2}, stride={1}, Int64, CPU:0, 0x55d05758e690]\n"
      ]
     }
    ],
@@ -886,10 +886,10 @@
       "a[1, 0:2, [1, 2]] = \n",
       "[[13 17],\n",
       " [14 18]]\n",
-      "Tensor[shape={2, 2}, stride={2, 1}, Int64, CPU:0, 0x56324fd0abb0]\n",
+      "Tensor[shape={2, 2}, stride={2, 1}, Int64, CPU:0, 0x55d05eceb810]\n",
       "\n",
       "a[(0, 1)] = [4 5 6 7]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x56324fc3ec20]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d05ed01170]\n",
       "\n",
       "a[[0, 1] = \n",
       "[[[0 1 2 3],\n",
@@ -898,14 +898,14 @@
       " [[12 13 14 15],\n",
       "  [16 17 18 19],\n",
       "  [20 21 22 23]]]\n",
-      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x5632ae46db40]\n",
+      "Tensor[shape={2, 3, 4}, stride={12, 4, 1}, Int64, CPU:0, 0x55d05ed03150]\n",
       "\n",
       "a[1, [[1, 2], [2, 1]], 0:4:2, [3, 4]] = \n",
       "[[[83 93],\n",
       "  [104 114]],\n",
       " [[103 113],\n",
       "  [84 94]]]\n",
-      "Tensor[shape={2, 2, 2}, stride={4, 2, 1}, Int64, CPU:0, 0x5632ae474df0]\n",
+      "Tensor[shape={2, 2, 2}, stride={4, 2, 1}, Int64, CPU:0, 0x55d056caa290]\n",
       "\n"
      ]
     }
@@ -945,10 +945,10 @@
      "output_type": "stream",
      "text": [
       "a = [1 -1 -2 3]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x56324fd0abb0]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d05eceb810]\n",
       "\n",
       "a = [1 19 18 3]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x56324fd0abb0]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d05eceb810]\n",
       "\n"
      ]
     }
@@ -990,19 +990,19 @@
      "output_type": "stream",
      "text": [
       "a AND b = [True False False False]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x56324fc75d30]\n",
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d05757ad90]\n",
       "a OR b = [True True True False]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x56324fc8e1c0]\n",
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d05ed0a1a0]\n",
       "a XOR b = [False True True False]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x5632ae1e0cc0]\n",
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d0bedd9040]\n",
       "NOT a = [False True False True]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x56324e54ff10]\n",
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d0bf0c0c50]\n",
       "\n",
       "a.any = True\n",
       "a.all = False\n",
       "\n",
       "c AND d = [False False True False]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x56324fd0e030]\n"
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d0bf0c0c50]\n"
      ]
     }
    ],
@@ -1037,7 +1037,7 @@
      "text": [
       "allclose : True\n",
       "isclose : [True True True True]\n",
-      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x5632ae1e3800]\n",
+      "Tensor[shape={4}, stride={1}, Bool, CPU:0, 0x55d0bedd9040]\n",
       "issame : False\n"
      ]
     }
@@ -1074,19 +1074,19 @@
      "output_type": "stream",
      "text": [
       "a > b = [False True False]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x5632ae16edf0]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d05ed04b10]\n",
       "a >= b = [True True False]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x5632ae174480]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d0a7cdbf60]\n",
       "a < b = [False False True]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x5632ada96370]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d056caa2e0]\n",
       "a <= b = [True False True]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x56324fc9b020]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d0565103e0]\n",
       "a == b = [True False False]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x56324fcd7d40]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d05ed0a1a0]\n",
       "a != b = [False True True]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x56324fc75d30]\n",
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d0bf3f40e0]\n",
       "a > b = [False True False]\n",
-      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x56324e54ff10]\n"
+      "Tensor[shape={3}, stride={1}, Bool, CPU:0, 0x55d05ed01130]\n"
      ]
     }
    ],
@@ -1128,17 +1128,17 @@
       "[[3 0 0],\n",
       " [0 4 0],\n",
       " [5 6 0]]\n",
-      "Tensor[shape={3, 3}, stride={3, 1}, Int64, CPU:0, 0x5632ae474d50]\n",
+      "Tensor[shape={3, 3}, stride={3, 1}, Int64, CPU:0, 0x55d056510470]\n",
       "\n",
       "a.nonzero() = \n",
-      "[[0 1 2 2],\n",
-      " [0 1 0 1]]\n",
-      "Tensor[shape={2, 4}, stride={4, 1}, Int64, CPU:0, 0x56324e4eddd0]\n",
+      "[[0 1 2 2]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d05ed0a290], [0 1 0 1]\n",
+      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x55d0bf3f4090]]\n",
       "\n",
       "a.nonzero(as_tuple = 1) = \n",
-      "[[0 1 2 2]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x56324fc3ecd0], [0 1 0 1]\n",
-      "Tensor[shape={4}, stride={1}, Int64, CPU:0, 0x5632ae474ca0]]\n"
+      "[[0 1 2 2],\n",
+      " [0 1 0 1]]\n",
+      "Tensor[shape={2, 4}, stride={4, 1}, Int64, CPU:0, 0x55d05758e690]\n"
      ]
     }
    ],
@@ -1149,114 +1149,6 @@
     "print(\"a.nonzero() = \\n{}\\n\".format(a.nonzero()))\n",
     "print(\"a.nonzero(as_tuple = 1) = \\n{}\".format(a.nonzero(as_tuple=1)))"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## TensorList\n",
-    "A tensorlist is a list of tensors of the same shape, similar to ```std::vector<Tensor>```. Internally, a tensorlist stores the tensors in one big internal tensor, where the begin dimension of the internal tensor is extendable. This enables storing of 3D points, colours in a contiguous manner."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a = \n",
-      "TensorList[size=0, shape={3, 4}, Float32, CPU:0]\n",
-      "b = \n",
-      "TensorList[size=1, shape={3, 4}, Float32, CPU:0]\n"
-     ]
-    }
-   ],
-   "source": [
-    "vals = np.array(range(24), dtype=np.float32).reshape((2, 3, 4))\n",
-    "\n",
-    "# Empty TensorList.\n",
-    "a = o3c.TensorList([3, 4])\n",
-    "print(\"a = {}\".format(a))\n",
-    "\n",
-    "# TensorList with single Tensor.\n",
-    "b = o3c.TensorList([3, 4], size=1)\n",
-    "print(\"b = {}\".format(b))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### from_tensor\n",
-    "We can create tensorlist from a single tensor where we breaking first dimension into multiple tensors. The first dimension of the tensor will be used as the `size` dimension of the tensorlist. Remaining dimensions will be used as the element shape of the tensor list. For example, if the input tensor has shape `(2, 3, 4)`, the resulting tensorlist will have size 2 and element shape `(3, 4)`. Here the memory will be copied by default.\n",
-    "If `inplace == true`, the tensorlist will share the same memory with the input tensor. The input tensor must be contiguous. The resulting tensorlist will not be resizable, and hence we cannot do certain operations like resize, push_back, extend, concatenate, and clear.\n",
-    "\n",
-    "### from_tensors\n",
-    "Tensorlist can also be created from a list of tensors. The tensors must have the same shape, dtype and device. Here the values will be copied."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "from tensor = \n",
-      "TensorList[size=2, shape={3, 4}, Float32, CPU:0]\n",
-      "\n",
-      "from tensors = \n",
-      "TensorList[size=2, shape={3, 4}, Float32, CPU:0]\n",
-      "\n",
-      "b + c = \n",
-      "TensorList[size=3, shape={3, 4}, Float32, CPU:0]\n",
-      "concat(b, c) = \n",
-      "TensorList[size=3, shape={3, 4}, Float32, CPU:0]\n",
-      "\n",
-      "d = \n",
-      "TensorList[size=3, shape={3, 4}, Float32, CPU:0]\n",
-      "\n",
-      "extended d = \n",
-      "TensorList[size=4, shape={3, 4}, Float32, CPU:0]\n"
-     ]
-    }
-   ],
-   "source": [
-    "vals = np.array(range(24), dtype=np.float32).reshape((2, 3, 4))\n",
-    "\n",
-    "# TensorList from tensor.\n",
-    "c = o3c.TensorList.from_tensor(o3c.Tensor(vals))\n",
-    "print(\"from tensor = {}\\n\".format(c))\n",
-    "\n",
-    "# TensorList from multiple tensors.\n",
-    "d = o3c.TensorList.from_tensors([o3c.Tensor(vals[0]), o3c.Tensor(vals[1])])\n",
-    "print(\"from tensors = {}\\n\".format(d))\n",
-    "\n",
-    "# Below operations are only valid for resizable tensorlist.\n",
-    "# Concatenate TensorLists.\n",
-    "print(\"b + c = {}\".format(b + c))\n",
-    "print(\"concat(b, c) = {}\\n\".format(o3c.TensorList.concat(b, c)))\n",
-    "\n",
-    "# Append a Tensor to TensorList.\n",
-    "d.push_back(o3c.Tensor(vals[0]))\n",
-    "print(\"d = {}\\n\".format(d))\n",
-    "\n",
-    "# Append a TensorList to another TensorList.\n",
-    "d.extend(b)\n",
-    "print(\"extended d = {}\".format(d))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1275,7 +1167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -49,7 +49,7 @@ SPHINX_RTD_VER=0.5.1
 NBSPHINX_VER=0.8.3
 MATPLOTLIB_VER=3.3.3
 M2R2_VER=0.2.7
-JINJA2_VER=2.11.3 # jinja2 3.x is not compatible with thsi sphinx version
+JINJA2_VER=2.11.3 # jinja2 3.x is not compatible with this sphinx version
 
 OPEN3D_INSTALL_DIR=~/open3d_install
 OPEN3D_SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null 2>&1 && pwd)"

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -49,6 +49,7 @@ SPHINX_RTD_VER=0.5.1
 NBSPHINX_VER=0.8.3
 MATPLOTLIB_VER=3.3.3
 M2R2_VER=0.2.7
+JINJA2_VER=2.11.3 # jinja2 3.x is not compatible with thsi sphinx version
 
 OPEN3D_INSTALL_DIR=~/open3d_install
 OPEN3D_SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null 2>&1 && pwd)"
@@ -455,7 +456,8 @@ install_docs_dependencies() {
         "sphinx==$SPHINX_VER" \
         "sphinx-rtd-theme==$SPHINX_RTD_VER" \
         "nbsphinx==$NBSPHINX_VER" \
-        "m2r2==$M2R2_VER"
+        "m2r2==$M2R2_VER" \
+        "jinja2==$JINJA2_VER"
     python -m pip install -U -q "yapf==$YAPF_VER"
     echo
     if [[ -d "$1" ]]; then


### PR DESCRIPTION
1. force `pip install jinja2==2.11.3`, `jinja2` was updated to `3.0.0` on May 11, 2021, causing incompatibilities with `nbsphinx` since then:
    ```python
    Notebook error:
    UndefinedError in tutorial/core/tensor.ipynb:
    'nbformat.notebooknode.NotebookNode object' has no attribute 'tags'
    
    Traceback (most recent call last):
      File "make_docs.py", line 529, in <module>
        sdb.run()
      File "make_docs.py", line 326, in run
        stderr=sys.stderr)
      File "/opt/hostedtoolcache/Python/3.6.13/x64/lib/python3.6/subprocess.py", line 311, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['sphinx-build', '-b', 'html', '.', '/home/runner/work/Open3D/Open3D/docs/_out/html']' returned non-zero exit status 2.
    Error: Process completed with exit code 1.
    ```
2. fix the wrong variable name in `make_docs.py`
3. execute `tensor.ipynb` and saved the new executed notebook. This notebook was also simplified to remove the tensorlist section.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3435)
<!-- Reviewable:end -->
