### PR TITLE
fix using wrong pip module for installing the pip package

### DIFF
--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -304,6 +304,7 @@ add_custom_target(pip-package
 add_custom_target(install-pip-package
     COMMAND ${CMAKE_COMMAND}
             -DPYTHON_PACKAGE_DST_DIR=${PYTHON_PACKAGE_DST_DIR}
+            -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
             -P ${CMAKE_CURRENT_SOURCE_DIR}/make_install_pip_package.cmake
     DEPENDS pip-package
 )

--- a/cpp/pybind/make_install_pip_package.cmake
+++ b/cpp/pybind/make_install_pip_package.cmake
@@ -4,4 +4,4 @@
 # Note: Since `make python-package` clears PYTHON_COMPILED_MODULE_DIR every time,
 #       it is guaranteed that there is only one wheel in ${PYTHON_PACKAGE_DST_DIR}/pip_package/*.whl
 file(GLOB WHEEL_FILE "${PYTHON_PACKAGE_DST_DIR}/pip_package/*.whl")
-execute_process(COMMAND pip install ${WHEEL_FILE} -U)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install ${WHEEL_FILE} -U)


### PR DESCRIPTION
This PR ensures that the `install-pip-package` target uses the pip module that matches the python environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3524)
<!-- Reviewable:end -->
