### PR TITLE
expose BufferConnection to python and enable implicit conversion to Tensor for the RPC functions

### DIFF
--- a/cpp/pybind/io/rpc.cpp
+++ b/cpp/pybind/io/rpc.cpp
@@ -24,10 +24,12 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
+#include "open3d/io/rpc/BufferConnection.h"
 #include "open3d/io/rpc/Connection.h"
 #include "open3d/io/rpc/DummyReceiver.h"
 #include "open3d/io/rpc/RemoteFunctions.h"
 #include "open3d/io/rpc/ZMQContext.h"
+#include "pybind/core/tensor_type_caster.h"
 #include "pybind/docstring.h"
 #include "pybind/open3d_pybind.h"
 
@@ -56,6 +58,16 @@ void pybind_rpc(py::module& m_io) {
                  "Creates a connection object",
                  "address"_a = "tcp://127.0.0.1:51454",
                  "connect_timeout"_a = 5000, "timeout"_a = 10000);
+
+    py::class_<rpc::BufferConnection, std::shared_ptr<rpc::BufferConnection>,
+               rpc::ConnectionBase>(m, "BufferConnection")
+            .def(py::init<>())
+            .def(
+                    "get_buffer",
+                    [](const rpc::BufferConnection& self) {
+                        return py::bytes(self.buffer().str());
+                    },
+                    "Returns a copy of the buffer.");
 
     py::class_<rpc::DummyReceiver, std::shared_ptr<rpc::DummyReceiver>>(
             m, "_DummyReceiver",


### PR DESCRIPTION
This PR
-exposes BufferConnection to python
-enables implicit conversion to Tensor for the rpc functions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3729)
<!-- Reviewable:end -->
