### PR TITLE
NNS Benchmark [Issue]

### DIFF
--- a/cpp/benchmarks/core/CMakeLists.txt
+++ b/cpp/benchmarks/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(benchmarks PRIVATE
     Hashmap.cpp
+    NNS.cpp
     Reduction.cpp
     Zeros.cpp
 )

--- a/cpp/benchmarks/core/NNS.cpp
+++ b/cpp/benchmarks/core/NNS.cpp
@@ -48,9 +48,9 @@ void HybridSearch(benchmark::State& state,
     t::io::ReadPointCloud(path, pcd, {"auto", false, false, false});
     pcd = pcd.To(device);
 
-    pcd.VoxelDownSample(voxel_size);
+    auto pcd_down = pcd.VoxelDownSample(voxel_size);
 
-    core::nns::NearestNeighborSearch tree(pcd.GetPoints());
+    core::nns::NearestNeighborSearch tree(pcd_down.GetPoints());
 
     bool check = tree.HybridIndex(radius);
     if (!check) {
@@ -61,10 +61,10 @@ void HybridSearch(benchmark::State& state,
     core::Tensor indices, distance, counts;
     // Warp up
     std::tie(indices, distance, counts) =
-            tree.HybridSearch(pcd.GetPoints(), radius, max_nn);
+            tree.HybridSearch(pcd_down.GetPoints(), radius, max_nn);
     for (auto _ : state) {
         std::tie(indices, distance, counts) =
-                tree.HybridSearch(pcd.GetPoints(), radius, max_nn);
+                tree.HybridSearch(pcd_down.GetPoints(), radius, max_nn);
     }
 }
 
@@ -77,9 +77,9 @@ void KnnSearch(benchmark::State& state,
     t::io::ReadPointCloud(path, pcd, {"auto", false, false, false});
     pcd = pcd.To(device);
 
-    pcd.VoxelDownSample(voxel_size);
+    auto pcd_down = pcd.VoxelDownSample(voxel_size);
 
-    core::nns::NearestNeighborSearch tree(pcd.GetPoints());
+    core::nns::NearestNeighborSearch tree(pcd_down.GetPoints());
 
     bool check = tree.KnnIndex();
     if (!check) {
@@ -88,9 +88,10 @@ void KnnSearch(benchmark::State& state,
 
     core::Tensor indices, distance, counts;
     // Warp up
-    std::tie(indices, distance) = tree.KnnSearch(pcd.GetPoints(), max_nn);
+    std::tie(indices, distance) = tree.KnnSearch(pcd_down.GetPoints(), max_nn);
     for (auto _ : state) {
-        std::tie(indices, distance) = tree.KnnSearch(pcd.GetPoints(), max_nn);
+        std::tie(indices, distance) =
+                tree.KnnSearch(pcd_down.GetPoints(), max_nn);
     }
 }
 

--- a/cpp/benchmarks/core/NNS.cpp
+++ b/cpp/benchmarks/core/NNS.cpp
@@ -1,0 +1,196 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include <benchmark/benchmark.h>
+
+#include "open3d/core/Tensor.h"
+#include "open3d/core/nns/NearestNeighborSearch.h"
+#include "open3d/geometry/KDTreeFlann.h"
+#include "open3d/io/PointCloudIO.h"
+#include "open3d/t/io/PointCloudIO.h"
+
+namespace open3d {
+namespace t {
+namespace geometry {
+
+static const std::string path = std::string(TEST_DATA_DIR) + "/fragment.ply";
+
+void HybridSearch(benchmark::State& state,
+                  const core::Device& device,
+                  double voxel_size,
+                  double radius,
+                  double max_nn) {
+    t::geometry::PointCloud pcd;
+
+    t::io::ReadPointCloud(path, pcd, {"auto", false, false, false});
+    pcd = pcd.To(device);
+
+    pcd.VoxelDownSample(voxel_size);
+
+    core::nns::NearestNeighborSearch tree(pcd.GetPoints());
+
+    bool check = tree.HybridIndex(radius);
+    if (!check) {
+        utility::LogError(
+                "NearestNeighborSearch::FixedRadiusIndex Index is not set.");
+    }
+
+    core::Tensor indices, distance, counts;
+    // Warp up
+    std::tie(indices, distance, counts) =
+            tree.HybridSearch(pcd.GetPoints(), radius, max_nn);
+    for (auto _ : state) {
+        std::tie(indices, distance, counts) =
+                tree.HybridSearch(pcd.GetPoints(), radius, max_nn);
+    }
+}
+
+void KnnSearch(benchmark::State& state,
+               const core::Device& device,
+               double voxel_size,
+               double max_nn) {
+    t::geometry::PointCloud pcd;
+
+    t::io::ReadPointCloud(path, pcd, {"auto", false, false, false});
+    pcd = pcd.To(device);
+
+    pcd.VoxelDownSample(voxel_size);
+
+    core::nns::NearestNeighborSearch tree(pcd.GetPoints());
+
+    bool check = tree.KnnIndex();
+    if (!check) {
+        utility::LogError("NearestNeighborSearch::KNN Index is not set.");
+    }
+
+    core::Tensor indices, distance, counts;
+    // Warp up
+    std::tie(indices, distance) = tree.KnnSearch(pcd.GetPoints(), max_nn);
+    for (auto _ : state) {
+        std::tie(indices, distance) = tree.KnnSearch(pcd.GetPoints(), max_nn);
+    }
+}
+
+void LegacySearchForPointCloud(
+        const open3d::geometry::PointCloud& pcd,
+        const open3d::geometry::KDTreeSearchParam& search_param) {
+    open3d::geometry::KDTreeFlann kdtree;
+
+    kdtree.SetGeometry(pcd);
+    auto points = pcd.points_;
+
+#pragma omp parallel for schedule(static)
+    for (int i = 0; i < (int)points.size(); i++) {
+        std::vector<int> indices;
+        std::vector<double> distance2;
+        kdtree.Search(points[i], search_param, indices, distance2);
+    }
+}
+
+void LegacySearch(benchmark::State& state,
+                  double voxel_size,
+                  const open3d::geometry::KDTreeSearchParam& search_param) {
+    open3d::geometry::PointCloud pcd;
+
+    open3d::io::ReadPointCloud(path, pcd, {"auto", false, false, false});
+
+    auto pcd_down = pcd.VoxelDownSample(voxel_size);
+
+    LegacySearchForPointCloud(*pcd_down, search_param);
+    for (auto _ : state) {
+        LegacySearchForPointCloud(*pcd_down, search_param);
+    }
+}
+
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.07 | 30] CPU, core::Device("CPU:0"), 0.02, 0.07, 30)
+        ->Unit(benchmark::kMillisecond);
+
+#ifdef BUILD_CUDA_MODULE
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.07 | 30] CUDA, core::Device("CUDA:0"), 0.02, 0.07, 30)
+        ->Unit(benchmark::kMillisecond);
+#endif
+
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.04 | 30] CPU, core::Device("CPU:0"), 0.04, 0.07, 30)
+        ->Unit(benchmark::kMillisecond);
+
+#ifdef BUILD_CUDA_MODULE
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.04 | 30] CUDA, core::Device("CUDA:0"), 0.04, 0.07, 30)
+        ->Unit(benchmark::kMillisecond);
+#endif
+
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.07 | 1] CPU, core::Device("CPU:0"), 0.02, 0.07, 1)
+        ->Unit(benchmark::kMillisecond);
+
+#ifdef BUILD_CUDA_MODULE
+BENCHMARK_CAPTURE(
+        HybridSearch, [0.07 | 1] CUDA, core::Device("CUDA:0"), 0.02, 0.07, 1)
+        ->Unit(benchmark::kMillisecond);
+#endif
+
+BENCHMARK_CAPTURE(KnnSearch, [30] CPU, core::Device("CPU:0"), 0.02, 1)
+        ->Unit(benchmark::kMillisecond);
+
+#ifdef BUILD_CUDA_MODULE
+BENCHMARK_CAPTURE(KnnSearch, [30] CUDA, core::Device("CUDA:0"), 0.02, 30)
+        ->Unit(benchmark::kMillisecond);
+#endif
+
+BENCHMARK_CAPTURE(KnnSearch, [1] CPU, core::Device("CPU:0"), 0.02, 1)
+        ->Unit(benchmark::kMillisecond);
+
+#ifdef BUILD_CUDA_MODULE
+BENCHMARK_CAPTURE(KnnSearch, [1] CUDA, core::Device("CUDA:0"), 0.02, 1)
+        ->Unit(benchmark::kMillisecond);
+#endif
+
+BENCHMARK_CAPTURE(
+        LegacySearch, [30] KNN, 0.02, open3d::geometry::KDTreeSearchParamKNN())
+        ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(
+        LegacySearch, [1] KNN, 0.02, open3d::geometry::KDTreeSearchParamKNN(1))
+        ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(LegacySearch,
+                  [0.07 | 30] Hybrid,
+                  0.02,
+                  open3d::geometry::KDTreeSearchParamHybrid(0.07, 30))
+        ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(LegacySearch,
+                  [0.07 | 1] Hybrid,
+                  0.02,
+                  open3d::geometry::KDTreeSearchParamHybrid(0.07, 1))
+        ->Unit(benchmark::kMillisecond);
+
+}  // namespace geometry
+}  // namespace t
+}  // namespace open3d


