### PR TITLE
Clarify minimum required CUDA version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,11 +380,9 @@ if(BUILD_CUDA_MODULE)
         elseif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.0")
             set(CMAKE_CUDA_ARCHITECTURES 35-real 37-real 50-real 52-real 53-real
                 60-real 61-real 62-real 70-real 72-real 75-real 80)
-        elseif(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "10.0")
+        else()
             set(CMAKE_CUDA_ARCHITECTURES 30-real 32-real 35-real 37-real 50-real
                 52-real 53-real 60-real 61-real 62-real 70-real 72-real 75)
-        else()
-            message(STATUS "Old CUDA <10.0 detected. Falling back to CMake's default architectures.")
         endif()
     else()
         if(CMAKE_CUDA_ARCHITECTURES)
@@ -431,6 +429,10 @@ if(BUILD_CUDA_MODULE)
 
     message(STATUS "CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
     enable_language(CUDA)
+
+    if (CMAKE_CUDA_COMPILER MATCHES "NVCC" AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.1")
+        message(FATAL_ERROR "CUDA 10.0 and older are not supported. Please upgrade to CUDA 10.1 or newer.")
+    endif()
 endif ()
 
 # OS specific settings

--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -27,12 +27,7 @@ if (${PYTHON_VERSION_MAJOR} EQUAL 2)
 endif()
 
 
-# NO_EXTRAS disables LTO which causes problems during link with nvcc 9.x
-if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.0.0")
-    pybind11_add_module(pybind NO_EXTRAS)
-else()
-    pybind11_add_module(pybind)
-endif()
+pybind11_add_module(pybind)
 
 add_subdirectory(camera)
 add_subdirectory(core)

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -25,7 +25,7 @@ System requirements
   * macOS: Install with Homebrew: ``brew install cmake``
   * Windows: Download from: `CMake download page <https://cmake.org/download/>`_
 
-* CUDA (optional): Open3D supports GPU acceleration of an increasing number
+* CUDA 10.1+ (optional): Open3D supports GPU acceleration of an increasing number
   of operations through CUDA on Linux. We recommend using CUDA 11.0 for the
   best compatibility with recent GPUs and optional external dependencies such
   as Tensorflow or PyTorch.


### PR DESCRIPTION
- State minimum supported version in documentation to be CUDA 10.1
- Remove workarounds for older CUDA versions
- Add compiler check and abort if too old CUDA version is detected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3575)
<!-- Reviewable:end -->
