### PR TITLE
Fixed GUI to be scrollable

### DIFF
--- a/cpp/open3d/visualization/gui/Button.cpp
+++ b/cpp/open3d/visualization/gui/Button.cpp
@@ -135,7 +135,8 @@ Widget::DrawResult Button::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
     auto result = Widget::DrawResult::NONE;
 
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     bool was_on = impl_->is_on_;
     if (was_on) {

--- a/cpp/open3d/visualization/gui/Checkbox.cpp
+++ b/cpp/open3d/visualization/gui/Checkbox.cpp
@@ -79,7 +79,8 @@ Size Checkbox::CalcPreferredSize(const LayoutContext& context,
 
 Widget::DrawResult Checkbox::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
     auto result = Widget::DrawResult::NONE;
 
     // ImGUI doesn't offer styling specific to checkboxes other than the

--- a/cpp/open3d/visualization/gui/ColorEdit.cpp
+++ b/cpp/open3d/visualization/gui/ColorEdit.cpp
@@ -75,7 +75,8 @@ Size ColorEdit::CalcPreferredSize(const LayoutContext& context,
 
 ColorEdit::DrawResult ColorEdit::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     auto new_value = impl_->value_;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/Combobox.cpp
+++ b/cpp/open3d/visualization/gui/Combobox.cpp
@@ -170,7 +170,8 @@ Combobox::DrawResult Combobox::Draw(const DrawContext& context) {
     bool did_open = false;
 
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     ImGui::PushStyleColor(
             ImGuiCol_Button,

--- a/cpp/open3d/visualization/gui/ImageWidget.cpp
+++ b/cpp/open3d/visualization/gui/ImageWidget.cpp
@@ -120,13 +120,16 @@ Widget::DrawResult ImageWidget::Draw(const DrawContext& context) {
     if (params.texture != visualization::rendering::TextureHandle::kBad) {
         ImTextureID image_id =
                 reinterpret_cast<ImTextureID>(params.texture.GetId());
-        ImGui::SetCursorScreenPos(ImVec2(params.pos_x, params.pos_y));
+        ImGui::SetCursorScreenPos(
+                ImVec2(params.pos_x, params.pos_y - ImGui::GetScrollY()));
         ImGui::Image(image_id, ImVec2(params.width, params.height),
                      ImVec2(params.u0, params.v0),
                      ImVec2(params.u1, params.v1));
     } else {
         // Draw error message if we don't have an image, instead of
         // quietly failing or something.
+        Rect frame = GetFrame();         // hide reference with a copy...
+        frame.y -= ImGui::GetScrollY();  // ... so we can adjust for scrolling
         const char* error_text = "  Error\nloading\n image";
         Color fg(1.0, 1.0, 1.0);
         ImGui::GetWindowDrawList()->AddRectFilled(

--- a/cpp/open3d/visualization/gui/Label.cpp
+++ b/cpp/open3d/visualization/gui/Label.cpp
@@ -133,7 +133,8 @@ Size Label::CalcPreferredSize(const LayoutContext& context,
 
 Widget::DrawResult Label::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
     ImGui::PushItemWidth(float(frame.width));
     bool is_default_color = (impl_->color_ == DEFAULT_COLOR);
     if (!is_default_color) {

--- a/cpp/open3d/visualization/gui/Layout.h
+++ b/cpp/open3d/visualization/gui/Layout.h
@@ -179,6 +179,25 @@ private:
     std::unique_ptr<Impl> impl_;
 };
 
+/// This a vertical layout that scrolls if it is smaller than its contents
+class ScrollableVert : public Vert {
+    using Super = Vert;
+
+public:
+    ScrollableVert();
+    ScrollableVert(int spacing, const Margins& margins = Margins());
+    ScrollableVert(int spacing,
+                   const Margins& margins,
+                   const std::vector<std::shared_ptr<Widget>>& children);
+    virtual ~ScrollableVert();
+
+    Widget::DrawResult Draw(const DrawContext& context) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
 /// Lays out widgets horizontally.
 class Horiz : public Layout1D {
 public:

--- a/cpp/open3d/visualization/gui/ListView.cpp
+++ b/cpp/open3d/visualization/gui/ListView.cpp
@@ -97,9 +97,14 @@ Size ListView::CalcPreferredSize(const LayoutContext &context,
     return Size(int(std::ceil(size.x + 2.0f * padding.x)), Widget::DIM_GROW);
 }
 
+Size ListView::CalcMinimumSize(const LayoutContext &context) const {
+    return Size(0, 3 * context.theme.font_size);
+}
+
 Widget::DrawResult ListView::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) + ImGui::GetScrollY()));
     ImGui::PushItemWidth(float(frame.width));
 
     ImGui::PushStyleColor(ImGuiCol_FrameBg,

--- a/cpp/open3d/visualization/gui/ListView.h
+++ b/cpp/open3d/visualization/gui/ListView.h
@@ -54,6 +54,8 @@ public:
     Size CalcPreferredSize(const LayoutContext& context,
                            const Constraints& constraints) const override;
 
+    Size CalcMinimumSize(const LayoutContext& context) const override;
+
     DrawResult Draw(const DrawContext& context) override;
 
     /// Calls onValueChanged(const char *selectedText, bool isDoubleClick)

--- a/cpp/open3d/visualization/gui/NumberEdit.cpp
+++ b/cpp/open3d/visualization/gui/NumberEdit.cpp
@@ -135,7 +135,8 @@ Size NumberEdit::CalcPreferredSize(const LayoutContext& context,
 
 Widget::DrawResult NumberEdit::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text edit borders

--- a/cpp/open3d/visualization/gui/Slider.cpp
+++ b/cpp/open3d/visualization/gui/Slider.cpp
@@ -100,7 +100,8 @@ Size Slider::CalcPreferredSize(const LayoutContext& context,
 
 Widget::DrawResult Slider::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     auto new_value = impl_->value_;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/TabControl.cpp
+++ b/cpp/open3d/visualization/gui/TabControl.cpp
@@ -97,7 +97,8 @@ void TabControl::Layout(const LayoutContext& context) {
 
 TabControl::DrawResult TabControl::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     auto result = Widget::DrawResult::NONE;
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/TextEdit.cpp
+++ b/cpp/open3d/visualization/gui/TextEdit.cpp
@@ -101,7 +101,8 @@ Size TextEdit::CalcPreferredSize(const LayoutContext &context,
 
 Widget::DrawResult TextEdit::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) + ImGui::GetScrollY()));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text editing

--- a/cpp/open3d/visualization/gui/ToggleSwitch.cpp
+++ b/cpp/open3d/visualization/gui/ToggleSwitch.cpp
@@ -80,7 +80,8 @@ Size ToggleSwitch::CalcPreferredSize(const LayoutContext& context,
 Widget::DrawResult ToggleSwitch::Draw(const DrawContext& context) {
     auto& theme = context.theme;
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
     auto result = Widget::DrawResult::NONE;
 
     DrawImGuiPushEnabledState();

--- a/cpp/open3d/visualization/gui/TreeView.cpp
+++ b/cpp/open3d/visualization/gui/TreeView.cpp
@@ -370,6 +370,10 @@ Size TreeView::CalcPreferredSize(const LayoutContext &context,
     return Size(constraints.width, Widget::DIM_GROW);
 }
 
+Size TreeView::CalcMinimumSize(const LayoutContext &context) const {
+    return Size(0, 3 * context.theme.font_size);
+}
+
 void TreeView::Layout(const LayoutContext &context) {
     // Nothing to do here. We don't know the x position because of the
     // indentations, which also means we don't know the size. So we need
@@ -381,7 +385,9 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
     auto &frame = GetFrame();
 
     DrawImGuiPushEnabledState();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    float outer_scroll_y = ImGui::GetScrollY();
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - outer_scroll_y));
 
     // ImGUI's tree wants to highlight the row as the user moves over it.
     // There are several problems here. First, there seems to be a bug in
@@ -408,8 +414,8 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
     Impl::Item *new_selection = nullptr;
 
     std::function<void(Impl::Item &)> DrawItem;
-    DrawItem = [&DrawItem, this, &frame, &context, &new_selection,
-                &result](Impl::Item &item) {
+    DrawItem = [&DrawItem, this, &frame, &context, &new_selection, &result,
+                outer_scroll_y](Impl::Item &item) {
         int height = item.cell
                              ->CalcPreferredSize({context.theme, context.fonts},
                                                  Constraints())
@@ -422,7 +428,8 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
             // of the tree's frame. To draw directly to the window list we
             // need to the absolute coordinates (relative the OS window's
             // upper left)
-            auto y = frame.y + ImGui::GetCursorPosY() - ImGui::GetScrollY();
+            auto y = frame.y - outer_scroll_y + ImGui::GetCursorPosY() -
+                     ImGui::GetScrollY();
             ImGui::GetWindowDrawList()->AddRectFilled(
                     ImVec2(float(frame.x), y),
                     ImVec2(float(frame.GetRight()), y + height),
@@ -445,11 +452,19 @@ Widget::DrawResult TreeView::Draw(const DrawContext &context) {
                                   bool is_selectable) {
             ImGui::SameLine(0, 0);
             auto x = int(std::round(ImGui::GetCursorScreenPos().x));
-            auto y = int(std::round(ImGui::GetCursorScreenPos().y));
+            auto y = int(std::round(
+                    ImGui::GetCursorScreenPos().y /*- ImGui::GetScrollY()*/));
+            auto scroll_y = ImGui::GetScrollY();
             auto scroll_width = int(ImGui::GetStyle().ScrollbarSize);
             auto indent = x - tree_frame.x;
-            item.cell->SetFrame(Rect(
-                    x, y, tree_frame.width - indent - scroll_width, height));
+            // Note that we add scroll_y to undo the Widget's Draw() subtracting
+            // it off. It needs to subtract it off if the whole ImGUI window
+            // is being scrolled, but not if it is in a TreeView, and it has no
+            // way of knowing the difference. Also it is necessary for clicks to
+            // work correctly.
+            item.cell->SetFrame(Rect(x, y + scroll_y,
+                                     tree_frame.width - indent - scroll_width,
+                                     height));
             // Now that we know the frame we can finally layout. It would be
             // nice to not relayout until something changed, which would
             // usually work, unless the cell changes shape in response to

--- a/cpp/open3d/visualization/gui/TreeView.h
+++ b/cpp/open3d/visualization/gui/TreeView.h
@@ -142,6 +142,7 @@ public:
 
     Size CalcPreferredSize(const LayoutContext& context,
                            const Constraints& constraints) const override;
+    Size CalcMinimumSize(const LayoutContext& context) const override;
 
     void Layout(const LayoutContext& context) override;
 

--- a/cpp/open3d/visualization/gui/VectorEdit.cpp
+++ b/cpp/open3d/visualization/gui/VectorEdit.cpp
@@ -76,7 +76,8 @@ Size VectorEdit::CalcPreferredSize(const LayoutContext& context,
 
 Widget::DrawResult VectorEdit::Draw(const DrawContext& context) {
     auto& frame = GetFrame();
-    ImGui::SetCursorScreenPos(ImVec2(float(frame.x), float(frame.y)));
+    ImGui::SetCursorScreenPos(
+            ImVec2(float(frame.x), float(frame.y) - ImGui::GetScrollY()));
 
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding,
                         0.0);  // macOS doesn't round text editing

--- a/cpp/open3d/visualization/gui/Widget.cpp
+++ b/cpp/open3d/visualization/gui/Widget.cpp
@@ -98,6 +98,10 @@ Size Widget::CalcPreferredSize(const LayoutContext&,
     return Size(DIM_GROW, DIM_GROW);
 }
 
+Size Widget::CalcMinimumSize(const LayoutContext& context) const {
+    return Size(0, 0);
+}
+
 void Widget::Layout(const LayoutContext& context) {
     for (auto& child : impl_->children_) {
         child->Layout(context);

--- a/cpp/open3d/visualization/gui/Widget.h
+++ b/cpp/open3d/visualization/gui/Widget.h
@@ -107,6 +107,8 @@ public:
     virtual Size CalcPreferredSize(const LayoutContext& context,
                                    const Constraints& constraints) const;
 
+    virtual Size CalcMinimumSize(const LayoutContext& context) const;
+
     virtual void Layout(const LayoutContext& context);
 
     enum class DrawResult { NONE, REDRAW, RELAYOUT };

--- a/cpp/open3d/visualization/gui/Window.cpp
+++ b/cpp/open3d/visualization/gui/Window.cpp
@@ -331,6 +331,7 @@ Window::Window(const std::string& title,
     style.FrameRounding = float(theme.border_radius);
     style.ChildRounding = float(theme.border_radius);
     style.Colors[ImGuiCol_WindowBg] = colorToImgui(theme.background_color);
+    style.Colors[ImGuiCol_ChildBg] = colorToImgui(theme.background_color);
     style.Colors[ImGuiCol_Text] = colorToImgui(theme.text_color);
     style.Colors[ImGuiCol_Border] = colorToImgui(theme.border_color);
     style.Colors[ImGuiCol_Button] = colorToImgui(theme.button_color);

--- a/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/GuiVisualizer.cpp
@@ -85,20 +85,16 @@ std::shared_ptr<gui::Dialog> CreateAboutDialog(gui::Window *window) {
             (std::string("Open3D ") + OPEN3D_VERSION).c_str());
     auto text = std::make_shared<gui::Label>(
             "The MIT License (MIT)\n"
-            "Copyright (c) 2018 - 2020 www.open3d.org\n\n"
+            "Copyright (c) 2018 - 2021 www.open3d.org\n\n"
 
             "Permission is hereby granted, free of charge, to any person "
-            "obtaining "
-            "a copy of this software and associated documentation files (the "
-            "\"Software\"), to deal in the Software without restriction, "
-            "including "
-            "without limitation the rights to use, copy, modify, merge, "
-            "publish, "
-            "distribute, sublicense, and/or sell copies of the Software, and "
-            "to "
-            "permit persons to whom the Software is furnished to do so, "
-            "subject to "
-            "the following conditions:\n\n"
+            "obtaining a copy of this software and associated documentation "
+            "files (the \"Software\"), to deal in the Software without "
+            "restriction, including without limitation the rights to use, "
+            "copy, modify, merge, publish, distribute, sublicense, and/or "
+            "sell copies of the Software, and to permit persons to whom "
+            "the Software is furnished to do so, subject to the following "
+            "conditions:\n\n"
 
             "The above copyright notice and this permission notice shall be "
             "included in all copies or substantial portions of the "
@@ -106,15 +102,12 @@ std::shared_ptr<gui::Dialog> CreateAboutDialog(gui::Window *window) {
 
             "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, "
             "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES "
-            "OF "
-            "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND "
-            "NONINFRINGEMENT. "
-            "IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR "
-            "ANY "
-            "CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF "
-            "CONTRACT, "
-            "TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE "
-            "SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.");
+            "OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND "
+            "NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT "
+            "HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, "
+            "WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING "
+            "FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR "
+            "OTHER DEALINGS IN THE SOFTWARE.");
     auto ok = std::make_shared<gui::Button>("OK");
     ok->SetOnClicked([window]() { window->CloseDialog(); });
 
@@ -122,7 +115,9 @@ std::shared_ptr<gui::Dialog> CreateAboutDialog(gui::Window *window) {
     auto layout = std::make_shared<gui::Vert>(0, margins);
     layout->AddChild(gui::Horiz::MakeCentered(title));
     layout->AddFixed(theme.font_size);
-    layout->AddChild(text);
+    auto v = std::make_shared<gui::ScrollableVert>(0);
+    v->AddChild(text);
+    layout->AddChild(v);
     layout->AddFixed(theme.font_size);
     layout->AddChild(gui::Horiz::MakeCentered(ok));
     dlg->AddChild(layout);

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -2099,7 +2099,7 @@ void O3DVisualizer::ExportCurrentImage(const std::string &path) {
 
 void O3DVisualizer::Layout(const gui::LayoutContext &context) {
     auto em = context.theme.font_size;
-    int settings_width = 15 * context.theme.font_size;
+    int settings_width = 16 * context.theme.font_size;
 #if !GROUPS_USE_TREE
     if (impl_->added_groups_.size() >= 2) {
         settings_width += 5 * context.theme.font_size;

--- a/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
+++ b/cpp/open3d/visualization/visualizer/O3DVisualizer.cpp
@@ -1666,7 +1666,6 @@ struct O3DVisualizer::Impl {
         }
         return false;
     }
-
     void UpdateAnimationTickClockTime(double now) {
         next_animation_tick_clock_time_ = now + ui_state_.frame_delay;
     }
@@ -1694,33 +1693,29 @@ struct O3DVisualizer::Impl {
                 (std::string("Open3D ") + OPEN3D_VERSION).c_str());
         auto text = std::make_shared<gui::Label>(
                 "The MIT License (MIT)\n"
-                "Copyright (c) 2018 - 2020 www.open3d.org\n\n"
+                "Copyright (c) 2018 - 2021 www.open3d.org\n\n"
 
                 "Permission is hereby granted, free of charge, to any person "
                 "obtaining a copy of this software and associated "
-                "documentation "
-                "files (the \"Software\"), to deal in the Software without "
-                "restriction, including without limitation the rights to use, "
-                "copy, modify, merge, publish, distribute, sublicense, and/or "
-                "sell copies of the Software, and to permit persons to whom "
-                "the Software is furnished to do so, subject to the following "
-                "conditions:\n\n"
+                "documentation files (the \"Software\"), to deal in the "
+                "Software without restriction, including without limitation "
+                "the rights to use, copy, modify, merge, publish, distribute, "
+                "sublicense, and/or sell copies of the Software, and to "
+                "permit persons to whom the Software is furnished to do so, "
+                "subject to the following conditions:\n\n"
 
                 "The above copyright notice and this permission notice shall "
-                "be "
-                "included in all copies or substantial portions of the "
+                "be included in all copies or substantial portions of the "
                 "Software.\n\n"
 
                 "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY "
-                "KIND, "
-                "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE "
-                "WARRANTIES "
-                "OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND "
-                "NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT "
-                "HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, "
-                "WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING "
-                "FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR "
-                "OTHER DEALINGS IN THE SOFTWARE.");
+                "KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE "
+                "WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR "
+                "PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR "
+                "COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER "
+                "LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR "
+                "OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE "
+                "SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.");
         auto ok = std::make_shared<gui::Button>("OK");
         ok->SetOnClicked([this]() { this->window_->CloseDialog(); });
 
@@ -1728,7 +1723,9 @@ struct O3DVisualizer::Impl {
         auto layout = std::make_shared<gui::Vert>(0, margins);
         layout->AddChild(gui::Horiz::MakeCentered(title));
         layout->AddFixed(theme.font_size);
-        layout->AddChild(text);
+        auto v = std::make_shared<gui::ScrollableVert>(0);
+        v->AddChild(text);
+        layout->AddChild(v);
         layout->AddFixed(theme.font_size);
         layout->AddChild(gui::Horiz::MakeCentered(ok));
         dlg->AddChild(layout);

--- a/cpp/pybind/visualization/gui/gui.cpp
+++ b/cpp/pybind/visualization/gui/gui.cpp
@@ -1563,6 +1563,27 @@ void pybind_gui_classes(py::module &m) {
                           "Set the font using the FontId returned from "
                           "Application.add_font()");
 
+    // ---- ScrollableVert ----
+    py::class_<ScrollableVert, UnownedPointer<ScrollableVert>, Vert> slayout(
+            m, "ScrollableVert", "Scrollable vertical layout");
+    slayout.def(py::init([](int spacing, const Margins &margins) {
+                    return new ScrollableVert(spacing, margins);
+                }),
+                "spacing"_a = 0, "margins"_a = Margins(),
+                "Creates a layout that arranges widgets vertically, top to "
+                "bottom, making their width equal to the layout's width. First "
+                "argument is the spacing between widgets, the second is the "
+                "margins. Both default to 0.")
+            .def(py::init([](float spacing, const Margins &margins) {
+                     return new ScrollableVert(int(std::round(spacing)),
+                                               margins);
+                 }),
+                 "spacing"_a = 0.0f, "margins"_a = Margins(),
+                 "Creates a layout that arranges widgets vertically, top to "
+                 "bottom, making their width equal to the layout's width. "
+                 "First argument is the spacing between widgets, the second "
+                 "is the margins. Both default to 0.");
+
     // ---- Horiz ----
     py::class_<Horiz, UnownedPointer<Horiz>, Layout1D> hlayout(
             m, "Horiz", "Horizontal layout");


### PR DESCRIPTION
- GUI is scrollable now, which improves usability when the window is too small for the UI. ImGUI automatically creates scrollbars for a top-level widget.
- Added ScrollableVert class, which is useful if you want to (potentially) scroll something like a long legal license, for instance.
- Updated About boxes to have scrollable text for the legal license.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3476)
<!-- Reviewable:end -->
