### PR TITLE
Registration Reduction6x6Impl template datatype support.

### DIFF
--- a/cpp/open3d/t/geometry/kernel/GeometryMacros.h
+++ b/cpp/open3d/t/geometry/kernel/GeometryMacros.h
@@ -31,7 +31,27 @@
 #include "open3d/core/CUDAUtils.h"
 
 #if defined(__CUDACC__)
+#if __CUDA_ARCH__ < 600
+__device__ double atomicAdd(double *address, double val) {
+    unsigned long long int *address_as_ull = (unsigned long long int *)address;
+    unsigned long long int old = *address_as_ull, assumed;
+
+    do {
+        assumed = old;
+        old = atomicCAS(
+                address_as_ull, assumed,
+                __double_as_longlong(val + __longlong_as_double(assumed)));
+
+        // Note: uses integer comparison to avoid hang in case of NaN (since NaN
+        // != NaN)
+    } while (assumed != old);
+
+    return __longlong_as_double(old);
+}
+#endif
+
 #define OPEN3D_ATOMIC_ADD(X, Y) atomicAdd(X, Y)
+
 #define ISNAN(X) isnan(X)
 #else
 #define OPEN3D_ATOMIC_ADD(X, Y) (*X).fetch_add(Y)

--- a/cpp/open3d/t/geometry/kernel/GeometryMacros.h
+++ b/cpp/open3d/t/geometry/kernel/GeometryMacros.h
@@ -31,6 +31,8 @@
 #include "open3d/core/CUDAUtils.h"
 
 #if defined(__CUDACC__)
