### PR TITLE
Simplify HTML copy command

### DIFF
--- a/cpp/open3d/visualization/webrtc_server/CMakeLists.txt
+++ b/cpp/open3d/visualization/webrtc_server/CMakeLists.txt
@@ -15,7 +15,7 @@ target_compile_definitions(webrtc_server PRIVATE
     _FILE_OFFSET_BITS=64 # for civetweb
     _LARGEFILE_SOURCE=1  # for civetweb
 )
-add_dependencies(webrtc_server trigger_copy_html)
+add_dependencies(webrtc_server copy_html_dir)
 
 open3d_show_and_abort_on_warning(webrtc_server)
 open3d_set_global_properties(webrtc_server)
@@ -30,20 +30,10 @@ message(STATUS "Copying ${CMAKE_CURRENT_SOURCE_DIR}/html to ${GUI_RESOURCE_DIR}.
 file(MAKE_DIRECTORY ${GUI_RESOURCE_DIR})
 
 # Force update ${GUI_RESOURCE_DIR}/html every time.
-# https://stackoverflow.com/a/32062884/1255535
-add_custom_target(trigger_copy_html ALL
-    DEPENDS copy_html
-)
-add_custom_command(
-    OUTPUT copy_html
+add_custom_target(copy_html_dir ALL
     COMMAND ${CMAKE_COMMAND} -E rm -rf
         ${GUI_RESOURCE_DIR}/html
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_CURRENT_SOURCE_DIR}/html
         ${GUI_RESOURCE_DIR}/html
-    DEPENDS always_rebuild
-)
-add_custom_command(
-    OUTPUT always_rebuild
-    COMMAND cmake -E echo
 )


### PR DESCRIPTION
The HTML copy command should update the resource directory on every build. However, the underlying logic is overly complicated and produces some noise, especially when the build is complete. Since `add_custom_target` is always out-dated by default, the simplified logic achieves the same result with less noise for the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3696)
<!-- Reviewable:end -->
