### PR TITLE
Last batch of fixes from the Klocwork scan

### DIFF
--- a/cpp/open3d/core/Indexer.cpp
+++ b/cpp/open3d/core/Indexer.cpp
@@ -233,10 +233,12 @@ std::unique_ptr<Indexer> Indexer::SplitLargestDim() {
     // Get the dimension to split.
     if (ndims_ == 0) {
         utility::LogError("Cannot split when ndims_ == 0");
+        return nullptr;
     }
     if (master_shape_[ndims_ - 1] < 2) {
         utility::LogError("master_shape_[ndims_ - 1] = {} < 2, cannot split.",
                           master_shape_[ndims_ - 1]);
+        return nullptr;
     }
     int64_t max_extent = -1;
     int64_t dim_to_split = -1;
@@ -265,16 +267,19 @@ std::unique_ptr<Indexer> Indexer::SplitLargestDim() {
         utility::LogError(
                 "Internal error: max_extent must be >= 0, but got {}.",
                 max_extent);
+        return nullptr;
     }
     if (!(dim_to_split >= 0 && dim_to_split < ndims_)) {
         utility::LogError(
                 "Internal error: 0 <= dim_to_split < {} required, but got {}.",
                 ndims_, dim_to_split);
+        return nullptr;
     }
     if (master_shape_[dim_to_split] < 2) {
         utility::LogError(
                 "Internal error: cannot split dimension size {}, must be >= 2.",
                 master_shape_[dim_to_split]);
+        return nullptr;
     }
 
     std::unique_ptr<Indexer> copy(new Indexer(*this));
@@ -351,9 +356,11 @@ void Indexer::ShrinkDim(int64_t dim, int64_t start, int64_t size) {
     // inputs_ and output_'s shapes are not important.
     if (!(dim >= 0 && dim < ndims_)) {
         utility::LogError("0 <= dim < {} required, but got {}.", ndims_, dim);
+        return;
     }
     if (size <= 0) {
         utility::LogError("Invalid size {}, must be > 0.", size);
+        return;
     }
     // Inputs
     for (int64_t i = 0; i < num_inputs_; ++i) {

--- a/cpp/open3d/core/NumpyIO.cpp
+++ b/cpp/open3d/core/NumpyIO.cpp
@@ -290,6 +290,7 @@ NumpyArray NumpyArray::Load(const std::string& file_name) {
     FILE* fp = fopen(file_name.c_str(), "rb");
     if (!fp) {
         utility::LogError("Load: Unable to open file {}.", file_name);
+        assert(fp);
     }
     SizeVector shape;
     int64_t word_size;
@@ -310,6 +311,7 @@ void NumpyArray::Save(std::string file_name) const {
     FILE* fp = fopen(file_name.c_str(), "wb");
     if (!fp) {
         utility::LogError("Save: Unable to open file {}.", file_name);
+        return;
     }
     std::vector<char> header = CreateNumpyHeader(shape_, GetDtype());
     fseek(fp, 0, SEEK_SET);

--- a/cpp/open3d/geometry/SurfaceReconstructionBallPivoting.cpp
+++ b/cpp/open3d/geometry/SurfaceReconstructionBallPivoting.cpp
@@ -336,6 +336,7 @@ public:
         const BallPivotingVertexPtr opp = edge->GetOppositeVertex();
         if (opp == nullptr) {
             utility::LogError("edge->GetOppositeVertex() returns nullptr.");
+            assert(opp == nullptr);
         }
         utility::LogDebug("[FindCandidateVertex] edge=({}, {}), opp={}",
                           src->idx_, tgt->idx_, opp->idx_);

--- a/cpp/tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
+++ b/cpp/tools/ManuallyAlignPointCloud/VisualizerForAlignment.cpp
@@ -353,6 +353,7 @@ void VisualizerForAlignment::EvaluateAlignmentAndSave(
     if (!f) {
         utility::LogError("EvaluateAlignmentAndSave: Unable to open file {}.",
                           source_binname);
+        return;
     }
     fwrite(source_dis.data(), sizeof(double), source_dis.size(), f);
     fclose(f);
@@ -363,6 +364,7 @@ void VisualizerForAlignment::EvaluateAlignmentAndSave(
     if (!f) {
         utility::LogError("EvaluateAlignmentAndSave: Unable to open file {}.",
                           target_binname);
+        return;
     }
     fwrite(target_dis.data(), sizeof(double), target_dis.size(), f);
     fclose(f);


### PR DESCRIPTION
n Indexer::SplitLargestDim() I return nullptr if the two error conditions are true (there are two log messages early that do input validation
	In NumpyArray::Load I added an assert if fp is null after the fopen
	In NumpyArray::Save I return if fp is null after the fopen
	in BallPivotingVertexPtr FindCandidateVertex I assert if opp is a nullptr
	in io::WritePointCloud I return if fp is null after fopen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3631)
<!-- Reviewable:end -->