### PR DESCRIPTION
NNS performance 
0.02 voxel size on test_data/fragment pointcloud. 
search radius: 0.04, 0.07
max_nn: 1, 30

### [Updated]
### Master
i7-7700HQ, GTX 1050Ti 4GB, 8GB RAM
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
HybridSearch/[0.07 | 30] CPU          14.3 ms         14.2 ms           47
HybridSearch/[0.07 | 30] CUDA         21.2 ms         21.2 ms           33
HybridSearch/[0.04 | 30] CPU          1.50 ms         1.50 ms          451
HybridSearch/[0.04 | 30] CUDA        0.807 ms        0.807 ms          860
HybridSearch/[0.07 | 1] CPU           13.9 ms         13.9 ms           48
HybridSearch/[0.07 | 1] CUDA          1.77 ms         1.77 ms          392
KnnSearch/[30] CPU                    9.89 ms         5.69 ms          102
KnnSearch/[30] CUDA                   95.2 ms         95.2 ms            7
KnnSearch/[1] CPU                     9.88 ms         4.59 ms          149
KnnSearch/[1] CUDA                    84.6 ms         84.6 ms            8
LegacySearch/[30] KNN                 26.4 ms         26.4 ms           27
LegacySearch/[1] KNN                  13.3 ms         13.3 ms           53
LegacySearch/[0.07 | 30] Hybrid       26.4 ms         26.4 ms           27
LegacySearch/[0.07 | 1] Hybrid        13.3 ms         13.3 ms           53
```
### PR 3237
i7-7700HQ, GTX 1050Ti 4GB, 8GB RAM
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
HybridSearch/[0.07 | 30] CPU          14.4 ms         14.4 ms           48
HybridSearch/[0.07 | 30] CUDA         4.86 ms         4.86 ms          128
HybridSearch/[0.04 | 30] CPU          1.55 ms         1.55 ms          446
HybridSearch/[0.04 | 30] CUDA        0.750 ms        0.750 ms          928
HybridSearch/[0.07 | 1] CPU           14.1 ms         14.1 ms           49
HybridSearch/[0.07 | 1] CUDA          2.42 ms         2.42 ms          294
KnnSearch/[30] CPU                    10.0 ms         5.52 ms          100
KnnSearch/[30] CUDA                   79.5 ms         79.5 ms            9
KnnSearch/[1] CPU                     10.3 ms         5.47 ms          147
KnnSearch/[1] CUDA                    60.3 ms         60.3 ms           12
LegacySearch/[30] KNN                 26.0 ms         26.0 ms           27
LegacySearch/[1] KNN                  13.4 ms         13.4 ms           52
LegacySearch/[0.07 | 30] Hybrid       26.5 ms         26.5 ms           27
LegacySearch/[0.07 | 1] Hybrid        13.5 ms         13.5 ms           52
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3688)
<!-- Reviewable:end -->
