### PR TITLE
Fix flickering transformation in the GUI

### DIFF
--- a/examples/cpp/VoxelHashingGUI.cpp
+++ b/examples/cpp/VoxelHashingGUI.cpp
@@ -582,7 +582,8 @@ protected:
                                             {0.0f, -1.0f, 0.0f});
                 });
 
-        Eigen::IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
+        Eigen::IOFormat CleanFmt(Eigen::StreamPrecision, 0, ", ", "\n", "[",
+                                 "]");
 
         const int fps_interval_len = 30;
         double time_interval = 0;
@@ -649,6 +650,8 @@ protected:
             trajectory_->parameters_.push_back(traj_param);
 
             std::stringstream info, fps;
+            info.setf(std::ios::fixed, std::ios::floatfield);
+            info.precision(4);
             info << fmt::format("Frame {}/{}\n\n", idx, rgb_files.size());
 
             info << "Transformation:\n";


### PR DESCRIPTION
Now the transformation is at the fixed-width, with or without negative signs.
![image](https://user-images.githubusercontent.com/6127282/118177384-9d7ac300-b400-11eb-9344-fbf26edacc65.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3440)
<!-- Reviewable:end -->
