### PR TITLE
physical cpu count and CPUInfo class

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -25,5 +25,7 @@ else()
     target_compile_definitions(benchmarks PRIVATE IPP_CONDITIONAL_TEST_STR=DISABLED_)
 endif()
 
-target_link_libraries(benchmarks PRIVATE benchmark::benchmark benchmark::benchmark_main)
-
+target_link_libraries(benchmarks PRIVATE benchmark::benchmark)
+target_sources(benchmarks PRIVATE
+    Main.cpp
+)

--- a/cpp/benchmarks/Main.cpp
+++ b/cpp/benchmarks/Main.cpp
@@ -23,47 +23,29 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include <cstring>
-#include <string>
-
-#ifdef BUILD_CUDA_MODULE
-#include "open3d/core/CUDAState.cuh"
-#endif
+#include <benchmark/benchmark.h>
 
 #include "open3d/utility/CPUInfo.h"
-#include "open3d/utility/Logging.h"
-#include "tests/UnitTest.h"
-
-#ifdef BUILD_CUDA_MODULE
-/// Returns true if --disable_p2p flag is used.
-bool ShallDisableP2P(int argc, char** argv) {
-    bool shall_disable_p2p = false;
-    for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "--disable_p2p") == 0) {
-            shall_disable_p2p = true;
-            break;
-        }
-    }
-    return shall_disable_p2p;
-}
-#endif
 
 int main(int argc, char** argv) {
-    using namespace open3d;
-#ifdef BUILD_CUDA_MODULE
-    if (ShallDisableP2P(argc, argv)) {
-        std::shared_ptr<core::CUDAState> cuda_state =
-                core::CUDAState::GetInstance();
-        cuda_state->ForceDisableP2PForTesting();
-        utility::LogInfo("P2P device transfer has been disabled.");
+    open3d::utility::CPUInfo::GetInstance().PrintInfo();
+    benchmark::Initialize(&argc, argv);
+    if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+        return 1;
     }
-#endif
-    testing::InitGoogleMock(&argc, argv);
-    utility::SetVerbosityLevel(utility::VerbosityLevel::Debug);
-    utility::CPUInfo::GetInstance().PrintInfo();
-    return RUN_ALL_TESTS();
+    benchmark::RunSpecifiedBenchmarks();
 }

--- a/cpp/open3d/utility/CMakeLists.txt
+++ b/cpp/open3d/utility/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(utility OBJECT)
 
 target_sources(utility PRIVATE
     Console.cpp
+    CPUInfo.cpp
     Eigen.cpp
     FileSystem.cpp
     Helper.cpp

--- a/cpp/open3d/utility/CPUInfo.cpp
+++ b/cpp/open3d/utility/CPUInfo.cpp
@@ -1,0 +1,157 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/utility/CPUInfo.h"
+
+#include <fstream>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef __linux__
+#include <sys/sysinfo.h>
+#elif __APPLE__
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif _WIN32
+#include <Windows.h>
+#endif
+
+#include "open3d/utility/Helper.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace utility {
+
+struct CPUInfo::Impl {
+    unsigned int num_cores_;
+    unsigned int num_threads_;
+};
+
+/// Returns the number of physical CPU cores.
+static unsigned int PhysicalConcurrency() {
+    try {
+#ifdef __linux__
+        // Ref: boost::thread::physical_concurrency().
+        std::ifstream proc_cpuinfo("/proc/cpuinfo");
+        const std::string physical_id("physical id");
+        const std::string core_id("core id");
+
+        // [physical ID, core id]
+        using CoreEntry = std::pair<unsigned int, unsigned int>;
+        std::set<CoreEntry> cores;
+        CoreEntry current_core_entry;
+
+        std::string line;
+        while (std::getline(proc_cpuinfo, line)) {
+            if (line.empty()) {
+                continue;
+            }
+            std::vector<std::string> key_val =
+                    utility::SplitString(line, ":", /*trim_empty_str=*/false);
+            if (key_val.size() != 2) {
+                return std::thread::hardware_concurrency();
+            }
+            std::string key = utility::StripString(key_val[0]);
+            std::string value = utility::StripString(key_val[1]);
+            if (key == physical_id) {
+                current_core_entry.first = std::stoi(value);
+                continue;
+            }
+            if (key == core_id) {
+                current_core_entry.second = std::stoi(value);
+                cores.insert(current_core_entry);
+                continue;
+            }
+        }
+        // Fall back to hardware_concurrency() in case
+        // /proc/cpuinfo is formatted differently than we expect.
+        return cores.size() != 0 ? cores.size()
+                                 : std::thread::hardware_concurrency();
+#elif __APPLE__
+        // Ref: boost::thread::physical_concurrency().
+        unsigned int count;
+        size_t size = sizeof(count);
+        return sysctlbyname("hw.physicalcpu", &count, &size, NULL, 0) ? 0
+                                                                      : count;
+#elif _WIN32
+        // Ref: https://stackoverflow.com/a/44247223/1255535.
+        DWORD length = 0;
+        const BOOL result_first = GetLogicalProcessorInformationEx(
+                RelationProcessorCore, nullptr, &length);
+        assert(GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+
+        std::unique_ptr<uint8_t[]> buffer(new uint8_t[length]);
+        const PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info =
+                reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+                        buffer.get());
+        const BOOL result_second = GetLogicalProcessorInformationEx(
+                RelationProcessorCore, info, &length);
+        assert(result_second != FALSE);
+
+        unsigned int nb_physical_cores = 0;
+        unsigned int offset = 0;
+        do {
+            const PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX current_info =
+                    reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+                            buffer.get() + offset);
+            offset += current_info->Size;
+            ++nb_physical_cores;
+        } while (offset < length);
+        return nb_physical_cores;
+#else
+        return std::thread::hardware_concurrency();
+#endif
+    } catch (...) {
+        return std::thread::hardware_concurrency();
+    }
+}
+
+CPUInfo::CPUInfo() : impl_(new CPUInfo::Impl()) {
+    impl_->num_cores_ = PhysicalConcurrency();
+    impl_->num_threads_ = std::thread::hardware_concurrency();
+}
+
+CPUInfo::~CPUInfo() {}
+
+CPUInfo& CPUInfo::GetInstance() {
+    static CPUInfo instance;
+    return instance;
+}
+
+unsigned int CPUInfo::NumCores() const { return impl_->num_cores_; }
+
+unsigned int CPUInfo::NumThreads() const { return impl_->num_threads_; }
+
+void CPUInfo::PrintInfo() const {
+    utility::LogInfo("CPUInfo: {} cores, {} threads.", NumCores(),
+                     NumThreads());
+}
+
+}  // namespace utility
+}  // namespace open3d


### PR DESCRIPTION
- Get the number of physical/logical CPU cores.
- Print CPU information before each unit test and benchmark runs.
- The information will be used in `ParallelFor` in the next PR.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3710)
<!-- Reviewable:end -->
