### PR TITLE
Respect sort flag in NanoFlannIndex

### DIFF
--- a/cpp/open3d/core/nns/NanoFlannIndex.cpp
+++ b/cpp/open3d/core/nns/NanoFlannIndex.cpp
@@ -155,6 +155,7 @@ std::tuple<Tensor, Tensor, Tensor> NanoFlannIndex::SearchRadius(
                 holder_.get());
 
         nanoflann::SearchParams params;
+        params.sorted = sort;
 
         // Check if the raii has negative values.
         Tensor below_zero = radii.Le(0);
@@ -227,7 +228,7 @@ std::tuple<Tensor, Tensor, Tensor> NanoFlannIndex::SearchRadius(
         Tensor radii(std::vector<scalar_t>(num_query_points,
                                            static_cast<scalar_t>(radius)),
                      {num_query_points}, dtype);
-        result = SearchRadius(query_points, radii);
+        result = SearchRadius(query_points, radii, sort);
     });
     return result;
 };


### PR DESCRIPTION
`NanoFlannIndex` always falls back to the default internal sorting flag of `nanoflann::SearchParams`, i.e. `sorted = true`, independent of the user-provided function parameter `NanoFlannIndex::SearchRadius(..., sort = true)`. Respect the provided parameter (`sort`) and always set the internal sort strategy (`sorted`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3624)
<!-- Reviewable:end -->
