### PR TITLE
moved downloader.py files to open3d_downloads

### DIFF
--- a/examples/python/utility/downloader.py
+++ b/examples/python/utility/downloader.py
@@ -25,7 +25,7 @@ def get_redwood_dataset():
         # download and unzip dataset
         for name in dataset_names:
             print("==================================")
-            file_downloader("http://redwood-data.org/indoor/data/%s-fragments-ply.zip" % \
+            file_downloader("https://github.com/intel-isl/open3d_downloads/releases/download/redwood/%s-fragments-ply.zip" % \
                     name)
             unzip_data("%s-fragments-ply.zip" % name,
                        "%s/%s" % (dataset_path, name))


### PR DESCRIPTION
Moved redwood dataset used in "examples/python/utility/downloader.py" to open3d_downloads repo:
https://github.com/intel-isl/open3d_downloads/releases/tag/redwood

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3488)
<!-- Reviewable:end -->
