### PR TITLE
Release CUDA cache in faiss index initialization

### DIFF
--- a/cpp/open3d/core/nns/FaissIndex.cpp
+++ b/cpp/open3d/core/nns/FaissIndex.cpp
@@ -77,6 +77,8 @@ bool FaissIndex::SetTensorData(const Tensor &dataset_points) {
         res.reset(new faiss::gpu::StandardGpuResources());
         faiss::gpu::GpuIndexFlatConfig config;
         config.device = dataset_points_.GetDevice().GetID();
+
+        CUDACachedMemoryManager::ReleaseCache();
         index.reset(new faiss::gpu::GpuIndexFlat(
                 res.get(), dimension, faiss::MetricType::METRIC_L2, config));
 #else


### PR DESCRIPTION
Running the unit tests with CUDA support enabled on a GPU with 8 GB VRAM (or less) likely fails because `faiss` is unable to allocate memory. Ideally, we would give it access to our cached memory manager, but for the time being, workaround this problem by releasing our CUDA memory cache instead.

Tested on NVIDIA RTX 2070 Max-Q with 8 GB VRAM.

Note that other out-of-memory failures on GPUs with less memory may still occur due to limitations of the cached memory manager (will be addressed separately.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3677)
<!-- Reviewable:end -->
