### PR TITLE
Fix changing directory to macOS bundle resource path on GLFW initialization

### DIFF
--- a/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
+++ b/cpp/open3d/visualization/gui/GLFWWindowSystem.cpp
@@ -130,6 +130,9 @@ void GLFWWindowSystem::Initialize() {
     MacTransformIntoApp();
 
     glfwInitHint(GLFW_COCOA_MENUBAR, GLFW_FALSE);  // no auto-create menubar
+    // Don't change directory to resource directory in bundle (which is awkward
+    // if using a framework version of Python).
+    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
 #endif
     glfwInit();
 }

--- a/cpp/open3d/visualization/visualizer/Visualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/Visualizer.cpp
@@ -60,6 +60,12 @@ public:
 
     static int InitGLFW() {
         GLFWEnvironmentSingleton::GetInstance();
+#if defined(__APPLE__)
+        // On macOS, GLFW changes the directory to the resource directory,
+        // which will cause an unexpected change of directory if using a
+        // framework build version of Python.
+        glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
+#endif
         return glfwInit();
     }
 


### PR DESCRIPTION
Fixes #3471

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3475)
<!-- Reviewable:end -->
