### PR TITLE
Return failure exit code on leaks at program end

### DIFF
--- a/cpp/open3d/core/MemoryManager.cpp
+++ b/cpp/open3d/core/MemoryManager.cpp
@@ -40,14 +40,15 @@ namespace core {
 
 void* MemoryManager::Malloc(size_t byte_size, const Device& device) {
     void* ptr = GetDeviceMemoryManager(device)->Malloc(byte_size, device);
-    MemoryManagerStatistic::GetInstance().IncrementCountMalloc(ptr, byte_size,
-                                                               device);
+    MemoryManagerStatistic::GetInstance().CountMalloc(ptr, byte_size, device);
     return ptr;
 }
 
 void MemoryManager::Free(void* ptr, const Device& device) {
+    // Update statistics before freeing the memory. This ensures a consistent
+    // order in case a subsequent Malloc requires the currently freed memory.
+    MemoryManagerStatistic::GetInstance().CountFree(ptr, device);
     GetDeviceMemoryManager(device)->Free(ptr, device);
-    MemoryManagerStatistic::GetInstance().IncrementCountFree(ptr, device);
 }
 
 void MemoryManager::Memcpy(void* dst_ptr,

--- a/cpp/open3d/core/MemoryManagerStatistic.cpp
+++ b/cpp/open3d/core/MemoryManagerStatistic.cpp
@@ -27,6 +27,7 @@
 #include "open3d/core/MemoryManagerStatistic.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <numeric>
 
 #include "open3d/utility/Logging.h"
@@ -52,6 +53,12 @@ MemoryManagerStatistic::~MemoryManagerStatistic() {
         // at this point in time.
         utility::Logger::GetInstance().ResetPrintFunction();
         Print();
+
+        // Indicate failure if possible leaks have been detected.
+        // This is useful to automatically let unit tests fail.
+        if (HasLeaks()) {
+            std::exit(EXIT_FAILURE);
+        }
     }
 }
 
@@ -66,61 +73,112 @@ void MemoryManagerStatistic::Print() const {
         return;
     }
 
-    auto is_unbalanced = [](const auto& value_pair) -> bool {
-        return value_pair.second.count_malloc_ != value_pair.second.count_free_;
-    };
-
-    if (level_ == PrintLevel::Unbalanced &&
-        std::count_if(statistics_.begin(), statistics_.end(), is_unbalanced) ==
-                0) {
+    if (level_ == PrintLevel::Unbalanced && !HasLeaks()) {
         return;
     }
+
+    // Ensure all information gets printed.
+    auto old_level = utility::GetVerbosityLevel();
+    utility::SetVerbosityLevel(utility::VerbosityLevel::Info);
 
     utility::LogInfo("Memory Statistics: (Device) (#Malloc) (#Free)");
     utility::LogInfo("---------------------------------------------");
     for (const auto& value_pair : statistics_) {
-        if (level_ == PrintLevel::Unbalanced && !is_unbalanced(value_pair)) {
+        // Simulate C++17 structured bindings for better readability.
+        const auto& device = value_pair.first;
+        const auto& statistics = value_pair.second;
+
+        if (level_ == PrintLevel::Unbalanced && statistics.IsBalanced()) {
             continue;
         }
 
-        if (is_unbalanced(value_pair)) {
-            size_t count_leaking = value_pair.second.count_malloc_ -
-                                   value_pair.second.count_free_;
+        if (!statistics.IsBalanced()) {
+            int64_t count_leaking =
+                    statistics.count_malloc_ - statistics.count_free_;
 
             size_t leaking_byte_size = std::accumulate(
-                    value_pair.second.active_allocations_.begin(),
-                    value_pair.second.active_allocations_.end(), 0,
+                    statistics.active_allocations_.begin(),
+                    statistics.active_allocations_.end(), 0,
                     [](size_t count, auto ptr_byte_size) -> size_t {
                         return count + ptr_byte_size.second;
                     });
 
-            utility::LogWarning("{}: {} {} --> {} with {} bytes",
-                                value_pair.first.ToString(),
-                                value_pair.second.count_malloc_,
-                                value_pair.second.count_free_, count_leaking,
+            utility::LogWarning("{}: {} {} --> {} with {} total bytes",
+                                device.ToString(), statistics.count_malloc_,
+                                statistics.count_free_, count_leaking,
                                 leaking_byte_size);
+
+            for (const auto& leak : statistics.active_allocations_) {
+                utility::LogWarning("    {} @ {} bytes", fmt::ptr(leak.first),
+                                    leak.second);
+            }
         } else {
-            utility::LogInfo("{}: {} {}", value_pair.first.ToString(),
-                             value_pair.second.count_malloc_,
-                             value_pair.second.count_free_);
+            utility::LogInfo("{}: {} {}", device.ToString(),
+                             statistics.count_malloc_, statistics.count_free_);
         }
     }
     utility::LogInfo("---------------------------------------------");
+
+    // Restore old verbosity level.
+    utility::SetVerbosityLevel(old_level);
 }
 
-void MemoryManagerStatistic::IncrementCountMalloc(void* ptr,
-                                                  size_t byte_size,
-                                                  const Device& device) {
-    std::lock_guard<std::mutex> lock(statistics_mutex_);
-    statistics_[device].count_malloc_++;
-    statistics_[device].active_allocations_.emplace(ptr, byte_size);
+bool MemoryManagerStatistic::HasLeaks() const {
+    return std::any_of(statistics_.begin(), statistics_.end(),
+                       [](const auto& value_pair) -> bool {
+                           return !value_pair.second.IsBalanced();
+                       });
 }
 
-void MemoryManagerStatistic::IncrementCountFree(void* ptr,
-                                                const Device& device) {
+void MemoryManagerStatistic::CountMalloc(void* ptr,
+                                         size_t byte_size,
+                                         const Device& device) {
     std::lock_guard<std::mutex> lock(statistics_mutex_);
-    statistics_[device].count_free_++;
-    statistics_[device].active_allocations_.erase(ptr);
+
+    // Filter nullptr. Empty allocations are not tracked.
+    if (ptr == nullptr && byte_size == 0) {
+        return;
+    }
+
+    auto it = statistics_[device].active_allocations_.emplace(ptr, byte_size);
+    if (it.second) {
+        statistics_[device].count_malloc_++;
+    } else {
+        utility::LogError(
+                "{} @ {} bytes on {} is still active and was not freed before",
+                fmt::ptr(ptr), byte_size, device.ToString());
+    }
+}
+
+void MemoryManagerStatistic::CountFree(void* ptr, const Device& device) {
+    std::lock_guard<std::mutex> lock(statistics_mutex_);
+
+    // Filter nullptr. Empty allocations are not tracked.
+    if (ptr == nullptr) {
+        return;
+    }
+
+    auto num_erased = statistics_[device].active_allocations_.erase(ptr);
+    if (num_erased == 1) {
+        statistics_[device].count_free_++;
+    } else if (num_erased == 0) {
+        // Either the statistics were reset before or the given pointer is
+        // invalid. Do not increase any counts and ignore both cases.
+    } else {
+        // Should never reach here.
+        utility::LogError(
+                "Invalid number of erased allocations {} for {} on {}",
+                num_erased, fmt::ptr(ptr), device.ToString());
+    }
+}
+
+void MemoryManagerStatistic::Reset() {
+    std::lock_guard<std::mutex> lock(statistics_mutex_);
+    statistics_.clear();
+}
+
+bool MemoryManagerStatistic::MemoryStatistics::IsBalanced() const {
+    return count_malloc_ == count_free_;
 }
 
 }  // namespace core

--- a/cpp/pybind/open3d_pybind.cpp
+++ b/cpp/pybind/open3d_pybind.cpp
@@ -26,6 +26,7 @@
 
 #include "pybind/open3d_pybind.h"
 
+#include "open3d/core/MemoryManagerStatistic.h"
 #include "open3d/utility/Logging.h"
 #include "pybind/camera/camera.h"
 #include "pybind/core/core.h"
@@ -65,6 +66,12 @@ PYBIND11_MODULE(pybind, m) {
     io::pybind_io(m);
     pipelines::pybind_pipelines(m);
     visualization::pybind_visualization(m);
+
+    // pybind11 will internally manage the lifetime of default arguments for
+    // function bindings. Since these objects will live longer than the memory
+    // manager statistics, the latter will report leaks. Reset the statistics to
+    // ignore them and transfer the responsibility to pybind11.
+    core::MemoryManagerStatistic::GetInstance().Reset();
 }
 
 }  // namespace open3d


### PR DESCRIPTION
Summary:
- Add `HasLeaks()` function to memory statistics to query current leak status. This simplifies some internal code.
- Add `Reset()` function to discard all recorded statistics. Used to suppress leak warning for objects managed by `pybind11`.
- Filter pointers and sizes to automatically account for previous calls to `Reset()`.
- Print list of leaking pointers to provide more information about their distribution.
- Fix underflow in balance computation by changing `size_t` to `int64_t` .

Manually checked exit code of C++ and Python unit tests with an intentional leak. Works as expected. CI must all pass as Open3D should be leak-free as of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3666)
<!-- Reviewable:end -->