+
+#if defined(__CUDA_ARCH__)
 #if __CUDA_ARCH__ < 600
 __device__ double atomicAdd(double *address, double val) {
     unsigned long long int *address_as_ull = (unsigned long long int *)address;
@@ -48,6 +50,7 @@ __device__ double atomicAdd(double *address, double val) {
 
     return __longlong_as_double(old);
 }
+#endif
 #endif
 
 #define OPEN3D_ATOMIC_ADD(X, Y) atomicAdd(X, Y)

--- a/cpp/open3d/t/pipelines/kernel/Reduction6x6Impl.cuh
+++ b/cpp/open3d/t/pipelines/kernel/Reduction6x6Impl.cuh
@@ -31,14 +31,16 @@
 #include <cmath>
 
 #include "open3d/core/CUDAUtils.h"
+#include "open3d/t/geometry/kernel/GeometryMacros.h"
 
 namespace open3d {
 namespace t {
 namespace pipelines {
 namespace kernel {
 
-template <typename T>
-__device__ inline void WarpReduceSum(volatile T* local_sum, const int tid) {
+template <typename scalar_t>
+__device__ inline void WarpReduceSum(volatile scalar_t* local_sum,
+                                     const int tid) {
     local_sum[tid] += local_sum[tid + 32];
     local_sum[tid] += local_sum[tid + 16];
     local_sum[tid] += local_sum[tid + 8];
@@ -47,8 +49,9 @@ __device__ inline void WarpReduceSum(volatile T* local_sum, const int tid) {
     local_sum[tid] += local_sum[tid + 1];
 }
 
-template <typename T, size_t BLOCK_SIZE>
-__device__ inline void BlockReduceSum(const int tid, volatile T* local_sum) {
+template <typename scalar_t, size_t BLOCK_SIZE>
+__device__ inline void BlockReduceSum(const int tid,
+                                      volatile scalar_t* local_sum) {
     if (BLOCK_SIZE >= 512) {
         if (tid < 256) {
             local_sum[tid] += local_sum[tid + 256];
@@ -68,14 +71,14 @@ __device__ inline void BlockReduceSum(const int tid, volatile T* local_sum) {
         __syncthreads();
     }
     if (tid < 32) {
-        WarpReduceSum<T>(local_sum, tid);
+        WarpReduceSum<scalar_t>(local_sum, tid);
     }
 }
 
-template <typename T, size_t BLOCK_SIZE>
+template <typename scalar_t, size_t BLOCK_SIZE>
 __device__ inline void BlockReduceSum(const int tid,
-                                      volatile T* local_sum0,
-                                      volatile T* local_sum1) {
+                                      volatile scalar_t* local_sum0,
+                                      volatile scalar_t* local_sum1) {
     if (BLOCK_SIZE >= 512) {
         if (tid < 256) {
             local_sum0[tid] += local_sum0[tid + 256];
@@ -99,16 +102,16 @@ __device__ inline void BlockReduceSum(const int tid,
     }
 
     if (tid < 32) {
-        WarpReduceSum<float>(local_sum0, tid);
-        WarpReduceSum<float>(local_sum1, tid);
+        WarpReduceSum<scalar_t>(local_sum0, tid);
+        WarpReduceSum<scalar_t>(local_sum1, tid);
     }
 }
 
-template <typename T, size_t BLOCK_SIZE>
+template <typename scalar_t, size_t BLOCK_SIZE>
 __device__ inline void BlockReduceSum(const int tid,
-                                      volatile T* local_sum0,
-                                      volatile T* local_sum1,
-                                      volatile T* local_sum2) {
+                                      volatile scalar_t* local_sum0,
+                                      volatile scalar_t* local_sum1,
+                                      volatile scalar_t* local_sum2) {
     if (BLOCK_SIZE >= 512) {
         if (tid < 256) {
             local_sum0[tid] += local_sum0[tid + 256];
@@ -137,20 +140,20 @@ __device__ inline void BlockReduceSum(const int tid,
     }
 
     if (tid < 32) {
-        WarpReduceSum<float>(local_sum0, tid);
-        WarpReduceSum<float>(local_sum1, tid);
-        WarpReduceSum<float>(local_sum2, tid);
+        WarpReduceSum<scalar_t>(local_sum0, tid);
+        WarpReduceSum<scalar_t>(local_sum1, tid);
+        WarpReduceSum<scalar_t>(local_sum2, tid);
     }
 }
 
-template <typename T, size_t BLOCK_SIZE>
+template <typename scalar_t, size_t BLOCK_SIZE>
 __device__ inline void ReduceSum6x6LinearSystem(const int tid,
                                                 bool valid,
-                                                const T* reduction,
-                                                volatile T* local_sum0,
-                                                volatile T* local_sum1,
-                                                volatile T* local_sum2,
-                                                T* global_sum) {
+                                                const scalar_t* reduction,
+                                                volatile scalar_t* local_sum0,
+                                                volatile scalar_t* local_sum1,
+                                                volatile scalar_t* local_sum2,
+                                                scalar_t* global_sum) {
     // Sum reduction: JtJ(21) and Jtr(6)
     for (size_t i = 0; i < 27; i += 3) {
         local_sum0[tid] = valid ? reduction[i + 0] : 0;
@@ -158,13 +161,13 @@ __device__ inline void ReduceSum6x6LinearSystem(const int tid,
         local_sum2[tid] = valid ? reduction[i + 2] : 0;
         __syncthreads();
 
-        BlockReduceSum<float, BLOCK_SIZE>(tid, local_sum0, local_sum1,
-                                          local_sum2);
+        BlockReduceSum<scalar_t, BLOCK_SIZE>(tid, local_sum0, local_sum1,
+                                             local_sum2);
 
         if (tid == 0) {
-            atomicAdd(&global_sum[i + 0], local_sum0[0]);
-            atomicAdd(&global_sum[i + 1], local_sum1[0]);
-            atomicAdd(&global_sum[i + 2], local_sum2[0]);
+            OPEN3D_ATOMIC_ADD(&global_sum[i + 0], local_sum0[0]);
+            OPEN3D_ATOMIC_ADD(&global_sum[i + 1], local_sum1[0]);
+            OPEN3D_ATOMIC_ADD(&global_sum[i + 2], local_sum2[0]);
         }
         __syncthreads();
     }
@@ -175,10 +178,10 @@ __device__ inline void ReduceSum6x6LinearSystem(const int tid,
         local_sum1[tid] = valid ? reduction[28] : 0;
         __syncthreads();
 
-        BlockReduceSum<float, BLOCK_SIZE>(tid, local_sum0, local_sum1);
+        BlockReduceSum<scalar_t, BLOCK_SIZE>(tid, local_sum0, local_sum1);
         if (tid == 0) {
-            atomicAdd(&global_sum[27], local_sum0[0]);
-            atomicAdd(&global_sum[28], local_sum1[0]);
+            OPEN3D_ATOMIC_ADD(&global_sum[27], local_sum0[0]);
+            OPEN3D_ATOMIC_ADD(&global_sum[28], local_sum1[0]);
         }
         __syncthreads();
     }

--- a/cpp/open3d/t/pipelines/kernel/Reduction6x6Impl.cuh
+++ b/cpp/open3d/t/pipelines/kernel/Reduction6x6Impl.cuh
@@ -165,9 +165,9 @@ __device__ inline void ReduceSum6x6LinearSystem(const int tid,
                                              local_sum2);
 
         if (tid == 0) {
-            OPEN3D_ATOMIC_ADD(&global_sum[i + 0], local_sum0[0]);
-            OPEN3D_ATOMIC_ADD(&global_sum[i + 1], local_sum1[0]);
-            OPEN3D_ATOMIC_ADD(&global_sum[i + 2], local_sum2[0]);
+            atomicAdd(&global_sum[i + 0], local_sum0[0]);
+            atomicAdd(&global_sum[i + 1], local_sum1[0]);
+            atomicAdd(&global_sum[i + 2], local_sum2[0]);
         }
         __syncthreads();
     }
@@ -180,8 +180,8 @@ __device__ inline void ReduceSum6x6LinearSystem(const int tid,
 
         BlockReduceSum<scalar_t, BLOCK_SIZE>(tid, local_sum0, local_sum1);
         if (tid == 0) {
-            OPEN3D_ATOMIC_ADD(&global_sum[27], local_sum0[0]);
-            OPEN3D_ATOMIC_ADD(&global_sum[28], local_sum1[0]);
+            atomicAdd(&global_sum[27], local_sum0[0]);
+            atomicAdd(&global_sum[28], local_sum1[0]);
         }
         __syncthreads();
     }


### PR DESCRIPTION
Changes:
Adding template dtype support in Reduction6x6Impl.


Issue re-solved [by @stotko ]: 
Adding 
```
#if __CUDA_ARCH__ < 600
__device__ double atomicAdd(double *address, double val) {
    unsigned long long int *address_as_ull = (unsigned long long int *)address;
    unsigned long long int old = *address_as_ull, assumed;

    do {
        assumed = old;
        old = atomicCAS(
                address_as_ull, assumed,
                __double_as_longlong(val + __longlong_as_double(assumed)));

        // Note: uses integer comparison to avoid hang in case of NaN (since NaN
        // != NaN)
    } while (assumed != old);

    return __longlong_as_double(old);
}
#endif
```
throws error 
```
.../Open3D/cpp/open3d/t/geometry/kernel/GeometryMacros.h(35): error: function "atomicAdd(double *, double)" has already been defined
```

Not adding the same, throws an error in some of the CIs, that atomicAdd(double *, double) is not defined.
[Refer to the CI failure in PR #3564 ]
```
D:\a\Open3D\Open3D\cpp\open3d/t/pipelines/kernel/Reduction6x6Impl.cuh(180): error : no instance of overloaded function "atomicAdd" matches the argument list [C:\Open3D\build\cpp\open3d\t\pipelines\kernel\tpipelines_kernel.vcxproj]
              argument types are: (double *, volatile double)
            detected during:
              instantiation of "void open3d::t::pipelines::kernel::ReduceSum6x6LinearSystem<T,BLOCK_SIZE>(int, __nv_bool, const T *, volatile T *, volatile T *, volatile T *, T *) [with T=double, BLOCK_SIZE=256ULL]" 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3636)
<!-- Reviewable:end -->
