### PR TITLE
Introduce memory manager statistics

### DIFF
--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(core PRIVATE
     Indexer.cpp
     MemoryManager.cpp
     MemoryManagerCPU.cpp
+    MemoryManagerStatistic.cpp
     NumpyIO.cpp
     ShapeUtil.cpp
     Tensor.cpp

--- a/cpp/open3d/core/Device.h
+++ b/cpp/open3d/core/Device.h
@@ -70,6 +70,10 @@ public:
 
     bool operator!=(const Device& other) const { return !operator==(other); }
 
+    bool operator<(const Device& other) const {
+        return ToString() < other.ToString();
+    }
+
     std::string ToString() const {
         std::string str = "";
         switch (device_type_) {
@@ -132,3 +136,12 @@ protected:
 
 }  // namespace core
 }  // namespace open3d
+
+namespace std {
+template <>
+struct hash<open3d::core::Device> {
+    std::size_t operator()(const open3d::core::Device& device) const {
+        return std::hash<std::string>{}(device.ToString());
+    }
+};
+}  // namespace std

--- a/cpp/open3d/core/MemoryManager.cpp
+++ b/cpp/open3d/core/MemoryManager.cpp
@@ -40,14 +40,14 @@ namespace core {
 
 void* MemoryManager::Malloc(size_t byte_size, const Device& device) {
     void* ptr = GetDeviceMemoryManager(device)->Malloc(byte_size, device);
-    MemoryManagerStatistic::GetInstance().IncrementCountMalloc(device, ptr,
-                                                               byte_size);
+    MemoryManagerStatistic::GetInstance().IncrementCountMalloc(ptr, byte_size,
+                                                               device);
     return ptr;
 }
 
 void MemoryManager::Free(void* ptr, const Device& device) {
     GetDeviceMemoryManager(device)->Free(ptr, device);
-    MemoryManagerStatistic::GetInstance().IncrementCountFree(device, ptr);
+    MemoryManagerStatistic::GetInstance().IncrementCountFree(ptr, device);
 }
 
 void MemoryManager::Memcpy(void* dst_ptr,

--- a/cpp/open3d/core/MemoryManager.cpp
+++ b/cpp/open3d/core/MemoryManager.cpp
@@ -31,6 +31,7 @@
 
 #include "open3d/core/Blob.h"
 #include "open3d/core/Device.h"
+#include "open3d/core/MemoryManagerStatistic.h"
 #include "open3d/utility/Helper.h"
 #include "open3d/utility/Logging.h"
 
@@ -38,10 +39,12 @@ namespace open3d {
 namespace core {
 
 void* MemoryManager::Malloc(size_t byte_size, const Device& device) {
+    MemoryManagerStatistic::getInstance().IncrementCountMalloc(device);
     return GetDeviceMemoryManager(device)->Malloc(byte_size, device);
 }
 
 void MemoryManager::Free(void* ptr, const Device& device) {
+    MemoryManagerStatistic::getInstance().IncrementCountFree(device);
     return GetDeviceMemoryManager(device)->Free(ptr, device);
 }
 

--- a/cpp/open3d/core/MemoryManager.cpp
+++ b/cpp/open3d/core/MemoryManager.cpp
@@ -39,13 +39,15 @@ namespace open3d {
 namespace core {
 
 void* MemoryManager::Malloc(size_t byte_size, const Device& device) {
-    MemoryManagerStatistic::getInstance().IncrementCountMalloc(device);
-    return GetDeviceMemoryManager(device)->Malloc(byte_size, device);
+    void* ptr = GetDeviceMemoryManager(device)->Malloc(byte_size, device);
+    MemoryManagerStatistic::GetInstance().IncrementCountMalloc(device, ptr,
+                                                               byte_size);
+    return ptr;
 }
 
 void MemoryManager::Free(void* ptr, const Device& device) {
-    MemoryManagerStatistic::getInstance().IncrementCountFree(device);
-    return GetDeviceMemoryManager(device)->Free(ptr, device);
+    GetDeviceMemoryManager(device)->Free(ptr, device);
+    MemoryManagerStatistic::GetInstance().IncrementCountFree(device, ptr);
 }
 
 void MemoryManager::Memcpy(void* dst_ptr,

--- a/cpp/open3d/core/MemoryManagerStatistic.cpp
+++ b/cpp/open3d/core/MemoryManagerStatistic.cpp
@@ -1,0 +1,98 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/MemoryManagerStatistic.h"
+
+#include <algorithm>
+
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+
+MemoryManagerStatistic& MemoryManagerStatistic::getInstance() {
+    // Ensure the static Logger instance is instantiated before the
+    // MemoryManagerStatistic instance.
+    // Since destruction of static instances happens in reverse order,
+    // this guarantees that the Logger can be used at any point in time.
+    open3d::utility::Logger::GetInstance();
+
+    static MemoryManagerStatistic instance;
+    return instance;
+}
+
+void MemoryManagerStatistic::setPrintLevel(PrintLevel level) { level_ = level; }
+
+void MemoryManagerStatistic::Print() const {
+    if (level_ == PrintLevel::None) {
+        return;
+    }
+
+    auto is_unbalanced = [](const auto& value_pair) {
+        return value_pair.second.count_malloc_ != value_pair.second.count_free_;
+    };
+
+    if (level_ == PrintLevel::Unbalanced &&
+        std::count_if(statistics_.begin(), statistics_.end(), is_unbalanced) ==
+                0) {
+        return;
+    }
+
+    open3d::utility::LogInfo("Memory Statistics: (Device) (#Malloc) (#Free)");
+    open3d::utility::LogInfo("---------------------------------------------");
+    for (const auto& value_pair : statistics_) {
+        if (level_ == PrintLevel::Unbalanced && !is_unbalanced(value_pair)) {
+            continue;
+        }
+
+        if (is_unbalanced(value_pair)) {
+            open3d::utility::LogWarning("{}: {} {} --> {}",
+                                        value_pair.first.ToString(),
+                                        value_pair.second.count_malloc_,
+                                        value_pair.second.count_free_,
+                                        value_pair.second.count_malloc_ -
+                                                value_pair.second.count_free_);
+        } else {
+            open3d::utility::LogInfo("{}: {} {}", value_pair.first.ToString(),
+                                     value_pair.second.count_malloc_,
+                                     value_pair.second.count_free_);
+        }
+    }
+    open3d::utility::LogInfo("---------------------------------------------");
+}
+
+void MemoryManagerStatistic::IncrementCountMalloc(const Device& device) {
+    std::lock_guard<std::mutex> lock(statistics_mutex_);
+    statistics_[device].count_malloc_++;
+}
+
+void MemoryManagerStatistic::IncrementCountFree(const Device& device) {
+    std::lock_guard<std::mutex> lock(statistics_mutex_);
+    statistics_[device].count_free_++;
+}
+
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/MemoryManagerStatistic.cpp
+++ b/cpp/open3d/core/MemoryManagerStatistic.cpp
@@ -108,16 +108,16 @@ void MemoryManagerStatistic::Print() const {
     utility::LogInfo("---------------------------------------------");
 }
 
-void MemoryManagerStatistic::IncrementCountMalloc(const Device& device,
-                                                  void* ptr,
-                                                  size_t byte_size) {
+void MemoryManagerStatistic::IncrementCountMalloc(void* ptr,
+                                                  size_t byte_size,
+                                                  const Device& device) {
     std::lock_guard<std::mutex> lock(statistics_mutex_);
     statistics_[device].count_malloc_++;
     statistics_[device].active_allocations_.emplace(ptr, byte_size);
 }
 
-void MemoryManagerStatistic::IncrementCountFree(const Device& device,
-                                                void* ptr) {
+void MemoryManagerStatistic::IncrementCountFree(void* ptr,
+                                                const Device& device) {
     std::lock_guard<std::mutex> lock(statistics_mutex_);
     statistics_[device].count_free_++;
     statistics_[device].active_allocations_.erase(ptr);

--- a/cpp/open3d/core/MemoryManagerStatistic.h
+++ b/cpp/open3d/core/MemoryManagerStatistic.h
@@ -59,10 +59,10 @@ public:
     void SetPrintAtProgramEnd(bool print);
     void Print() const;
 
-    void IncrementCountMalloc(const Device& device,
-                              void* ptr,
-                              size_t byte_size);
-    void IncrementCountFree(const Device& device, void* ptr);
+    void IncrementCountMalloc(void* ptr,
+                              size_t byte_size,
+                              const Device& device);
+    void IncrementCountFree(void* ptr, const Device& device);
 
 private:
     MemoryManagerStatistic() = default;
@@ -73,18 +73,12 @@ private:
         std::unordered_map<void*, size_t> active_allocations_;
     };
 
-    struct DeviceComparator {
-        bool operator()(const Device& lhs, const Device& rhs) const {
-            return lhs.ToString() < rhs.ToString();
-        }
-    };
-
     /// Only print unbalanced statistics by default.
     PrintLevel level_ = PrintLevel::Unbalanced;
     bool print_at_program_end_ = true;
 
     std::mutex statistics_mutex_;
-    std::map<Device, MemoryStatistics, DeviceComparator> statistics_;
+    std::map<Device, MemoryStatistics> statistics_;
 };
 
 }  // namespace core

--- a/cpp/open3d/core/MemoryManagerStatistic.h
+++ b/cpp/open3d/core/MemoryManagerStatistic.h
@@ -24,42 +24,63 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#include "open3d/core/linalg/LUImpl.h"
-#include "open3d/core/linalg/LapackWrapper.h"
-#include "open3d/core/linalg/LinalgUtils.h"
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <mutex>
+
+#include "open3d/core/Device.h"
 
 namespace open3d {
 namespace core {
 
-void LUCUDA(void* A_data,
-            void* ipiv_data,
-            int64_t rows,
-            int64_t cols,
-            Dtype dtype,
-            const Device& device) {
-    cusolverDnHandle_t handle = CuSolverContext::GetInstance()->GetHandle();
-    DISPATCH_LINALG_DTYPE_TO_TEMPLATE(dtype, [&]() {
-        int len;
-        OPEN3D_CUSOLVER_CHECK(
-                getrf_cuda_buffersize<scalar_t>(handle, rows, cols, rows, &len),
-                "getrf_buffersize failed in LUCUDA");
+class MemoryManagerStatistic {
+public:
+    enum class PrintLevel {
+        /// Statistics for all used devices are printed.
+        All = 0,
+        /// Only devices with unbalanced counts are printed.
+        /// This is typically an indicator for memory leaks.
+        Unbalanced = 1,
+        /// No statistics are printed.
+        None = 2,
+    };
 
-        int* dinfo =
-                static_cast<int*>(MemoryManager::Malloc(sizeof(int), device));
-        void* workspace = MemoryManager::Malloc(len * sizeof(scalar_t), device);
+    static MemoryManagerStatistic& getInstance();
 
-        cusolverStatus_t getrf_status = getrf_cuda<scalar_t>(
-                handle, rows, cols, static_cast<scalar_t*>(A_data), rows,
-                static_cast<scalar_t*>(workspace), static_cast<int*>(ipiv_data),
-                dinfo);
+    MemoryManagerStatistic(const MemoryManagerStatistic&) = delete;
+    MemoryManagerStatistic& operator=(MemoryManagerStatistic&) = delete;
 
-        MemoryManager::Free(workspace, device);
-        MemoryManager::Free(dinfo, device);
+    /// Always print the statistics at the end of the program.
+    ~MemoryManagerStatistic() { Print(); }
 
-        OPEN3D_CUSOLVER_CHECK_WITH_DINFO(getrf_status, "getrf failed in LUCUDA",
-                                         dinfo, device);
-    });
-}
+    void setPrintLevel(PrintLevel level);
+    void Print() const;
+
+    void IncrementCountMalloc(const Device& device);
+    void IncrementCountFree(const Device& device);
+
+private:
+    MemoryManagerStatistic() = default;
+
+    struct MemoryStatistics {
+        size_t count_malloc_ = 0;
+        size_t count_free_ = 0;
+    };
+
+    struct DeviceComparator {
+        bool operator()(const Device& lhs, const Device& rhs) const {
+            return lhs.ToString() < rhs.ToString();
+        }
+    };
+
+    /// Only print unbalanced statistics by default.
+    PrintLevel level_ = PrintLevel::Unbalanced;
+
+    std::mutex statistics_mutex_;
+    std::map<Device, MemoryStatistics, DeviceComparator> statistics_;
+};
 
 }  // namespace core
 }  // namespace open3d


### PR DESCRIPTION
Features:
- Thread-safe `MemoryManagerStatistic` instance implemented as a singleton
- Per `Device` logging of memory allocations and frees
- Configurable print modes: `All`, `Unbalanced`, `None`
- Automatic print at the end of the program, defaults to `Unbalanced` to minimize noise

Detected memory leaks in unit tests:
- Skipped `Free` in LU decomposition when the operation fails

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3639)
<!-- Reviewable:end -->
