### PR TITLE
Fix inconsistent help dialogue in examples

### DIFF
--- a/examples/cpp/AzureKinectMKVReader.cpp
+++ b/examples/cpp/AzureKinectMKVReader.cpp
@@ -78,21 +78,27 @@ Json::Value GenerateDatasetConfig(const std::string &output_path) {
     return value;
 }
 
-void PrintUsage() {
+void PrintHelp() {
+    using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo("AzureKinectMKVReader --input input.mkv [--output] [path]");
+    utility::LogInfo("    > AzureKinectMKVReader --input input.mkv [--output] [path]");
     // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char **argv) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (!utility::ProgramOptionExists(argc, argv, "--input")) {
-        PrintUsage();
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        !utility::ProgramOptionExists(argc, argv, "--input")) {
+        PrintHelp();
         return 1;
     }
+
     std::string mkv_filename =
             utility::GetProgramOptionAsString(argc, argv, "--input");
 

--- a/examples/cpp/AzureKinectRecord.cpp
+++ b/examples/cpp/AzureKinectRecord.cpp
@@ -14,30 +14,29 @@
 
 using namespace open3d;
 
-void PrintUsage() {
+void PrintHelp() {
+    using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage: ");
-    utility::LogInfo("Options: ");
-    utility::LogInfo("--config  Config .json file (default: none)");
-    utility::LogInfo("--list    List the currently connected K4A devices");
-    utility::LogInfo("--device  Specify the device index to use (default: 0)");
-    utility::LogInfo("--output  Output mkv file name (default: current_time.mkv)");
-    utility::LogInfo("-a        Align depth with color image (default: disabled)");
-    utility::LogInfo("-h        Print this helper");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > AzureKinectRecord [options]");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --config                  : Config .json file (default: none)");
+    utility::LogInfo("    --list                    : List the currently connected K4A devices");
+    utility::LogInfo("    --device                  : Specify the device index to use (default: 0)");
+    utility::LogInfo("    --output                  : Output mkv file name (default: current_time.mkv)");
+    utility::LogInfo("    -a                        : Align depth with color image (default: disabled)");
     // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        PrintUsage();
-        return 0;
-    }
-
-    // Parse arguments
-    if (utility::ProgramOptionExists(argc, argv, "-h")) {
-        PrintUsage();
-        return 0;
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
+        PrintHelp();
+        return 1;
     }
 
     if (utility::ProgramOptionExists(argc, argv, "--list")) {
@@ -123,7 +122,7 @@ int main(int argc, char **argv) {
             });
 
     utility::LogInfo(
-            "In the visulizer window, "
+            "In the visualizer window, "
             "press [SPACE] to start recording, "
             "press [ESC] to exit.");
 

--- a/examples/cpp/AzureKinectViewer.cpp
+++ b/examples/cpp/AzureKinectViewer.cpp
@@ -14,23 +14,28 @@
 
 using namespace open3d;
 
-void PrintUsage() {
+void PrintHelp() {
+    using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Options: ");
-    utility::LogInfo("--config  Config .json file (default: none)");
-    utility::LogInfo("--list    List the currently connected K4A devices");
-    utility::LogInfo("--device  Specify the device index to use (default: 0)");
-    utility::LogInfo("-a        Align depth with color image (default: disabled)");
-    utility::LogInfo("-h        Print this helper");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > AzureKinectViewer [options]");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --help, -h                : Print help information.");
+    utility::LogInfo("    --config                  : Config .json file (default: none)");
+    utility::LogInfo("    --list                    : List the currently connected K4A devices");
+    utility::LogInfo("    --device                  : Specify the device index to use (default: 0)");
+    utility::LogInfo("    -a                        : Align depth with color image (default: disabled)");
     // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char **argv) {
-    // Parse arguments
-    if (utility::ProgramOptionExists(argc, argv, "-h")) {
-        PrintUsage();
-        return 0;
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
+        PrintHelp();
+        return 1;
     }
 
     if (utility::ProgramOptionExists(argc, argv, "--list")) {

--- a/examples/cpp/CameraPoseTrajectory.cpp
+++ b/examples/cpp/CameraPoseTrajectory.cpp
@@ -30,13 +30,25 @@
 
 #include "open3d/Open3D.h"
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo(">    CameraPoseTrajectory [trajectory_file] [pcds_dir]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc != 3) {
-        utility::LogInfo("Usage :");
-        utility::LogInfo(">    CameraPoseTrajectory trajectory_file pcds_dir");
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
         return 1;
     }
     const int NUM_OF_COLOR_PALETTE = 5;

--- a/examples/cpp/ColorMapOptimization.cpp
+++ b/examples/cpp/ColorMapOptimization.cpp
@@ -44,9 +44,8 @@ int main(int argc, char *argv[]) {
     using namespace open3d::utility::filesystem;
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/ColorMapOptimization.cpp
+++ b/examples/cpp/ColorMapOptimization.cpp
@@ -28,14 +28,26 @@
 
 #include "open3d/Open3D.h"
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo(">    ColorMapOptimization [data_dir]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
     using namespace open3d::utility::filesystem;
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc != 2) {
-        utility::LogInfo("Usage :");
-        utility::LogInfo(">    ColorMapOptimization data_dir");
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
     // Read RGBD images

--- a/examples/cpp/DepthCapture.cpp
+++ b/examples/cpp/DepthCapture.cpp
@@ -84,12 +84,23 @@ protected:
     }
 };
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > DepthCapture  [filename]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc < 2) {
-        PrintOpen3DVersion();
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > DepthCapture  [filename]");
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/DepthCapture.cpp
+++ b/examples/cpp/DepthCapture.cpp
@@ -97,9 +97,8 @@ void PrintHelp() {
 
 int main(int argc, char *argv[]) {
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/EvaluateFeatureMatch.cpp
+++ b/examples/cpp/EvaluateFeatureMatch.cpp
@@ -162,8 +162,8 @@ void WriteBinaryResult(const std::string &filename, std::vector<double> &data) {
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
-    if (argc <= 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/EvaluatePCDMatch.cpp
+++ b/examples/cpp/EvaluatePCDMatch.cpp
@@ -107,8 +107,8 @@ bool ReadLogFile(const std::string &filename,
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
-    if (argc <= 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/FileDialog.cpp
+++ b/examples/cpp/FileDialog.cpp
@@ -30,16 +30,24 @@
 
 void PrintHelp() {
     using namespace open3d;
-    utility::LogInfo("Usage :");
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
     utility::LogInfo("    > FileDialog [save|load]");
+    // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char *argv[]) {
     using namespace open3d;
-    if (argc == 1) {
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
         PrintHelp();
         return 1;
     }
+
     std::string option(argv[1]);
     char const *pattern = "*.*";
     if (option == "load") {

--- a/examples/cpp/FileDialog.cpp
+++ b/examples/cpp/FileDialog.cpp
@@ -41,9 +41,8 @@ void PrintHelp() {
 
 int main(int argc, char *argv[]) {
     using namespace open3d;
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/FileSystem.cpp
+++ b/examples/cpp/FileSystem.cpp
@@ -46,9 +46,8 @@ void PrintHelp() {
 int main(int argc, char *argv[]) {
     using namespace open3d;
     using namespace open3d::utility::filesystem;
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        !(argc == 2 || argc == 3)) {
+    if (!(argc == 2 || argc == 3) ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/FileSystem.cpp
+++ b/examples/cpp/FileSystem.cpp
@@ -30,28 +30,35 @@
 
 void PrintHelp() {
     using namespace open3d;
-    utility::LogInfo("Usage :");
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
     utility::LogInfo("    > FileSystem ls [dir]");
     utility::LogInfo("    > FileSystem mkdir [dir]");
     utility::LogInfo("    > FileSystem rmdir [dir]");
     utility::LogInfo("    > FileSystem rmfile [file]");
     utility::LogInfo("    > FileSystem fileexists [file]");
+    // clang-format on
+    utility::LogInfo("");
 }
 
-int main(int argc, char **args) {
+int main(int argc, char *argv[]) {
+    using namespace open3d;
     using namespace open3d::utility::filesystem;
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        !(argc == 2 || argc == 3)) {
+        PrintHelp();
+        return 1;
+    }
 
     std::string directory, function;
-    if (argc <= 1) {
-        PrintHelp();
-        return 0;
+    function = std::string(argv[1]);
+    if (argc == 2) {
+        directory = ".";
     } else {
-        function = std::string(args[1]);
-        if (argc <= 2) {
-            directory = ".";
-        } else {
-            directory = std::string(args[2]);
-        }
+        directory = std::string(argv[2]);
     }
 
     if (function == "ls") {

--- a/examples/cpp/Flann.cpp
+++ b/examples/cpp/Flann.cpp
@@ -30,14 +30,24 @@
 
 #include "open3d/Open3D.h"
 
-int main(int argc, char **argv) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > Flann [filename]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char *argv[]) {
     using namespace open3d;
     using namespace flann;
-
-    if (argc < 2) {
-        PrintOpen3DVersion();
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > Flann [filename]");
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/Flann.cpp
+++ b/examples/cpp/Flann.cpp
@@ -44,9 +44,8 @@ void PrintHelp() {
 int main(int argc, char *argv[]) {
     using namespace open3d;
     using namespace flann;
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/ISSKeypoints.cpp
+++ b/examples/cpp/ISSKeypoints.cpp
@@ -35,14 +35,26 @@
 
 #include "open3d/Open3D.h"
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ISSKeypoints [mesh|pointcloud] [filename]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc < 3) {
-        utility::LogInfo("Open3D {}", OPEN3D_VERSION);
-        utility::LogInfo("Usage:");
-        utility::LogInfo("\t> {} [mesh|pointcloud] [filename] ...\n", argv[0]);
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/ISSKeypoints.cpp
+++ b/examples/cpp/ISSKeypoints.cpp
@@ -51,9 +51,8 @@ int main(int argc, char *argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 3) {
+    if (argc != 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Image.cpp
+++ b/examples/cpp/Image.cpp
@@ -51,9 +51,8 @@ int main(int argc, char *argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 3) {
+    if (argc != 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Image.cpp
+++ b/examples/cpp/Image.cpp
@@ -28,24 +28,33 @@
 
 #include "open3d/Open3D.h"
 
-int main(int argc, char **argv) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > Image [image filename] [depth filename]");
+    utility::LogInfo("    The program will :");
+    utility::LogInfo("    1) Read 8bit RGB and 16bit depth image");
+    utility::LogInfo("    2) Convert RGB image to single channel float image");
+    utility::LogInfo("    3) 3x3, 5x5, 7x7 Gaussian filters are applied");
+    utility::LogInfo("    4) 3x3 Sobel filter for x-and-y-directions are applied");
+    utility::LogInfo("    5) Make image pyramid that includes Gaussian blur and downsampling");
+    utility::LogInfo("    6) Will save all the layers in the image pyramid");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc != 3) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > Image [image filename] [depth filename]");
-        utility::LogInfo("    The program will :");
-        utility::LogInfo("    1) Read 8bit RGB and 16bit depth image");
-        utility::LogInfo("    2) Convert RGB image to single channel float image");
-        utility::LogInfo("    3) 3x3, 5x5, 7x7 Gaussian filters are applied");
-        utility::LogInfo("    4) 3x3 Sobel filter for x-and-y-directions are applied");
-        utility::LogInfo("    5) Make image pyramid that includes Gaussian blur and downsampling");
-        utility::LogInfo("    6) Will save all the layers in the image pyramid");
-        // clang-format on
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/IntegrateRGBD.cpp
+++ b/examples/cpp/IntegrateRGBD.cpp
@@ -55,8 +55,8 @@ void PrintHelp() {
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
-    if (argc <= 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/LineSet.cpp
+++ b/examples/cpp/LineSet.cpp
@@ -30,26 +30,35 @@
 
 #include "open3d/Open3D.h"
 
-int main(int argc, char **argv) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > LineSet [filename]");
+    utility::LogInfo("    The program will :");
+    utility::LogInfo("    1. load the pointcloud in [filename].");
+    utility::LogInfo("    2. use KDTreeFlann to compute 50 nearest neighbors of point0.");
+    utility::LogInfo("    3. convert the correspondences to LineSet and render it.");
+    utility::LogInfo("    4. rotate the point cloud slightly to get another point cloud.");
+    utility::LogInfo("    5. find closest point of the original point cloud on the new point cloud, mark as correspondences.");
+    utility::LogInfo("    6. convert to LineSet and render it.");
+    utility::LogInfo("    7. distance below 0.05 are rendered as red, others as black.");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char *argv[]) {
     using namespace open3d;
     using namespace flann;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc < 2) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > LineSet [filename]");
-        utility::LogInfo("    The program will :");
-        utility::LogInfo("    1. load the pointcloud in [filename].");
-        utility::LogInfo("    2. use KDTreeFlann to compute 50 nearest neighbors of point0.");
-        utility::LogInfo("    3. convert the correspondences to LineSet and render it.");
-        utility::LogInfo("    4. rotate the point cloud slightly to get another point cloud.");
-        utility::LogInfo("    5. find closest point of the original point cloud on the new point cloud, mark as correspondences.");
-        utility::LogInfo("    6. convert to LineSet and render it.");
-        utility::LogInfo("    7. distance below 0.05 are rendered as red, others as black.");
-        // clang-format on
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/LineSet.cpp
+++ b/examples/cpp/LineSet.cpp
@@ -55,9 +55,8 @@ int main(int argc, char *argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Octree.cpp
+++ b/examples/cpp/Octree.cpp
@@ -79,9 +79,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Octree.cpp
+++ b/examples/cpp/Octree.cpp
@@ -63,20 +63,30 @@ bool f_traverse(const std::shared_ptr<geometry::OctreeNode>& node,
     return false;
 }
 
-int main(int argc, char** args) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > Octree [pointcloud_filename]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc < 2) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > Octree [pointcloud_filename]");
-        // clang-format on
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
 
-    auto pcd = io::CreatePointCloudFromFile(args[1]);
+    auto pcd = io::CreatePointCloudFromFile(argv[1]);
     constexpr int max_depth = 3;
     auto octree = std::make_shared<geometry::Octree>(max_depth);
     octree->ConvertFromPointCloud(*pcd);

--- a/examples/cpp/OdometryRGBD.cpp
+++ b/examples/cpp/OdometryRGBD.cpp
@@ -35,13 +35,14 @@ void PrintHelp(char* argv[]) {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    OdometryRGBD [color_source] [depth_source] [color_target] [depth_target] [options]");
-    utility::LogInfo("     Given RGBD image pair, estimate 6D odometry.");
-    utility::LogInfo("     [options]");
-    utility::LogInfo("     --camera_intrinsic [intrinsic_path]");
-    utility::LogInfo("     --rgbd_type [number] (0:Redwood, 1:TUM, 2:SUN, 3:NYU)");
-    utility::LogInfo("     --verbose : indicate this to display detailed information");
-    utility::LogInfo("     --hybrid : compute odometry using hybrid objective");
+    utility::LogInfo("    > OdometryRGBD [color_source] [depth_source] [color_target] [depth_target] [options]");
+    utility::LogInfo("      Given RGBD image pair, estimate 6D odometry.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --camera_intrinsic [intrinsic_path]");
+    utility::LogInfo("    --rgbd_type [number] (0:Redwood, 1:TUM, 2:SUN, 3:NYU)");
+    utility::LogInfo("    --verbose : indicate this to display detailed information");
+    utility::LogInfo("    --hybrid : compute odometry using hybrid objective");
     // clang-NewPormat on
     utility::LogInfo("");
 }

--- a/examples/cpp/PCDFileFormat.cpp
+++ b/examples/cpp/PCDFileFormat.cpp
@@ -26,23 +26,31 @@
 
 #include "open3d/Open3D.h"
 
-int main(int argc, char **argv) {
+void PrintHelp() {
     using namespace open3d;
-    using namespace flann;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > PCDFileFormat [filename] [ascii|binary|compressed]");
+    utility::LogInfo("      The program will :");
+    utility::LogInfo("      1. load the pointcloud in [filename].");
+    utility::LogInfo("      2. visualize the point cloud.");
+    utility::LogInfo("      3. if a save method is specified, write the point cloud into data.pcd.");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
+    using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc < 2) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > PCDFileFormat [filename] [ascii|binary|compressed]");
-        utility::LogInfo("    The program will :");
-        utility::LogInfo("    1. load the pointcloud in [filename].");
-        utility::LogInfo("    2. visualize the point cloud.");
-        utility::LogInfo("    3. if a save method is specified, write the point cloud into data.pcd.");
-        // clang-format on
-        return 0;
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        !(argc == 2 || argc == 3)) {
+        PrintHelp();
+        return 1;
     }
 
     auto cloud_ptr = io::CreatePointCloudFromFile(argv[1]);

--- a/examples/cpp/PCDFileFormat.cpp
+++ b/examples/cpp/PCDFileFormat.cpp
@@ -46,9 +46,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        !(argc == 2 || argc == 3)) {
+    if (!(argc == 2 || argc == 3) ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/PointCloud.cpp
+++ b/examples/cpp/PointCloud.cpp
@@ -61,10 +61,28 @@ void PrintPointCloud(const open3d::geometry::PointCloud &pointcloud) {
     utility::LogInfo("End of the list.");
 }
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > PointCloud [pointcloud_filename]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
+        return 1;
+    }
 
     auto pcd = io::CreatePointCloudFromFile(argv[1]);
     {

--- a/examples/cpp/PointCloud.cpp
+++ b/examples/cpp/PointCloud.cpp
@@ -77,9 +77,8 @@ int main(int argc, char *argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/PoseGraph.cpp
+++ b/examples/cpp/PoseGraph.cpp
@@ -57,9 +57,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 2) {
+    if (argc != 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/PoseGraph.cpp
+++ b/examples/cpp/PoseGraph.cpp
@@ -33,23 +33,34 @@
 
 using namespace open3d;
 
-int main(int argc, char **argv) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > PoseGraph [posegraph_for_optimization].json");
+    utility::LogInfo("      The program will :");
+    utility::LogInfo("      1) Generate random PoseGraph");
+    utility::LogInfo("      2) Save random PoseGraph as test_pose_graph.json");
+    utility::LogInfo("      3) Reads PoseGraph from test_pose_graph.json");
+    utility::LogInfo("      4) Save loaded PoseGraph as test_pose_graph_copy.json");
+    utility::LogInfo("      5) Load PoseGraph from [posegraph_for_optimization].json");
+    utility::LogInfo("      6) Optimize PoseGraph");
+    utility::LogInfo("      7) Save PoseGraph to pose_graph_optimized.json");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc != 2) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > PoseGraph [posegraph_for_optimization].json");
-        utility::LogInfo("    The program will :");
-        utility::LogInfo("    1) Generate random PoseGraph");
-        utility::LogInfo("    2) Save random PoseGraph as test_pose_graph.json");
-        utility::LogInfo("    3) Reads PoseGraph from test_pose_graph.json");
-        utility::LogInfo("    4) Save loaded PoseGraph as test_pose_graph_copy.json");
-        utility::LogInfo("    5) Load PoseGraph from [posegraph_for_optimization].json");
-        utility::LogInfo("    6) Optimize PoseGraph");
-        utility::LogInfo("    7) Save PoseGraph to pose_graph_optimized.json");
-        // clang-format on
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 2) {
+        PrintHelp();
         return 1;
     }
 

--- a/examples/cpp/ProgramOptions.cpp
+++ b/examples/cpp/ProgramOptions.cpp
@@ -28,16 +28,20 @@
 
 void PrintHelp() {
     using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
-    utility::LogInfo("Usage :");
-    utility::LogInfo("    > ProgramOptions [--help] [--switch] [--int i] [--double d] [--string str] [--vector (x,y,z,...)]");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > ProgramOptions [-h|--help] [--switch] [--int i] [--double d] [--string str] [--vector (x,y,z,...)]");
     // clang-format on
+    utility::LogInfo("");
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     using namespace open3d;
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help")) {
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }
@@ -55,7 +59,7 @@ int main(int argc, char *argv[]) {
     std::vector<std::string> strs = utility::SplitString(
             utility::GetProgramOptionAsString(argc, argv, "--string"), ",.",
             true);
-    for (auto &str : strs) {
+    for (auto& str : strs) {
         utility::LogInfo("\tSubstring : {}", str);
     }
     Eigen::VectorXd vec =

--- a/examples/cpp/RGBDOdometry.cpp
+++ b/examples/cpp/RGBDOdometry.cpp
@@ -28,12 +28,6 @@
 
 using namespace open3d;
 
-void PrintHelp() {
-    PrintOpen3DVersion();
-    utility::LogInfo("Usage :");
-    utility::LogInfo("    > RGBDOdometry [color1] [depth1] [color2] [depth2]");
-}
-
 std::shared_ptr<geometry::RGBDImage> ReadRGBDImage(
         const char* color_filename,
         const char* depth_filename,
@@ -63,13 +57,29 @@ std::shared_ptr<geometry::RGBDImage> ReadRGBDImage(
     return rgbd_image;
 }
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > RGBDOdometry [color1] [depth1] [color2] [depth2]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char* argv[]) {
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
+    using namespace open3d;
+
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
         argc != 5) {
         PrintHelp();
         return 1;
     }
-    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
     camera::PinholeCameraIntrinsic intrinsic = camera::PinholeCameraIntrinsic(
             camera::PinholeCameraIntrinsicParameters::PrimeSenseDefault);
     bool visualize = true;

--- a/examples/cpp/RGBDOdometry.cpp
+++ b/examples/cpp/RGBDOdometry.cpp
@@ -73,9 +73,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 5) {
+    if (argc != 5 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/RealSenseBagReader.cpp
+++ b/examples/cpp/RealSenseBagReader.cpp
@@ -83,19 +83,29 @@ Json::Value GenerateDatasetConfig(const std::string &output_path,
     return value;
 }
 
-void PrintUsage() {
+void PrintHelp() {
+    using namespace open3d;
+
     PrintOpen3DVersion();
-    utility::LogInfo("Usage:");
     // clang-format off
-    utility::LogInfo("RealSenseBagReader [-V] --input input.bag [--output path]");
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > RealSenseBagReader [-V] --input input.bag [--output path]");
     // clang-format on
+    utility::LogInfo("");
 }
 
-int main(int argc, char **argv) {
-    if (!utility::ProgramOptionExists(argc, argv, "--input")) {
-        PrintUsage();
+int main(int argc, char *argv[]) {
+    using namespace open3d;
+
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        !utility::ProgramOptionExists(argc, argv, "--input")) {
+        PrintHelp();
         return 1;
     }
+
     if (utility::ProgramOptionExists(argc, argv, "-V")) {
         utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
     } else {

--- a/examples/cpp/RealSenseRecorder.cpp
+++ b/examples/cpp/RealSenseRecorder.cpp
@@ -34,28 +34,33 @@ using namespace open3d;
 namespace tio = open3d::t::io;
 namespace sc = std::chrono;
 
-void PrintUsage() {
+void PrintHelp() {
+    using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > RealSenseRecorder [-V] [-l|--list-devices] [--align] [--record rgbd_video_file.bag] [-c|--config rs-config.json]");
     utility::LogInfo(
             "Open a RealSense camera and display live color and depth streams. You can set\n"
             "frame sizes and frame rates for each stream and the depth stream can be\n"
             "optionally aligned to the color stream. NOTE: An error of 'UNKNOWN: Couldn't\n"
             "resolve requests' implies  unsupported stream format settings.");
     // clang-format on
-    utility::LogInfo("Usage:");
-    utility::LogInfo(
-            "RealSenseRecorder [-h|--help] [-V] [-l|--list-devices] [--align]\n"
-            "[--record rgbd_video_file.bag] [-c|--config rs-config.json]");
+    utility::LogInfo("");
 }
 
-int main(int argc, char **argv) {
-    // Parse command line arguments
-    if (utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
-        PrintUsage();
-        return 0;
+int main(int argc, char *argv[]) {
+    using namespace open3d;
+
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
+        PrintHelp();
+        return 1;
     }
+
     if (utility::ProgramOptionExists(argc, argv, "--list-devices") ||
         utility::ProgramOptionExists(argc, argv, "-l")) {
         tio::RealSenseSensor::ListDevices();

--- a/examples/cpp/RegistrationColoredICP.cpp
+++ b/examples/cpp/RegistrationColoredICP.cpp
@@ -32,17 +32,6 @@
 
 using namespace open3d;
 
-void PrintHelp() {
-    using namespace open3d;
-
-    PrintOpen3DVersion();
-    // clang-format off
-    utility::LogInfo("Usage:");
-    utility::LogInfo(">    RegistrationColoredICP source_pcd target_pcd [--visualize]");
-    // clang-format on
-    utility::LogInfo("");
-}
-
 void VisualizeRegistration(const open3d::geometry::PointCloud &source,
                            const open3d::geometry::PointCloud &target,
                            const Eigen::Matrix4d &Transformation) {
@@ -56,12 +45,24 @@ void VisualizeRegistration(const open3d::geometry::PointCloud &source,
                                   "Registration result");
 }
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > RegistrationColoredICP source_pcd target_pcd [--visualize]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc < 3) {
+    if (argc < 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/RegistrationRANSAC.cpp
+++ b/examples/cpp/RegistrationRANSAC.cpp
@@ -57,16 +57,25 @@ void VisualizeRegistration(const open3d::geometry::PointCloud &source,
                                   "Registration result");
 }
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > RegistrationRANSAC source_pcd target_pcd [--method=feature_matching] [--mutual_filter] [--visualize]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc < 3 || argc > 7) {
-        utility::LogInfo(
-                "Usage : RegistrationRANSAC path_to_first_point_cloud "
-                "path_to_second_point_cloud [--method=feature_matching] "
-                "[--mutual_filter] [--visualize]");
+    if (argc < 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
+        PrintHelp();
         return 1;
     }
 
@@ -85,7 +94,8 @@ int main(int argc, char *argv[]) {
     }
     if (method != kMethodFeature && method != kMethodCorres) {
         utility::LogInfo(
-                "--method must be \'feature_matching\' or \'correspondence\'");
+                "--method must be \'feature_matching\' or "
+                "\'correspondence\'");
         return 1;
     }
 

--- a/examples/cpp/SLAC.cpp
+++ b/examples/cpp/SLAC.cpp
@@ -36,23 +36,27 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    SLAC [dataset_folder] [options]");
-    utility::LogInfo("--method [default: rigid, optional: slac]");
-    utility::LogInfo("--voxel_size [default: 0.05]");
-    utility::LogInfo("--weight [default: 1]");
-    utility::LogInfo("--distance_threshold [default: 0.07]");
-    utility::LogInfo("--fitness_threshold [default: 0.3]");
-    utility::LogInfo("--iterations [default: 5]");
-    utility::LogInfo("--device [default: CPU:0]");
-    utility::LogInfo("--debug");
-    utility::LogInfo("--debug_node [default: 0]");
+    utility::LogInfo("    > SLAC [dataset_folder] [options]");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --method [default: rigid, optional: slac]");
+    utility::LogInfo("    --voxel_size [default: 0.05]");
+    utility::LogInfo("    --weight [default: 1]");
+    utility::LogInfo("    --distance_threshold [default: 0.07]");
+    utility::LogInfo("    --fitness_threshold [default: 0.3]");
+    utility::LogInfo("    --iterations [default: 5]");
+    utility::LogInfo("    --device [default: CPU:0]");
+    utility::LogInfo("    --debug");
+    utility::LogInfo("    --debug_node [default: 0]");
     // clang-format on
     utility::LogInfo("");
 }
 
-int main(int argc, char** argv) {
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        argc < 2) {
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/SLACIntegrate.cpp
+++ b/examples/cpp/SLACIntegrate.cpp
@@ -36,26 +36,32 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    SLACIntegrate [dataset_folder] [slac_folder] [options]");
-    utility::LogInfo("     --color_subfolder [default: color, rgb, image]");
-    utility::LogInfo("     --depth_subfolder [default: depth]");
-    utility::LogInfo("     --voxel_size [=0.0058 (m)]");
-    utility::LogInfo("     --intrinsic_path [camera_intrinsic]");
-    utility::LogInfo("     --block_count [=40000]");
-    utility::LogInfo("     --depth_scale [=1000.0]");
-    utility::LogInfo("     --max_depth [=3.0]");
-    utility::LogInfo("     --sdf_trunc [=0.04]");
-    utility::LogInfo("     --device [CPU:0]");
-    utility::LogInfo("     --mesh");
-    utility::LogInfo("     --pointcloud");
-    utility::LogInfo("--debug");
+    utility::LogInfo("    > SLACIntegrate [dataset_folder] [slac_folder] [options]");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --color_subfolder [default: color, rgb, image]");
+    utility::LogInfo("    --depth_subfolder [default: depth]");
+    utility::LogInfo("    --voxel_size [=0.0058 (m)]");
+    utility::LogInfo("    --intrinsic_path [camera_intrinsic]");
+    utility::LogInfo("    --block_count [=40000]");
+    utility::LogInfo("    --depth_scale [=1000.0]");
+    utility::LogInfo("    --max_depth [=3.0]");
+    utility::LogInfo("    --sdf_trunc [=0.04]");
+    utility::LogInfo("    --device [CPU:0]");
+    utility::LogInfo("    --mesh");
+    utility::LogInfo("    --pointcloud");
+    utility::LogInfo("    --debug");
     // clang-format on
     utility::LogInfo("");
 }
 
-int main(int argc, char** argv) {
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        argc < 3) {
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc < 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TICPOdometry.cpp
+++ b/examples/cpp/TICPOdometry.cpp
@@ -709,9 +709,8 @@ void PrintHelp() {
 int main(int argc, char* argv[]) {
     using namespace open3d;
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 3) {
+    if (argc != 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TICPOdometry.cpp
+++ b/examples/cpp/TICPOdometry.cpp
@@ -695,11 +695,27 @@ private:
     core::Dtype dtype_;
 };
 
-//------------------------------------------------------------------------------
-int main(int argc, const char* argv[]) {
-    if (argc < 3) {
-        utility::LogError("Expected [device] and [config file path] as input");
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > TICPOdometry [device] [config_file_path]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
+        return 1;
     }
+
     const std::string path_config = std::string(argv[2]);
 
     device_string = std::string(argv[1]);
@@ -707,7 +723,7 @@ int main(int argc, const char* argv[]) {
     widget_string = widget_string + device_string;
 
     auto& app = gui::Application::GetInstance();
-    app.Initialize(argc, argv);
+    app.Initialize(argc, (const char**)argv);
     app.AddWindow(std::make_shared<ExampleWindow>(path_config,
                                                   core::Device(device_string)));
     app.Run();

--- a/examples/cpp/TICPReconstruction.cpp
+++ b/examples/cpp/TICPReconstruction.cpp
@@ -705,9 +705,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 3) {
+    if (argc != 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TICPReconstruction.cpp
+++ b/examples/cpp/TICPReconstruction.cpp
@@ -689,17 +689,35 @@ private:
     t::pipelines::registration::RegistrationResult result_;
 };
 
-//------------------------------------------------------------------------------
-int main(int argc, const char* argv[]) {
-    if (argc < 3) {
-        utility::LogError("Expected dataset path as input");
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > TICPReconstruction [device] [config_file_path]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
+        return 1;
     }
+
     const std::string path_config = std::string(argv[2]);
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
     auto& app = gui::Application::GetInstance();
-    app.Initialize(argc, argv);
+    app.Initialize(argc, (const char**)argv);
     app.AddWindow(std::make_shared<ExampleWindow>(path_config,
                                                   core::Device(argv[1])));
     app.Run();

--- a/examples/cpp/TIntegrateRGBD.cpp
+++ b/examples/cpp/TIntegrateRGBD.cpp
@@ -34,25 +34,28 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    TIntegrateRGBD [color_folder] [depth_folder] [trajectory] [options]");
-    utility::LogInfo("     Given RGBD images, reconstruct mesh or point cloud from color and depth images");
-    utility::LogInfo("     [options]");
-    utility::LogInfo("     --voxel_size [=0.0058 (m)]");
-    utility::LogInfo("     --intrinsic_path [camera_intrinsic]");
-    utility::LogInfo("     --depth_scale [=1000.0]");
-    utility::LogInfo("     --depth_max [=3.0]");
-    utility::LogInfo("     --sdf_trunc [=0.04]");
-    utility::LogInfo("     --device [CPU:0]");
-    utility::LogInfo("     --raycast");
-    utility::LogInfo("     --mesh");
-    utility::LogInfo("     --pointcloud");
+    utility::LogInfo("    > TIntegrateRGBD [color_folder] [depth_folder] [trajectory] [options]");
+    utility::LogInfo("      Given RGBD images, reconstruct mesh or point cloud from color and depth images");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --voxel_size [=0.0058 (m)]");
+    utility::LogInfo("    --intrinsic_path [camera_intrinsic]");
+    utility::LogInfo("    --depth_scale [=1000.0]");
+    utility::LogInfo("    --depth_max [=3.0]");
+    utility::LogInfo("    --sdf_trunc [=0.04]");
+    utility::LogInfo("    --device [CPU:0]");
+    utility::LogInfo("    --raycast");
+    utility::LogInfo("    --mesh");
+    utility::LogInfo("    --pointcloud");
     // clang-format on
     utility::LogInfo("");
 }
 
-int main(int argc, char** argv) {
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        argc < 4) {
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    if (argc < 4 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TOdometryRGBD.cpp
+++ b/examples/cpp/TOdometryRGBD.cpp
@@ -31,19 +31,20 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    TOdometryRGBD [src_depth] [dst_depth] [src_color] [dst_color]");
-    utility::LogInfo("     Given two RGBD images, perform rgbd odometry and visualize results.");
-    utility::LogInfo("     [options]");
-    utility::LogInfo("     --intrinsic_path [camera_intrinsic]");
-    utility::LogInfo("     --depth_scale [=1000.0]");
-    utility::LogInfo("     --depth_diff [=0.07]");
-    utility::LogInfo("     --method [=PointToPlane | Intensity | Hybrid]");
-    utility::LogInfo("     --device [CPU:0]");
+    utility::LogInfo("    > TOdometryRGBD [src_depth] [dst_depth] [src_color] [dst_color]");
+    utility::LogInfo("      Given two RGBD images, perform rgbd odometry and visualize results.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --intrinsic_path [camera_intrinsic]");
+    utility::LogInfo("    --depth_scale [=1000.0]");
+    utility::LogInfo("    --depth_diff [=0.07]");
+    utility::LogInfo("    --method [=PointToPlane | Intensity | Hybrid]");
+    utility::LogInfo("    --device [CPU:0]");
     // clang-format on
     utility::LogInfo("");
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char* argv[]) {
     using namespace open3d;
     using core::Tensor;
     using t::geometry::PointCloud;
@@ -51,8 +52,8 @@ int main(int argc, char **argv) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        argc < 3) {
+    if (argc < 4 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TriangleMesh.cpp
+++ b/examples/cpp/TriangleMesh.cpp
@@ -28,14 +28,6 @@
 
 #include "open3d/Open3D.h"
 
-void PrintHelp() {
-    using namespace open3d;
-    utility::LogInfo("Usage :");
-    utility::LogInfo("    > TriangleMesh sphere");
-    utility::LogInfo("    > TriangleMesh merge <file1> <file2>");
-    utility::LogInfo("    > TriangleMesh normal <file1> <file2>");
-}
-
 void PaintMesh(open3d::geometry::TriangleMesh &mesh,
                const Eigen::Vector3d &color) {
     mesh.vertex_colors_.resize(mesh.vertices_.size());
@@ -44,12 +36,26 @@ void PaintMesh(open3d::geometry::TriangleMesh &mesh,
     }
 }
 
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > TriangleMesh sphere");
+    utility::LogInfo("    > TriangleMesh merge [file1] [file2]");
+    utility::LogInfo("    > TriangleMesh normal [file1] [file2]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc < 2) {
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/TrimMeshBasedOnPointCloud.cpp
+++ b/examples/cpp/TrimMeshBasedOnPointCloud.cpp
@@ -28,11 +28,12 @@
 
 void PrintHelp() {
     using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
     utility::LogInfo("    > TrimMeshBasedOnPointCloud [options]");
-    utility::LogInfo("      Trim a mesh baesd on distance to a point cloud.");
+    utility::LogInfo("      Trim a mesh based on distance to a point cloud.");
     utility::LogInfo("");
     utility::LogInfo("Basic options:");
     utility::LogInfo("    --help, -h                : Print help information.");
@@ -41,17 +42,19 @@ void PrintHelp() {
     utility::LogInfo("    --out_mesh mesh_file      : Output mesh file. MUST HAVE.");
     utility::LogInfo("    --pointcloud pcd_file     : Reference pointcloud file. MUST HAVE.");
     utility::LogInfo("    --distance d              : Maximum distance. MUST HAVE.");
-    // clang-format on
+    // clang-format onZ
+    utility::LogInfo("");
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     using namespace open3d;
 
-    if (argc < 4 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    if (argc < 4 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ) {
         PrintHelp();
         return 1;
     }
+
     int verbose = utility::GetProgramOptionAsInt(argc, argv, "--verbose", 5);
     utility::SetVerbosityLevel((utility::VerbosityLevel)verbose);
     auto in_mesh_file =

--- a/examples/cpp/ViewDistances.cpp
+++ b/examples/cpp/ViewDistances.cpp
@@ -28,6 +28,7 @@
 
 void PrintHelp() {
     using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
@@ -43,16 +44,20 @@ void PrintHelp() {
     utility::LogInfo("    --write_color_back        : Write color back to source_file.");
     utility::LogInfo("    --without_gui             : Without GUI.");
     // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
-    if (argc <= 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }
+
     int verbose = utility::GetProgramOptionAsInt(argc, argv, "--verbose", 5);
     utility::SetVerbosityLevel((utility::VerbosityLevel)verbose);
     double max_distance = utility::GetProgramOptionAsDouble(

--- a/examples/cpp/ViewPCDMatch.cpp
+++ b/examples/cpp/ViewPCDMatch.cpp
@@ -88,6 +88,7 @@ bool ReadLogFile(const std::string &filename,
 
 void PrintHelp() {
     using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
@@ -100,16 +101,20 @@ void PrintHelp() {
     utility::LogInfo("    --dir directory           : The directory storing all pcd files. By default it is the parent directory of the log file + pcd/.");
     utility::LogInfo("    --verbose n               : Set verbose level (0-4). Default: 2.");
     // clang-format on
+    utility::LogInfo("");
 }
 
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
-    if (argc <= 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        utility::ProgramOptionExists(argc, argv, "-h")) {
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
+
+    if (argc <= 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }
+
     const int NUM_OF_COLOR_PALETTE = 5;
     Eigen::Vector3d color_palette[NUM_OF_COLOR_PALETTE] = {
             Eigen::Vector3d(255, 180, 0) / 255.0,

--- a/examples/cpp/Visualizer.cpp
+++ b/examples/cpp/Visualizer.cpp
@@ -30,8 +30,9 @@
 
 #include "open3d/Open3D.h"
 
-void PrintUsage() {
+void PrintHelp() {
     using namespace open3d;
+
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
@@ -39,13 +40,17 @@ void PrintUsage() {
     utility::LogInfo("    > Visualizer [animation] [filename] [trajectoryfile]");
     utility::LogInfo("    > Visualizer [rgbd] [color] [depth] [--rgbd_type]");
     // clang-format on
+    utility::LogInfo("");
 }
+
 int main(int argc, char *argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc < 3) {
-        PrintUsage();
+
+    if (argc < 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
+        PrintHelp();
         return 1;
     }
 
@@ -160,7 +165,7 @@ int main(int argc, char *argv[]) {
                                       image_ptr->height_);
     } else if (option == "rgbd") {
         if (argc < 4) {
-            PrintUsage();
+            PrintHelp();
             return 1;
         }
 

--- a/examples/cpp/VoxelHashing.cpp
+++ b/examples/cpp/VoxelHashing.cpp
@@ -32,34 +32,36 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo(">    VoxelHashing [color_folder] [depth_folder]");
-    utility::LogInfo("     Given an RGBD image sequence, perform frame-to-model tracking and mapping, and reconstruct the surface.");
-    utility::LogInfo("     [options]");
-    utility::LogInfo("     --intrinsic_path [camera_intrinsic]");
-    utility::LogInfo("     --voxel_size [=0.0058 (m)]");
-    utility::LogInfo("     --depth_scale [=1000.0]");
-    utility::LogInfo("     --max_depth [=3.0]");
-    utility::LogInfo("     --sdf_trunc [=0.04]");
-    utility::LogInfo("     --block_count [=10000]");
-    utility::LogInfo("     --device [CPU:0]");
-    utility::LogInfo("     --pointcloud");
+    utility::LogInfo("    > VoxelHashing [color_folder] [depth_folder]");
+    utility::LogInfo("      Given an RGBD image sequence, perform frame-to-model tracking and mapping, and reconstruct the surface.");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --intrinsic_path [camera_intrinsic]");
+    utility::LogInfo("    --voxel_size [=0.0058 (m)]");
+    utility::LogInfo("    --depth_scale [=1000.0]");
+    utility::LogInfo("    --max_depth [=3.0]");
+    utility::LogInfo("    --sdf_trunc [=0.04]");
+    utility::LogInfo("    --block_count [=10000]");
+    utility::LogInfo("    --device [CPU:0]");
+    utility::LogInfo("    --pointcloud");
     // clang-format on
     utility::LogInfo("");
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char* argv[]) {
     using namespace open3d;
     using core::Tensor;
     using t::geometry::Image;
     using t::geometry::PointCloud;
 
-    if (argc == 1 || utility::ProgramOptionExists(argc, argv, "--help") ||
-        argc < 4) {
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Info);
+
+    if (argc < 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }
 
-    utility::SetVerbosityLevel(utility::VerbosityLevel::Info);
     // Device
     std::string device_code = "CPU:0";
     if (utility::ProgramOptionExists(argc, argv, "--device")) {

--- a/examples/cpp/VoxelHashingGUI.cpp
+++ b/examples/cpp/VoxelHashingGUI.cpp
@@ -802,17 +802,22 @@ void PrintHelp() {
     PrintOpen3DVersion();
     // clang-format off
     utility::LogInfo("Usage:");
-    utility::LogInfo("     VoxelHashingGUI [dataset_path]");
-    utility::LogInfo("     Given a sequence of RGBD images, reconstruct point cloud from color and depth images");
-    utility::LogInfo("     [options]");
-    utility::LogInfo("     --voxel_size [=0.0058 (m)]");
-    utility::LogInfo("     --intrinsic_path [camera_intrinsic.json]");
-    utility::LogInfo("     --device [CUDA:0]");
+    utility::LogInfo("    > VoxelHashingGUI [dataset_path]");
+    utility::LogInfo("      Given a sequence of RGBD images, reconstruct point cloud from color and depth images");
+    utility::LogInfo("");
+    utility::LogInfo("Basic options:");
+    utility::LogInfo("    --voxel_size [=0.0058 (m)]");
+    utility::LogInfo("    --intrinsic_path [camera_intrinsic.json]");
+    utility::LogInfo("    --device [CUDA:0]");
     // clang-format on
+    utility::LogInfo("");
 }
 
-int main(int argc, char** argv) {
-    if (argc < 2) {
+int main(int argc, char* argv[]) {
+    using namespace open3d;
+
+    if (argc < 2 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Voxelization.cpp
+++ b/examples/cpp/Voxelization.cpp
@@ -54,9 +54,8 @@ int main(int argc, char* argv[]) {
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
 
-    if (argc == 1 ||
-        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
-        argc != 3) {
+    if (argc != 3 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"})) {
         PrintHelp();
         return 1;
     }

--- a/examples/cpp/Voxelization.cpp
+++ b/examples/cpp/Voxelization.cpp
@@ -38,26 +38,36 @@ void PrintVoxelGridInformation(const geometry::VoxelGrid& voxel_grid) {
     return;
 }
 
-int main(int argc, char** args) {
+void PrintHelp() {
+    using namespace open3d;
+
+    PrintOpen3DVersion();
+    // clang-format off
+    utility::LogInfo("Usage:");
+    utility::LogInfo("    > Voxelization [pointcloud_filename] [voxel_filename_ply]");
+    // clang-format on
+    utility::LogInfo("");
+}
+
+int main(int argc, char* argv[]) {
     using namespace open3d;
 
     utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    if (argc < 3) {
-        PrintOpen3DVersion();
-        // clang-format off
-        utility::LogInfo("Usage:");
-        utility::LogInfo("    > Voxelization [pointcloud_filename] [voxel_filename_ply]");
-        // clang-format on
+
+    if (argc == 1 ||
+        utility::ProgramOptionExistsAny(argc, argv, {"-h", "--help"}) ||
+        argc != 3) {
+        PrintHelp();
         return 1;
     }
 
-    auto pcd = io::CreatePointCloudFromFile(args[1]);
+    auto pcd = io::CreatePointCloudFromFile(argv[1]);
     auto voxel = geometry::VoxelGrid::CreateFromPointCloud(*pcd, 0.05);
     PrintVoxelGridInformation(*voxel);
     visualization::DrawGeometries({pcd, voxel});
-    io::WriteVoxelGrid(args[2], *voxel, true);
+    io::WriteVoxelGrid(argv[2], *voxel, true);
 
-    auto voxel_read = io::CreateVoxelGridFromFile(args[2]);
+    auto voxel_read = io::CreateVoxelGridFromFile(argv[2]);
     PrintVoxelGridInformation(*voxel_read);
     visualization::DrawGeometries({pcd, voxel_read});
 }


### PR DESCRIPTION
- Fix crash in some examples if calling without parameters, i.e. `./<example>`
- Fix unrecognized `-h` and/or `--help` arguments
- Fix inconsistent formatting of help dialogue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3472)
<!-- Reviewable:end -->
