### PR TITLE
Add Clang 12 detection for Filament dependency

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -917,8 +917,8 @@ if(BUILD_GUI)
             endif()
             # If the default version is not sufficient, look for some specific versions
             if(NOT FILAMENT_C_COMPILER OR NOT FILAMENT_CXX_COMPILER)
-                find_program(CLANG_VERSIONED_CC NAMES clang-11 clang-10 clang-9 clang-8 clang-7)
-                find_program(CLANG_VERSIONED_CXX NAMES clang++11 clang++-10 clang++-9 clang++-8 clang++-7)
+                find_program(CLANG_VERSIONED_CC NAMES clang-12 clang-11 clang-10 clang-9 clang-8 clang-7)
+                find_program(CLANG_VERSIONED_CXX NAMES clang++-12 clang++11 clang++-10 clang++-9 clang++-8 clang++-7)
                 if (CLANG_VERSIONED_CC AND CLANG_VERSIONED_CXX)
                     set(FILAMENT_C_COMPILER "${CLANG_VERSIONED_CC}")
                     set(FILAMENT_CXX_COMPILER "${CLANG_VERSIONED_CXX}")
@@ -969,19 +969,13 @@ if(BUILD_GUI)
         # Find CLANG_LIBDIR if it is not defined. Mutiple paths will be searched.
         if (NOT CLANG_LIBDIR)
             find_library(CPPABI_LIBRARY c++abi PATH_SUFFIXES
-                         llvm-11/lib llvm-10/lib llvm-9/lib llvm-8/lib llvm-7/lib
+                         llvm-12/lib llvm-11/lib llvm-10/lib llvm-9/lib llvm-8/lib llvm-7/lib
                          REQUIRED)
             get_filename_component(CLANG_LIBDIR ${CPPABI_LIBRARY} DIRECTORY)
         endif()
         # Find clang libraries at the exact path ${CLANG_LIBDIR}.
         find_library(CPP_LIBRARY    c++    PATHS ${CLANG_LIBDIR} REQUIRED NO_DEFAULT_PATH)
         find_library(CPPABI_LIBRARY c++abi PATHS ${CLANG_LIBDIR} REQUIRED NO_DEFAULT_PATH)
-        if(CPP_LIBRARY-NOTFOUND)
-            message(FATAL_ERROR "CPP_LIBRARY-NOTFOUND")
-        endif()
-        if(CPPABI_LIBRARY-NOTFOUND)
-            message(FATAL_ERROR "CPPABI_LIBRARY-NOTFOUND")
-        endif()
         # Ensure that libstdc++ gets linked first
         target_link_libraries(3rdparty_filament INTERFACE -lstdc++
                               ${CPP_LIBRARY} ${CPPABI_LIBRARY})

--- a/cpp/open3d/utility/ParallelScan.h
+++ b/cpp/open3d/utility/ParallelScan.h
@@ -28,9 +28,28 @@
 
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_scan.h>
+
 #if TBB_INTERFACE_VERSION >= 10000
+
+// Check if the C++ standard library implements parallel algorithms
+// and use this over parallelstl to avoid conflicts.
+// Clang does not implement it so far, so checking for C++17 is not sufficient.
+#ifdef __cpp_lib_parallel_algorithm
+#include <execution>
+#include <numeric>
+#else
 #include <pstl/execution>
 #include <pstl/numeric>
+
+// parallelstl incorrectly assumes MSVC to unconditionally implement
+// parallel algorithms even if __cpp_lib_parallel_algorithm is not defined.
+// So manually include the header which pulls all "pstl::execution" definitions
+// into the "std" namespace.
+#if __PSTL_CPP17_EXECUTION_POLICIES_PRESENT
+#include <pstl/internal/glue_execution_defs.h>
+#endif
+
+#endif
 #endif
 
 namespace open3d {
@@ -66,7 +85,7 @@ template <class Tin, class Tout>
 void InclusivePrefixSum(const Tin* first, const Tin* last, Tout* out) {
 #if TBB_INTERFACE_VERSION >= 10000
     // use parallelstl if we have TBB 2018 or later
-    std::inclusive_scan(pstl::execution::par_unseq, first, last, out);
+    std::inclusive_scan(std::execution::par_unseq, first, last, out);
 #else
     ScanSumBody<Tin, Tout> body(out, first);
     size_t n = std::distance(first, last);


### PR DESCRIPTION
- Clang 12 has been released mid of April, so add detection for it in the Filament dependency setup
- Remove library check which is already handled by the `REQUIRED` keyword for CMake 3.18 and newer
- Fix `parallelstl` include if compiler has parallel algorithms support

Fixes #3520

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3522)
<!-- Reviewable:end -->
