### PR TITLE
print warning if the torch wheel may have compatibility problems with CUDA 11

### DIFF
--- a/python/open3d/ml/torch/__init__.py
+++ b/python/open3d/ml/torch/__init__.py
@@ -40,6 +40,34 @@ if _torch.__version__.split('.')[:2] != _o3d_torch_version[:2]:
                     'version {} is installed!'.format(match_torch_ver,
                                                       _torch.__version__))
 
+# Precompiled wheels at
+# https://github.com/intel-isl/open3d_downloads/releases/tag/torch1.7.1
+# have been compiled with '-Xcompiler -fno-gnu-unique' and have an additional
+# attribute that we test here. Print a warning if the attribute is missing.
+if _build_config["BUILD_CUDA_MODULE"] and not hasattr(_torch,
+                                                      "_TORCH_NVCC_FLAGS"):
+    print("""
+--------------------------------------------------------------------------------
+
+ Using the Open3D PyTorch ops with CUDA 11 may have stability issues!
+
+ We recommend to compile PyTorch from source with compile flags
+   '-Xcompiler -fno-gnu-unique'
+
+ or use the PyTorch wheels at
+   https://github.com/intel-isl/open3d_downloads/releases/tag/torch1.7.1
+
+
+ Ignore this message if PyTorch has been compiled with the aforementioned
+ flags.
+
+ See https://github.com/intel-isl/Open3D/issues/3324 and
+ https://github.com/pytorch/pytorch/issues/52663 for more information on this
+ problem.
+
+--------------------------------------------------------------------------------
+""")
+
 _lib_path = []
 # allow overriding the path to the op library with an env var.
 if 'OPEN3D_TORCH_OP_LIB' in _os.environ:


### PR DESCRIPTION
This PR adds a warning message when importing ```open3d.ml.torch``` with a torch wheel that may be affected by a compatibility problem with CUDA 11.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3451)
<!-- Reviewable:end -->
