### PR TITLE
Add batch support for fixed_radius_search and SparseConvolution in tensorflow

### DIFF
--- a/python/open3d/ml/tf/python/layers/convolutions.py
+++ b/python/open3d/ml/tf/python/layers/convolutions.py
@@ -545,11 +545,11 @@ class SparseConv(tf.keras.layers.Layer):
         if inp_importance is None:
             inp_importance = tf.ones((0,), dtype=tf.float32)
 
-        if type(inp_positions) != type(inp_features) or type(
-                inp_positions) != type(out_positions):
-            raise Exception(
-                "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
-            )
+        if isinstance(inp_features, tf.RaggedTensor):
+            assert (
+                isinstance(inp_positions, tf.RaggedTensor) and
+                isinstance(out_positions, tf.RaggedTensor)
+            ), "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
 
         hash_table_size_factor = 1 / 64
         self.nns = self.fixed_radius_search(
@@ -762,11 +762,11 @@ class SparseConvTranspose(tf.keras.layers.Layer):
 
         empty_vec = tf.ones((0,), dtype=tf.float32)
 
-        if type(inp_positions) != type(inp_features) or type(
-                inp_positions) != type(out_positions):
-            raise Exception(
-                "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
-            )
+        if isinstance(inp_features, tf.RaggedTensor):
+            assert (
+                isinstance(inp_positions, tf.RaggedTensor) and
+                isinstance(out_positions, tf.RaggedTensor)
+            ), "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
 
         hash_table_size_factor = 1 / 64
         self.nns_inp = self.fixed_radius_search(

--- a/python/open3d/ml/tf/python/layers/convolutions.py
+++ b/python/open3d/ml/tf/python/layers/convolutions.py
@@ -545,6 +545,12 @@ class SparseConv(tf.keras.layers.Layer):
         if inp_importance is None:
             inp_importance = tf.ones((0,), dtype=tf.float32)
 
+        if type(inp_positions) != type(inp_features) or type(
+                inp_positions) != type(out_positions):
+            raise Exception(
+                "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+            )
+
         hash_table_size_factor = 1 / 64
         self.nns = self.fixed_radius_search(
             inp_positions,
@@ -552,6 +558,13 @@ class SparseConv(tf.keras.layers.Layer):
             radius=self.kernel_size[0] * voxel_size * 0.51,
             hash_table_size_factor=hash_table_size_factor,
             hash_table=fixed_radius_search_hash_table)
+
+        out_positions_split = None
+        if isinstance(inp_positions, tf.RaggedTensor):
+            inp_positions = inp_positions.values
+            inp_features = inp_features.values
+            out_positions_split = out_positions.row_splits
+            out_positions = out_positions.values
 
         # for stats and debugging
         num_pairs = tf.shape(self.nns.neighbors_index)[0]
@@ -583,6 +596,10 @@ class SparseConv(tf.keras.layers.Layer):
         if self.use_bias:
             out_features += self.bias
         out_features = self.activation(out_features)
+
+        if out_positions_split is not None:
+            out_features = tf.RaggedTensor.from_row_splits(
+                values=out_features, row_splits=out_positions_split)
 
         return out_features
 
@@ -745,6 +762,12 @@ class SparseConvTranspose(tf.keras.layers.Layer):
 
         empty_vec = tf.ones((0,), dtype=tf.float32)
 
+        if type(inp_positions) != type(inp_features) or type(
+                inp_positions) != type(out_positions):
+            raise Exception(
+                "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+            )
+
         hash_table_size_factor = 1 / 64
         self.nns_inp = self.fixed_radius_search(
             out_positions,
@@ -752,6 +775,13 @@ class SparseConvTranspose(tf.keras.layers.Layer):
             radius=self.kernel_size[0] * voxel_size * 0.51,
             hash_table_size_factor=hash_table_size_factor,
             hash_table=fixed_radius_search_hash_table)
+
+        out_positions_split = None
+        if isinstance(inp_positions, tf.RaggedTensor):
+            inp_positions = inp_positions.values
+            inp_features = inp_features.values
+            out_positions_split = out_positions.row_splits
+            out_positions = out_positions.values
 
         num_out = tf.shape(out_positions, out_type=tf.int64)[0]
 
@@ -792,6 +822,10 @@ class SparseConvTranspose(tf.keras.layers.Layer):
         if self.use_bias:
             out_features += self.bias
         out_features = self.activation(out_features)
+
+        if out_positions_split is not None:
+            out_features = tf.RaggedTensor.from_row_splits(
+                values=out_features, row_splits=out_positions_split)
 
         return out_features
 

--- a/python/open3d/ml/tf/python/layers/convolutions.py
+++ b/python/open3d/ml/tf/python/layers/convolutions.py
@@ -546,10 +546,11 @@ class SparseConv(tf.keras.layers.Layer):
             inp_importance = tf.ones((0,), dtype=tf.float32)
 
         if isinstance(inp_features, tf.RaggedTensor):
-            assert (
-                isinstance(inp_positions, tf.RaggedTensor) and
-                isinstance(out_positions, tf.RaggedTensor)
-            ), "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+            if not (isinstance(inp_positions, tf.RaggedTensor) and
+                    isinstance(out_positions, tf.RaggedTensor)):
+                raise Exception(
+                    "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+                )
 
         hash_table_size_factor = 1 / 64
         self.nns = self.fixed_radius_search(
@@ -763,10 +764,11 @@ class SparseConvTranspose(tf.keras.layers.Layer):
         empty_vec = tf.ones((0,), dtype=tf.float32)
 
         if isinstance(inp_features, tf.RaggedTensor):
-            assert (
-                isinstance(inp_positions, tf.RaggedTensor) and
-                isinstance(out_positions, tf.RaggedTensor)
-            ), "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+            if not (isinstance(inp_positions, tf.RaggedTensor) and
+                    isinstance(out_positions, tf.RaggedTensor)):
+                raise Exception(
+                    "All of inp_positions, inp_features and out_positions must be tf.Tensor, or tf.RaggedTensor"
+                )
 
         hash_table_size_factor = 1 / 64
         self.nns_inp = self.fixed_radius_search(

--- a/python/open3d/ml/tf/python/layers/neighbor_search.py
+++ b/python/open3d/ml/tf/python/layers/neighbor_search.py
@@ -34,6 +34,8 @@ class FixedRadiusSearch(tf.keras.layers.Layer):
     """Fixed radius search for 3D point clouds.
 
     This layer computes the neighbors for a fixed radius on a point cloud.
+    For batch support, you can either pass 'points' and 'queries' as RaggedTensor,
+    or pass the 'row_splits' information.
 
     Example:
       This example shows a neighbor search that returns the indices to the
@@ -89,10 +91,10 @@ class FixedRadiusSearch(tf.keras.layers.Layer):
 
         Arguments:
 
-          points: The 3D positions of the input points. *This argument must be
-            given as a positional argument!*
+          points: The 3D positions of the input points. It can be a RaggedTensor.
+          *This argument must be given as a positional argument!*
 
-          queries: The 3D positions of the query points.
+          queries: The 3D positions of the query points. It can be a RaggedTensor.
 
           radius: A scalar with the neighborhood radius
 
@@ -129,6 +131,13 @@ class FixedRadiusSearch(tf.keras.layers.Layer):
             Note that the distances are squared if metric is L2.
             This is a zero length Tensor if 'return_distances' is False.
         """
+        if isinstance(points, tf.RaggedTensor):
+            points_row_splits = points.row_splits
+            points = points.values
+        if isinstance(queries, tf.RaggedTensor):
+            queries_row_splits = queries.row_splits
+            queries = queries.values
+
         if points_row_splits is None:
             points_row_splits = tf.cast(tf.stack([0, tf.shape(points)[0]]),
                                         dtype=tf.int64)

--- a/python/test/ml_ops/test_sparseconv.py
+++ b/python/test/ml_ops/test_sparseconv.py
@@ -149,6 +149,141 @@ def test_compare_to_conv3d(ml, dtype, kernel_size, out_channels, in_channels,
 
 
 # yapf: disable
+@pytest.mark.parametrize("kernel_size, out_channels, in_channels, with_inp_importance, with_normalization, batch_size",[
+                             ([1,1,1],            2,           7,                True,              False,          2),
+                             ([2,2,2],            1,           1,               False,              False,          3),
+                             ([3,3,3],            4,           2,                True,               True,          3),
+                             ([4,4,4],            3,           4,                True,               True,          8),
+                             ([5,5,5],            5,           3,               False,               True,          8),
+                        ])
+# yapf: enable
+@mltest.parametrize.ml
+@pytest.mark.parametrize('dtype', [np.float32])
+def test_compare_to_conv3d_batches(ml, dtype, kernel_size, out_channels,
+                                   in_channels, with_inp_importance,
+                                   with_normalization, batch_size):
+    """Compares to the 3D convolution in tensorflow"""
+    # the problem is specific to tensorflow
+    if ml.module.__name__ != 'tensorflow':
+        return
+
+    # This test requires tensorflow
+    try:
+        import tensorflow as tf
+    except ImportError:
+        return
+
+    np.random.seed(0)
+
+    filters = np.random.random(size=(*kernel_size, in_channels,
+                                     out_channels)).astype(dtype)
+    bias = np.random.random(size=(out_channels,)).astype(dtype)
+
+    max_grid_extent = 10
+
+    # create array defining start and end of each batch
+    inp_positions_row_splits = np.zeros(shape=(batch_size + 1,), dtype=np.int64)
+    out_positions_row_splits = np.zeros(shape=(batch_size + 1,), dtype=np.int64)
+    for i in range(batch_size - 1):
+        inp_positions_row_splits[
+            i + 1] = np.random.randint(15) + inp_positions_row_splits[i]
+        out_positions_row_splits[
+            i + 1] = np.random.randint(15) + out_positions_row_splits[i]
+
+    inp_positions = np.unique(np.random.randint(0, max_grid_extent,
+                                                (256, 3)).astype(dtype),
+                              axis=0)
+    inp_positions_int = inp_positions.astype(np.int32)
+
+    inp_positions_row_splits[-1] = inp_positions.shape[0]
+
+    if with_inp_importance:
+        inp_importance = np.random.rand(
+            inp_positions.shape[0]).astype(dtype) - 0.5
+    else:
+        inp_importance = np.empty((0,), dtype=dtype)
+    out_positions = np.unique(np.random.randint(
+        np.max(kernel_size) // 2, max_grid_extent - np.max(kernel_size) // 2,
+        (256, 3)).astype(dtype),
+                              axis=0)
+    out_positions_int = out_positions.astype(np.int32)
+    out_positions_row_splits[-1] = out_positions.shape[0]
+
+    voxel_size = 0.2
+
+    inp_features = np.random.uniform(size=inp_positions.shape[0:1] +
+                                     (in_channels,)).astype(dtype)
+
+    kernel_initializer = tf.constant_initializer(filters)
+    bias_initializer = tf.constant_initializer(bias)
+
+    sparse_conv = ml.layers.SparseConv(in_channels=in_channels,
+                                       filters=out_channels,
+                                       kernel_size=kernel_size,
+                                       normalize=with_normalization,
+                                       kernel_initializer=kernel_initializer,
+                                       bias_initializer=bias_initializer)
+
+    inp_positions = tf.RaggedTensor.from_row_splits(
+        values=inp_positions, row_splits=inp_positions_row_splits)
+    out_positions = tf.RaggedTensor.from_row_splits(
+        values=out_positions, row_splits=out_positions_row_splits)
+    inp_features = tf.RaggedTensor.from_row_splits(
+        values=inp_features, row_splits=inp_positions_row_splits)
+
+    y = mltest.run_op(ml, ml.device, True, sparse_conv, inp_features,
+                      inp_positions * voxel_size, out_positions * voxel_size,
+                      voxel_size, inp_importance)
+    for idx in range(batch_size):
+        inp_pos = inp_positions[idx].numpy()
+        inp_feat = inp_features[idx].numpy()
+        out_pos = out_positions[idx].numpy()
+        inp_pos_int = inp_pos.astype(np.int32)
+        out_pos_int = out_pos.astype(np.int32)
+        y_out = y[idx]
+
+        # Compare the output to a standard 3d conv
+        # store features in a volume to use standard 3d convs
+        inp_volume = np.zeros(
+            (1, max_grid_extent, max_grid_extent, max_grid_extent, in_channels),
+            dtype=dtype)
+
+        if with_inp_importance:
+            inp_feat *= inp_importance[
+                inp_positions_row_splits[idx]:inp_positions_row_splits[idx + 1],
+                np.newaxis]
+        inp_volume[0, inp_pos_int[:, 2], inp_pos_int[:, 1],
+                   inp_pos_int[:, 0], :] = inp_feat
+
+        conv3d = tf.keras.layers.Conv3D(
+            out_channels,
+            kernel_size,
+            kernel_initializer=tf.constant_initializer(filters),
+            use_bias=False,
+            padding='same')
+        y_conv3d = conv3d(inp_volume).numpy()
+
+        # extract result at output positions
+        y_conv3d = np.ascontiguousarray(y_conv3d[0, out_pos_int[:, 2],
+                                                 out_pos_int[:, 1],
+                                                 out_pos_int[:, 0], :])
+        # raise Exception(y_conv3d.shape, out_positions_row_splits)
+        if with_normalization:
+            for i, v in enumerate(y_conv3d):
+                num_neighbors = mltest.to_numpy(
+                    sparse_conv.nns.neighbors_row_splits[
+                        out_positions_row_splits[idx] + i + 1] -
+                    sparse_conv.nns.neighbors_row_splits[
+                        out_positions_row_splits[idx] + i])
+                if num_neighbors > 0:
+                    v /= dtype(num_neighbors)
+
+        y_conv3d += bias
+
+        np.testing.assert_allclose(y_out, y_conv3d, rtol=1e-3, atol=1e-5)
+
+
+# yapf: disable
 @pytest.mark.parametrize("kernel_size, out_channels, in_channels, with_out_importance, with_normalization",[
                              ([1,1,1],            2,           7,                True,              False),
                              ([2,2,2],            1,           1,               False,              False),

--- a/python/test/ml_ops/test_sparseconv.py
+++ b/python/test/ml_ops/test_sparseconv.py
@@ -193,7 +193,6 @@ def test_compare_to_conv3d_batches(ml, dtype, kernel_size, out_channels,
     inp_positions = np.unique(np.random.randint(0, max_grid_extent,
                                                 (256, 3)).astype(dtype),
                               axis=0)
-    inp_positions_int = inp_positions.astype(np.int32)
 
     inp_positions_row_splits[-1] = inp_positions.shape[0]
 
@@ -206,7 +205,6 @@ def test_compare_to_conv3d_batches(ml, dtype, kernel_size, out_channels,
         np.max(kernel_size) // 2, max_grid_extent - np.max(kernel_size) // 2,
         (256, 3)).astype(dtype),
                               axis=0)
-    out_positions_int = out_positions.astype(np.int32)
     out_positions_row_splits[-1] = out_positions.shape[0]
 
     voxel_size = 0.2
@@ -267,7 +265,6 @@ def test_compare_to_conv3d_batches(ml, dtype, kernel_size, out_channels,
         y_conv3d = np.ascontiguousarray(y_conv3d[0, out_pos_int[:, 2],
                                                  out_pos_int[:, 1],
                                                  out_pos_int[:, 0], :])
-        # raise Exception(y_conv3d.shape, out_positions_row_splits)
         if with_normalization:
             for i, v in enumerate(y_conv3d):
                 num_neighbors = mltest.to_numpy(
@@ -399,3 +396,141 @@ def test_compare_to_conv3dtranspose(ml, dtype, kernel_size, out_channels,
     y_conv3d += bias
 
     np.testing.assert_allclose(y, y_conv3d, rtol=1e-3, atol=1e-8)
+
+
+# yapf: disable
+@pytest.mark.parametrize("kernel_size, out_channels, in_channels, with_out_importance, with_normalization, batch_size",[
+                             ([1,1,1],            2,           7,                True,              False,          2),
+                             ([2,2,2],            1,           1,               False,              False,          3),
+                             ([3,3,3],            4,           2,                True,               True,          3),
+                             ([4,4,4],            3,           4,                True,               True,          8),
+                             ([5,5,5],            5,           3,               False,               True,          8),
+                        ])
+# yapf: enable
+@mltest.parametrize.ml
+@pytest.mark.parametrize('dtype', [np.float32])
+def test_compare_to_conv3dtranspose_batches(ml, dtype, kernel_size,
+                                            out_channels, in_channels,
+                                            with_out_importance,
+                                            with_normalization, batch_size):
+    """Compares to the 3D convolution in tensorflow"""
+    # the problem is specific to tensorflow
+    if ml.module.__name__ != 'tensorflow':
+        return
+
+    # This test requires tensorflow
+    try:
+        import tensorflow as tf
+    except ImportError:
+        return
+
+    np.random.seed(0)
+
+    filters = np.random.random(size=(*kernel_size, in_channels,
+                                     out_channels)).astype(dtype)
+    bias = np.random.random(size=(out_channels,)).astype(dtype)
+
+    max_grid_extent = 10
+
+    # create array defining start and end of each batch
+    inp_positions_row_splits = np.zeros(shape=(batch_size + 1,), dtype=np.int64)
+    out_positions_row_splits = np.zeros(shape=(batch_size + 1,), dtype=np.int64)
+    for i in range(batch_size - 1):
+        inp_positions_row_splits[
+            i + 1] = np.random.randint(15) + inp_positions_row_splits[i]
+        out_positions_row_splits[
+            i + 1] = np.random.randint(15) + out_positions_row_splits[i]
+
+    inp_positions = np.unique(np.random.randint(0, max_grid_extent,
+                                                (512, 3)).astype(dtype),
+                              axis=0)
+
+    inp_positions_row_splits[-1] = inp_positions.shape[0]
+
+    out_positions = np.unique(np.random.randint(
+        np.max(kernel_size) // 2, max_grid_extent - np.max(kernel_size) // 2,
+        (256, 3)).astype(dtype),
+                              axis=0)
+    out_positions_row_splits[-1] = out_positions.shape[0]
+
+    if with_out_importance:
+        out_importance = np.random.rand(
+            out_positions.shape[0]).astype(dtype) - 0.5
+    else:
+        out_importance = np.empty((0,), dtype=dtype)
+
+    voxel_size = 0.2
+
+    inp_features = np.random.uniform(size=inp_positions.shape[0:1] +
+                                     (in_channels,)).astype(dtype)
+
+    kernel_initializer = tf.constant_initializer(filters)
+    bias_initializer = tf.constant_initializer(bias)
+
+    sparse_conv_transpose = ml.layers.SparseConvTranspose(
+        in_channels=in_channels,
+        filters=out_channels,
+        kernel_size=kernel_size,
+        normalize=with_normalization,
+        kernel_initializer=kernel_initializer,
+        bias_initializer=bias_initializer)
+
+    inp_positions = tf.RaggedTensor.from_row_splits(
+        values=inp_positions, row_splits=inp_positions_row_splits)
+    out_positions = tf.RaggedTensor.from_row_splits(
+        values=out_positions, row_splits=out_positions_row_splits)
+    inp_features = tf.RaggedTensor.from_row_splits(
+        values=inp_features, row_splits=inp_positions_row_splits)
+
+    y = mltest.run_op(ml, ml.device, True, sparse_conv_transpose, inp_features,
+                      inp_positions * voxel_size, out_positions * voxel_size,
+                      voxel_size, out_importance)
+    for idx in range(batch_size):
+        inp_pos = inp_positions[idx].numpy()
+        inp_feat = inp_features[idx].numpy()
+        out_pos = out_positions[idx].numpy()
+        inp_pos_int = inp_pos.astype(np.int32)
+        out_pos_int = out_pos.astype(np.int32)
+        y_out = y[idx]
+
+        # Compare the output to a standard 3d conv
+        # store features in a volume to use standard 3d convs
+        inp_volume = np.zeros(
+            (1, max_grid_extent, max_grid_extent, max_grid_extent, in_channels),
+            dtype=dtype)
+
+        if with_normalization:
+            for i, v in enumerate(inp_feat):
+                num_neighbors = mltest.to_numpy(
+                    sparse_conv_transpose.nns_inp.neighbors_row_splits[
+                        inp_positions_row_splits[idx] + i + 1] -
+                    sparse_conv_transpose.nns_inp.neighbors_row_splits[
+                        inp_positions_row_splits[idx] + i])
+                if num_neighbors:
+                    v /= dtype(num_neighbors)
+
+        inp_volume[0, inp_pos_int[:, 2], inp_pos_int[:, 1],
+                   inp_pos_int[:, 0], :] = inp_feat
+
+        conv3d = tf.keras.layers.Conv3DTranspose(
+            out_channels,
+            kernel_size,
+            kernel_initializer=tf.constant_initializer(
+                filters.transpose([0, 1, 2, 4, 3])),
+            use_bias=False,
+            padding='same')
+        y_conv3d = conv3d(inp_volume).numpy()
+
+        # extract result at output positions
+        y_conv3d = np.ascontiguousarray(y_conv3d[0, out_pos_int[:, 2],
+                                                 out_pos_int[:, 1],
+                                                 out_pos_int[:, 0], :])
+
+        if with_out_importance:
+            y_conv3d *= out_importance[
+                out_positions_row_splits[idx]:out_positions_row_splits[idx + 1],
+                np.newaxis]
+
+        y_conv3d += bias
+
+        np.testing.assert_allclose(y_out, y_conv3d, rtol=1e-3, atol=1e-5)


### PR DESCRIPTION
1) Added `tf.RaggedTensor` support for Fixed Radius Search, SparseConv and SparseConvTranspose layers.
2) Enabled batching support for same ops in tensorflow.
3) Added unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3553)
<!-- Reviewable:end -->
