### PR TITLE
Refactor cpu_launcher and cuda_launcher as namespaces

### DIFF
--- a/cpp/open3d/core/EigenConverter.cpp
+++ b/cpp/open3d/core/EigenConverter.cpp
@@ -126,7 +126,7 @@ static core::Tensor EigenVector3xVectorToTensor(
     core::Indexer indexer({tensor_cpu}, tensor_cpu,
                           core::DtypePolicy::ALL_SAME);
     DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-        core::kernel::CPULauncher::LaunchIndexFillKernel(
+        kernel::cpu_launcher::LaunchIndexFillKernel(
                 indexer, [&](void *ptr, int64_t workload_idx) {
                     // Fills the flattened tensor tensor_cpu[:] with dtype
                     // casting. tensor_cpu[:][i] corresponds to the (i/3)-th

--- a/cpp/open3d/core/kernel/ArangeCPU.cpp
+++ b/cpp/open3d/core/kernel/ArangeCPU.cpp
@@ -43,7 +43,7 @@ void ArangeCPU(const Tensor& start,
         scalar_t sstep = step.Item<scalar_t>();
         scalar_t* dst_ptr = dst.GetDataPtr<scalar_t>();
         int64_t n = dst.GetLength();
-        CPULauncher::LaunchGeneralKernel(n, [&](int64_t workload_idx) {
+        cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
             dst_ptr[workload_idx] =
                     sstart + static_cast<scalar_t>(sstep * workload_idx);
         });

--- a/cpp/open3d/core/kernel/ArangeCPU.cpp
+++ b/cpp/open3d/core/kernel/ArangeCPU.cpp
@@ -43,7 +43,7 @@ void ArangeCPU(const Tensor& start,
         scalar_t sstep = step.Item<scalar_t>();
         scalar_t* dst_ptr = dst.GetDataPtr<scalar_t>();
         int64_t n = dst.GetLength();
-        cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
+        cpu_launcher::ParallelFor(n, [&](int64_t workload_idx) {
             dst_ptr[workload_idx] =
                     sstart + static_cast<scalar_t>(sstep * workload_idx);
         });

--- a/cpp/open3d/core/kernel/ArangeCUDA.cu
+++ b/cpp/open3d/core/kernel/ArangeCUDA.cu
@@ -43,8 +43,8 @@ void ArangeCUDA(const Tensor& start,
         scalar_t sstep = step.Item<scalar_t>();
         scalar_t* dst_ptr = dst.GetDataPtr<scalar_t>();
         int64_t n = dst.GetLength();
-        CUDALauncher::LaunchGeneralKernel(n, [=] OPEN3D_HOST_DEVICE(
-                                                     int64_t workload_idx) {
+        cuda_launcher::LaunchParallel(n, [=] OPEN3D_HOST_DEVICE(
+                                                 int64_t workload_idx) {
             dst_ptr[workload_idx] =
                     sstart + static_cast<scalar_t>(sstep * workload_idx);
         });

--- a/cpp/open3d/core/kernel/ArangeCUDA.cu
+++ b/cpp/open3d/core/kernel/ArangeCUDA.cu
@@ -43,8 +43,8 @@ void ArangeCUDA(const Tensor& start,
         scalar_t sstep = step.Item<scalar_t>();
         scalar_t* dst_ptr = dst.GetDataPtr<scalar_t>();
         int64_t n = dst.GetLength();
-        cuda_launcher::LaunchParallel(n, [=] OPEN3D_HOST_DEVICE(
-                                                 int64_t workload_idx) {
+        cuda_launcher::ParallelFor(n, [=] OPEN3D_HOST_DEVICE(
+                                              int64_t workload_idx) {
             dst_ptr[workload_idx] =
                     sstart + static_cast<scalar_t>(sstep * workload_idx);
         });

--- a/cpp/open3d/core/kernel/BinaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/BinaryEWCPU.cpp
@@ -132,39 +132,39 @@ static void LaunchBoolBinaryEWCPUKernel(const Tensor& lhs,
                                         const Indexer& indexer) {
     switch (op_code) {
         case BinaryEWOpCode::LogicalAnd:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPULogicalAndElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::LogicalOr:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPULogicalOrElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::LogicalXor:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPULogicalXorElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Gt:
-            CPULauncher::LaunchBinaryEWKernel(indexer,
-                                              CPUGtElementKernel<src_t, dst_t>);
+            cpu_launcher::LaunchBinaryEWKernel(
+                    indexer, CPUGtElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Lt:
-            CPULauncher::LaunchBinaryEWKernel(indexer,
-                                              CPULtElementKernel<src_t, dst_t>);
+            cpu_launcher::LaunchBinaryEWKernel(
+                    indexer, CPULtElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Ge:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPUGeqElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Le:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPULeqElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Eq:
-            CPULauncher::LaunchBinaryEWKernel(indexer,
-                                              CPUEqElementKernel<src_t, dst_t>);
+            cpu_launcher::LaunchBinaryEWKernel(
+                    indexer, CPUEqElementKernel<src_t, dst_t>);
             break;
         case BinaryEWOpCode::Ne:
-            CPULauncher::LaunchBinaryEWKernel(
+            cpu_launcher::LaunchBinaryEWKernel(
                     indexer, CPUNeqElementKernel<src_t, dst_t>);
             break;
         default:
@@ -206,19 +206,19 @@ void BinaryEWCPU(const Tensor& lhs,
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             switch (op_code) {
                 case BinaryEWOpCode::Add:
-                    CPULauncher::LaunchBinaryEWKernel(
+                    cpu_launcher::LaunchBinaryEWKernel(
                             indexer, CPUAddElementKernel<scalar_t>);
                     break;
                 case BinaryEWOpCode::Sub:
-                    CPULauncher::LaunchBinaryEWKernel(
+                    cpu_launcher::LaunchBinaryEWKernel(
                             indexer, CPUSubElementKernel<scalar_t>);
                     break;
                 case BinaryEWOpCode::Mul:
-                    CPULauncher::LaunchBinaryEWKernel(
+                    cpu_launcher::LaunchBinaryEWKernel(
                             indexer, CPUMulElementKernel<scalar_t>);
                     break;
                 case BinaryEWOpCode::Div:
-                    CPULauncher::LaunchBinaryEWKernel(
+                    cpu_launcher::LaunchBinaryEWKernel(
                             indexer, CPUDivElementKernel<scalar_t>);
                     break;
                 default:

--- a/cpp/open3d/core/kernel/BinaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/BinaryEWCUDA.cu
@@ -150,7 +150,7 @@ void LaunchBoolBinaryEWCUDAKernel(const Tensor& lhs,
                                   const Indexer& indexer) {
     switch (op_code) {
         case BinaryEWOpCode::LogicalAnd:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDALogicalAndElementKernel<src_t, dst_t>(lhs, rhs,
@@ -158,14 +158,14 @@ void LaunchBoolBinaryEWCUDAKernel(const Tensor& lhs,
                     });
             break;
         case BinaryEWOpCode::LogicalOr:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDALogicalOrElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::LogicalXor:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDALogicalXorElementKernel<src_t, dst_t>(lhs, rhs,
@@ -173,42 +173,42 @@ void LaunchBoolBinaryEWCUDAKernel(const Tensor& lhs,
                     });
             break;
         case BinaryEWOpCode::Gt:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDAGtElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::Lt:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDALtElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::Ge:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDAGeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::Le:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDALeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::Eq:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDAEqElementKernel<src_t, dst_t>(lhs, rhs, dst);
                     });
             break;
         case BinaryEWOpCode::Ne:
-            CUDALauncher::LaunchBinaryEWKernel(
+            cuda_launcher::LaunchBinaryEWKernel(
                     indexer, [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                    void* dst) {
                         CUDANeqElementKernel<src_t, dst_t>(lhs, rhs, dst);
@@ -260,7 +260,7 @@ void BinaryEWCUDA(const Tensor& lhs,
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             switch (op_code) {
                 case BinaryEWOpCode::Add:
-                    CUDALauncher::LaunchBinaryEWKernel(
+                    cuda_launcher::LaunchBinaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -268,7 +268,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Sub:
-                    CUDALauncher::LaunchBinaryEWKernel(
+                    cuda_launcher::LaunchBinaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -276,7 +276,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Mul:
-                    CUDALauncher::LaunchBinaryEWKernel(
+                    cuda_launcher::LaunchBinaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {
@@ -284,7 +284,7 @@ void BinaryEWCUDA(const Tensor& lhs,
                             });
                     break;
                 case BinaryEWOpCode::Div:
-                    CUDALauncher::LaunchBinaryEWKernel(
+                    cuda_launcher::LaunchBinaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* lhs, void* rhs,
                                                   void* dst) {

--- a/cpp/open3d/core/kernel/CPULauncher.h
+++ b/cpp/open3d/core/kernel/CPULauncher.h
@@ -37,149 +37,151 @@
 namespace open3d {
 namespace core {
 namespace kernel {
+namespace cpu_launcher {
 
-class CPULauncher {
-public:
-    /// Fills tensor[:][i] with element_kernel(i).
-    ///
-    /// \param indexer The input tensor and output tensor to the indexer are the
-    /// same (as a hack), since the tensor are filled in-place.
-    /// \param element_kernel A function that takes pointer location and
-    /// workload_idx, computes the value to fill, and fills the value at the
-    /// pointer location.
-    template <typename func_t>
-    static void LaunchIndexFillKernel(const Indexer& indexer,
-                                      func_t element_kernel) {
+/// Run a function in parallel on CPU.
+///
+/// This is typically used together with cuda_launcher::LaunchParallel() to
+/// share the same code between CPU and CUDA. For example:
+///
+/// ```cpp
+/// #if defined(__CUDACC__)
+///     namespace launcher = core::kernel::cuda_launcher;
+/// #else
+///     namespace launcher = core::kernel::cpu_launcher;
+/// #endif
+///
+/// launcher::LaunchParallel(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
+///     process_workload(idx);
+/// });
+/// ```
+///
+/// \param n The number of workloads.
+/// \param func The function to be executed in parallel. The function should
+/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+template <typename func_t>
+void LaunchParallel(int64_t n, const func_t& func) {
 #pragma omp parallel for schedule(static)
-        for (int64_t workload_idx = 0; workload_idx < indexer.NumWorkloads();
-             ++workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx), workload_idx);
-        }
+    for (int64_t i = 0; i < n; ++i) {
+        func(i);
     }
+}
 
-    template <typename func_t>
-    static void LaunchUnaryEWKernel(const Indexer& indexer,
-                                    func_t element_kernel) {
+/// Fills tensor[:][i] with func(i).
+///
+/// \param indexer The input tensor and output tensor to the indexer are the
+/// same (as a hack), since the tensor are filled in-place.
+/// \param func A function that takes pointer location and
+/// workload index i, computes the value to fill, and fills the value at the
+/// pointer location.
+template <typename func_t>
+void LaunchIndexFillKernel(const Indexer& indexer, const func_t& func) {
 #pragma omp parallel for schedule(static)
-        for (int64_t workload_idx = 0; workload_idx < indexer.NumWorkloads();
-             ++workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        }
+    for (int64_t i = 0; i < indexer.NumWorkloads(); ++i) {
+        func(indexer.GetInputPtr(0, i), i);
     }
+}
 
-    template <typename func_t>
-    static void LaunchBinaryEWKernel(const Indexer& indexer,
-                                     func_t element_kernel) {
+template <typename func_t>
+void LaunchUnaryEWKernel(const Indexer& indexer, const func_t& func) {
 #pragma omp parallel for schedule(static)
-        for (int64_t workload_idx = 0; workload_idx < indexer.NumWorkloads();
-             ++workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx),
-                           indexer.GetInputPtr(1, workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        }
+    for (int64_t i = 0; i < indexer.NumWorkloads(); ++i) {
+        func(indexer.GetInputPtr(0, i), indexer.GetOutputPtr(i));
     }
+}
 
-    template <typename func_t>
-    static void LaunchAdvancedIndexerKernel(const AdvancedIndexer& indexer,
-                                            func_t element_kernel) {
+template <typename func_t>
+void LaunchBinaryEWKernel(const Indexer& indexer, const func_t& func) {
 #pragma omp parallel for schedule(static)
-        for (int64_t workload_idx = 0; workload_idx < indexer.NumWorkloads();
-             ++workload_idx) {
-            element_kernel(indexer.GetInputPtr(workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        }
+    for (int64_t i = 0; i < indexer.NumWorkloads(); ++i) {
+        func(indexer.GetInputPtr(0, i), indexer.GetInputPtr(1, i),
+             indexer.GetOutputPtr(i));
     }
+}
 
-    template <typename scalar_t, typename func_t>
-    static void LaunchReductionKernelSerial(const Indexer& indexer,
-                                            func_t element_kernel) {
-        for (int64_t workload_idx = 0; workload_idx < indexer.NumWorkloads();
-             ++workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        }
-    }
-
-    /// Create num_threads workers to compute partial reductions and then reduce
-    /// to the final results. This only applies to reduction op with one output.
-    template <typename scalar_t, typename func_t>
-    static void LaunchReductionKernelTwoPass(const Indexer& indexer,
-                                             func_t element_kernel,
-                                             scalar_t identity) {
-        if (indexer.NumOutputElements() > 1) {
-            utility::LogError(
-                    "Internal error: two-pass reduction only works for "
-                    "single-output reduction ops.");
-        }
-        int64_t num_workloads = indexer.NumWorkloads();
-        int64_t num_threads = GetMaxThreads();
-        int64_t workload_per_thread =
-                (num_workloads + num_threads - 1) / num_threads;
-        std::vector<scalar_t> thread_results(num_threads, identity);
-
+template <typename func_t>
+void LaunchAdvancedIndexerKernel(const AdvancedIndexer& indexer,
+                                 const func_t& func) {
 #pragma omp parallel for schedule(static)
-        for (int64_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
-            int64_t start = thread_idx * workload_per_thread;
-            int64_t end = std::min(start + workload_per_thread, num_workloads);
-            for (int64_t workload_idx = start; workload_idx < end;
-                 ++workload_idx) {
-                element_kernel(indexer.GetInputPtr(0, workload_idx),
-                               &thread_results[thread_idx]);
-            }
-        }
-        void* output_ptr = indexer.GetOutputPtr(0);
-        for (int64_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
-            element_kernel(&thread_results[thread_idx], output_ptr);
-        }
+    for (int64_t i = 0; i < indexer.NumWorkloads(); ++i) {
+        func(indexer.GetInputPtr(i), indexer.GetOutputPtr(i));
     }
+}
 
-    template <typename scalar_t, typename func_t>
-    static void LaunchReductionParallelDim(const Indexer& indexer,
-                                           func_t element_kernel) {
-        // Prefers outer dimension >= num_threads.
-        const int64_t* indexer_shape = indexer.GetMasterShape();
-        const int64_t num_dims = indexer.NumDims();
-        int64_t num_threads = GetMaxThreads();
+template <typename scalar_t, typename func_t>
+void LaunchReductionKernelSerial(const Indexer& indexer, const func_t& func) {
+    for (int64_t i = 0; i < indexer.NumWorkloads(); ++i) {
+        func(indexer.GetInputPtr(0, i), indexer.GetOutputPtr(i));
+    }
+}
 
-        // Init best_dim as the outer-most non-reduction dim.
-        int64_t best_dim = num_dims - 1;
-        while (best_dim >= 0 && indexer.IsReductionDim(best_dim)) {
-            best_dim--;
-        }
-        for (int64_t dim = best_dim; dim >= 0 && !indexer.IsReductionDim(dim);
-             --dim) {
-            if (indexer_shape[dim] >= num_threads) {
-                best_dim = dim;
-                break;
-            } else if (indexer_shape[dim] > indexer_shape[best_dim]) {
-                best_dim = dim;
-            }
-        }
-        if (best_dim == -1) {
-            utility::LogError(
-                    "Internal error: all dims are reduction dims, use "
-                    "LaunchReductionKernelTwoPass instead.");
-        }
+/// Create num_threads workers to compute partial reductions and then reduce
+/// to the final results. This only applies to reduction op with one output.
+template <typename scalar_t, typename func_t>
+void LaunchReductionKernelTwoPass(const Indexer& indexer,
+                                  const func_t& func,
+                                  scalar_t identity) {
+    if (indexer.NumOutputElements() > 1) {
+        utility::LogError(
+                "Internal error: two-pass reduction only works for "
+                "single-output reduction ops.");
+    }
+    int64_t num_workloads = indexer.NumWorkloads();
+    int64_t num_threads = GetMaxThreads();
+    int64_t workload_per_thread =
+            (num_workloads + num_threads - 1) / num_threads;
+    std::vector<scalar_t> thread_results(num_threads, identity);
 
 #pragma omp parallel for schedule(static)
-        for (int64_t i = 0; i < indexer_shape[best_dim]; ++i) {
-            Indexer sub_indexer(indexer);
-            sub_indexer.ShrinkDim(best_dim, i, 1);
-            LaunchReductionKernelSerial<scalar_t>(sub_indexer, element_kernel);
+    for (int64_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+        int64_t start = thread_idx * workload_per_thread;
+        int64_t end = std::min(start + workload_per_thread, num_workloads);
+        for (int64_t i = start; i < end; ++i) {
+            func(indexer.GetInputPtr(0, i), &thread_results[thread_idx]);
         }
     }
+    void* output_ptr = indexer.GetOutputPtr(0);
+    for (int64_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+        func(&thread_results[thread_idx], output_ptr);
+    }
+}
 
-    /// General kernels with non-conventional indexers
-    template <typename func_t>
-    static void LaunchGeneralKernel(int64_t n, func_t element_kernel) {
+template <typename scalar_t, typename func_t>
+void LaunchReductionParallelDim(const Indexer& indexer, const func_t& func) {
+    // Prefers outer dimension >= num_threads.
+    const int64_t* indexer_shape = indexer.GetMasterShape();
+    const int64_t num_dims = indexer.NumDims();
+    int64_t num_threads = GetMaxThreads();
+
+    // Init best_dim as the outer-most non-reduction dim.
+    int64_t best_dim = num_dims - 1;
+    while (best_dim >= 0 && indexer.IsReductionDim(best_dim)) {
+        best_dim--;
+    }
+    for (int64_t dim = best_dim; dim >= 0 && !indexer.IsReductionDim(dim);
+         --dim) {
+        if (indexer_shape[dim] >= num_threads) {
+            best_dim = dim;
+            break;
+        } else if (indexer_shape[dim] > indexer_shape[best_dim]) {
+            best_dim = dim;
+        }
+    }
+    if (best_dim == -1) {
+        utility::LogError(
+                "Internal error: all dims are reduction dims, use "
+                "LaunchReductionKernelTwoPass instead.");
+    }
+
 #pragma omp parallel for schedule(static)
-        for (int64_t workload_idx = 0; workload_idx < n; ++workload_idx) {
-            element_kernel(workload_idx);
-        }
+    for (int64_t i = 0; i < indexer_shape[best_dim]; ++i) {
+        Indexer sub_indexer(indexer);
+        sub_indexer.ShrinkDim(best_dim, i, 1);
+        LaunchReductionKernelSerial<scalar_t>(sub_indexer, func);
     }
-};
+}
 
+}  // namespace cpu_launcher
 }  // namespace kernel
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/kernel/CPULauncher.h
+++ b/cpp/open3d/core/kernel/CPULauncher.h
@@ -41,7 +41,7 @@ namespace cpu_launcher {
 
 /// \brief Run a function in parallel on CPU.
 ///
-/// This is typically used together with cuda_launcher::LaunchParallel() to
+/// This is typically used together with cuda_launcher::ParallelFor() to
 /// share the same code between CPU and CUDA. For example:
 ///
 /// ```cpp
@@ -51,7 +51,7 @@ namespace cpu_launcher {
 ///     namespace launcher = core::kernel::cpu_launcher;
 /// #endif
 ///
-/// launcher::LaunchParallel(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
+/// launcher::ParallelFor(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
 ///     process_workload(idx);
 /// });
 /// ```
@@ -66,7 +66,7 @@ namespace cpu_launcher {
 /// instead of all to prevent accidental race conditions. If you want the kernel
 /// to be used on both CPU and CUDA, capture the variables by value.
 template <typename func_t>
-void LaunchParallel(int64_t n, const func_t& func) {
+void ParallelFor(int64_t n, const func_t& func) {
 #pragma omp parallel for schedule(static)
     for (int64_t i = 0; i < n; ++i) {
         func(i);

--- a/cpp/open3d/core/kernel/CPULauncher.h
+++ b/cpp/open3d/core/kernel/CPULauncher.h
@@ -39,7 +39,7 @@ namespace core {
 namespace kernel {
 namespace cpu_launcher {
 
-/// Run a function in parallel on CPU.
+/// \brief Run a function in parallel on CPU.
 ///
 /// This is typically used together with cuda_launcher::LaunchParallel() to
 /// share the same code between CPU and CUDA. For example:
@@ -59,6 +59,12 @@ namespace cpu_launcher {
 /// \param n The number of workloads.
 /// \param func The function to be executed in parallel. The function should
 /// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+///
+/// \note This is optimized for uniform work items, i.e. where each call to \p
+/// func takes the same time.
+/// \note If you use a lambda function, capture only the required variables
+/// instead of all to prevent accidental race conditions. If you want the kernel
+/// to be used on both CPU and CUDA, capture the variables by value.
 template <typename func_t>
 void LaunchParallel(int64_t n, const func_t& func) {
 #pragma omp parallel for schedule(static)

--- a/cpp/open3d/core/kernel/CUDALauncher.cuh
+++ b/cpp/open3d/core/kernel/CUDALauncher.cuh
@@ -66,7 +66,7 @@ __global__ void ElementWiseKernel(int64_t n, func_t f) {
 
 /// Run a function in parallel with CUDA.
 ///
-/// This is typically used together with cpu_launcher::LaunchParallel() to share
+/// This is typically used together with cpu_launcher::ParallelFor() to share
 /// the same code between CPU and CUDA. For example:
 ///
 /// ```cpp
@@ -76,7 +76,7 @@ __global__ void ElementWiseKernel(int64_t n, func_t f) {
 ///     namespace launcher = core::kernel::cpu_launcher;
 /// #endif
 ///
-/// launcher::LaunchParallel(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
+/// launcher::ParallelFor(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
 ///     process_workload(idx);
 /// });
 /// ```
@@ -91,7 +91,7 @@ __global__ void ElementWiseKernel(int64_t n, func_t f) {
 /// instead of all to prevent accidental race conditions. If you want the kernel
 /// to be used on both CPU and CUDA, capture the variables by value.
 template <typename func_t>
-void LaunchParallel(int64_t n, const func_t& func) {
+void ParallelFor(int64_t n, const func_t& func) {
     if (n == 0) {
         return;
     }
@@ -100,7 +100,7 @@ void LaunchParallel(int64_t n, const func_t& func) {
 
     ElementWiseKernel<default_block_size, default_thread_size>
             <<<grid_size, default_block_size, 0>>>(n, func);
-    OPEN3D_GET_LAST_CUDA_ERROR("LaunchParallel failed.");
+    OPEN3D_GET_LAST_CUDA_ERROR("ParallelFor failed.");
 }
 
 template <typename func_t>

--- a/cpp/open3d/core/kernel/CUDALauncher.cuh
+++ b/cpp/open3d/core/kernel/CUDALauncher.cuh
@@ -84,6 +84,12 @@ __global__ void ElementWiseKernel(int64_t n, func_t f) {
 /// \param n The number of workloads.
 /// \param func The function to be executed in parallel. The function should
 /// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+///
+/// \note This is optimized for uniform work items, i.e. where each call to \p
+/// func takes the same time.
+/// \note If you use a lambda function, capture only the required variables
+/// instead of all to prevent accidental race conditions. If you want the kernel
+/// to be used on both CPU and CUDA, capture the variables by value.
 template <typename func_t>
 void LaunchParallel(int64_t n, const func_t& func) {
     if (n == 0) {

--- a/cpp/open3d/core/kernel/CUDALauncher.cuh
+++ b/cpp/open3d/core/kernel/CUDALauncher.cuh
@@ -47,6 +47,7 @@ static constexpr int64_t default_thread_size = 4;
 namespace open3d {
 namespace core {
 namespace kernel {
+namespace cuda_launcher {
 
 // Applies f for each element
 // Works for unary / binary elementwise operations
@@ -63,91 +64,102 @@ __global__ void ElementWiseKernel(int64_t n, func_t f) {
     }
 }
 
-class CUDALauncher {
-public:
-    template <typename func_t>
-    static void LaunchUnaryEWKernel(const Indexer& indexer,
-                                    func_t element_kernel) {
-        OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
-
-        int64_t n = indexer.NumWorkloads();
-        if (n == 0) {
-            return;
-        }
-        int64_t items_per_block = default_block_size * default_thread_size;
-        int64_t grid_size = (n + items_per_block - 1) / items_per_block;
-
-        auto f = [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        };
-
-        ElementWiseKernel<default_block_size, default_thread_size>
-                <<<grid_size, default_block_size, 0>>>(n, f);
-        OPEN3D_GET_LAST_CUDA_ERROR("LaunchUnaryEWKernel failed.");
+/// Run a function in parallel with CUDA.
+///
+/// This is typically used together with cpu_launcher::LaunchParallel() to share
+/// the same code between CPU and CUDA. For example:
+///
+/// ```cpp
+/// #if defined(__CUDACC__)
+///     namespace launcher = core::kernel::cuda_launcher;
+/// #else
+///     namespace launcher = core::kernel::cpu_launcher;
+/// #endif
+///
+/// launcher::LaunchParallel(num_workloads, [=] OPEN3D_DEVICE(int64_t idx) {
+///     process_workload(idx);
+/// });
+/// ```
+///
+/// \param n The number of workloads.
+/// \param func The function to be executed in parallel. The function should
+/// take an int64_t workload index and returns void, i.e., `void func(int64_t)`.
+template <typename func_t>
+void LaunchParallel(int64_t n, const func_t& func) {
+    if (n == 0) {
+        return;
     }
+    int64_t items_per_block = default_block_size * default_thread_size;
+    int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
-    template <typename func_t>
-    static void LaunchBinaryEWKernel(const Indexer& indexer,
-                                     func_t element_kernel) {
-        OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
+    ElementWiseKernel<default_block_size, default_thread_size>
+            <<<grid_size, default_block_size, 0>>>(n, func);
+    OPEN3D_GET_LAST_CUDA_ERROR("LaunchParallel failed.");
+}
 
-        int64_t n = indexer.NumWorkloads();
-        if (n == 0) {
-            return;
-        }
-        int64_t items_per_block = default_block_size * default_thread_size;
-        int64_t grid_size = (n + items_per_block - 1) / items_per_block;
+template <typename func_t>
+void LaunchUnaryEWKernel(const Indexer& indexer, const func_t& func) {
+    OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
-        auto f = [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
-            element_kernel(indexer.GetInputPtr(0, workload_idx),
-                           indexer.GetInputPtr(1, workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        };
-
-        ElementWiseKernel<default_block_size, default_thread_size>
-                <<<grid_size, default_block_size, 0>>>(n, f);
-        OPEN3D_GET_LAST_CUDA_ERROR("LaunchBinaryEWKernel failed.");
+    int64_t n = indexer.NumWorkloads();
+    if (n == 0) {
+        return;
     }
+    int64_t items_per_block = default_block_size * default_thread_size;
+    int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
-    template <typename func_t>
-    static void LaunchAdvancedIndexerKernel(const AdvancedIndexer& indexer,
-                                            func_t element_kernel) {
-        OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
+    auto f = [=] OPEN3D_HOST_DEVICE(int64_t i) {
+        func(indexer.GetInputPtr(0, i), indexer.GetOutputPtr(i));
+    };
 
-        int64_t n = indexer.NumWorkloads();
-        if (n == 0) {
-            return;
-        }
-        int64_t items_per_block = default_block_size * default_thread_size;
-        int64_t grid_size = (n + items_per_block - 1) / items_per_block;
+    ElementWiseKernel<default_block_size, default_thread_size>
+            <<<grid_size, default_block_size, 0>>>(n, f);
+    OPEN3D_GET_LAST_CUDA_ERROR("LaunchUnaryEWKernel failed.");
+}
 
-        auto f = [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
-            element_kernel(indexer.GetInputPtr(workload_idx),
-                           indexer.GetOutputPtr(workload_idx));
-        };
+template <typename func_t>
+void LaunchBinaryEWKernel(const Indexer& indexer, const func_t& func) {
+    OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
 
-        ElementWiseKernel<default_block_size, default_thread_size>
-                <<<grid_size, default_block_size, 0>>>(n, f);
-        OPEN3D_GET_LAST_CUDA_ERROR("LaunchAdvancedIndexerKernel failed.");
+    int64_t n = indexer.NumWorkloads();
+    if (n == 0) {
+        return;
     }
+    int64_t items_per_block = default_block_size * default_thread_size;
+    int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
-    /// General kernels with non-conventional indexers
-    /// Do not assert host_device compatible, because there can be some GPU-only
-    /// operations (e.g., atomicAdd, __shfl_sync).
-    template <typename func_t>
-    static void LaunchGeneralKernel(int64_t n, func_t element_kernel) {
-        if (n == 0) {
-            return;
-        }
-        int64_t items_per_block = default_block_size * default_thread_size;
-        int64_t grid_size = (n + items_per_block - 1) / items_per_block;
+    auto f = [=] OPEN3D_HOST_DEVICE(int64_t i) {
+        func(indexer.GetInputPtr(0, i), indexer.GetInputPtr(1, i),
+             indexer.GetOutputPtr(i));
+    };
 
-        ElementWiseKernel<default_block_size, default_thread_size>
-                <<<grid_size, default_block_size, 0>>>(n, element_kernel);
-        OPEN3D_GET_LAST_CUDA_ERROR("LaunchGeneralKernel failed.");
+    ElementWiseKernel<default_block_size, default_thread_size>
+            <<<grid_size, default_block_size, 0>>>(n, f);
+    OPEN3D_GET_LAST_CUDA_ERROR("LaunchBinaryEWKernel failed.");
+}
+
+template <typename func_t>
+void LaunchAdvancedIndexerKernel(const AdvancedIndexer& indexer,
+                                 const func_t& func) {
+    OPEN3D_ASSERT_HOST_DEVICE_LAMBDA(func_t);
+
+    int64_t n = indexer.NumWorkloads();
+    if (n == 0) {
+        return;
     }
-};
+    int64_t items_per_block = default_block_size * default_thread_size;
+    int64_t grid_size = (n + items_per_block - 1) / items_per_block;
+
+    auto f = [=] OPEN3D_HOST_DEVICE(int64_t i) {
+        func(indexer.GetInputPtr(i), indexer.GetOutputPtr(i));
+    };
+
+    ElementWiseKernel<default_block_size, default_thread_size>
+            <<<grid_size, default_block_size, 0>>>(n, f);
+    OPEN3D_GET_LAST_CUDA_ERROR("LaunchAdvancedIndexerKernel failed.");
+}
+
+}  // namespace cuda_launcher
 }  // namespace kernel
 }  // namespace core
 }  // namespace open3d

--- a/cpp/open3d/core/kernel/IndexGetSetCPU.cpp
+++ b/cpp/open3d/core/kernel/IndexGetSetCPU.cpp
@@ -58,13 +58,13 @@ void IndexGetCPU(const Tensor& src,
                        AdvancedIndexer::AdvancedIndexerMode::GET);
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
-        CPULauncher::LaunchAdvancedIndexerKernel(
+        cpu_launcher::LaunchAdvancedIndexerKernel(
                 ai, [&](const void* src, void* dst) {
                     CPUCopyObjectElementKernel(src, dst, object_byte_size);
                 });
     } else {
         DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-            CPULauncher::LaunchAdvancedIndexerKernel(
+            cpu_launcher::LaunchAdvancedIndexerKernel(
                     ai, CPUCopyElementKernel<scalar_t>);
         });
     }
@@ -80,13 +80,13 @@ void IndexSetCPU(const Tensor& src,
                        AdvancedIndexer::AdvancedIndexerMode::SET);
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
-        CPULauncher::LaunchAdvancedIndexerKernel(
+        cpu_launcher::LaunchAdvancedIndexerKernel(
                 ai, [&](const void* src, void* dst) {
                     CPUCopyObjectElementKernel(src, dst, object_byte_size);
                 });
     } else {
         DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-            CPULauncher::LaunchAdvancedIndexerKernel(
+            cpu_launcher::LaunchAdvancedIndexerKernel(
                     ai, CPUCopyElementKernel<scalar_t>);
         });
     }

--- a/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
@@ -61,13 +61,13 @@ void IndexGetCUDA(const Tensor& src,
     CUDADeviceSwitcher switcher(src.GetDevice());
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
-        CUDALauncher::LaunchAdvancedIndexerKernel(
+        cuda_launcher::LaunchAdvancedIndexerKernel(
                 ai, [=] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                     CUDACopyObjectElementKernel(src, dst, object_byte_size);
                 });
     } else {
         DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-            CUDALauncher::LaunchAdvancedIndexerKernel(
+            cuda_launcher::LaunchAdvancedIndexerKernel(
                     ai,
                     // Need to wrap as extended CUDA lambda function
                     [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
@@ -88,13 +88,13 @@ void IndexSetCUDA(const Tensor& src,
     CUDADeviceSwitcher switcher(dst.GetDevice());
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
-        CUDALauncher::LaunchAdvancedIndexerKernel(
+        cuda_launcher::LaunchAdvancedIndexerKernel(
                 ai, [=] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                     CUDACopyObjectElementKernel(src, dst, object_byte_size);
                 });
     } else {
         DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
-            CUDALauncher::LaunchAdvancedIndexerKernel(
+            cuda_launcher::LaunchAdvancedIndexerKernel(
                     ai,
                     // Need to wrap as extended CUDA lambda function
                     [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {

--- a/cpp/open3d/core/kernel/UnaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.cpp
@@ -155,7 +155,7 @@ void CopyCPU(const Tensor& src, Tensor& dst) {
         DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
             scalar_t scalar_element = src.To(dst_dtype).Item<scalar_t>();
             scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
-            CPULauncher::LaunchGeneralKernel(
+            cpu_launcher::LaunchParallel(
                     num_elements, [&](int64_t workload_idx) {
                         dst_ptr[workload_idx] = scalar_element;
                     });
@@ -164,7 +164,7 @@ void CopyCPU(const Tensor& src, Tensor& dst) {
         Indexer indexer({src}, dst, DtypePolicy::NONE);
         if (src.GetDtype().IsObject()) {
             int64_t object_byte_size = src.GetDtype().ByteSize();
-            CPULauncher::LaunchUnaryEWKernel(
+            cpu_launcher::LaunchUnaryEWKernel(
                     indexer, [&](const void* src, void* dst) {
                         CPUCopyObjectElementKernel(src, dst, object_byte_size);
                     });
@@ -174,7 +174,7 @@ void CopyCPU(const Tensor& src, Tensor& dst) {
                 using src_t = scalar_t;
                 DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
                     using dst_t = scalar_t;
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUCopyElementKernel<src_t, dst_t>);
                 });
             });
@@ -199,13 +199,13 @@ void UnaryEWCPU(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
         DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src_dtype, [&]() {
             if (dst_dtype == src_dtype) {
                 Indexer indexer({src}, dst, DtypePolicy::ALL_SAME);
-                CPULauncher::LaunchUnaryEWKernel(
+                cpu_launcher::LaunchUnaryEWKernel(
                         indexer,
                         CPULogicalNotElementKernel<scalar_t, scalar_t>);
             } else if (dst_dtype == Dtype::Bool) {
                 Indexer indexer({src}, dst,
                                 DtypePolicy::INPUT_SAME_OUTPUT_BOOL);
-                CPULauncher::LaunchUnaryEWKernel(
+                cpu_launcher::LaunchUnaryEWKernel(
                         indexer, CPULogicalNotElementKernel<scalar_t, bool>);
             } else {
                 utility::LogError(
@@ -220,14 +220,14 @@ void UnaryEWCPU(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
         Indexer indexer({src}, dst, DtypePolicy::INPUT_SAME_OUTPUT_BOOL);
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             if (op_code == UnaryEWOpCode::IsNan) {
-                CPULauncher::LaunchUnaryEWKernel(
+                cpu_launcher::LaunchUnaryEWKernel(
                         indexer, CPUIsNanElementKernel<scalar_t>);
             } else if (op_code == UnaryEWOpCode::IsInf) {
-                CPULauncher::LaunchUnaryEWKernel(
+                cpu_launcher::LaunchUnaryEWKernel(
                         indexer, CPUIsInfElementKernel<scalar_t>);
 
             } else if (op_code == UnaryEWOpCode::IsFinite) {
-                CPULauncher::LaunchUnaryEWKernel(
+                cpu_launcher::LaunchUnaryEWKernel(
                         indexer, CPUIsFiniteElementKernel<scalar_t>);
             }
         });
@@ -237,46 +237,46 @@ void UnaryEWCPU(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
             switch (op_code) {
                 case UnaryEWOpCode::Sqrt:
                     assert_dtype_is_float(src_dtype);
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUSqrtElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Sin:
                     assert_dtype_is_float(src_dtype);
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUSinElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Cos:
                     assert_dtype_is_float(src_dtype);
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUCosElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Neg:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUNegElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Exp:
                     assert_dtype_is_float(src_dtype);
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUExpElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Abs:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUAbsElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Floor:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUFloorElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Ceil:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUCeilElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Round:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPURoundElementKernel<scalar_t>);
                     break;
                 case UnaryEWOpCode::Trunc:
-                    CPULauncher::LaunchUnaryEWKernel(
+                    cpu_launcher::LaunchUnaryEWKernel(
                             indexer, CPUTruncElementKernel<scalar_t>);
                     break;
                 default:

--- a/cpp/open3d/core/kernel/UnaryEWCPU.cpp
+++ b/cpp/open3d/core/kernel/UnaryEWCPU.cpp
@@ -155,10 +155,9 @@ void CopyCPU(const Tensor& src, Tensor& dst) {
         DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
             scalar_t scalar_element = src.To(dst_dtype).Item<scalar_t>();
             scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
-            cpu_launcher::LaunchParallel(
-                    num_elements, [&](int64_t workload_idx) {
-                        dst_ptr[workload_idx] = scalar_element;
-                    });
+            cpu_launcher::ParallelFor(num_elements, [&](int64_t workload_idx) {
+                dst_ptr[workload_idx] = scalar_element;
+            });
         });
     } else {
         Indexer indexer({src}, dst, DtypePolicy::NONE);

--- a/cpp/open3d/core/kernel/UnaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/UnaryEWCUDA.cu
@@ -174,7 +174,7 @@ void CopyCUDA(const Tensor& src, Tensor& dst) {
             DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
                 scalar_t scalar_element = src.To(dst_dtype).Item<scalar_t>();
                 scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
-                cuda_launcher::LaunchParallel(
+                cuda_launcher::ParallelFor(
                         num_elements,
                         [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
                             dst_ptr[workload_idx] = scalar_element;

--- a/cpp/open3d/core/kernel/UnaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/UnaryEWCUDA.cu
@@ -174,7 +174,7 @@ void CopyCUDA(const Tensor& src, Tensor& dst) {
             DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
                 scalar_t scalar_element = src.To(dst_dtype).Item<scalar_t>();
                 scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
-                CUDALauncher::LaunchGeneralKernel(
+                cuda_launcher::LaunchParallel(
                         num_elements,
                         [=] OPEN3D_HOST_DEVICE(int64_t workload_idx) {
                             dst_ptr[workload_idx] = scalar_element;
@@ -188,7 +188,7 @@ void CopyCUDA(const Tensor& src, Tensor& dst) {
             Indexer indexer({src}, dst, DtypePolicy::NONE);
             if (src.GetDtype().IsObject()) {
                 int64_t object_byte_size = src.GetDtype().ByteSize();
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [=] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDACopyObjectElementKernel(src, dst,
@@ -200,7 +200,7 @@ void CopyCUDA(const Tensor& src, Tensor& dst) {
                     using src_t = scalar_t;
                     DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(dst_dtype, [&]() {
                         using dst_t = scalar_t;
-                        CUDALauncher::LaunchUnaryEWKernel(
+                        cuda_launcher::LaunchUnaryEWKernel(
                                 indexer,
                                 // Need to wrap as extended CUDA lambda function
                                 [] OPEN3D_HOST_DEVICE(const void* src,
@@ -250,7 +250,7 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
         DISPATCH_DTYPE_TO_TEMPLATE_WITH_BOOL(src_dtype, [&]() {
             if (dst_dtype == src_dtype) {
                 Indexer indexer({src}, dst, DtypePolicy::ALL_SAME);
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDALogicalNotElementKernel<scalar_t, scalar_t>(
@@ -259,7 +259,7 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
             } else if (dst_dtype == Dtype::Bool) {
                 Indexer indexer({src}, dst,
                                 DtypePolicy::INPUT_SAME_OUTPUT_BOOL);
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDALogicalNotElementKernel<scalar_t, bool>(src,
@@ -278,19 +278,19 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
         Indexer indexer({src}, dst, DtypePolicy::INPUT_SAME_OUTPUT_BOOL);
         DISPATCH_DTYPE_TO_TEMPLATE(src_dtype, [&]() {
             if (op_code == UnaryEWOpCode::IsNan) {
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDAIsNanElementKernel<scalar_t>(src, dst);
                         });
             } else if (op_code == UnaryEWOpCode::IsInf) {
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDAIsInfElementKernel<scalar_t>(src, dst);
                         });
             } else if (op_code == UnaryEWOpCode::IsFinite) {
-                CUDALauncher::LaunchUnaryEWKernel(
+                cuda_launcher::LaunchUnaryEWKernel(
                         indexer,
                         [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                             CUDAIsFiniteElementKernel<scalar_t>(src, dst);
@@ -303,7 +303,7 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
             switch (op_code) {
                 case UnaryEWOpCode::Sqrt:
                     assert_dtype_is_float(src_dtype);
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDASqrtElementKernel<scalar_t>(src, dst);
@@ -311,7 +311,7 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
                     break;
                 case UnaryEWOpCode::Sin:
                     assert_dtype_is_float(src_dtype);
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDASinElementKernel<scalar_t>(src, dst);
@@ -319,14 +319,14 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
                     break;
                 case UnaryEWOpCode::Cos:
                     assert_dtype_is_float(src_dtype);
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDACosElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Neg:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDANegElementKernel<scalar_t>(src, dst);
@@ -334,42 +334,42 @@ void UnaryEWCUDA(const Tensor& src, Tensor& dst, UnaryEWOpCode op_code) {
                     break;
                 case UnaryEWOpCode::Exp:
                     assert_dtype_is_float(src_dtype);
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDAExpElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Abs:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDAAbsElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Floor:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDAFloorElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Ceil:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDACeilElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Round:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDARoundElementKernel<scalar_t>(src, dst);
                             });
                     break;
                 case UnaryEWOpCode::Trunc:
-                    CUDALauncher::LaunchUnaryEWKernel(
+                    cuda_launcher::LaunchUnaryEWKernel(
                             indexer,
                             [] OPEN3D_HOST_DEVICE(const void* src, void* dst) {
                                 CUDATruncElementKernel<scalar_t>(src, dst);

--- a/cpp/open3d/core/linalg/TriCPU.cpp
+++ b/cpp/open3d/core/linalg/TriCPU.cpp
@@ -41,7 +41,7 @@ void TriuCPU(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cpu_launcher::LaunchParallel(
+        kernel::cpu_launcher::ParallelFor(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -61,7 +61,7 @@ void TrilCPU(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cpu_launcher::LaunchParallel(
+        kernel::cpu_launcher::ParallelFor(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -85,7 +85,7 @@ void TriulCPU(const Tensor &A,
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cpu_launcher::LaunchParallel(
+        kernel::cpu_launcher::ParallelFor(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;

--- a/cpp/open3d/core/linalg/TriCPU.cpp
+++ b/cpp/open3d/core/linalg/TriCPU.cpp
@@ -41,7 +41,7 @@ void TriuCPU(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CPULauncher::LaunchGeneralKernel(
+        kernel::cpu_launcher::LaunchParallel(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -61,7 +61,7 @@ void TrilCPU(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CPULauncher::LaunchGeneralKernel(
+        kernel::cpu_launcher::LaunchParallel(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -85,7 +85,7 @@ void TriulCPU(const Tensor &A,
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CPULauncher::LaunchGeneralKernel(
+        kernel::cpu_launcher::LaunchParallel(
                 n, [&] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;

--- a/cpp/open3d/core/linalg/TriCUDA.cu
+++ b/cpp/open3d/core/linalg/TriCUDA.cu
@@ -41,7 +41,7 @@ void TriuCUDA(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CUDALauncher::LaunchGeneralKernel(
+        kernel::cuda_launcher::LaunchParallel(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -61,7 +61,7 @@ void TrilCUDA(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CUDALauncher::LaunchGeneralKernel(
+        kernel::cuda_launcher::LaunchParallel(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -85,7 +85,7 @@ void TriulCUDA(const Tensor &A,
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        core::kernel::CUDALauncher::LaunchGeneralKernel(
+        kernel::cuda_launcher::LaunchParallel(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;

--- a/cpp/open3d/core/linalg/TriCUDA.cu
+++ b/cpp/open3d/core/linalg/TriCUDA.cu
@@ -41,7 +41,7 @@ void TriuCUDA(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cuda_launcher::LaunchParallel(
+        kernel::cuda_launcher::ParallelFor(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -61,7 +61,7 @@ void TrilCUDA(const Tensor &A, Tensor &output, const int diagonal) {
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cuda_launcher::LaunchParallel(
+        kernel::cuda_launcher::ParallelFor(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;
@@ -85,7 +85,7 @@ void TriulCUDA(const Tensor &A,
         int cols = A.GetShape()[1];
         int n = A.GetShape()[0] * cols;
 
-        kernel::cuda_launcher::LaunchParallel(
+        kernel::cuda_launcher::ParallelFor(
                 n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                     const int64_t idx = workload_idx / cols;
                     const int64_t idy = workload_idx % cols;

--- a/cpp/open3d/geometry/PointCloudCluster.cpp
+++ b/cpp/open3d/geometry/PointCloudCluster.cpp
@@ -49,7 +49,7 @@ std::vector<int> PointCloud::ClusterDBSCAN(double eps,
         std::vector<double> dists2;
         kdtree.SearchRadius(points_[idx], eps, nbs[idx], dists2);
 
-#pragma omp critical
+#pragma omp critical(ClusterDBSCAN)
         { ++progress_bar; }
     }
     utility::LogDebug("Done Precompute neighbors.");

--- a/cpp/open3d/pipelines/color_map/ColorMapUtils.cpp
+++ b/cpp/open3d/pipelines/color_map/ColorMapUtils.cpp
@@ -178,7 +178,7 @@ CreateVertexAndImageVisibility(
                 continue;
             }
             visibility_image_to_vertex[camera_id].push_back(vertex_id);
-#pragma omp critical
+#pragma omp critical(CreateVertexAndImageVisibility)
             { visibility_vertex_to_image[vertex_id].push_back(camera_id); }
         }
     }
@@ -283,7 +283,7 @@ void SetGeometryColorAverage(
                 sum += 1.0;
             }
         }
-#pragma omp critical
+#pragma omp critical(SetGeometryColorAverage)
         {
             if (sum > 0.0) {
                 mesh.vertex_colors_[i] /= sum;

--- a/cpp/open3d/pipelines/color_map/NonRigidOptimizer.cpp
+++ b/cpp/open3d/pipelines/color_map/NonRigidOptimizer.cpp
@@ -104,7 +104,7 @@ static std::tuple<MatOutType, VecOutType, double> ComputeJTJandJTrNonRigid(
             }
             r2_sum_private += r * r;
         }
-#pragma omp critical
+#pragma omp critical(ComputeJTJandJTrNonRigid)
         {
             JTJ += JTJ_private;
             JTr += JTr_private;
@@ -362,7 +362,7 @@ geometry::TriangleMesh RunNonRigidOptimizer(
             }
             opt_camera_trajectory.parameters_[c].extrinsic_ = pose;
 
-#pragma omp critical
+#pragma omp critical(RunNonRigidOptimizer)
             {
                 residual += r2;
                 residual_reg += rr_reg;

--- a/cpp/open3d/pipelines/color_map/RigidOptimizer.cpp
+++ b/cpp/open3d/pipelines/color_map/RigidOptimizer.cpp
@@ -200,7 +200,7 @@ geometry::TriangleMesh RunRigidOptimizer(
                                                                          JTr);
             pose = delta * pose;
             opt_camera_trajectory.parameters_[c].extrinsic_ = pose;
-#pragma omp critical
+#pragma omp critical(RunRigidOptimizer)
             {
                 residual += r2;
                 total_num_ += int(visibility_image_to_vertex[c].size());

--- a/cpp/open3d/pipelines/odometry/Odometry.cpp
+++ b/cpp/open3d/pipelines/odometry/Odometry.cpp
@@ -164,7 +164,7 @@ static CorrespondenceSetPixelWise ComputeCorrespondence(
                 }
             }
         }
-#pragma omp critical
+#pragma omp critical(ComputeCorrespondence)
         {
             MergeCorrespondenceMaps(correspondence_map, depth_buffer,
                                     correspondence_map_private,
@@ -279,7 +279,7 @@ static Eigen::Matrix6d CreateInformationMatrix(
             G_r_private(5) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
         }
-#pragma omp critical
+#pragma omp critical(CreateInformationMatrix)
         { GTG += GTG_private; }
     }
     return GTG;

--- a/cpp/open3d/pipelines/registration/Registration.cpp
+++ b/cpp/open3d/pipelines/registration/Registration.cpp
@@ -65,7 +65,7 @@ static RegistrationResult GetRegistrationResultAndCorrespondences(
                         Eigen::Vector2i(i, indices[0]));
             }
         }
-#pragma omp critical
+#pragma omp critical(GetRegistrationResultAndCorrespondences)
         {
             for (int i = 0; i < (int)correspondence_set_private.size(); i++) {
                 result.correspondence_set_.push_back(
@@ -255,7 +255,7 @@ RegistrationResult RegistrationRANSACBasedOnCorrespondence(
                 }
             }  // if < exit_itr_local
         }      // for loop
-#pragma omp critical
+#pragma omp critical(RegistrationRANSACBasedOnCorrespondence)
         {
             if (best_result_local.IsBetterRANSACThan(best_result)) {
                 best_result = best_result_local;
@@ -394,7 +394,7 @@ Eigen::Matrix6d GetInformationMatrixFromPointClouds(
             G_r_private(5) = 1.0;
             GTG_private.noalias() += G_r_private * G_r_private.transpose();
         }
-#pragma omp critical
+#pragma omp critical(GetInformationMatrixFromPointClouds)
         { GTG += GTG_private; }
     }
     return GTG;

--- a/cpp/open3d/t/geometry/kernel/ImageImpl.h
+++ b/cpp/open3d/t/geometry/kernel/ImageImpl.h
@@ -60,24 +60,23 @@ void ClipTransformCPU
     int64_t n = rows * cols;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
 
     DISPATCH_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
-        launcher.LaunchGeneralKernel(
-                n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                    int64_t y = workload_idx / cols;
-                    int64_t x = workload_idx % cols;
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+            int64_t y = workload_idx / cols;
+            int64_t x = workload_idx % cols;
 
-                    float in = static_cast<float>(
-                            *src_indexer.GetDataPtr<scalar_t>(x, y));
-                    float out = in / scale;
-                    out = out <= min_value ? clip_fill : out;
-                    out = out >= max_value ? clip_fill : out;
-                    *dst_indexer.GetDataPtr<float>(x, y) = out;
-                });
+            float in =
+                    static_cast<float>(*src_indexer.GetDataPtr<scalar_t>(x, y));
+            float out = in / scale;
+            out = out <= min_value ? clip_fill : out;
+            out = out >= max_value ? clip_fill : out;
+            *dst_indexer.GetDataPtr<float>(x, y) = out;
+        });
     });
 }
 
@@ -109,15 +108,15 @@ void PyrDownDepthCPU
     const float gweights[3] = {0.375f, 0.25f, 0.0625f};
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
     using std::abs;
     using std::max;
     using std::min;
 #endif
 
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         int y = workload_idx / cols_down;
         int x = workload_idx % cols_down;
 
@@ -176,13 +175,14 @@ void CreateVertexMapCPU
     int64_t n = rows * cols;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
     using std::isinf;
     using std::isnan;
 #endif
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         auto is_invalid = [invalid_fill] OPEN3D_DEVICE(float v) {
             if (isinf(invalid_fill)) return isinf(v);
             if (isnan(invalid_fill)) return isnan(v);
@@ -219,12 +219,12 @@ void CreateNormalMapCPU
     int64_t n = rows * cols;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
 
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         int64_t y = workload_idx / cols;
         int64_t x = workload_idx % cols;
 
@@ -291,15 +291,14 @@ void ColorizeDepthCPU
     int64_t n = rows * cols;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
 
     float inv_interval = 255.0f / (max_value - min_value);
     DISPATCH_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
-        launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(
-                                                int64_t workload_idx) {
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
             int64_t y = workload_idx / cols;
             int64_t x = workload_idx % cols;
 

--- a/cpp/open3d/t/geometry/kernel/ImageImpl.h
+++ b/cpp/open3d/t/geometry/kernel/ImageImpl.h
@@ -66,7 +66,7 @@ void ClipTransformCPU
 #endif
 
     DISPATCH_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
-        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+        launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
             int64_t y = workload_idx / cols;
             int64_t x = workload_idx % cols;
 
@@ -116,7 +116,7 @@ void PyrDownDepthCPU
     using std::min;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         int y = workload_idx / cols_down;
         int x = workload_idx % cols_down;
 
@@ -182,7 +182,7 @@ void CreateVertexMapCPU
     using std::isnan;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         auto is_invalid = [invalid_fill] OPEN3D_DEVICE(float v) {
             if (isinf(invalid_fill)) return isinf(v);
             if (isnan(invalid_fill)) return isnan(v);
@@ -224,7 +224,7 @@ void CreateNormalMapCPU
     namespace launcher = core::kernel::cpu_launcher;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         int64_t y = workload_idx / cols;
         int64_t x = workload_idx % cols;
 
@@ -298,7 +298,7 @@ void ColorizeDepthCPU
 
     float inv_interval = 255.0f / (max_value - min_value);
     DISPATCH_DTYPE_TO_TEMPLATE(src.GetDtype(), [&]() {
-        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+        launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
             int64_t y = workload_idx / cols;
             int64_t x = workload_idx % cols;
 

--- a/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
@@ -85,7 +85,7 @@ void ProjectCPU(
         float* depth_ptr = depth_indexer.GetDataPtr<float>(
                 static_cast<int64_t>(u), static_cast<int64_t>(v));
         float d = zc * depth_scale;
-#pragma omp critical
+#pragma omp critical(ProjectCPU)
         {
             if (*depth_ptr == 0 || *depth_ptr >= d) {
                 *depth_ptr = d;

--- a/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
@@ -67,50 +67,43 @@ void ProjectCPU(
         color_indexer = NDArrayIndexer(image_colors.value().get(), 2);
     }
 
-    core::kernel::CPULauncher::LaunchGeneralKernel(
-            n, [&](int64_t workload_idx) {
-                float x = points_ptr[3 * workload_idx + 0];
-                float y = points_ptr[3 * workload_idx + 1];
-                float z = points_ptr[3 * workload_idx + 2];
+    core::kernel::cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
+        float x = points_ptr[3 * workload_idx + 0];
+        float y = points_ptr[3 * workload_idx + 1];
+        float z = points_ptr[3 * workload_idx + 2];
 
-                // coordinate in camera (in voxel -> in meter)
-                float xc, yc, zc, u, v;
-                transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
+        // coordinate in camera (in voxel -> in meter)
+        float xc, yc, zc, u, v;
+        transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
 
-                // coordinate in image (in pixel)
-                transform_indexer.Project(xc, yc, zc, &u, &v);
-                if (!depth_indexer.InBoundary(u, v) || zc <= 0 ||
-                    zc > depth_max) {
-                    return;
-                }
+        // coordinate in image (in pixel)
+        transform_indexer.Project(xc, yc, zc, &u, &v);
+        if (!depth_indexer.InBoundary(u, v) || zc <= 0 || zc > depth_max) {
+            return;
+        }
 
-                float* depth_ptr = depth_indexer.GetDataPtr<float>(
-                        static_cast<int64_t>(u), static_cast<int64_t>(v));
-                float d = zc * depth_scale;
+        float* depth_ptr = depth_indexer.GetDataPtr<float>(
+                static_cast<int64_t>(u), static_cast<int64_t>(v));
+        float d = zc * depth_scale;
 #pragma omp critical
-                {
-                    if (*depth_ptr == 0 || *depth_ptr >= d) {
-                        *depth_ptr = d;
+        {
+            if (*depth_ptr == 0 || *depth_ptr >= d) {
+                *depth_ptr = d;
 
-                        if (has_colors) {
-                            uint8_t* color_ptr =
-                                    color_indexer.GetDataPtr<uint8_t>(
-                                            static_cast<int64_t>(u),
-                                            static_cast<int64_t>(v));
+                if (has_colors) {
+                    uint8_t* color_ptr = color_indexer.GetDataPtr<uint8_t>(
+                            static_cast<int64_t>(u), static_cast<int64_t>(v));
 
-                            color_ptr[0] = static_cast<uint8_t>(
-                                    point_colors_ptr[3 * workload_idx + 0] *
-                                    255.0);
-                            color_ptr[1] = static_cast<uint8_t>(
-                                    point_colors_ptr[3 * workload_idx + 1] *
-                                    255.0);
-                            color_ptr[2] = static_cast<uint8_t>(
-                                    point_colors_ptr[3 * workload_idx + 2] *
-                                    255.0);
-                        }
-                    }
+                    color_ptr[0] = static_cast<uint8_t>(
+                            point_colors_ptr[3 * workload_idx + 0] * 255.0);
+                    color_ptr[1] = static_cast<uint8_t>(
+                            point_colors_ptr[3 * workload_idx + 1] * 255.0);
+                    color_ptr[2] = static_cast<uint8_t>(
+                            point_colors_ptr[3 * workload_idx + 2] * 255.0);
                 }
-            });
+            }
+        }
+    });
 }
 }  // namespace pointcloud
 }  // namespace kernel

--- a/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCPU.cpp
@@ -67,7 +67,7 @@ void ProjectCPU(
         color_indexer = NDArrayIndexer(image_colors.value().get(), 2);
     }
 
-    core::kernel::cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
+    core::kernel::cpu_launcher::ParallelFor(n, [&](int64_t workload_idx) {
         float x = points_ptr[3 * workload_idx + 0];
         float y = points_ptr[3 * workload_idx + 1];
         float z = points_ptr[3 * workload_idx + 2];

--- a/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
@@ -63,7 +63,7 @@ void ProjectCUDA(
     NDArrayIndexer depth_indexer(depth, 2);
 
     // Pass 1: depth map
-    core::kernel::CUDALauncher::LaunchGeneralKernel(
+    core::kernel::cuda_launcher::LaunchParallel(
             n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 float x = points_ptr[3 * workload_idx + 0];
                 float y = points_ptr[3 * workload_idx + 1];
@@ -94,7 +94,7 @@ void ProjectCUDA(
 
     NDArrayIndexer color_indexer(image_colors.value().get(), 2);
     float precision_bound = depth_scale * 1e-4;
-    core::kernel::CUDALauncher::LaunchGeneralKernel(
+    core::kernel::cuda_launcher::LaunchParallel(
             n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 float x = points_ptr[3 * workload_idx + 0];
                 float y = points_ptr[3 * workload_idx + 1];

--- a/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
+++ b/cpp/open3d/t/geometry/kernel/PointCloudCUDA.cu
@@ -63,68 +63,66 @@ void ProjectCUDA(
     NDArrayIndexer depth_indexer(depth, 2);
 
     // Pass 1: depth map
-    core::kernel::cuda_launcher::LaunchParallel(
-            n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                float x = points_ptr[3 * workload_idx + 0];
-                float y = points_ptr[3 * workload_idx + 1];
-                float z = points_ptr[3 * workload_idx + 2];
+    core::kernel::cuda_launcher::ParallelFor(n, [=] OPEN3D_DEVICE(
+                                                        int64_t workload_idx) {
+        float x = points_ptr[3 * workload_idx + 0];
+        float y = points_ptr[3 * workload_idx + 1];
+        float z = points_ptr[3 * workload_idx + 2];
 
-                // coordinate in camera (in voxel -> in meter)
-                float xc, yc, zc, u, v;
-                transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
+        // coordinate in camera (in voxel -> in meter)
+        float xc, yc, zc, u, v;
+        transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
 
-                // coordinate in image (in pixel)
-                transform_indexer.Project(xc, yc, zc, &u, &v);
-                if (!depth_indexer.InBoundary(u, v) || zc <= 0 ||
-                    zc > depth_max) {
-                    return;
-                }
+        // coordinate in image (in pixel)
+        transform_indexer.Project(xc, yc, zc, &u, &v);
+        if (!depth_indexer.InBoundary(u, v) || zc <= 0 || zc > depth_max) {
+            return;
+        }
 
-                float* depth_ptr = depth_indexer.GetDataPtr<float>(
-                        static_cast<int64_t>(u), static_cast<int64_t>(v));
-                float d = zc * depth_scale;
-                float d_old = atomicExch(depth_ptr, d);
-                if (d_old > 0) {
-                    atomicMinf(depth_ptr, d_old);
-                }
-            });
+        float* depth_ptr = depth_indexer.GetDataPtr<float>(
+                static_cast<int64_t>(u), static_cast<int64_t>(v));
+        float d = zc * depth_scale;
+        float d_old = atomicExch(depth_ptr, d);
+        if (d_old > 0) {
+            atomicMinf(depth_ptr, d_old);
+        }
+    });
 
     // Pass 2: color map
     if (!has_colors) return;
 
     NDArrayIndexer color_indexer(image_colors.value().get(), 2);
     float precision_bound = depth_scale * 1e-4;
-    core::kernel::cuda_launcher::LaunchParallel(
-            n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                float x = points_ptr[3 * workload_idx + 0];
-                float y = points_ptr[3 * workload_idx + 1];
-                float z = points_ptr[3 * workload_idx + 2];
+    core::kernel::cuda_launcher::ParallelFor(n, [=] OPEN3D_DEVICE(
+                                                        int64_t workload_idx) {
+        float x = points_ptr[3 * workload_idx + 0];
+        float y = points_ptr[3 * workload_idx + 1];
+        float z = points_ptr[3 * workload_idx + 2];
 
-                // coordinate in camera (in voxel -> in meter)
-                float xc, yc, zc, u, v;
-                transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
+        // coordinate in camera (in voxel -> in meter)
+        float xc, yc, zc, u, v;
+        transform_indexer.RigidTransform(x, y, z, &xc, &yc, &zc);
 
-                // coordinate in image (in pixel)
-                transform_indexer.Project(xc, yc, zc, &u, &v);
-                if (!depth_indexer.InBoundary(u, v) || zc <= 0 ||
-                    zc > depth_max) {
-                    return;
-                }
+        // coordinate in image (in pixel)
+        transform_indexer.Project(xc, yc, zc, &u, &v);
+        if (!depth_indexer.InBoundary(u, v) || zc <= 0 || zc > depth_max) {
+            return;
+        }
 
-                float dmap = *depth_indexer.GetDataPtr<float>(
-                        static_cast<int64_t>(u), static_cast<int64_t>(v));
-                float d = zc * depth_scale;
-                if (d < dmap + precision_bound) {
-                    uint8_t* color_ptr = color_indexer.GetDataPtr<uint8_t>(
-                            static_cast<int64_t>(u), static_cast<int64_t>(v));
-                    color_ptr[0] = static_cast<uint8_t>(
-                            point_colors_ptr[3 * workload_idx + 0] * 255.0);
-                    color_ptr[1] = static_cast<uint8_t>(
-                            point_colors_ptr[3 * workload_idx + 1] * 255.0);
-                    color_ptr[2] = static_cast<uint8_t>(
-                            point_colors_ptr[3 * workload_idx + 2] * 255.0);
-                }
-            });
+        float dmap = *depth_indexer.GetDataPtr<float>(static_cast<int64_t>(u),
+                                                      static_cast<int64_t>(v));
+        float d = zc * depth_scale;
+        if (d < dmap + precision_bound) {
+            uint8_t* color_ptr = color_indexer.GetDataPtr<uint8_t>(
+                    static_cast<int64_t>(u), static_cast<int64_t>(v));
+            color_ptr[0] = static_cast<uint8_t>(
+                    point_colors_ptr[3 * workload_idx + 0] * 255.0);
+            color_ptr[1] = static_cast<uint8_t>(
+                    point_colors_ptr[3 * workload_idx + 1] * 255.0);
+            color_ptr[2] = static_cast<uint8_t>(
+                    point_colors_ptr[3 * workload_idx + 2] * 255.0);
+        }
+    });
 }
 }  // namespace pointcloud
 }  // namespace kernel

--- a/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
+++ b/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
@@ -104,7 +104,7 @@ void UnprojectCPU
 #endif
 
     DISPATCH_DTYPE_TO_TEMPLATE(depth.GetDtype(), [&]() {
-        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+        launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
             int64_t y = (workload_idx / cols_strided) * stride;
             int64_t x = (workload_idx % cols_strided) * stride;
 

--- a/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
+++ b/cpp/open3d/t/geometry/kernel/PointCloudImpl.h
@@ -96,15 +96,15 @@ void UnprojectCPU
 #endif
 
     int64_t n = rows_strided * cols_strided;
+
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
 
     DISPATCH_DTYPE_TO_TEMPLATE(depth.GetDtype(), [&]() {
-        launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(
-                                                int64_t workload_idx) {
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
             int64_t y = (workload_idx / cols_strided) * stride;
             int64_t x = (workload_idx % cols_strided) * stride;
 

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCPU.cpp
@@ -82,32 +82,25 @@ void TouchCPU(std::shared_ptr<core::Hashmap>&
     const float* pcd_ptr = static_cast<const float*>(points.GetDataPtr());
 
     tbb::concurrent_unordered_set<Coord3i, Coord3iHash> set;
-    core::kernel::CPULauncher::LaunchGeneralKernel(
-            n, [&](int64_t workload_idx) {
-                float x = pcd_ptr[3 * workload_idx + 0];
-                float y = pcd_ptr[3 * workload_idx + 1];
-                float z = pcd_ptr[3 * workload_idx + 2];
+    core::kernel::cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
+        float x = pcd_ptr[3 * workload_idx + 0];
+        float y = pcd_ptr[3 * workload_idx + 1];
+        float z = pcd_ptr[3 * workload_idx + 2];
 
-                int xb_lo = static_cast<int>(
-                        std::floor((x - sdf_trunc) / block_size));
-                int xb_hi = static_cast<int>(
-                        std::floor((x + sdf_trunc) / block_size));
-                int yb_lo = static_cast<int>(
-                        std::floor((y - sdf_trunc) / block_size));
-                int yb_hi = static_cast<int>(
-                        std::floor((y + sdf_trunc) / block_size));
-                int zb_lo = static_cast<int>(
-                        std::floor((z - sdf_trunc) / block_size));
-                int zb_hi = static_cast<int>(
-                        std::floor((z + sdf_trunc) / block_size));
-                for (int xb = xb_lo; xb <= xb_hi; ++xb) {
-                    for (int yb = yb_lo; yb <= yb_hi; ++yb) {
-                        for (int zb = zb_lo; zb <= zb_hi; ++zb) {
-                            set.emplace(xb, yb, zb);
-                        }
-                    }
+        int xb_lo = static_cast<int>(std::floor((x - sdf_trunc) / block_size));
+        int xb_hi = static_cast<int>(std::floor((x + sdf_trunc) / block_size));
+        int yb_lo = static_cast<int>(std::floor((y - sdf_trunc) / block_size));
+        int yb_hi = static_cast<int>(std::floor((y + sdf_trunc) / block_size));
+        int zb_lo = static_cast<int>(std::floor((z - sdf_trunc) / block_size));
+        int zb_hi = static_cast<int>(std::floor((z + sdf_trunc) / block_size));
+        for (int xb = xb_lo; xb <= xb_hi; ++xb) {
+            for (int yb = yb_lo; yb <= yb_hi; ++yb) {
+                for (int zb = zb_lo; zb <= zb_hi; ++zb) {
+                    set.emplace(xb, yb, zb);
                 }
-            });
+            }
+        }
+    });
 
     int64_t block_count = set.size();
     if (block_count == 0) {

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCPU.cpp
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCPU.cpp
@@ -82,7 +82,7 @@ void TouchCPU(std::shared_ptr<core::Hashmap>&
     const float* pcd_ptr = static_cast<const float*>(points.GetDataPtr());
 
     tbb::concurrent_unordered_set<Coord3i, Coord3iHash> set;
-    core::kernel::cpu_launcher::LaunchParallel(n, [&](int64_t workload_idx) {
+    core::kernel::cpu_launcher::ParallelFor(n, [&](int64_t workload_idx) {
         float x = pcd_ptr[3 * workload_idx + 0];
         float y = pcd_ptr[3 * workload_idx + 1];
         float z = pcd_ptr[3 * workload_idx + 2];

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCUDA.cu
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridCUDA.cu
@@ -74,7 +74,7 @@ void TouchCUDA(std::shared_ptr<core::Hashmap>& hashmap,
     core::Tensor count(std::vector<int>{0}, {}, core::Dtype::Int32, device);
     int* count_ptr = static_cast<int*>(count.GetDataPtr());
 
-    core::kernel::CUDALauncher::LaunchGeneralKernel(
+    core::kernel::cuda_launcher::LaunchParallel(
             n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 float x = pcd_ptr[3 * workload_idx + 0];
                 float y = pcd_ptr[3 * workload_idx + 1];

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
@@ -1072,7 +1072,7 @@ void EstimateRangeCPU
                 atomicMinf(&(range_ptr[0]), z_min);
                 atomicMaxf(&(range_ptr[1]), z_max);
 #else
-#pragma omp critical
+#pragma omp critical(EstimateRangeCPU)
                 {
                     range_ptr[0] = min(z_min, range_ptr[0]);
                     range_ptr[1] = max(z_max, range_ptr[1]);

--- a/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
+++ b/cpp/open3d/t/geometry/kernel/TSDFVoxelGridImpl.h
@@ -91,15 +91,15 @@ void IntegrateCPU
     int64_t n = indices.GetLength() * resolution3;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
 
     DISPATCH_BYTESIZE_TO_VOXEL(
             voxel_block_buffer_indexer.ElementByteSize(), [&]() {
-                launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(
-                                                        int64_t workload_idx) {
+                launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(
+                                                    int64_t workload_idx) {
                     // Natural index (0, N) -> (block_idx, voxel_idx)
                     int block_idx = indices_ptr[workload_idx / resolution3];
                     int voxel_idx = workload_idx % resolution3;
@@ -215,10 +215,11 @@ void ExtractSurfacePointsCPU
 #endif
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
+
     if (valid_size < 0) {
         utility::LogWarning(
                 "No estimated max point cloud size provided, using a 2-pass "
@@ -226,61 +227,55 @@ void ExtractSurfacePointsCPU
         // This pass determines valid number of points.
         DISPATCH_BYTESIZE_TO_VOXEL(
                 voxel_block_buffer_indexer.ElementByteSize(), [&]() {
-                    launcher.LaunchGeneralKernel(
-                            n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                                auto GetVoxelAt = [&] OPEN3D_DEVICE(
-                                                          int xo, int yo,
-                                                          int zo,
-                                                          int curr_block_idx)
-                                        -> voxel_t* {
-                                    return DeviceGetVoxelAt<voxel_t>(
-                                            xo, yo, zo, curr_block_idx,
-                                            static_cast<int>(resolution),
-                                            nb_block_masks_indexer,
-                                            nb_block_indices_indexer,
-                                            voxel_block_buffer_indexer);
-                                };
+                    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(
+                                                        int64_t workload_idx) {
+                        auto GetVoxelAt =
+                                [&] OPEN3D_DEVICE(
+                                        int xo, int yo, int zo,
+                                        int curr_block_idx) -> voxel_t* {
+                            return DeviceGetVoxelAt<voxel_t>(
+                                    xo, yo, zo, curr_block_idx,
+                                    static_cast<int>(resolution),
+                                    nb_block_masks_indexer,
+                                    nb_block_indices_indexer,
+                                    voxel_block_buffer_indexer);
+                        };
 
-                                // Natural index (0, N) -> (block_idx,
-                                // voxel_idx)
-                                int64_t workload_block_idx =
-                                        workload_idx / resolution3;
-                                int64_t block_idx =
-                                        indices_ptr[workload_block_idx];
-                                int64_t voxel_idx = workload_idx % resolution3;
+                        // Natural index (0, N) -> (block_idx,
+                        // voxel_idx)
+                        int64_t workload_block_idx = workload_idx / resolution3;
+                        int64_t block_idx = indices_ptr[workload_block_idx];
+                        int64_t voxel_idx = workload_idx % resolution3;
 
-                                // voxel_idx -> (x_voxel, y_voxel, z_voxel)
-                                int64_t xv, yv, zv;
-                                voxel_indexer.WorkloadToCoord(voxel_idx, &xv,
-                                                              &yv, &zv);
+                        // voxel_idx -> (x_voxel, y_voxel, z_voxel)
+                        int64_t xv, yv, zv;
+                        voxel_indexer.WorkloadToCoord(voxel_idx, &xv, &yv, &zv);
 
-                                voxel_t* voxel_ptr =
-                                        voxel_block_buffer_indexer
-                                                .GetDataPtr<voxel_t>(xv, yv, zv,
-                                                                     block_idx);
-                                float tsdf_o = voxel_ptr->GetTSDF();
-                                float weight_o = voxel_ptr->GetWeight();
-                                if (weight_o <= weight_threshold) return;
+                        voxel_t* voxel_ptr =
+                                voxel_block_buffer_indexer.GetDataPtr<voxel_t>(
+                                        xv, yv, zv, block_idx);
+                        float tsdf_o = voxel_ptr->GetTSDF();
+                        float weight_o = voxel_ptr->GetWeight();
+                        if (weight_o <= weight_threshold) return;
 
-                                // Enumerate x-y-z directions
-                                for (int i = 0; i < 3; ++i) {
-                                    voxel_t* ptr = GetVoxelAt(
-                                            static_cast<int>(xv) + (i == 0),
-                                            static_cast<int>(yv) + (i == 1),
-                                            static_cast<int>(zv) + (i == 2),
-                                            static_cast<int>(
-                                                    workload_block_idx));
-                                    if (ptr == nullptr) continue;
+                        // Enumerate x-y-z directions
+                        for (int i = 0; i < 3; ++i) {
+                            voxel_t* ptr = GetVoxelAt(
+                                    static_cast<int>(xv) + (i == 0),
+                                    static_cast<int>(yv) + (i == 1),
+                                    static_cast<int>(zv) + (i == 2),
+                                    static_cast<int>(workload_block_idx));
+                            if (ptr == nullptr) continue;
 
-                                    float tsdf_i = ptr->GetTSDF();
-                                    float weight_i = ptr->GetWeight();
+                            float tsdf_i = ptr->GetTSDF();
+                            float weight_i = ptr->GetWeight();
 
-                                    if (weight_i > weight_threshold &&
-                                        tsdf_i * tsdf_o < 0) {
-                                        OPEN3D_ATOMIC_ADD(count_ptr, 1);
-                                    }
-                                }
-                            });
+                            if (weight_i > weight_threshold &&
+                                tsdf_i * tsdf_o < 0) {
+                                OPEN3D_ATOMIC_ADD(count_ptr, 1);
+                            }
+                        }
+                    });
                 });
 
 #if defined(__CUDACC__)
@@ -328,8 +323,8 @@ void ExtractSurfacePointsCPU
                     color_indexer = NDArrayIndexer(colors.value().get(), 1);
                 }
 
-                launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(
-                                                        int64_t workload_idx) {
+                launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(
+                                                    int64_t workload_idx) {
                     auto GetVoxelAt = [&] OPEN3D_DEVICE(
                                               int xo, int yo, int zo,
                                               int curr_block_idx) -> voxel_t* {
@@ -541,15 +536,15 @@ void ExtractSurfaceMeshCPU
     int64_t n = n_blocks * resolution3;
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
     int64_t voxel_bytesize = voxel_block_buffer_indexer.ElementByteSize();
     // Pass 0: analyze mesh structure, set up one-on-one correspondences
     // from edges to vertices.
     DISPATCH_BYTESIZE_TO_VOXEL(voxel_bytesize, [&]() {
-        launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t widx) {
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t widx) {
             auto GetVoxelAt = [&] OPEN3D_DEVICE(
                                       int xo, int yo, int zo,
                                       int curr_block_idx) -> voxel_t* {
@@ -633,7 +628,7 @@ void ExtractSurfaceMeshCPU
 #endif
 
     if (vertex_count < 0) {
-        launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t widx) {
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t widx) {
             // Natural index (0, N) -> (block_idx, voxel_idx)
             int64_t workload_block_idx = widx / resolution3;
             int64_t voxel_idx = widx % resolution3;
@@ -705,7 +700,7 @@ void ExtractSurfaceMeshCPU
             color_indexer = NDArrayIndexer(colors.value().get(), 1);
         }
 
-        launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t widx) {
+        launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t widx) {
             auto GetVoxelAt = [&] OPEN3D_DEVICE(
                                       int xo, int yo, int zo,
                                       int curr_block_idx) -> voxel_t* {
@@ -839,7 +834,7 @@ void ExtractSurfaceMeshCPU
 #else
     (*count_ptr) = 0;
 #endif
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t widx) {
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t widx) {
         // Natural index (0, N) -> (block_idx, voxel_idx)
         int64_t workload_block_idx = widx / resolution3;
         int64_t voxel_idx = widx % resolution3;
@@ -943,16 +938,17 @@ void EstimateRangeCPU
     std::atomic<int> count_atomic(0);
     std::atomic<int>* count_ptr = &count_atomic;
 #endif
+
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
     using std::max;
     using std::min;
 #endif
 
     // Pass 0: iterate over blocks, fill-in an rendering fragment array
-    launcher.LaunchGeneralKernel(
+    launcher::LaunchParallel(
             block_keys.GetLength(), [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 int* key = block_keys_indexer.GetDataPtr<int>(workload_idx);
 
@@ -1040,7 +1036,7 @@ void EstimateRangeCPU
 #endif
 
     // Pass 0.5: Fill in range map to prepare for atomic min/max
-    launcher.LaunchGeneralKernel(
+    launcher::LaunchParallel(
             h_down * w_down, [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 int v = workload_idx / w_down;
                 int u = workload_idx % w_down;
@@ -1050,7 +1046,7 @@ void EstimateRangeCPU
             });
 
     // Pass 1: iterate over rendering fragment array, fill-in range
-    launcher.LaunchGeneralKernel(
+    launcher::LaunchParallel(
             frag_count * fragment_size * fragment_size,
             [=] OPEN3D_DEVICE(int64_t workload_idx) {
                 int frag_idx = workload_idx / (fragment_size * fragment_size);
@@ -1187,322 +1183,303 @@ void RayCastCPU
     int64_t cols = w;
 
     float block_size = voxel_size * block_resolution;
-#if defined(BUILD_CUDA_MODULE) && defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+
+#if defined(__CUDACC__)
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
     using std::max;
 #endif
 
     DISPATCH_BYTESIZE_TO_VOXEL(voxel_block_buffer_indexer.ElementByteSize(), [&]() {
-        launcher.LaunchGeneralKernel(
-                rows * cols, [=] OPEN3D_DEVICE(int64_t workload_idx) {
-                    auto GetVoxelAtP = [&] OPEN3D_DEVICE(
-                                               int x_b, int y_b, int z_b,
-                                               int x_v, int y_v, int z_v,
-                                               core::addr_t block_addr,
-                                               BlockCache& cache) -> voxel_t* {
-                        int x_vn = (x_v + block_resolution) % block_resolution;
-                        int y_vn = (y_v + block_resolution) % block_resolution;
-                        int z_vn = (z_v + block_resolution) % block_resolution;
+        launcher::LaunchParallel(rows * cols, [=] OPEN3D_DEVICE(
+                                                      int64_t workload_idx) {
+            auto GetVoxelAtP =
+                    [&] OPEN3D_DEVICE(int x_b, int y_b, int z_b, int x_v,
+                                      int y_v, int z_v, core::addr_t block_addr,
+                                      BlockCache& cache) -> voxel_t* {
+                int x_vn = (x_v + block_resolution) % block_resolution;
+                int y_vn = (y_v + block_resolution) % block_resolution;
+                int z_vn = (z_v + block_resolution) % block_resolution;
 
-                        int dx_b = Sign(x_v - x_vn);
-                        int dy_b = Sign(y_v - y_vn);
-                        int dz_b = Sign(z_v - z_vn);
+                int dx_b = Sign(x_v - x_vn);
+                int dy_b = Sign(y_v - y_vn);
+                int dz_b = Sign(z_v - z_vn);
 
-                        if (dx_b == 0 && dy_b == 0 && dz_b == 0) {
-                            return voxel_block_buffer_indexer
-                                    .GetDataPtr<voxel_t>(x_v, y_v, z_v,
-                                                         block_addr);
-                        } else {
-                            Key key;
-                            key.Set(0, x_b + dx_b);
-                            key.Set(1, y_b + dy_b);
-                            key.Set(2, z_b + dz_b);
+                if (dx_b == 0 && dy_b == 0 && dz_b == 0) {
+                    return voxel_block_buffer_indexer.GetDataPtr<voxel_t>(
+                            x_v, y_v, z_v, block_addr);
+                } else {
+                    Key key;
+                    key.Set(0, x_b + dx_b);
+                    key.Set(1, y_b + dy_b);
+                    key.Set(2, z_b + dz_b);
 
-                            int block_addr = cache.Check(key.Get(0), key.Get(1),
-                                                         key.Get(2));
-                            if (block_addr < 0) {
-                                auto iter = hashmap_impl.find(key);
-                                if (iter == hashmap_impl.end()) return nullptr;
-                                block_addr = iter->second;
-                                cache.Update(key.Get(0), key.Get(1), key.Get(2),
-                                             block_addr);
-                            }
-
-                            return voxel_block_buffer_indexer
-                                    .GetDataPtr<voxel_t>(x_vn, y_vn, z_vn,
-                                                         block_addr);
-                        }
-                    };
-
-                    auto GetVoxelAtT = [&] OPEN3D_DEVICE(
-                                               float x_o, float y_o, float z_o,
-                                               float x_d, float y_d, float z_d,
-                                               float t,
-                                               BlockCache& cache) -> voxel_t* {
-                        float x_g = x_o + t * x_d;
-                        float y_g = y_o + t * y_d;
-                        float z_g = z_o + t * z_d;
-
-                        // Block coordinate and look up
-                        int x_b = static_cast<int>(floorf(x_g / block_size));
-                        int y_b = static_cast<int>(floorf(y_g / block_size));
-                        int z_b = static_cast<int>(floorf(z_g / block_size));
-
-                        Key key;
-                        key.Set(0, x_b);
-                        key.Set(1, y_b);
-                        key.Set(2, z_b);
-
-                        int block_addr = cache.Check(x_b, y_b, z_b);
-                        if (block_addr < 0) {
-                            auto iter = hashmap_impl.find(key);
-                            if (iter == hashmap_impl.end()) return nullptr;
-                            block_addr = iter->second;
-                            cache.Update(x_b, y_b, z_b, block_addr);
-                        }
-
-                        // Voxel coordinate and look up
-                        int x_v = int((x_g - x_b * block_size) / voxel_size);
-                        int y_v = int((y_g - y_b * block_size) / voxel_size);
-                        int z_v = int((z_g - z_b * block_size) / voxel_size);
-                        return voxel_block_buffer_indexer.GetDataPtr<voxel_t>(
-                                x_v, y_v, z_v, block_addr);
-                    };
-
-                    int64_t y = workload_idx / cols;
-                    int64_t x = workload_idx % cols;
-
-                    float *depth_ptr = nullptr, *vertex_ptr = nullptr,
-                          *normal_ptr = nullptr, *color_ptr = nullptr;
-                    if (enable_depth) {
-                        depth_ptr = depth_map_indexer.GetDataPtr<float>(x, y);
-                        *depth_ptr = 0;
-                    }
-                    if (enable_vertex) {
-                        vertex_ptr = vertex_map_indexer.GetDataPtr<float>(x, y);
-                        vertex_ptr[0] = 0;
-                        vertex_ptr[1] = 0;
-                        vertex_ptr[2] = 0;
-                    }
-                    if (enable_color) {
-                        color_ptr = color_map_indexer.GetDataPtr<float>(x, y);
-                        color_ptr[0] = 0;
-                        color_ptr[1] = 0;
-                        color_ptr[2] = 0;
-                    }
-                    if (enable_normal) {
-                        normal_ptr = normal_map_indexer.GetDataPtr<float>(x, y);
-                        normal_ptr[0] = 0;
-                        normal_ptr[1] = 0;
-                        normal_ptr[2] = 0;
+                    int block_addr =
+                            cache.Check(key.Get(0), key.Get(1), key.Get(2));
+                    if (block_addr < 0) {
+                        auto iter = hashmap_impl.find(key);
+                        if (iter == hashmap_impl.end()) return nullptr;
+                        block_addr = iter->second;
+                        cache.Update(key.Get(0), key.Get(1), key.Get(2),
+                                     block_addr);
                     }
 
-                    const float* range =
-                            range_map_indexer.GetDataPtr<float>(x / 8, y / 8);
-                    float t = range[0];
-                    const float t_max = range[1];
-                    if (t >= t_max) return;
+                    return voxel_block_buffer_indexer.GetDataPtr<voxel_t>(
+                            x_vn, y_vn, z_vn, block_addr);
+                }
+            };
 
-                    // Coordinates in camera and global
-                    float x_c = 0, y_c = 0, z_c = 0;
-                    float x_g = 0, y_g = 0, z_g = 0;
-                    float x_o = 0, y_o = 0, z_o = 0;
+            auto GetVoxelAtT = [&] OPEN3D_DEVICE(
+                                       float x_o, float y_o, float z_o,
+                                       float x_d, float y_d, float z_d, float t,
+                                       BlockCache& cache) -> voxel_t* {
+                float x_g = x_o + t * x_d;
+                float y_g = y_o + t * y_d;
+                float z_g = z_o + t * z_d;
 
-                    // Iterative ray intersection check
-                    float t_prev = t;
+                // Block coordinate and look up
+                int x_b = static_cast<int>(floorf(x_g / block_size));
+                int y_b = static_cast<int>(floorf(y_g / block_size));
+                int z_b = static_cast<int>(floorf(z_g / block_size));
 
-                    float tsdf_prev = -1.0f;
-                    float tsdf = 1.0;
-                    float w = 0.0;
+                Key key;
+                key.Set(0, x_b);
+                key.Set(1, y_b);
+                key.Set(2, z_b);
 
-                    // Camera origin
-                    c2w_transform_indexer.RigidTransform(0, 0, 0, &x_o, &y_o,
-                                                         &z_o);
+                int block_addr = cache.Check(x_b, y_b, z_b);
+                if (block_addr < 0) {
+                    auto iter = hashmap_impl.find(key);
+                    if (iter == hashmap_impl.end()) return nullptr;
+                    block_addr = iter->second;
+                    cache.Update(x_b, y_b, z_b, block_addr);
+                }
 
-                    // Direction
-                    c2w_transform_indexer.Unproject(static_cast<float>(x),
-                                                    static_cast<float>(y), 1.0f,
-                                                    &x_c, &y_c, &z_c);
-                    c2w_transform_indexer.RigidTransform(x_c, y_c, z_c, &x_g,
-                                                         &y_g, &z_g);
-                    float x_d = (x_g - x_o);
-                    float y_d = (y_g - y_o);
-                    float z_d = (z_g - z_o);
+                // Voxel coordinate and look up
+                int x_v = int((x_g - x_b * block_size) / voxel_size);
+                int y_v = int((y_g - y_b * block_size) / voxel_size);
+                int z_v = int((z_g - z_b * block_size) / voxel_size);
+                return voxel_block_buffer_indexer.GetDataPtr<voxel_t>(
+                        x_v, y_v, z_v, block_addr);
+            };
 
-                    BlockCache cache{0, 0, 0, -1};
-                    bool surface_found = false;
-                    while (t < t_max) {
-                        voxel_t* voxel_ptr = GetVoxelAtT(x_o, y_o, z_o, x_d,
-                                                         y_d, z_d, t, cache);
+            int64_t y = workload_idx / cols;
+            int64_t x = workload_idx % cols;
 
-                        if (!voxel_ptr) {
-                            t_prev = t;
-                            t += block_size;
-                        } else {
-                            tsdf_prev = tsdf;
-                            tsdf = voxel_ptr->GetTSDF();
-                            w = voxel_ptr->GetWeight();
-                            if (tsdf_prev > 0 && w >= weight_threshold &&
-                                tsdf <= 0) {
-                                surface_found = true;
-                                break;
-                            }
-                            t_prev = t;
-                            float delta = tsdf * sdf_trunc;
-                            t += delta < voxel_size ? voxel_size : delta;
-                        }
+            float *depth_ptr = nullptr, *vertex_ptr = nullptr,
+                  *normal_ptr = nullptr, *color_ptr = nullptr;
+            if (enable_depth) {
+                depth_ptr = depth_map_indexer.GetDataPtr<float>(x, y);
+                *depth_ptr = 0;
+            }
+            if (enable_vertex) {
+                vertex_ptr = vertex_map_indexer.GetDataPtr<float>(x, y);
+                vertex_ptr[0] = 0;
+                vertex_ptr[1] = 0;
+                vertex_ptr[2] = 0;
+            }
+            if (enable_color) {
+                color_ptr = color_map_indexer.GetDataPtr<float>(x, y);
+                color_ptr[0] = 0;
+                color_ptr[1] = 0;
+                color_ptr[2] = 0;
+            }
+            if (enable_normal) {
+                normal_ptr = normal_map_indexer.GetDataPtr<float>(x, y);
+                normal_ptr[0] = 0;
+                normal_ptr[1] = 0;
+                normal_ptr[2] = 0;
+            }
+
+            const float* range =
+                    range_map_indexer.GetDataPtr<float>(x / 8, y / 8);
+            float t = range[0];
+            const float t_max = range[1];
+            if (t >= t_max) return;
+
+            // Coordinates in camera and global
+            float x_c = 0, y_c = 0, z_c = 0;
+            float x_g = 0, y_g = 0, z_g = 0;
+            float x_o = 0, y_o = 0, z_o = 0;
+
+            // Iterative ray intersection check
+            float t_prev = t;
+
+            float tsdf_prev = -1.0f;
+            float tsdf = 1.0;
+            float w = 0.0;
+
+            // Camera origin
+            c2w_transform_indexer.RigidTransform(0, 0, 0, &x_o, &y_o, &z_o);
+
+            // Direction
+            c2w_transform_indexer.Unproject(static_cast<float>(x),
+                                            static_cast<float>(y), 1.0f, &x_c,
+                                            &y_c, &z_c);
+            c2w_transform_indexer.RigidTransform(x_c, y_c, z_c, &x_g, &y_g,
+                                                 &z_g);
+            float x_d = (x_g - x_o);
+            float y_d = (y_g - y_o);
+            float z_d = (z_g - z_o);
+
+            BlockCache cache{0, 0, 0, -1};
+            bool surface_found = false;
+            while (t < t_max) {
+                voxel_t* voxel_ptr =
+                        GetVoxelAtT(x_o, y_o, z_o, x_d, y_d, z_d, t, cache);
+
+                if (!voxel_ptr) {
+                    t_prev = t;
+                    t += block_size;
+                } else {
+                    tsdf_prev = tsdf;
+                    tsdf = voxel_ptr->GetTSDF();
+                    w = voxel_ptr->GetWeight();
+                    if (tsdf_prev > 0 && w >= weight_threshold && tsdf <= 0) {
+                        surface_found = true;
+                        break;
+                    }
+                    t_prev = t;
+                    float delta = tsdf * sdf_trunc;
+                    t += delta < voxel_size ? voxel_size : delta;
+                }
+            }
+
+            if (surface_found) {
+                float t_intersect =
+                        (t * tsdf_prev - t_prev * tsdf) / (tsdf_prev - tsdf);
+                x_g = x_o + t_intersect * x_d;
+                y_g = y_o + t_intersect * y_d;
+                z_g = z_o + t_intersect * z_d;
+
+                // Trivial vertex assignment
+                if (enable_depth) {
+                    *depth_ptr = t_intersect * depth_scale;
+                }
+                if (enable_vertex) {
+                    w2c_transform_indexer.RigidTransform(
+                            x_g, y_g, z_g, vertex_ptr + 0, vertex_ptr + 1,
+                            vertex_ptr + 2);
+                }
+
+                // Trilinear interpolation
+                // TODO(wei): simplify the flow by splitting the
+                // functions given what is enabled
+                if (enable_color || enable_normal) {
+                    int x_b = static_cast<int>(floorf(x_g / block_size));
+                    int y_b = static_cast<int>(floorf(y_g / block_size));
+                    int z_b = static_cast<int>(floorf(z_g / block_size));
+                    float x_v = (x_g - float(x_b) * block_size) / voxel_size;
+                    float y_v = (y_g - float(y_b) * block_size) / voxel_size;
+                    float z_v = (z_g - float(z_b) * block_size) / voxel_size;
+
+                    Key key;
+                    key.Set(0, x_b);
+                    key.Set(1, y_b);
+                    key.Set(2, z_b);
+
+                    int block_addr = cache.Check(x_b, y_b, z_b);
+                    if (block_addr < 0) {
+                        auto iter = hashmap_impl.find(key);
+                        if (iter == hashmap_impl.end()) return;
+                        block_addr = iter->second;
+                        cache.Update(x_b, y_b, z_b, block_addr);
                     }
 
-                    if (surface_found) {
-                        float t_intersect = (t * tsdf_prev - t_prev * tsdf) /
-                                            (tsdf_prev - tsdf);
-                        x_g = x_o + t_intersect * x_d;
-                        y_g = y_o + t_intersect * y_d;
-                        z_g = z_o + t_intersect * z_d;
+                    int x_v_floor = static_cast<int>(floorf(x_v));
+                    int y_v_floor = static_cast<int>(floorf(y_v));
+                    int z_v_floor = static_cast<int>(floorf(z_v));
 
-                        // Trivial vertex assignment
-                        if (enable_depth) {
-                            *depth_ptr = t_intersect * depth_scale;
+                    float ratio_x = x_v - float(x_v_floor);
+                    float ratio_y = y_v - float(y_v_floor);
+                    float ratio_z = z_v - float(z_v_floor);
+
+                    float sum_weight_color = 0.0;
+                    float sum_weight_normal = 0.0;
+                    for (int k = 0; k < 8; ++k) {
+                        int dx_v = (k & 1) > 0 ? 1 : 0;
+                        int dy_v = (k & 2) > 0 ? 1 : 0;
+                        int dz_v = (k & 4) > 0 ? 1 : 0;
+                        float ratio =
+                                (dx_v * (ratio_x) +
+                                 (1 - dx_v) * (1 - ratio_x)) *
+                                (dy_v * (ratio_y) +
+                                 (1 - dy_v) * (1 - ratio_y)) *
+                                (dz_v * (ratio_z) + (1 - dz_v) * (1 - ratio_z));
+
+                        voxel_t* voxel_ptr_k =
+                                GetVoxelAtP(x_b, y_b, z_b, x_v_floor + dx_v,
+                                            y_v_floor + dy_v, z_v_floor + dz_v,
+                                            block_addr, cache);
+
+                        if (enable_color && voxel_ptr_k &&
+                            voxel_ptr_k->GetWeight() > 0) {
+                            sum_weight_color += ratio;
+                            color_ptr[0] += ratio * voxel_ptr_k->GetR();
+                            color_ptr[1] += ratio * voxel_ptr_k->GetG();
+                            color_ptr[2] += ratio * voxel_ptr_k->GetB();
                         }
-                        if (enable_vertex) {
-                            w2c_transform_indexer.RigidTransform(
-                                    x_g, y_g, z_g, vertex_ptr + 0,
-                                    vertex_ptr + 1, vertex_ptr + 2);
-                        }
 
-                        // Trilinear interpolation
-                        // TODO(wei): simplify the flow by splitting the
-                        // functions given what is enabled
-                        if (enable_color || enable_normal) {
-                            int x_b =
-                                    static_cast<int>(floorf(x_g / block_size));
-                            int y_b =
-                                    static_cast<int>(floorf(y_g / block_size));
-                            int z_b =
-                                    static_cast<int>(floorf(z_g / block_size));
-                            float x_v = (x_g - float(x_b) * block_size) /
-                                        voxel_size;
-                            float y_v = (y_g - float(y_b) * block_size) /
-                                        voxel_size;
-                            float z_v = (z_g - float(z_b) * block_size) /
-                                        voxel_size;
-
-                            Key key;
-                            key.Set(0, x_b);
-                            key.Set(1, y_b);
-                            key.Set(2, z_b);
-
-                            int block_addr = cache.Check(x_b, y_b, z_b);
-                            if (block_addr < 0) {
-                                auto iter = hashmap_impl.find(key);
-                                if (iter == hashmap_impl.end()) return;
-                                block_addr = iter->second;
-                                cache.Update(x_b, y_b, z_b, block_addr);
-                            }
-
-                            int x_v_floor = static_cast<int>(floorf(x_v));
-                            int y_v_floor = static_cast<int>(floorf(y_v));
-                            int z_v_floor = static_cast<int>(floorf(z_v));
-
-                            float ratio_x = x_v - float(x_v_floor);
-                            float ratio_y = y_v - float(y_v_floor);
-                            float ratio_z = z_v - float(z_v_floor);
-
-                            float sum_weight_color = 0.0;
-                            float sum_weight_normal = 0.0;
-                            for (int k = 0; k < 8; ++k) {
-                                int dx_v = (k & 1) > 0 ? 1 : 0;
-                                int dy_v = (k & 2) > 0 ? 1 : 0;
-                                int dz_v = (k & 4) > 0 ? 1 : 0;
-                                float ratio = (dx_v * (ratio_x) +
-                                               (1 - dx_v) * (1 - ratio_x)) *
-                                              (dy_v * (ratio_y) +
-                                               (1 - dy_v) * (1 - ratio_y)) *
-                                              (dz_v * (ratio_z) +
-                                               (1 - dz_v) * (1 - ratio_z));
-
-                                voxel_t* voxel_ptr_k = GetVoxelAtP(
-                                        x_b, y_b, z_b, x_v_floor + dx_v,
-                                        y_v_floor + dy_v, z_v_floor + dz_v,
+                        if (enable_normal) {
+                            for (int dim = 0; dim < 3; ++dim) {
+                                voxel_t* voxel_ptr_k_plus = GetVoxelAtP(
+                                        x_b, y_b, z_b,
+                                        x_v_floor + dx_v + (dim == 0),
+                                        y_v_floor + dy_v + (dim == 1),
+                                        z_v_floor + dz_v + (dim == 2),
+                                        block_addr, cache);
+                                voxel_t* voxel_ptr_k_minus = GetVoxelAtP(
+                                        x_b, y_b, z_b,
+                                        x_v_floor + dx_v - (dim == 0),
+                                        y_v_floor + dy_v - (dim == 1),
+                                        z_v_floor + dz_v - (dim == 2),
                                         block_addr, cache);
 
-                                if (enable_color && voxel_ptr_k &&
-                                    voxel_ptr_k->GetWeight() > 0) {
-                                    sum_weight_color += ratio;
-                                    color_ptr[0] += ratio * voxel_ptr_k->GetR();
-                                    color_ptr[1] += ratio * voxel_ptr_k->GetG();
-                                    color_ptr[2] += ratio * voxel_ptr_k->GetB();
+                                bool valid = false;
+                                if (voxel_ptr_k_plus &&
+                                    voxel_ptr_k_plus->GetWeight() > 0) {
+                                    normal_ptr[dim] +=
+                                            ratio *
+                                            voxel_ptr_k_plus->GetTSDF() /
+                                            (2 * voxel_size);
+                                    valid = true;
                                 }
 
-                                if (enable_normal) {
-                                    for (int dim = 0; dim < 3; ++dim) {
-                                        voxel_t* voxel_ptr_k_plus = GetVoxelAtP(
-                                                x_b, y_b, z_b,
-                                                x_v_floor + dx_v + (dim == 0),
-                                                y_v_floor + dy_v + (dim == 1),
-                                                z_v_floor + dz_v + (dim == 2),
-                                                block_addr, cache);
-                                        voxel_t* voxel_ptr_k_minus =
-                                                GetVoxelAtP(x_b, y_b, z_b,
-                                                            x_v_floor + dx_v -
-                                                                    (dim == 0),
-                                                            y_v_floor + dy_v -
-                                                                    (dim == 1),
-                                                            z_v_floor + dz_v -
-                                                                    (dim == 2),
-                                                            block_addr, cache);
-
-                                        bool valid = false;
-                                        if (voxel_ptr_k_plus &&
-                                            voxel_ptr_k_plus->GetWeight() > 0) {
-                                            normal_ptr[dim] +=
-                                                    ratio *
-                                                    voxel_ptr_k_plus
-                                                            ->GetTSDF() /
-                                                    (2 * voxel_size);
-                                            valid = true;
-                                        }
-
-                                        if (voxel_ptr_k_minus &&
-                                            voxel_ptr_k_minus->GetWeight() >
-                                                    0) {
-                                            normal_ptr[dim] -=
-                                                    ratio *
-                                                    voxel_ptr_k_minus
-                                                            ->GetTSDF() /
-                                                    (2 * voxel_size);
-                                            valid = true;
-                                        }
-                                        sum_weight_normal += valid ? ratio : 0;
-                                    }
-                                }  // if (enable_normal)
-                            }      // loop over 8 neighbors
-
-                            if (enable_color && sum_weight_color > 0) {
-                                sum_weight_color *= 255.0;
-                                color_ptr[0] /= sum_weight_color;
-                                color_ptr[1] /= sum_weight_color;
-                                color_ptr[2] /= sum_weight_color;
+                                if (voxel_ptr_k_minus &&
+                                    voxel_ptr_k_minus->GetWeight() > 0) {
+                                    normal_ptr[dim] -=
+                                            ratio *
+                                            voxel_ptr_k_minus->GetTSDF() /
+                                            (2 * voxel_size);
+                                    valid = true;
+                                }
+                                sum_weight_normal += valid ? ratio : 0;
                             }
-                            if (enable_normal && sum_weight_normal > 0) {
-                                normal_ptr[0] /= sum_weight_normal;
-                                normal_ptr[1] /= sum_weight_normal;
-                                normal_ptr[2] /= sum_weight_normal;
-                                float norm =
-                                        sqrt(normal_ptr[0] * normal_ptr[0] +
-                                             normal_ptr[1] * normal_ptr[1] +
-                                             normal_ptr[2] * normal_ptr[2]);
-                                w2c_transform_indexer.Rotate(
-                                        normal_ptr[0] / norm,
-                                        normal_ptr[1] / norm,
-                                        normal_ptr[2] / norm, normal_ptr + 0,
-                                        normal_ptr + 1, normal_ptr + 2);
-                            }
-                        }  // if (color or normal)
-                    }      // if (tsdf < 0)
-                });
+                        }  // if (enable_normal)
+                    }      // loop over 8 neighbors
+
+                    if (enable_color && sum_weight_color > 0) {
+                        sum_weight_color *= 255.0;
+                        color_ptr[0] /= sum_weight_color;
+                        color_ptr[1] /= sum_weight_color;
+                        color_ptr[2] /= sum_weight_color;
+                    }
+                    if (enable_normal && sum_weight_normal > 0) {
+                        normal_ptr[0] /= sum_weight_normal;
+                        normal_ptr[1] /= sum_weight_normal;
+                        normal_ptr[2] /= sum_weight_normal;
+                        float norm = sqrt(normal_ptr[0] * normal_ptr[0] +
+                                          normal_ptr[1] * normal_ptr[1] +
+                                          normal_ptr[2] * normal_ptr[2]);
+                        w2c_transform_indexer.Rotate(
+                                normal_ptr[0] / norm, normal_ptr[1] / norm,
+                                normal_ptr[2] / norm, normal_ptr + 0,
+                                normal_ptr + 1, normal_ptr + 2);
+                    }
+                }  // if (color or normal)
+            }      // if (tsdf < 0)
+        });
     });
 
 #if defined(__CUDACC__)

--- a/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
@@ -115,7 +115,7 @@ void FillInRigidAlignmentTermCPU
         }
         atomicAdd(residual_ptr, r * r);
 #else
-#pragma omp critical
+#pragma omp critical(FillInRigidAlignmentTermCPU)
         {
             for (int i_local = 0; i_local < 12; ++i_local) {
                 for (int j_local = 0; j_local < 12; ++j_local) {
@@ -291,7 +291,7 @@ void FillInSLACAlignmentTermCPU
         }
         atomicAdd(residual_ptr, r * r);
 #else
-#pragma omp critical
+#pragma omp critical(FillInSLACAlignmentTermCPU)
         {
             for (int ki = 0; ki < 60; ++ki) {
                 for (int kj = 0; kj < 60; ++kj) {
@@ -583,7 +583,7 @@ void FillInSLACRegularizerTermCPU
                               -weight * local_r[axis]);
                 }
 #else
-#pragma omp critical
+#pragma omp critical(FillInSLACRegularizerTermCPU)
                 {
                     // Update residual
                     *residual_ptr += weight * (local_r[0] * local_r[0] +

--- a/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
@@ -75,11 +75,12 @@ void FillInRigidAlignmentTermCPU
             static_cast<const float *>(Ri_normal_ps.GetDataPtr());
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         const float *p_prime = Ti_ps_ptr + 3 * workload_idx;
         const float *q_prime = Tj_qs_ptr + 3 * workload_idx;
         const float *normal_p_prime = Ri_normal_ps_ptr + 3 * workload_idx;
@@ -213,11 +214,12 @@ void FillInSLACAlignmentTermCPU
             static_cast<const float *>(cgrid_ratio_qs.GetDataPtr());
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         const float *Ti_Cp = Ti_Cps_ptr + 3 * workload_idx;
         const float *Tj_Cq = Tj_Cqs_ptr + 3 * workload_idx;
         const float *Cnormal_p = Cnormal_ps_ptr + 3 * workload_idx;
@@ -408,11 +410,12 @@ void FillInSLACRegularizerTermCPU
             static_cast<const float *>(positions_curr.GetDataPtr());
 
 #if defined(__CUDACC__)
-    core::kernel::CUDALauncher launcher;
+    namespace launcher = core::kernel::cuda_launcher;
 #else
-    core::kernel::CPULauncher launcher;
+    namespace launcher = core::kernel::cpu_launcher;
 #endif
-    launcher.LaunchGeneralKernel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+
+    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         // Enumerate 6 neighbors
         int idx_i = grid_idx_ptr[workload_idx];
 

--- a/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
+++ b/cpp/open3d/t/pipelines/kernel/FillInLinearSystemImpl.h
@@ -80,7 +80,7 @@ void FillInRigidAlignmentTermCPU
     namespace launcher = core::kernel::cpu_launcher;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         const float *p_prime = Ti_ps_ptr + 3 * workload_idx;
         const float *q_prime = Tj_qs_ptr + 3 * workload_idx;
         const float *normal_p_prime = Ri_normal_ps_ptr + 3 * workload_idx;
@@ -219,7 +219,7 @@ void FillInSLACAlignmentTermCPU
     namespace launcher = core::kernel::cpu_launcher;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         const float *Ti_Cp = Ti_Cps_ptr + 3 * workload_idx;
         const float *Tj_Cq = Tj_Cqs_ptr + 3 * workload_idx;
         const float *Cnormal_p = Cnormal_ps_ptr + 3 * workload_idx;
@@ -415,7 +415,7 @@ void FillInSLACRegularizerTermCPU
     namespace launcher = core::kernel::cpu_launcher;
 #endif
 
-    launcher::LaunchParallel(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
+    launcher::ParallelFor(n, [=] OPEN3D_DEVICE(int64_t workload_idx) {
         // Enumerate 6 neighbors
         int idx_i = grid_idx_ptr[workload_idx];
 

--- a/cpp/open3d/utility/Eigen.cpp
+++ b/cpp/open3d/utility/Eigen.cpp
@@ -189,7 +189,7 @@ std::tuple<MatType, VecType, double> ComputeJTJandJTr(
             JTr_private.noalias() += J_r * w * r;
             r2_sum_private += r * r;
         }
-#pragma omp critical
+#pragma omp critical(ComputeJTJandJTr)
         {
             JTJ += JTJ_private;
             JTr += JTr_private;
@@ -236,7 +236,7 @@ std::tuple<MatType, VecType, double> ComputeJTJandJTr(
                 r2_sum_private += r[j] * r[j];
             }
         }
-#pragma omp critical
+#pragma omp critical(ComputeJTJandJTr)
         {
             JTJ += JTJ_private;
             JTr += JTr_private;


### PR DESCRIPTION
Changes:
- `CPULauncher` and `CUDALauncher` are now be namespaces, not classes
- Rename `LaunchGeneralKernel` to `LaunchParallel`
- Add comments

(This PR is to prepare us for the upcoming "parallel for" PR.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3638)
<!-- Reviewable:end -->
