### PR TITLE
Cleanup git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "3rdparty/tinygltf"]
 	path = 3rdparty/tinygltf/tinygltf
 	url = https://github.com/syoyo/tinygltf.git
-[submodule "3rdparty/libjpeg-turbo/libjpeg-turbo"]
-	path = 3rdparty/libjpeg-turbo/libjpeg-turbo
-	url = https://github.com/libjpeg-turbo/libjpeg-turbo.git
 [submodule "3rdparty/PoissonRecon/Open3D-PoissonRecon"]
 	path = 3rdparty/PoissonRecon/PoissonRecon
 	url = https://github.com/intel-isl/Open3D-PoissonRecon.git
@@ -43,9 +40,6 @@
 [submodule "3rdparty/cutlass"]
 	path = 3rdparty/cutlass
 	url = https://github.com/NVIDIA/cutlass
-[submodule "3rdparty/filament/filament"]
-	path = 3rdparty/filament/filament
-	url = https://github.com/google/filament.git
 [submodule "3rdparty/imgui"]
 	path = 3rdparty/imgui
 	url = https://github.com/ocornut/imgui.git

--- a/3rdparty/find_dependencies.cmake
+++ b/3rdparty/find_dependencies.cmake
@@ -538,9 +538,9 @@ if(NOT USE_SYSTEM_JPEG)
     message(STATUS "Building third-party library JPEG from source")
     include(${Open3D_3RDPARTY_DIR}/libjpeg-turbo/libjpeg-turbo.cmake)
     import_3rdparty_library(3rdparty_jpeg
-        INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/libjpeg-turbo-install/include/
-        LIBRARIES ${JPEG_TURBO_LIBRARIES}
-        LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/libjpeg-turbo-install/${Open3D_INSTALL_LIB_DIR}
+        INCLUDE_DIRS ${JPEG_TURBO_INCLUDE_DIRS}
+        LIB_DIR      ${JPEG_TURBO_LIB_DIR}
+        LIBRARIES    ${JPEG_TURBO_LIBRARIES}
     )
     add_dependencies(3rdparty_jpeg ext_turbojpeg)
     set(JPEG_TARGET "3rdparty_jpeg")

--- a/3rdparty/libjpeg-turbo/libjpeg-turbo.cmake
+++ b/3rdparty/libjpeg-turbo/libjpeg-turbo.cmake
@@ -42,8 +42,6 @@ else()
 endif()
 message(STATUS "libturbojpeg: WITH_CRT_DLL=${WITH_CRT_DLL}")
 
-set(JPEG_TURBO_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libjpeg-turbo-install)
-
 # If MSVC, the OUTPUT_NAME was set to turbojpeg-static
 if(MSVC)
     set(lib_name "turbojpeg-static")
@@ -54,21 +52,22 @@ endif()
 ExternalProject_Add(
     ext_turbojpeg
     PREFIX turbojpeg
-    SOURCE_DIR ${Open3D_3RDPARTY_DIR}/libjpeg-turbo/libjpeg-turbo
+    URL https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.0.6.tar.gz
+    URL_HASH SHA256=005aee2fcdca252cee42271f7f90574dda64ca6505d9f8b86ae61abc2b426371
+    DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/libjpeg-turbo"
     UPDATE_COMMAND ""
-    CMAKE_GENERATOR ${CMAKE_GENERATOR}
-    CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
-    CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
     CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DWITH_CRT_DLL=${WITH_CRT_DLL}
         -DENABLE_STATIC=ON
         -DENABLE_SHARED=OFF
         -DWITH_SIMD=${WITH_SIMD}
-        -DCMAKE_INSTALL_PREFIX=${JPEG_TURBO_INSTALL_PREFIX}
         ${ExternalProject_CMAKE_ARGS_hidden}
     BUILD_BYPRODUCTS
-        ${JPEG_TURBO_INSTALL_PREFIX}/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib_name}${CMAKE_STATIC_LIBRARY_SUFFIX}
+        <INSTALL_DIR>/${Open3D_INSTALL_LIB_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib_name}${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
-# For linking with Open3D's after installation
+ExternalProject_Get_Property(ext_turbojpeg INSTALL_DIR)
+set(JPEG_TURBO_INCLUDE_DIRS ${INSTALL_DIR}/include/) # "/" is critical.
+set(JPEG_TURBO_LIB_DIR ${INSTALL_DIR}/${Open3D_INSTALL_LIB_DIR})
 set(JPEG_TURBO_LIBRARIES ${lib_name})


### PR DESCRIPTION
Some git submodules are not really used for :

- Remove unused `google/filament` submodule because we rely on our fork `intel-isl/filament`
- Remove `libjpeg-turbo` submodule and use `ExternalProject_Add` URL downloading instead
- Upgrade `libjpeg-turbo` from commit between versions 2.0.2 and 2.0.3 to release version 2.0.6 (upgrade to 2.1.1 involves major changes and is deferred for future consideration)

In the future, we might port more/all submodules to URL downloading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3621)
<!-- Reviewable:end -->
