### PR TITLE
moved open3d_tutorial.py downloads to open3d_downloads release

### DIFF
--- a/examples/python/open3d_tutorial.py
+++ b/examples/python/open3d_tutorial.py
@@ -261,7 +261,7 @@ def get_eagle_pcd():
     path = _relative_path("../test_data/eagle.ply")
     if not os.path.exists(path):
         print("downloading eagle pcl")
-        url = "https://github.com/intel-isl/open3d_downloads/releases/download/open3d_tutorial/eagle.points.ply"
+        url = "http://www.cs.jhu.edu/~misha/Code/PoissonRecon/eagle.points.ply"
         urllib.request.urlretrieve(url, path)
     pcd = o3d.io.read_point_cloud(path)
     return pcd

--- a/examples/python/open3d_tutorial.py
+++ b/examples/python/open3d_tutorial.py
@@ -124,7 +124,7 @@ def download_fountain_dataset():
     fountain_zip_path = _relative_path("../test_data/fountain.zip")
     if not os.path.exists(fountain_path):
         print("downloading fountain dataset")
-        url = "https://storage.googleapis.com/isl-datasets/open3d-dev/fountain.zip"
+        url = "https://github.com/intel-isl/open3d_downloads/releases/download/open3d_tutorial/fountain.zip"
         urllib.request.urlretrieve(url, fountain_zip_path)
         print("extract fountain dataset")
         with zipfile.ZipFile(fountain_zip_path, "r") as zip_ref:
@@ -261,7 +261,7 @@ def get_eagle_pcd():
     path = _relative_path("../test_data/eagle.ply")
     if not os.path.exists(path):
         print("downloading eagle pcl")
-        url = "http://www.cs.jhu.edu/~misha/Code/PoissonRecon/eagle.points.ply"
+        url = "https://github.com/intel-isl/open3d_downloads/releases/download/open3d_tutorial/eagle.points.ply"
         urllib.request.urlretrieve(url, path)
     pcd = o3d.io.read_point_cloud(path)
     return pcd

--- a/python/test/open3d_test.py
+++ b/python/test/open3d_test.py
@@ -96,7 +96,7 @@ def download_fountain_dataset():
     fountain_zip_path = os.path.join(test_data_dir, "fountain.zip")
     if not os.path.exists(fountain_path):
         print("Downloading fountain dataset")
-        url = "https://storage.googleapis.com/isl-datasets/open3d-dev/fountain.zip"
+        url = "https://github.com/intel-isl/open3d_downloads/releases/download/open3d_tutorial/fountain.zip"
         urllib.request.urlretrieve(url, fountain_zip_path)
         print("Extracting fountain dataset")
         with zipfile.ZipFile(fountain_zip_path, "r") as zip_ref:


### PR DESCRIPTION
Moved open3d_tutorial.py downloads to 
https://github.com/intel-isl/open3d_downloads/releases/tag/open3d_tutorial

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3477)
<!-- Reviewable:end -->
