### PR TITLE
Improve performance of Tensorflow and PyTorch modules

### DIFF
--- a/3rdparty/CMake/FindPytorch.cmake
+++ b/3rdparty/CMake/FindPytorch.cmake
@@ -20,21 +20,27 @@ if(NOT Pytorch_FOUND)
 
     message(STATUS "Getting PyTorch properties ...")
 
-    # Get Pytorch_VERSION
-    execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} "-c"
-                "import torch; print(torch.__version__, end='')"
-        OUTPUT_VARIABLE Pytorch_VERSION)
-
-    # Get Pytorch_ROOT
+    set(Pytorch_FETCH_PROPERTIES
+        "import os"
+        "import torch"
+        "print(torch.__version__, end=';')"
+        "print(os.path.dirname(torch.__file__), end=';')"
+        "print(torch._C._GLIBCXX_USE_CXX11_ABI, end=';')"
+    )
     execute_process(
         COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import os; import torch; print(os.path.dirname(torch.__file__), end='')"
-        OUTPUT_VARIABLE Pytorch_ROOT)
+            ${PYTHON_EXECUTABLE} "-c" "${Pytorch_FETCH_PROPERTIES}"
+        OUTPUT_VARIABLE PyTorch_PROPERTIES
+    )
+
+    list(GET PyTorch_PROPERTIES 0 Pytorch_VERSION)
+    list(GET PyTorch_PROPERTIES 1 Pytorch_ROOT)
+    list(GET PyTorch_PROPERTIES 2 Pytorch_CXX11_ABI)
+
+    unset(PyTorch_PROPERTIES)
 
     # Use the cmake config provided by torch
-    find_package(Torch REQUIRED PATHS "${Pytorch_ROOT}/share/cmake/Torch"
+    find_package(Torch REQUIRED PATHS "${Pytorch_ROOT}"
                  NO_DEFAULT_PATH)
 
     if(BUILD_CUDA_MODULE)
@@ -62,14 +68,6 @@ if(NOT Pytorch_FOUND)
         set_target_properties( torch_cuda PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
         set_target_properties( torch_cpu PROPERTIES INTERFACE_COMPILE_OPTIONS "" )
     endif()
-
-    # Get Pytorch_CXX11_ABI: True/False
-    execute_process(
-        COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import torch; print(torch._C._GLIBCXX_USE_CXX11_ABI, end='')"
-        OUTPUT_VARIABLE Pytorch_CXX11_ABI
-    )
 endif()
 
 message(STATUS "PyTorch         version: ${Pytorch_VERSION}")

--- a/3rdparty/CMake/FindTensorflow.cmake
+++ b/3rdparty/CMake/FindTensorflow.cmake
@@ -13,26 +13,30 @@ if(NOT Tensorflow_FOUND)
 
     message(STATUS "Getting TensorFlow properties ...")
 
-    # Get Tensorflow_VERSION
+    set(Tensorflow_FETCH_PROPERTIES
+        "import tensorflow as tf"
+        "print(tf.__version__, end=';')"
+        "print(tf.sysconfig.get_include(), end=';')"
+        "print(tf.sysconfig.get_lib(), end=';')"
+        "defs = [ x[2:] for x in tf.sysconfig.get_compile_flags() if x.startswith('-D')]; print('::'.join(defs), end=';')"
+        "print(tf.__cxx11_abi_flag__, end=';')"
+    )
     execute_process(
         COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import tensorflow as tf; print(tf.__version__, end='')"
-            OUTPUT_VARIABLE Tensorflow_VERSION)
+            ${PYTHON_EXECUTABLE} "-c" "${Tensorflow_FETCH_PROPERTIES}"
+        OUTPUT_VARIABLE Tensorflow_PROPERTIES
+    )
 
-    # Get Tensorflow_INCLUDE_DIR
-    execute_process(
-        COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import tensorflow as tf; print(tf.sysconfig.get_include(), end='')"
-        OUTPUT_VARIABLE Tensorflow_INCLUDE_DIR)
+    list(GET Tensorflow_PROPERTIES 0 Tensorflow_VERSION)
+    list(GET Tensorflow_PROPERTIES 1 Tensorflow_INCLUDE_DIR)
+    list(GET Tensorflow_PROPERTIES 2 Tensorflow_LIB_DIR)
+    list(GET Tensorflow_PROPERTIES 3 Tensorflow_DEFINITIONS)
+    list(GET Tensorflow_PROPERTIES 4 Tensorflow_CXX11_ABI)
 
-    # Get Tensorflow_LIB_DIR
-    execute_process(
-        COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import tensorflow as tf; print(tf.sysconfig.get_lib(), end='')"
-        OUTPUT_VARIABLE Tensorflow_LIB_DIR)
+    unset(Tensorflow_PROPERTIES)
+
+    # Decode definitions into a proper list
+    string(REGEX REPLACE "::" ";" Tensorflow_DEFINITIONS ${Tensorflow_DEFINITIONS})
 
     # Get Tensorflow_FRAMEWORK_LIB
     find_library(
@@ -40,22 +44,6 @@ if(NOT Tensorflow_FOUND)
         NAMES tensorflow_framework libtensorflow_framework.so.2
         PATHS "${Tensorflow_LIB_DIR}"
         NO_DEFAULT_PATH
-    )
-
-    # Get Tensorflow_DEFINITIONS
-    execute_process(
-        COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import tensorflow as tf; defs = [ x[2:] for x in tf.sysconfig.get_compile_flags() if x.startswith('-D')]; print(';'.join(defs), end='')"
-        OUTPUT_VARIABLE Tensorflow_DEFINITIONS
-    )
-
-    # Get TensorFlow CXX11_ABI: 0/1
-    execute_process(
-        COMMAND
-            ${PYTHON_EXECUTABLE} "-c"
-            "import tensorflow; print(tensorflow.__cxx11_abi_flag__, end='')"
-        OUTPUT_VARIABLE Tensorflow_CXX11_ABI
     )
 endif()
 


### PR DESCRIPTION
Retrieving properties from Tensorflow and Pytorch in our find modules is expensive because calling Python and importing either of them comes with a significant cost. Improve the performance by fetching all required properties in a single pass instead of 1 property per pass:

`time cmake -DCMAKE_INSTALL_PREFIX=../bin -DBUILD_CUDA_MODULE=ON -DBUILD_UNIT_TESTS=ON -DBUILD_BENCHMARKS=ON -DBUILD_PYTORCH_OPS=ON -DBUILD_TENSORFLOW_OPS=ON -DBUNDLE_OPEN3D_ML=ON -DOPEN3D_ML_ROOT=../../Open3D-ML -DOPEN3D_THIRD_PARTY_DOWNLOAD_DIR=~/workspace/open3d-downloads -DBUILD_JUPYTER_EXTENSION=ON -DBUILD_RPC_INTERFACE=ON -DBUILD_LIBREALSENSE=ON -DBUILD_AZURE_KINECT=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..`

#### Before
real    0m19,039s
user    0m21,909s
sys     0m22,577s

#### After
real    0m9,561s
user    0m8,882s
sys     0m6,575s

In a future PR, the performance could be improved even further by only calling the find modules once instead of twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3550)
<!-- Reviewable:end -->
