### PR TITLE
Reduce noise of k4a archive extraction

### DIFF
--- a/3rdparty/azure_kinect/azure_kinect.cmake
+++ b/3rdparty/azure_kinect/azure_kinect.cmake
@@ -42,10 +42,17 @@ else()
         URL https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/libk/libk4a1.4-dev/libk4a1.4-dev_1.4.1_amd64.deb
         URL_HASH SHA256=08303094b9ad36ea74c19bc8b8950c97055e73dd2e8bd18e2af5e165a2289cd2
         DOWNLOAD_DIR "${OPEN3D_THIRD_PARTY_DOWNLOAD_DIR}/k4a"
-        UPDATE_COMMAND ${CMAKE_COMMAND} -E tar xvf data.tar.gz
+        UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
+    )
+    ExternalProject_Add_Step(ext_k4a extract_headers
+        COMMAND ${CMAKE_COMMAND} -E tar xvf data.tar.gz
+        WORKING_DIRECTORY <SOURCE_DIR>
+        DEPENDEES download
+        DEPENDERS update
+        INDEPENDENT TRUE
     )
     ExternalProject_Get_Property(ext_k4a SOURCE_DIR)
     set(K4A_INCLUDE_DIR ${SOURCE_DIR}/usr/include/) # "/" is critical


### PR DESCRIPTION
Every time we build Open3D, we get this as part of the output:
```
x ./usr/
x ./usr/include/
x ./usr/include/k4a/
x ./usr/include/k4a/k4a.h
x ./usr/include/k4a/k4a.hpp
x ./usr/include/k4a/k4a_export.h
x ./usr/include/k4a/k4atypes.h
x ./usr/include/k4a/k4aversion.h
x ./usr/include/k4arecord/
x ./usr/include/k4arecord/k4arecord_export.h
x ./usr/include/k4arecord/playback.h
x ./usr/include/k4arecord/playback.hpp
x ./usr/include/k4arecord/record.h
x ./usr/include/k4arecord/record.hpp
x ./usr/include/k4arecord/types.h
x ./usr/lib/
x ./usr/lib/x86_64-linux-gnu/
x ./usr/lib/x86_64-linux-gnu/cmake/
x ./usr/lib/x86_64-linux-gnu/cmake/k4a/
x ./usr/lib/x86_64-linux-gnu/cmake/k4a/k4aConfig.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4a/k4aConfigVersion.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4a/k4aTargets-relwithdebinfo.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4a/k4aTargets.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4arecord/
x ./usr/lib/x86_64-linux-gnu/cmake/k4arecord/k4arecordConfig.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4arecord/k4arecordConfigVersion.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4arecord/k4arecordTargets-relwithdebinfo.cmake
x ./usr/lib/x86_64-linux-gnu/cmake/k4arecord/k4arecordTargets.cmake
```
Extracting the archive is only required once after downloading, so we can move this to a custom step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3644)
<!-- Reviewable:end -->
