### PR TITLE
Cleanup ssh key individually for each GCE run when deleting VM

### DIFF
--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -121,7 +121,6 @@ create-vm)
             --zone="${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
             --accelerator="$GCE_GPU" \
             --maintenance-policy=TERMINATE \
-            --metadata enable-oslogin=TRUE \
             --machine-type=$GCE_INSTANCE_TYPE \
             --boot-disk-size=$GCE_BOOT_DISK_SIZE \
             --boot-disk-type=$GCE_BOOT_DISK_TYPE \
@@ -158,6 +157,8 @@ delete-image)
 
 delete-vm)
     gcloud compute instances delete "${GCE_INSTANCE}" --zone "${GCE_INSTANCE_ZONE[$GCE_ZID]}"
+    # Remove ssh key to prevent metadata buildup in login profile
+    gcloud compute os-login ssh-keys remove --key-file "${HOME}"/.ssh/google_compute_engine.pub
     ;;
 
 ssh-vm)

--- a/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
+++ b/util/docker/open3d-gpu/scripts/gce-ubuntu-docker-run.sh
@@ -63,11 +63,6 @@ case "$1" in
 gcloud-setup)
     gcloud auth configure-docker
     gcloud info
-    # https://github.com/kyma-project/test-infra/issues/93#issuecomment-457263589
-    for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do
-        echo "Removing ssh key"
-        gcloud compute os-login ssh-keys remove --key $i || true
-    done
     ;;
 
     # Build the Docker image
@@ -126,6 +121,7 @@ create-vm)
             --zone="${GCE_INSTANCE_ZONE[$GCE_ZID]}" \
             --accelerator="$GCE_GPU" \
             --maintenance-policy=TERMINATE \
+            --metadata enable-oslogin=TRUE \
             --machine-type=$GCE_INSTANCE_TYPE \
             --boot-disk-size=$GCE_BOOT_DISK_SIZE \
             --boot-disk-type=$GCE_BOOT_DISK_TYPE \


### PR DESCRIPTION
Remove deleting *all* ssh keys that may cause GCE VM login errors in other runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3586)
<!-- Reviewable:end -->
