### PR TITLE
libusb not required for running Open3D in docker

### DIFF
--- a/docs/getting_started.rst.in
+++ b/docs/getting_started.rst.in
@@ -115,7 +115,6 @@ A minimal ``Dockerfile`` looks like this:
     RUN apt-get update && apt-get install --no-install-recommends -y \
         libgl1 \
         libgomp1 \
-        libusb-1.0-0 \
         python3-pip \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
libusb-1.0-0 is statically linked.
Verified in Ubuntu focal and bionic.
Update docs. 
FYI: @nachovizzo 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3657)
<!-- Reviewable:end -->
