### PR TITLE
Add octree IO in python bind

### DIFF
--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -35,12 +35,12 @@
 #include "open3d/io/ImageIO.h"
 #include "open3d/io/LineSetIO.h"
 #include "open3d/io/ModelIO.h"
+#include "open3d/io/OctreeIO.h"
 #include "open3d/io/PinholeCameraTrajectoryIO.h"
 #include "open3d/io/PointCloudIO.h"
 #include "open3d/io/PoseGraphIO.h"
 #include "open3d/io/TriangleMeshIO.h"
 #include "open3d/io/VoxelGridIO.h"
-#include "open3d/io/OctreeIO.h"
 #include "open3d/visualization/rendering/Model.h"
 #include "pybind/docstring.h"
 #include "pybind/io/io.h"
@@ -294,7 +294,6 @@ void pybind_class_io(py::module &m_io) {
     docstring::FunctionDocInject(m_io, "write_voxel_grid",
                                  map_shared_argument_docstrings);
 
-
     // open3d::geometry::Octree
     m_io.def(
             "read_octree",
@@ -311,8 +310,7 @@ void pybind_class_io(py::module &m_io) {
 
     m_io.def(
             "write_octree",
-            [](const std::string &filename,
-               const geometry::Octree &octree) {
+            [](const std::string &filename, const geometry::Octree &octree) {
                 py::gil_scoped_release release;
                 return WriteOctree(filename, octree);
             },

--- a/cpp/pybind/io/class_io.cpp
+++ b/cpp/pybind/io/class_io.cpp
@@ -40,6 +40,7 @@
 #include "open3d/io/PoseGraphIO.h"
 #include "open3d/io/TriangleMeshIO.h"
 #include "open3d/io/VoxelGridIO.h"
+#include "open3d/io/OctreeIO.h"
 #include "open3d/visualization/rendering/Model.h"
 #include "pybind/docstring.h"
 #include "pybind/io/io.h"
@@ -89,6 +90,7 @@ static const std::unordered_map<std::string, std::string>
                 {"line_set", "The ``LineSet`` object for I/O"},
                 {"image", "The ``Image`` object for I/O"},
                 {"voxel_grid", "The ``VoxelGrid`` object for I/O"},
+                {"octree", "The ``Octree`` object for I/O"},
                 {"trajectory",
                  "The ``PinholeCameraTrajectory`` object for I/O"},
                 {"intrinsic", "The ``PinholeCameraIntrinsic`` object for I/O"},
@@ -290,6 +292,32 @@ void pybind_class_io(py::module &m_io) {
             "write_ascii"_a = false, "compressed"_a = false,
             "print_progress"_a = false);
     docstring::FunctionDocInject(m_io, "write_voxel_grid",
+                                 map_shared_argument_docstrings);
+
+
+    // open3d::geometry::Octree
+    m_io.def(
+            "read_octree",
+            [](const std::string &filename, const std::string &format) {
+                py::gil_scoped_release release;
+                geometry::Octree octree;
+                ReadOctree(filename, octree, format);
+                return octree;
+            },
+            "Function to read Octree from file", "filename"_a,
+            "format"_a = "auto");
+    docstring::FunctionDocInject(m_io, "read_octree",
+                                 map_shared_argument_docstrings);
+
+    m_io.def(
+            "write_octree",
+            [](const std::string &filename,
+               const geometry::Octree &octree) {
+                py::gil_scoped_release release;
+                return WriteOctree(filename, octree);
+            },
+            "Function to write Octree to file", "filename"_a, "octree"_a);
+    docstring::FunctionDocInject(m_io, "write_octree",
                                  map_shared_argument_docstrings);
 
     // open3d::camera


### PR DESCRIPTION
I noticed that `Octree` didn't have the IO function in python bind yet, but I found the C++ file. 

I made this modification so we could use the `write_octree()` and `read_octree()` function the same way we use `write_voxel_grid()` or `write_point_cloud()`.

Just let me know if tests or docs are additionally necessary.

Some example code:

``` python
pcd = o3d.io.read_point_cloud("some_ply_file.ply")
voxel_grid = getVoxelStructure(pcd)
octree = getOctreeStructure(pcd)

o3d.visualization.draw_geometries([pcd])
o3d.visualization.draw_geometries([voxel_grid])
o3d.visualization.draw_geometries([octree])

o3d.io.write_point_cloud("pointcloud.pcd", pcd)
o3d.io.write_voxel_grid("voxel_grid.ply", voxel_grid)
o3d.io.write_octree("octree.json", octree)

pcd2 = o3d.io.read_point_cloud("pointcloud.pcd")
voxel_grid_2 = o3d.io.read_voxel_grid("voxel_grid.ply")
octree2 = o3d.io.read_octree("octree.json")

o3d.visualization.draw_geometries([pcd2])
o3d.visualization.draw_geometries([voxel_grid_2])
o3d.visualization.draw_geometries([octree2])
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3646)
<!-- Reviewable:end -->
