### PR TITLE
Fix wheel folder structure to prevent auditwheel crash

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -25,6 +25,7 @@
 # ----------------------------------------------------------------------------
 
 from setuptools import setup, find_packages
+from setuptools.command.install import install as _install
 import os
 import glob
 import ctypes
@@ -98,6 +99,20 @@ except ImportError:
         'Warning: cannot import "wheel" package to build platform-specific wheel'
     )
     print('Install the "wheel" package to fix this warning')
+
+
+# Force use of "platlib" dir for auditwheel to recognize this is a non-pure
+# build
+# http://lxr.yanyahua.com/source/llvmlite/setup.py
+class install(_install):
+
+    def finalize_options(self):
+        _install.finalize_options(self)
+        self.install_libbase = self.install_platlib
+        self.install_lib = self.install_platlib
+
+
+cmdclass['install'] = install
 
 # Read requirements.
 with open('requirements.txt', 'r') as f:


### PR DESCRIPTION
The current wheel (since v0.12 or earlier) causes `auditwheel` to crash when tested:
```
$ auditwheel show open3d-0.12.0-cp36-cp36m-manylinux2014_x86_64.whl
....
RuntimeError: Invalid binary wheel, found the following shared library/libraries in purelib folder:
	libc++.so.1
	libc++abi.so.1
	open3d_tf_ops.so
	open3d_torch_ops.so
	pybind.cpython-36m-x86_64-linux-gnu.so
	open3d_tf_ops.so
	open3d_torch_ops.so
	pybind.cpython-36m-x86_64-linux-gnu.so
The wheel has to be platlib compliant in order to be repaired by auditwheel.
```
This PR updates `setup.py` so that the purelib folder is not used. This produces a wheel that auditwheel can check without crashing (with warnings):

```
$ auditwheel show lib/python_package/pip_package/open3d-0.12.0+90f52cde6-cp36-cp36m-manylinux_2_31_x86_64.whl

open3d-0.12.0+90f52cde6-cp36-cp36m-manylinux_2_31_x86_64.whl is
consistent with the following platform tag: "linux_x86_64".

The wheel references external versioned symbols in these
system-provided shared libraries: libgcc_s.so.1 with versions
{'GCC_3.3.1', 'GCC_3.0'}, libpthread.so.0 with versions {'GLIBC_2.12',
'GLIBC_2.2.5', 'GLIBC_2.3.4', 'GLIBC_2.3.3', 'GLIBC_2.3.2'}, libc.so.6
with versions {'GLIBC_2.15', 'GLIBC_2.8', 'GLIBC_2.6', 'GLIBC_2.3',
'GLIBC_2.2.5', 'GLIBC_2.28', 'GLIBC_2.14', 'GLIBC_2.3.3', 'GLIBC_2.4',
'GLIBC_2.17', 'GLIBC_2.11', 'GLIBC_2.7', 'GLIBC_2.3.4', 'GLIBC_2.18',
'GLIBC_2.16', 'GLIBC_2.9', 'GLIBC_2.3.2'}, librt.so.1 with versions
{'GLIBC_2.2.5'}, libnppim.so.11 with versions {'libnppim.so.11'},
libcublas.so.11 with versions {'libcublas.so.11'}, libnppig.so.11 with
versions {'libnppig.so.11'}, libnppicc.so.11 with versions
{'libnppicc.so.11'}, libcusolver.so.10 with versions
{'libcusolver.so.10'}, libm.so.6 with versions {'GLIBC_2.2.5',
'GLIBC_2.29', 'GLIBC_2.27'}, libgomp.so.1 with versions {'GOMP_4.0',
'GOMP_4.5', 'GOMP_1.0', 'OMP_1.0'}, libdl.so.2 with versions
{'GLIBC_2.2.5'}, libstdc++.so.6 with versions {'GLIBCXX_3.4.21',
'GLIBCXX_3.4.9', 'GLIBCXX_3.4.17', 'CXXABI_1.3.2', 'GLIBCXX_3.4.20',
'GLIBCXX_3.4.14', 'GLIBCXX_3.4.15', 'GLIBCXX_3.4.10', 'CXXABI_1.3.3',
'GLIBCXX_3.4.22', 'CXXABI_1.3.9', 'GLIBCXX_3.4.19', 'GLIBCXX_3.4',
'GLIBCXX_3.4.18', 'CXXABI_1.3', 'CXXABI_1.3.11', 'CXXABI_1.3.8',
'CXXABI_1.3.5', 'GLIBCXX_3.4.11', 'GLIBCXX_3.4.26'}, libnppif.so.11
with versions {'libnppif.so.11'}, libnppc.so.11 with versions
{'libnppc.so.11'}, libcublasLt.so.11 with versions
{'libcublasLt.so.11'}

This constrains the platform tag to "linux_x86_64". In order to
achieve a more compatible tag, you would need to recompile a new wheel
from source on a system with earlier versions of these libraries, such
as a recent manylinux image.
```
Old wheel folder structure:
```
open3d-0.12.0-cp36-cp36m-manylinux2014_x86_64
├── open3d-0.12.0.data
│   ├── data
│   │   ├── etc
│   │   └── share
│   └── purelib
│       └── open3d
└── open3d-0.12.0.dist-info
    ├── LICENSE.txt
    ├── METADATA
    ├── RECORD
    ├── top_level.txt
    └── WHEEL
```

New folder structure:
```
lib/python_package/pip_package/open3d-0.12.0+90f52cde6-cp36-cp36m-manylinux_2_31_x86_64
├── open3d
│   ├── _build_config.py
│   ├── core.py
│   ├── cuda
│   ├── __init__.py
│   ├── libc++abi.so.1
│   ├── libc++.so.1
│   ├── ml
│   ├── resources
│   ├── visualization
│   └── web_visualizer.py
├── open3d-0.12.0+616937684.data
│   └── data    
|       ├── etc
|       └── share
└── open3d-0.12.0+90f52cde6.dist-info
    ├── LICENSE.txt
    ├── METADATA
    ├── RECORD
    ├── top_level.txt
    └── WHEEL
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3516)
<!-- Reviewable:end -->
