### PR TITLE
Test for -load_hidden flag

### DIFF
--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -217,14 +217,16 @@ endfunction()
 set(OPEN3D_HIDDEN_3RDPARTY_LINK_OPTIONS)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
-    find_library(LexLIB libl.a)    # test archive
+    find_library(LexLIB libl.a)    # test archive in macOS
     if (LexLIB)
         include(CheckCXXSourceCompiles)
         set(CMAKE_REQUIRED_LINK_OPTIONS -load_hidden ${LexLIB})
         check_cxx_source_compiles("int main() {return 0;}" FLAG_load_hidden)
-    else()
-        set(FLAG_load_hidden 0 CACHE)
+        unset(CMAKE_REQUIRED_LINK_OPTIONS)
     endif()
+endif()
+if (NOT FLAG_load_hidden)
+    set(FLAG_load_hidden 0)
 endif()
 
 # import_3rdparty_library(name ...)

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -216,6 +216,17 @@ endfunction()
 # party dependencies. Only needed with GCC, not AppleClang.
 set(OPEN3D_HIDDEN_3RDPARTY_LINK_OPTIONS)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
+    find_library(LexLIB libl.a)    # test archive
+    if (LexLIB)
+        include(CheckCXXSourceCompiles)
+        set(CMAKE_REQUIRED_LINK_OPTIONS -load_hidden ${LexLIB})
+        check_cxx_source_compiles("int main() {return 0;}" FLAG_load_hidden)
+    else()
+        set(FLAG_load_hidden 0 CACHE)
+    endif()
+endif()
+
 # import_3rdparty_library(name ...)
 #
 # Imports a third-party library that has been built independently in a sub project.
@@ -288,7 +299,7 @@ function(import_3rdparty_library name)
             endif()
             # Apple compiler ld
             target_link_libraries(${name} INTERFACE
-                "$<BUILD_INTERFACE:$<$<AND:${HIDDEN},$<CXX_COMPILER_ID:AppleClang>>:-load_hidden >${arg_LIB_DIR}/${library_filename}>")
+                "$<BUILD_INTERFACE:$<$<AND:${HIDDEN},${FLAG_load_hidden}>:-load_hidden >${arg_LIB_DIR}/${library_filename}>")
             if(NOT BUILD_SHARED_LIBS OR arg_PUBLIC)
                 install(FILES ${arg_LIB_DIR}/${library_filename}
                     DESTINATION ${Open3D_INSTALL_LIB_DIR}


### PR DESCRIPTION
Prevent build failures on older AppleClang compilers where the linker flag is absent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3576)
<!-- Reviewable:end -->
