### PR TITLE
Raise error is required attr. is missing [Fix #3455] 

### DIFF
--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -118,10 +118,22 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
         const geometry::PointCloud &source,
         const geometry::PointCloud &target,
         const CorrespondenceSet &corres) const {
-    if (corres.empty() || !target.HasNormals() || !target.HasColors() ||
-        !source.HasColors()) {
-        return Eigen::Matrix4d::Identity();
+    if (corres.empty()) {
+        utility::LogError(
+                "No correspondences found between source and target "
+                "pointcloud.");
     }
+    if (!target.HasNormals()) {
+        utility::LogError(
+                "ColoredICP requires target pointcloud to have normals.");
+    }
+    if (!target.HasColors()) {
+        utility::LogError(
+                "ColoredICP requires target pointcloud to have colors.");
+    }
+    if (!source.HasColors()) {
+        utility::LogError(
+                "ColoredICP requires source pointcloud to have colors.");
 
     double sqrt_lambda_geometric = sqrt(lambda_geometric_);
     double lambda_photometric = 1.0 - lambda_geometric_;
@@ -231,6 +243,19 @@ RegistrationResult RegistrationColoredICP(
         /*TransformationEstimationForColoredICP()*/,
         const ICPConvergenceCriteria
                 &criteria /* = ICPConvergenceCriteria()*/) {
+    if (!target.HasNormals()) {
+        utility::LogError(
+                "ColoredICP requires target pointcloud to have normals.");
+    }
+    if (!target.HasColors()) {
+        utility::LogError(
+                "ColoredICP requires target pointcloud to have colors.");
+    }
+    if (!source.HasColors()) {
+        utility::LogError(
+                "ColoredICP requires source pointcloud to have colors.");
+    }
+
     auto target_c = InitializePointCloudForColoredICP(
             target, geometry::KDTreeSearchParamHybrid(max_distance * 2.0, 30));
     return RegistrationICP(source, *target_c, max_distance, init, estimation,

--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -134,6 +134,7 @@ Eigen::Matrix4d TransformationEstimationForColoredICP::ComputeTransformation(
     if (!source.HasColors()) {
         utility::LogError(
                 "ColoredICP requires source pointcloud to have colors.");
+    }
 
     double sqrt_lambda_geometric = sqrt(lambda_geometric_);
     double lambda_photometric = 1.0 - lambda_geometric_;

--- a/cpp/open3d/pipelines/registration/ColoredICP.cpp
+++ b/cpp/open3d/pipelines/registration/ColoredICP.cpp
@@ -241,7 +241,7 @@ RegistrationResult RegistrationColoredICP(
         double max_distance,
         const Eigen::Matrix4d &init /* = Eigen::Matrix4d::Identity()*/,
         const TransformationEstimationForColoredICP &estimation
-        /*TransformationEstimationForColoredICP()*/,
+        /* = TransformationEstimationForColoredICP()*/,
         const ICPConvergenceCriteria
                 &criteria /* = ICPConvergenceCriteria()*/) {
     if (!target.HasNormals()) {


### PR DESCRIPTION
Change:
- Raise error is point cloud is missing colors to avoid seg. fault in `RegistrationColoredICP`. [Fix for Issue #3455].

Pending Issues:
- One might still get a segmentation fault if one is using legacy `RegistrationICP` function directly with `estimation = TransformationEstimationType::ColoredICP`. To fix this, some refactoring is required. It will be done in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3466)
<!-- Reviewable:end -->
