### PR TITLE
Use same warning level in python bindings

### DIFF
--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -63,6 +63,8 @@ target_include_directories(pybind SYSTEM PRIVATE
     ${PYBIND11_INCLUDE_DIR}
     ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
 )
+
+open3d_show_and_abort_on_warning(pybind)
 open3d_set_global_properties(pybind)
 
 if (WIN32)

--- a/cpp/pybind/core/tensor_accessor.cpp
+++ b/cpp/pybind/core/tensor_accessor.cpp
@@ -164,7 +164,7 @@ static void pybind_getitem(py::class_<Tensor>& tensor) {
     // E.g. a[1:2, [3, 4, 5], 3:10] results in a tuple of size 3.
     tensor.def("__getitem__", [](const Tensor& tensor, const py::tuple& key) {
         std::vector<TensorKey> tks;
-        for (const py::handle& item : key) {
+        for (const py::handle item : key) {
             tks.push_back(PyHandleToTensorKey(item));
         }
         return tensor.GetItem(tks);
@@ -223,7 +223,7 @@ static void pybind_setitem(py::class_<Tensor>& tensor) {
     tensor.def("__setitem__", [](Tensor& tensor, const py::tuple& key,
                                  const py::handle& value) {
         std::vector<TensorKey> tks;
-        for (const py::handle& item : key) {
+        for (const py::handle item : key) {
             tks.push_back(PyHandleToTensorKey(item));
         }
         return tensor.SetItem(tks, PyHandleToTensor(value, tensor.GetDtype(),

--- a/cpp/pybind/core/tensor_converter.cpp
+++ b/cpp/pybind/core/tensor_converter.cpp
@@ -255,7 +255,7 @@ Tensor PyHandleToTensor(const py::handle& handle,
 
 SizeVector PyTupleToSizeVector(const py::tuple& tuple) {
     SizeVector shape;
-    for (const py::handle& item : tuple) {
+    for (const py::handle item : tuple) {
         if (std::string(py::str(item.get_type())) == "<class 'int'>") {
             shape.push_back(static_cast<int64_t>(item.cast<py::int_>()));
         } else {
@@ -269,7 +269,7 @@ SizeVector PyTupleToSizeVector(const py::tuple& tuple) {
 
 SizeVector PyListToSizeVector(const py::list& list) {
     SizeVector shape;
-    for (const py::handle& item : list) {
+    for (const py::handle item : list) {
         if (std::string(py::str(item.get_type())) == "<class 'int'>") {
             shape.push_back(static_cast<int64_t>(item.cast<py::int_>()));
         } else {

--- a/cpp/pybind/ml/contrib/contrib_subsample.cpp
+++ b/cpp/pybind/ml/contrib/contrib_subsample.cpp
@@ -191,7 +191,8 @@ const py::tuple SubsampleBatch(py::array points,
     // Wrap result subsampled_classes. Data will be copied.
     core::Tensor subsampled_classes_t;
     if (classes.has_value()) {
-        if (subsampled_classes.size() != num_subsampled_points) {
+        if (static_cast<int64_t>(subsampled_classes.size()) !=
+            num_subsampled_points) {
             utility::LogError(
                     "Error: subsampled_classes.size() {} != "
                     "num_subsampled_points {}.",
@@ -338,7 +339,8 @@ const py::object Subsample(py::array points,
     // Wrap result subsampled_classes. Data will be copied.
     core::Tensor subsampled_classes_t;
     if (classes.has_value()) {
-        if (subsampled_classes.size() != num_subsampled_points) {
+        if (static_cast<int64_t>(subsampled_classes.size()) !=
+            num_subsampled_points) {
             utility::LogError(
                     "Error: subsampled_classes.size() {} != "
                     "num_subsampled_points {}.",

--- a/cpp/pybind/utility/eigen.cpp
+++ b/cpp/pybind/utility/eigen.cpp
@@ -56,7 +56,7 @@ py::class_<Vector, holder_type> bind_vector_without_repr(
 template <typename EigenVector>
 std::vector<EigenVector> py_array_to_vectors_double(
         py::array_t<double, py::array::c_style | py::array::forcecast> array) {
-    size_t eigen_vector_size = EigenVector::SizeAtCompileTime;
+    int64_t eigen_vector_size = EigenVector::SizeAtCompileTime;
     if (array.ndim() != 2 || array.shape(1) != eigen_vector_size) {
         throw py::cast_error();
     }
@@ -74,7 +74,7 @@ std::vector<EigenVector> py_array_to_vectors_double(
 template <typename EigenVector>
 std::vector<EigenVector> py_array_to_vectors_int(
         py::array_t<int, py::array::c_style | py::array::forcecast> array) {
-    size_t eigen_vector_size = EigenVector::SizeAtCompileTime;
+    int64_t eigen_vector_size = EigenVector::SizeAtCompileTime;
     if (array.ndim() != 2 || array.shape(1) != eigen_vector_size) {
         throw py::cast_error();
     }
@@ -91,7 +91,7 @@ template <typename EigenVector,
 std::vector<EigenVector, EigenAllocator>
 py_array_to_vectors_int_eigen_allocator(
         py::array_t<int, py::array::c_style | py::array::forcecast> array) {
-    size_t eigen_vector_size = EigenVector::SizeAtCompileTime;
+    int64_t eigen_vector_size = EigenVector::SizeAtCompileTime;
     if (array.ndim() != 2 || array.shape(1) != eigen_vector_size) {
         throw py::cast_error();
     }
@@ -108,7 +108,7 @@ template <typename EigenVector,
 std::vector<EigenVector, EigenAllocator>
 py_array_to_vectors_int64_eigen_allocator(
         py::array_t<int64_t, py::array::c_style | py::array::forcecast> array) {
-    size_t eigen_vector_size = EigenVector::SizeAtCompileTime;
+    int64_t eigen_vector_size = EigenVector::SizeAtCompileTime;
     if (array.ndim() != 2 || array.shape(1) != eigen_vector_size) {
         throw py::cast_error();
     }


### PR DESCRIPTION
We already use the increased warning level for the core library as well as for tests, examples, etc. The `pybind` target should also follow that standard and maintain that high quality level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3551)
<!-- Reviewable:end -->
