### PR TITLE
moved redwood simulated dataset to open3d_downloads

### DIFF
--- a/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
+++ b/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
@@ -4,9 +4,9 @@ set -e
 download_redwood_scene()
 {
     DATA_NAME=$1
-    wget http://redwood-data.org/indoor/data/$DATA_NAME-color.zip
-    wget http://redwood-data.org/indoor/data/$DATA_NAME-depth-clean.zip
-    wget http://redwood-data.org/indoor/data/$DATA_NAME-depth-simulated.zip
+    wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-color.zip
+    wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-clean.zip
+    wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-simulated.zip
 }
 
 unzip_redwood_scene()

--- a/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
+++ b/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
@@ -4,14 +4,14 @@ set -e
 download_redwood_scene()
 {
     DATA_NAME=$1
-    
-    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-color.zip
+
+    # Source: http://redwood-data.org/indoor/data/$DATA_NAME-color.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-color.zip
     
-    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-depth-clean.zip
+    # Source: http://redwood-data.org/indoor/data/$DATA_NAME-depth-clean.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-clean.zip
     
-    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-depth-simulated.zip
+    # Source: http://redwood-data.org/indoor/data/$DATA_NAME-depth-simulated.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-simulated.zip
 
 }

--- a/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
+++ b/examples/python/reconstruction_system/scripts/download_redwood_simulated.sh
@@ -4,9 +4,16 @@ set -e
 download_redwood_scene()
 {
     DATA_NAME=$1
+    
+    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-color.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-color.zip
+    
+    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-depth-clean.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-clean.zip
+    
+    # original_link: http://redwood-data.org/indoor/data/$DATA_NAME-depth-simulated.zip
     wget https://github.com/intel-isl/open3d_downloads/releases/download/redwood-simulated/$DATA_NAME-depth-simulated.zip
+
 }
 
 unzip_redwood_scene()


### PR DESCRIPTION
Moved redwood-simulated dataset used in "examples/python/reconstruction_system/scripts/download_redwood_simulated.sh"
to open3d_downloads.
https://github.com/intel-isl/open3d_downloads/releases/tag/redwood-simulated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3505)
<!-- Reviewable:end -->
