### PR TITLE
Introduce CUDAScopedStream class for Multi-Stream Support

### DIFF
--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -11,6 +11,11 @@ target_compile_definitions(benchmarks PRIVATE TEST_DATA_DIR="${PROJECT_SOURCE_DI
 target_compile_definitions(benchmarks PRIVATE BENCHMARK_DATA_DIR="${PROJECT_SOURCE_DIR}/data/Benchmark")
 
 target_link_libraries(benchmarks PRIVATE Open3D::Open3D)
+if (BUILD_CUDA_MODULE)
+    find_package(CUDAToolkit REQUIRED)
+    target_link_libraries(benchmarks PRIVATE CUDA::cudart)
+endif()
+
 open3d_show_and_abort_on_warning(benchmarks)
 open3d_set_global_properties(benchmarks)
 open3d_link_3rdparty_libraries(benchmarks)

--- a/cpp/open3d/core/CUDAState.cuh
+++ b/cpp/open3d/core/CUDAState.cuh
@@ -26,7 +26,7 @@
 
 /// \file CUDAState.cuh
 ///
-/// CUDAState.cuh can only be included by nvcc compiled source code.
+/// CUDAState.cuh can only be included by NVCC compiled source code.
 
 #pragma once
 
@@ -43,75 +43,92 @@
 namespace open3d {
 namespace core {
 
-/// \class CUDADeviceSwitcher
+/// \class CUDAScopedDevice
 ///
-/// Switch CUDA device id in the current scope. The device id will be resetted
+/// Switch CUDA device id in the current scope. The device id will be reset
 /// once leaving the scope.
 ///
-/// CUDADeviceSwitcher provies an
+/// CUDAScopedDevice provides an
 /// [RAII-style](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)
 /// mechanism for setting and resetting CUDA devices of a scoped block.
 ///
 /// Example:
 /// ```cpp
 /// void my_func() {
-///     // The switcher recoreds the previous device when it is constructed.
-///     // Let's assume cudaGetDevice == 0 initially.
-///     CUDADeviceSwitcher switcher;
+///     // The scoped wrapper records the previous device when it is
+///     constructed.
+///     // Let's assume the current device is 0 initially.
+///     CUDAScopedDevice scoped_device(1);
 ///
-///     switcher.SwitchTo(1);
-///     // Now cudaGetDevice == 1.
+///     // Now the current device is 1.
 ///     // Make cuda calls here for device 1.
 ///
-///     switcher.SwitchTo(2);
-///     // Now cudaGetDevice == 2.
-///     // Make cuda calls here for device 1.
-///
-///     // After `my_func` returns, `switcher` goes out-of-scope,
-///     // so cudaGetDevice will be reset back to 0.
+///     // After `my_func` returns, `scoped_device` goes out-of-scope,
+///     // so the global device will be reset back to 0.
 /// }
-/// ```
-///
-/// You may also directly initialize and switch to a device:
-/// void my_func() {
-///     // The switcher recoreds the previous device and switch to device 1.
-///     CUDADeviceSwitcher switcher(1);
-///
-///     // After `my_func` returns, `switcher` goes out-of-scope,
-///     // so cudaGetDevice will be reset back to the previous device.
-/// }
-class CUDADeviceSwitcher {
+class CUDAScopedDevice {
 public:
-    /// Init CUDADeviceSwitcher class and keep using the current device.
-    CUDADeviceSwitcher() { OPEN3D_CUDA_CHECK(cudaGetDevice(&prev_device_id_)); }
-
-    CUDADeviceSwitcher(int device_id) : CUDADeviceSwitcher() {
-        SwitchTo(device_id);
+    explicit CUDAScopedDevice(int device_id)
+        : prev_device_id_(cuda::GetDevice()) {
+        cuda::SetDevice(device_id);
     }
 
-    CUDADeviceSwitcher(const Device& device)
-        : CUDADeviceSwitcher(device.GetID()) {}
+    explicit CUDAScopedDevice(const Device& device)
+        : CUDAScopedDevice(device.GetID()) {}
 
-    void SwitchTo(int device_id) const {
-        OPEN3D_CUDA_CHECK(cudaSetDevice(device_id));
-    }
+    ~CUDAScopedDevice() { cuda::SetDevice(prev_device_id_); }
 
-    void SwitchTo(const Device& device) const { SwitchTo(device.GetID()); }
-
-    ~CUDADeviceSwitcher() { OPEN3D_CUDA_CHECK(cudaSetDevice(prev_device_id_)); }
-
-    CUDADeviceSwitcher(CUDADeviceSwitcher const&) = delete;
-
-    void operator=(CUDADeviceSwitcher const&) = delete;
+    CUDAScopedDevice(const CUDAScopedDevice&) = delete;
+    void operator=(const CUDAScopedDevice&) = delete;
 
 private:
     int prev_device_id_;
 };
 
+/// \class CUDAScopedStream
+///
+/// Switch CUDA stream in the current scope. The stream will be reset
+/// once leaving the scope.
+///
+/// CUDAScopedStream provides an
+/// [RAII-style](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization)
+/// mechanism for setting and resetting CUDA streams of a scoped block.
+///
+/// Example:
+/// ```cpp
+/// void my_func(cudaStream_t stream) {
+///     // The scoped wrapper records the previous stream when it is
+///     constructed.
+///     // Let's assume the current stream is 0 initially.
+///     CUDAScopedStream scoped_stream(stream);
+///
+///     // Now the current stream is 1.
+///     // Make cuda calls here for stream 1.
+///
+///     // After `my_func` returns, `scoped_stream` goes out-of-scope,
+///     // so the global stream will be reset back to 0.
+/// }
+/// ```
+class CUDAScopedStream {
+public:
+    explicit CUDAScopedStream(cudaStream_t stream)
+        : prev_stream_(cuda::GetStream()) {
+        cuda::SetStream(stream);
+    }
+
+    ~CUDAScopedStream() { cuda::SetStream(prev_stream_); }
+
+    CUDAScopedStream(const CUDAScopedStream&) = delete;
+    void operator=(const CUDAScopedStream&) = delete;
+
+private:
+    cudaStream_t prev_stream_;
+};
+
 /// CUDAState is a lazy-evaluated singleton class that initializes and stores
 /// the states of CUDA devices.
 ///
-/// Currenty is stores total number of devices and peer-to-peer availbility.
+/// Currently is stores total number of devices and peer-to-peer availability.
 ///
 /// In the future, it can also be used to store
 /// - Device allocators
@@ -160,18 +177,13 @@ public:
 
     int GetNumDevices() const { return num_devices_; }
 
-    int GetWarpSize() const { return warp_sizes_[GetCurentDeviceID()]; }
+    int GetWarpSize() const { return warp_sizes_[GetCurrentDeviceID()]; }
 
-    int GetCurentDeviceID() const {
-        int device_id;
-        OPEN3D_CUDA_CHECK(cudaGetDevice(&device_id));
-        return device_id;
-    }
+    int GetCurrentDeviceID() const { return cuda::GetDevice(); }
 
     /// Disable P2P device transfer by marking p2p_enabled_ to `false`, in order
     /// to run non-p2p tests on a p2p-capable machine.
     void ForceDisableP2PForTesting() {
-        CUDADeviceSwitcher switcher;
         for (int src_id = 0; src_id < num_devices_; ++src_id) {
             for (int tar_id = 0; tar_id < num_devices_; ++tar_id) {
                 if (src_id != tar_id && p2p_enabled_[src_id][tar_id]) {
@@ -183,7 +195,6 @@ public:
 
 private:
     CUDAState() {
-        CUDADeviceSwitcher switcher;
         OPEN3D_CUDA_CHECK(cudaGetDeviceCount(&num_devices_));
 
         // Check and enable all possible peer to peer access.
@@ -195,7 +206,8 @@ private:
                 if (src_id == tar_id) {
                     p2p_enabled_[src_id][tar_id] = true;
                 } else {
-                    switcher.SwitchTo(src_id);
+                    CUDAScopedDevice scoped_device(src_id);
+
                     // Check access.
                     int can_access = 0;
                     OPEN3D_CUDA_CHECK(cudaDeviceCanAccessPeer(&can_access,

--- a/cpp/open3d/core/CUDAUtils.h
+++ b/cpp/open3d/core/CUDAUtils.h
@@ -28,7 +28,7 @@
 /// \brief Common CUDA utilities
 ///
 /// CUDAUtils.h may be included from CPU-only code.
-/// Use \#ifdef __CUDACC__ to mark conitional compilation
+/// Use \#ifdef __CUDACC__ to mark conditional compilation
 
 #pragma once
 
@@ -90,26 +90,7 @@ inline void __OPEN3D_GET_LAST_CUDA_ERROR(const char* message,
 }
 
 /// Returns the texture alignment in bytes for the current device.
-inline int GetCUDACurrentDeviceTextureAlignment() {
-    int device = 0;
-    cudaError_t err = cudaGetDevice(&device);
-    if (err != cudaSuccess) {
-        utility::LogError(
-                "GetCUDACurrentDeviceTextureAlignment(): cudaGetDevice failed "
-                "with {}",
-                cudaGetErrorString(err));
-    }
-
-    int value = 0;
-    err = cudaDeviceGetAttribute(&value, cudaDevAttrTextureAlignment, device);
-    if (err != cudaSuccess) {
-        utility::LogError(
-                "GetCUDACurrentDeviceTextureAlignment(): "
-                "cudaDeviceGetAttribute failed with {}",
-                cudaGetErrorString(err));
-    }
-    return value;
-}
+int GetCUDACurrentDeviceTextureAlignment();
 #endif
 
 namespace cuda {
@@ -117,6 +98,17 @@ namespace cuda {
 int DeviceCount();
 bool IsAvailable();
 void ReleaseCache();
+
+#ifdef BUILD_CUDA_MODULE
+
+int GetDevice();
+void SetDevice(int device_id);
+
+cudaStream_t GetStream();
+void SetStream(cudaStream_t stream);
+cudaStream_t GetDefaultStream();
+
+#endif
 
 }  // namespace cuda
 }  // namespace core

--- a/cpp/open3d/core/MemoryManager.h
+++ b/cpp/open3d/core/MemoryManager.h
@@ -196,7 +196,7 @@ public:
                 size_t num_bytes) override;
 
 protected:
-    bool IsCUDAPointer(const void* ptr);
+    bool IsCUDAPointer(const void* ptr, const Device& device);
 };
 #endif
 

--- a/cpp/open3d/core/MemoryManagerCUDA.cu
+++ b/cpp/open3d/core/MemoryManagerCUDA.cu
@@ -35,10 +35,16 @@ namespace open3d {
 namespace core {
 
 void* CUDAMemoryManager::Malloc(size_t byte_size, const Device& device) {
-    CUDADeviceSwitcher switcher(device);
+    CUDAScopedDevice scoped_device(device);
+
     void* ptr;
     if (device.GetType() == Device::DeviceType::CUDA) {
+#if CUDART_VERSION >= 11020
+        OPEN3D_CUDA_CHECK(cudaMallocAsync(static_cast<void**>(&ptr), byte_size,
+                                          cuda::GetStream()));
+#else
         OPEN3D_CUDA_CHECK(cudaMalloc(static_cast<void**>(&ptr), byte_size));
+#endif
     } else {
         utility::LogError("CUDAMemoryManager::Malloc: Unimplemented device.");
     }
@@ -46,10 +52,15 @@ void* CUDAMemoryManager::Malloc(size_t byte_size, const Device& device) {
 }
 
 void CUDAMemoryManager::Free(void* ptr, const Device& device) {
-    CUDADeviceSwitcher switcher(device);
+    CUDAScopedDevice scoped_device(device);
+
     if (device.GetType() == Device::DeviceType::CUDA) {
-        if (ptr && IsCUDAPointer(ptr)) {
+        if (ptr && IsCUDAPointer(ptr, device)) {
+#if CUDART_VERSION >= 11020
+            OPEN3D_CUDA_CHECK(cudaFreeAsync(ptr, cuda::GetStream()));
+#else
             OPEN3D_CUDA_CHECK(cudaFree(ptr));
+#endif
         }
     } else {
         utility::LogError("CUDAMemoryManager::Free: Unimplemented device.");
@@ -63,48 +74,55 @@ void CUDAMemoryManager::Memcpy(void* dst_ptr,
                                size_t num_bytes) {
     if (dst_device.GetType() == Device::DeviceType::CUDA &&
         src_device.GetType() == Device::DeviceType::CPU) {
-        CUDADeviceSwitcher switcher(dst_device);
-        if (!IsCUDAPointer(dst_ptr)) {
+        if (!IsCUDAPointer(dst_ptr, dst_device)) {
             utility::LogError("dst_ptr is not a CUDA pointer.");
         }
-        OPEN3D_CUDA_CHECK(cudaMemcpy(dst_ptr, src_ptr, num_bytes,
-                                     cudaMemcpyHostToDevice));
+        CUDAScopedDevice scoped_device(dst_device);
+        OPEN3D_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, num_bytes,
+                                          cudaMemcpyHostToDevice,
+                                          cuda::GetStream()));
     } else if (dst_device.GetType() == Device::DeviceType::CPU &&
                src_device.GetType() == Device::DeviceType::CUDA) {
-        CUDADeviceSwitcher switcher(src_device);
-        if (!IsCUDAPointer(src_ptr)) {
+        if (!IsCUDAPointer(src_ptr, src_device)) {
             utility::LogError("src_ptr is not a CUDA pointer.");
         }
-        OPEN3D_CUDA_CHECK(cudaMemcpy(dst_ptr, src_ptr, num_bytes,
-                                     cudaMemcpyDeviceToHost));
+        CUDAScopedDevice scoped_device(src_device);
+        OPEN3D_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, num_bytes,
+                                          cudaMemcpyDeviceToHost,
+                                          cuda::GetStream()));
     } else if (dst_device.GetType() == Device::DeviceType::CUDA &&
                src_device.GetType() == Device::DeviceType::CUDA) {
-        CUDADeviceSwitcher switcher(dst_device);
-        if (!IsCUDAPointer(dst_ptr)) {
+        if (!IsCUDAPointer(dst_ptr, dst_device)) {
             utility::LogError("dst_ptr is not a CUDA pointer.");
         }
-        switcher.SwitchTo(src_device);
-        if (!IsCUDAPointer(src_ptr)) {
+        if (!IsCUDAPointer(src_ptr, src_device)) {
             utility::LogError("src_ptr is not a CUDA pointer.");
         }
 
         if (dst_device == src_device) {
-            switcher.SwitchTo(src_device);
-            OPEN3D_CUDA_CHECK(cudaMemcpy(dst_ptr, src_ptr, num_bytes,
-                                         cudaMemcpyDeviceToDevice));
+            CUDAScopedDevice scoped_device(src_device);
+            OPEN3D_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, src_ptr, num_bytes,
+                                              cudaMemcpyDeviceToDevice,
+                                              cuda::GetStream()));
         } else if (CUDAState::GetInstance()->IsP2PEnabled(src_device.GetID(),
                                                           dst_device.GetID())) {
-            OPEN3D_CUDA_CHECK(cudaMemcpyPeer(dst_ptr, dst_device.GetID(),
-                                             src_ptr, src_device.GetID(),
-                                             num_bytes));
+            OPEN3D_CUDA_CHECK(cudaMemcpyPeerAsync(
+                    dst_ptr, dst_device.GetID(), src_ptr, src_device.GetID(),
+                    num_bytes, cuda::GetStream()));
         } else {
             void* cpu_buf = MemoryManager::Malloc(num_bytes, Device("CPU:0"));
-            switcher.SwitchTo(src_device);
-            OPEN3D_CUDA_CHECK(cudaMemcpy(cpu_buf, src_ptr, num_bytes,
-                                         cudaMemcpyDeviceToHost));
-            switcher.SwitchTo(dst_device);
-            OPEN3D_CUDA_CHECK(cudaMemcpy(dst_ptr, cpu_buf, num_bytes,
-                                         cudaMemcpyHostToDevice));
+            {
+                CUDAScopedDevice scoped_device(src_device);
+                OPEN3D_CUDA_CHECK(cudaMemcpyAsync(cpu_buf, src_ptr, num_bytes,
+                                                  cudaMemcpyDeviceToHost,
+                                                  cuda::GetStream()));
+            }
+            {
+                CUDAScopedDevice scoped_device(dst_device);
+                OPEN3D_CUDA_CHECK(cudaMemcpyAsync(dst_ptr, cpu_buf, num_bytes,
+                                                  cudaMemcpyHostToDevice,
+                                                  cuda::GetStream()));
+            }
             MemoryManager::Free(cpu_buf, Device("CPU:0"));
         }
     } else {
@@ -112,13 +130,12 @@ void CUDAMemoryManager::Memcpy(void* dst_ptr,
     }
 }
 
-bool CUDAMemoryManager::IsCUDAPointer(const void* ptr) {
+bool CUDAMemoryManager::IsCUDAPointer(const void* ptr, const Device& device) {
+    CUDAScopedDevice scoped_device(device);
+
     cudaPointerAttributes attributes;
     cudaPointerGetAttributes(&attributes, ptr);
-    if (attributes.devicePointer != nullptr) {
-        return true;
-    }
-    return false;
+    return attributes.devicePointer != nullptr ? true : false;
 }
 
 }  // namespace core

--- a/cpp/open3d/core/hashmap/CUDA/CUDAHashmapBufferAccessor.h
+++ b/cpp/open3d/core/hashmap/CUDA/CUDAHashmapBufferAccessor.h
@@ -71,8 +71,8 @@ public:
 
         const int blocks =
                 (capacity_ + kThreadsPerBlock - 1) / kThreadsPerBlock;
-        ResetHashmapBufferKernel<<<blocks, kThreadsPerBlock>>>(heap_,
-                                                               capacity_);
+        ResetHashmapBufferKernel<<<blocks, kThreadsPerBlock, 0,
+                                   core::cuda::GetStream()>>>(heap_, capacity_);
         OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
         OPEN3D_CUDA_CHECK(cudaGetLastError());
     }

--- a/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabHashmap.h
@@ -190,7 +190,7 @@ void SlabHashmap<Key, Hash>::Find(const void* input_keys,
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
-    FindKernel<<<num_blocks, kThreadsPerBlock>>>(
+    FindKernel<<<num_blocks, kThreadsPerBlock, 0, core::cuda::GetStream()>>>(
             impl_, input_keys, output_addrs, output_masks, count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
@@ -210,10 +210,12 @@ void SlabHashmap<Key, Hash>::Erase(const void* input_keys,
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
-    EraseKernelPass0<<<num_blocks, kThreadsPerBlock>>>(
+    EraseKernelPass0<<<num_blocks, kThreadsPerBlock, 0,
+                       core::cuda::GetStream()>>>(
             impl_, input_keys, iterator_addrs, output_masks, count);
-    EraseKernelPass1<<<num_blocks, kThreadsPerBlock>>>(impl_, iterator_addrs,
-                                                       output_masks, count);
+    EraseKernelPass1<<<num_blocks, kThreadsPerBlock, 0,
+                       core::cuda::GetStream()>>>(impl_, iterator_addrs,
+                                                  output_masks, count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
@@ -231,8 +233,9 @@ int64_t SlabHashmap<Key, Hash>::GetActiveIndices(addr_t* output_addrs) {
     const int64_t num_blocks =
             (impl_.bucket_count_ * kWarpSize + kThreadsPerBlock - 1) /
             kThreadsPerBlock;
-    GetActiveIndicesKernel<<<num_blocks, kThreadsPerBlock>>>(
-            impl_, output_addrs, iterator_count);
+    GetActiveIndicesKernel<<<num_blocks, kThreadsPerBlock, 0,
+                             core::cuda::GetStream()>>>(impl_, output_addrs,
+                                                        iterator_count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
 
@@ -276,7 +279,8 @@ std::vector<int64_t> SlabHashmap<Key, Hash>::BucketSizes() const {
 
     const int64_t num_blocks =
             (impl_.capacity_ + kThreadsPerBlock - 1) / kThreadsPerBlock;
-    CountElemsPerBucketKernel<<<num_blocks, kThreadsPerBlock>>>(
+    CountElemsPerBucketKernel<<<num_blocks, kThreadsPerBlock, 0,
+                                core::cuda::GetStream()>>>(
             impl_, thrust::raw_pointer_cast(elems_per_bucket.data()));
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
     OPEN3D_CUDA_CHECK(cudaGetLastError());
@@ -308,11 +312,14 @@ void SlabHashmap<Key, Hash>::InsertImpl(const void* input_keys,
 
     const int64_t num_blocks =
             (count + kThreadsPerBlock - 1) / kThreadsPerBlock;
-    InsertKernelPass0<<<num_blocks, kThreadsPerBlock>>>(
+    InsertKernelPass0<<<num_blocks, kThreadsPerBlock, 0,
+                        core::cuda::GetStream()>>>(
             impl_, input_keys, output_addrs, prev_heap_counter, count);
-    InsertKernelPass1<<<num_blocks, kThreadsPerBlock>>>(
+    InsertKernelPass1<<<num_blocks, kThreadsPerBlock, 0,
+                        core::cuda::GetStream()>>>(
             impl_, input_keys, output_addrs, output_masks, count);
-    InsertKernelPass2<<<num_blocks, kThreadsPerBlock>>>(
+    InsertKernelPass2<<<num_blocks, kThreadsPerBlock, 0,
+                        core::cuda::GetStream()>>>(
             impl_, input_values, output_addrs, output_masks, count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
     OPEN3D_CUDA_CHECK(cudaGetLastError());

--- a/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
+++ b/cpp/open3d/core/hashmap/CUDA/SlabNodeManager.h
@@ -277,7 +277,8 @@ public:
         int num_mem_units = kBlocksPerSuperBlock * 32;
         int num_cuda_blocks =
                 (num_mem_units + kThreadsPerBlock - 1) / kThreadsPerBlock;
-        CountSlabsPerSuperblockKernel<<<num_cuda_blocks, kThreadsPerBlock>>>(
+        CountSlabsPerSuperblockKernel<<<num_cuda_blocks, kThreadsPerBlock, 0,
+                                        core::cuda::GetStream()>>>(
                 impl_, thrust::raw_pointer_cast(slabs_per_superblock.data()));
         OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
         OPEN3D_CUDA_CHECK(cudaGetLastError());

--- a/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
+++ b/cpp/open3d/core/hashmap/CUDA/StdGPUHashmap.h
@@ -174,9 +174,9 @@ void StdGPUHashmap<Key, Hash>::Find(const void* input_keys,
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
 
-    STDGPUFindKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
-                                          static_cast<const Key*>(input_keys),
-                                          output_addrs, output_masks, count);
+    STDGPUFindKernel<<<blocks, threads, 0, core::cuda::GetStream()>>>(
+            impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
+            output_addrs, output_masks, count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
 }
 
@@ -216,9 +216,9 @@ void StdGPUHashmap<Key, Hash>::Erase(const void* input_keys,
             core::Tensor({count}, Dtype::Int32, this->device_);
     addr_t* output_addrs = static_cast<addr_t*>(toutput_addrs.GetDataPtr());
 
-    STDGPUEraseKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
-                                           static_cast<const Key*>(input_keys),
-                                           output_addrs, output_masks, count);
+    STDGPUEraseKernel<<<blocks, threads, 0, core::cuda::GetStream()>>>(
+            impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
+            output_addrs, output_masks, count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
 }
 
@@ -353,10 +353,10 @@ void StdGPUHashmap<Key, Hash>::InsertImpl(const void* input_keys,
     uint32_t threads = 128;
     uint32_t blocks = (count + threads - 1) / threads;
 
-    STDGPUInsertKernel<<<blocks, threads>>>(impl_, buffer_accessor_,
-                                            static_cast<const Key*>(input_keys),
-                                            input_values, this->dsize_value_,
-                                            output_addrs, output_masks, count);
+    STDGPUInsertKernel<<<blocks, threads, 0, core::cuda::GetStream()>>>(
+            impl_, buffer_accessor_, static_cast<const Key*>(input_keys),
+            input_values, this->dsize_value_, output_addrs, output_masks,
+            count);
     OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());
 }
 

--- a/cpp/open3d/core/kernel/BinaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/BinaryEWCUDA.cu
@@ -243,7 +243,7 @@ void BinaryEWCUDA(const Tensor& lhs,
     Dtype src_dtype = lhs.GetDtype();
     Dtype dst_dtype = dst.GetDtype();
 
-    CUDADeviceSwitcher switcher(src_device);
+    CUDAScopedDevice scoped_device(src_device);
 
     if (s_boolean_binary_ew_op_codes.find(op_code) !=
         s_boolean_binary_ew_op_codes.end()) {

--- a/cpp/open3d/core/kernel/CUDALauncher.cuh
+++ b/cpp/open3d/core/kernel/CUDALauncher.cuh
@@ -94,7 +94,8 @@ void ParallelFor(int64_t n, const func_t& func) {
     int64_t grid_size = (n + items_per_block - 1) / items_per_block;
 
     ElementWiseKernel<default_block_size, default_thread_size>
-            <<<grid_size, default_block_size, 0>>>(n, func);
+            <<<grid_size, default_block_size, 0, core::cuda::GetStream()>>>(
+                    n, func);
     OPEN3D_GET_LAST_CUDA_ERROR("ParallelFor failed.");
 }
 

--- a/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
+++ b/cpp/open3d/core/kernel/IndexGetSetCUDA.cu
@@ -71,7 +71,8 @@ void IndexGetCUDA(const Tensor& src,
     Dtype dtype = src.GetDtype();
     AdvancedIndexer ai(src, dst, index_tensors, indexed_shape, indexed_strides,
                        AdvancedIndexer::AdvancedIndexerMode::GET);
-    CUDADeviceSwitcher switcher(src.GetDevice());
+
+    CUDAScopedDevice scoped_device(src.GetDevice());
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
         LaunchAdvancedIndexerKernel(
@@ -98,7 +99,8 @@ void IndexSetCUDA(const Tensor& src,
     Dtype dtype = src.GetDtype();
     AdvancedIndexer ai(src, dst, index_tensors, indexed_shape, indexed_strides,
                        AdvancedIndexer::AdvancedIndexerMode::SET);
-    CUDADeviceSwitcher switcher(dst.GetDevice());
+
+    CUDAScopedDevice scoped_device(dst.GetDevice());
     if (dtype.IsObject()) {
         int64_t object_byte_size = dtype.ByteSize();
         LaunchAdvancedIndexerKernel(

--- a/cpp/open3d/core/kernel/UnaryEWCUDA.cu
+++ b/cpp/open3d/core/kernel/UnaryEWCUDA.cu
@@ -197,7 +197,8 @@ void CopyCUDA(const Tensor& src, Tensor& dst) {
             // For more optimized version, one can check if P2P from src to
             // dst is enabled, then put synchronization with streams on both
             // src and dst to wait for copy kernel to complete.
-            CUDADeviceSwitcher switcher(src_device);
+            CUDAScopedDevice scoped_device(src_device);
+
             Indexer indexer({src}, dst, DtypePolicy::NONE);
             if (src.GetDtype().IsObject()) {
                 int64_t object_byte_size = src.GetDtype().ByteSize();

--- a/cpp/open3d/ml/Helper.h
+++ b/cpp/open3d/ml/Helper.h
@@ -34,58 +34,82 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// TODO: Disable fmt() macro defined in fmt<7.0.0.
+// TODO: Remove this line once Open3D upgrades its fmt dependency.
+#define FMT_STRING_ALIAS 0
+
+#include "open3d/core/CUDAState.cuh"
+#include "open3d/core/CUDAUtils.h"
+#include "open3d/utility/Logging.h"
+
 #endif  // #ifdef BUILD_CUDA_MODULE
-
-#include <stdio.h>
-
-#include <stdexcept>
-#include <string>
-
-#ifdef BUILD_CUDA_MODULE
-/// TODO: Link Open3D and use OPEN3D_CUDA_CHECK instead.
-#define OPEN3D_ML_CUDA_CHECK(err) \
-    { open3d::ml::__OPEN3D_ML_CUDA_CHECK((err), __FILE__, __LINE__); }
-#endif
 
 namespace open3d {
 namespace ml {
 
 #ifdef BUILD_CUDA_MODULE
-/// Returns the texture alignment in bytes for the current device.
-inline int GetCUDACurrentDeviceTextureAlignment() {
-    int device = 0;
-    cudaError_t err = cudaGetDevice(&device);
-    if (err != cudaSuccess) {
-        throw std::runtime_error(
-                "GetCUDACurrentDeviceTextureAlignment(): cudaGetDevice failed "
-                "with {}" +
-                std::string(cudaGetErrorString(err)));
-    }
 
-    int value = 0;
-    err = cudaDeviceGetAttribute(&value, cudaDevAttrTextureAlignment, device);
-    if (err != cudaSuccess) {
-        throw std::runtime_error(
-                "GetCUDACurrentDeviceTextureAlignment(): cudaGetDevice failed "
-                "with {}" +
-                std::string(cudaGetErrorString(err)));
-    }
-    return value;
-}
+#define OPEN3D_ML_CUDA_DRIVER_CHECK(err) \
+    __OPEN3D_ML_CUDA_DRIVER_CHECK(err, __FILE__, __LINE__)
 
-/// TODO: Link Open3D and use OPEN3D_CUDA_CHECK instead.
-inline void __OPEN3D_ML_CUDA_CHECK(cudaError_t err,
-                                   const char *file,
-                                   int line,
-                                   bool abort = true) {
-    if (err != cudaSuccess) {
-        fprintf(stderr, "%s:%d CUDA runtime error: %s\n", file, line,
-                cudaGetErrorString(err));
-        if (abort) {
-            exit(err);
+inline void __OPEN3D_ML_CUDA_DRIVER_CHECK(CUresult err,
+                                          const char *file,
+                                          const int line,
+                                          bool abort = true) {
+    if (err != CUDA_SUCCESS) {
+        const char *error_string;
+        CUresult err_get_string = cuGetErrorString(err, &error_string);
+
+        if (err_get_string == CUDA_SUCCESS) {
+            utility::LogError("{}:{} CUDA driver error: {}", file, line,
+                              error_string);
+        } else {
+            utility::LogError("{}:{} CUDA driver error: UNKNOWN", file, line);
         }
     }
 }
+
+inline cudaStream_t GetDefaultStream() { (cudaStream_t)0; }
+
+inline int GetDevice(cudaStream_t stream) {
+    if (stream == GetDefaultStream()) {
+        // Default device.
+        return 0;
+    }
+
+    // Remember current context.
+    CUcontext current_context;
+    OPEN3D_ML_CUDA_DRIVER_CHECK(cuCtxGetCurrent(&current_context));
+
+    // Switch to context of provided stream.
+    CUcontext context;
+    OPEN3D_ML_CUDA_DRIVER_CHECK(cuStreamGetCtx(stream, &context));
+    OPEN3D_ML_CUDA_DRIVER_CHECK(cuCtxSetCurrent(context));
+
+    // Query device of current context.
+    // This is the device of the provided stream.
+    CUdevice device;
+    OPEN3D_ML_CUDA_DRIVER_CHECK(cuCtxGetDevice(&device));
+
+    // Restore previous context.
+    OPEN3D_ML_CUDA_DRIVER_CHECK(cuCtxSetCurrent(current_context));
+
+    // CUdevice is a typedef to int.
+    return device;
+}
+
+class CUDAScopedDeviceStream {
+public:
+    explicit CUDAScopedDeviceStream(cudaStream_t stream)
+        : scoped_device_(GetDevice(stream)), scoped_stream_(stream) {}
+
+    CUDAScopedDeviceStream(CUDAScopedDeviceStream const &) = delete;
+    void operator=(CUDAScopedDeviceStream const &) = delete;
+
+private:
+    core::CUDAScopedDevice scoped_device_;
+    core::CUDAScopedStream scoped_stream_;
+};
 #endif
 
 }  // namespace ml

--- a/cpp/open3d/ml/contrib/Nms.cu
+++ b/cpp/open3d/ml/contrib/Nms.cu
@@ -148,19 +148,18 @@ std::vector<int64_t> NmsCUDAKernel(const float *boxes,
 
     // Compute sort indices.
     float *scores_copy = nullptr;
-    OPEN3D_ML_CUDA_CHECK(cudaMalloc((void **)&scores_copy, n * sizeof(float)));
-    OPEN3D_ML_CUDA_CHECK(cudaMemcpy(scores_copy, scores, n * sizeof(float),
-                                    cudaMemcpyDeviceToDevice));
+    OPEN3D_CUDA_CHECK(cudaMalloc((void **)&scores_copy, n * sizeof(float)));
+    OPEN3D_CUDA_CHECK(cudaMemcpy(scores_copy, scores, n * sizeof(float),
+                                 cudaMemcpyDeviceToDevice));
     int64_t *sort_indices = nullptr;
-    OPEN3D_ML_CUDA_CHECK(
-            cudaMalloc((void **)&sort_indices, n * sizeof(int64_t)));
+    OPEN3D_CUDA_CHECK(cudaMalloc((void **)&sort_indices, n * sizeof(int64_t)));
     SortIndices(scores_copy, sort_indices, n, true);
-    OPEN3D_ML_CUDA_CHECK(cudaFree(scores_copy));
+    OPEN3D_CUDA_CHECK(cudaFree(scores_copy));
 
     // Allocate masks on device.
     uint64_t *mask_ptr = nullptr;
-    OPEN3D_ML_CUDA_CHECK(cudaMalloc((void **)&mask_ptr,
-                                    n * num_block_cols * sizeof(uint64_t)));
+    OPEN3D_CUDA_CHECK(cudaMalloc((void **)&mask_ptr,
+                                 n * num_block_cols * sizeof(uint64_t)));
 
     // Launch kernel.
     dim3 blocks(utility::DivUp(n, NMS_BLOCK_SIZE),
@@ -172,16 +171,15 @@ std::vector<int64_t> NmsCUDAKernel(const float *boxes,
     // Copy cuda masks to cpu.
     std::vector<uint64_t> mask_vec(n * num_block_cols);
     uint64_t *mask = mask_vec.data();
-    OPEN3D_ML_CUDA_CHECK(cudaMemcpy(mask_vec.data(), mask_ptr,
-                                    n * num_block_cols * sizeof(uint64_t),
-                                    cudaMemcpyDeviceToHost));
-    OPEN3D_ML_CUDA_CHECK(cudaFree(mask_ptr));
+    OPEN3D_CUDA_CHECK(cudaMemcpy(mask_vec.data(), mask_ptr,
+                                 n * num_block_cols * sizeof(uint64_t),
+                                 cudaMemcpyDeviceToHost));
+    OPEN3D_CUDA_CHECK(cudaFree(mask_ptr));
 
     // Copy sort_indices to cpu.
     std::vector<int64_t> sort_indices_cpu(n);
-    OPEN3D_ML_CUDA_CHECK(cudaMemcpy(sort_indices_cpu.data(), sort_indices,
-                                    n * sizeof(int64_t),
-                                    cudaMemcpyDeviceToHost));
+    OPEN3D_CUDA_CHECK(cudaMemcpy(sort_indices_cpu.data(), sort_indices,
+                                 n * sizeof(int64_t), cudaMemcpyDeviceToHost));
 
     // Write to keep_indices in CPU.
     // remv_cpu has n bits in total. If the bit is 1, the corresponding
@@ -208,7 +206,7 @@ std::vector<int64_t> NmsCUDAKernel(const float *boxes,
             }
         }
     }
-    OPEN3D_ML_CUDA_CHECK(cudaFree(sort_indices));
+    OPEN3D_CUDA_CHECK(cudaFree(sort_indices));
     return keep_indices;
 }
 

--- a/cpp/open3d/ml/pytorch/CMakeLists.txt
+++ b/cpp/open3d/ml/pytorch/CMakeLists.txt
@@ -137,6 +137,7 @@ if (BUILD_CUDA_MODULE)
     target_link_libraries(open3d_torch_ops PRIVATE
         Open3D::3rdparty_cutlass
         ${TORCH_LIBRARIES}
+        CUDA::cuda_driver
     )
 
     if (TARGET Open3D::3rdparty_cub)

--- a/cpp/open3d/ml/tensorflow/CMakeLists.txt
+++ b/cpp/open3d/ml/tensorflow/CMakeLists.txt
@@ -173,6 +173,7 @@ target_link_libraries(open3d_tf_ops PRIVATE
 if (BUILD_CUDA_MODULE)
     target_link_libraries(open3d_tf_ops PRIVATE
         Open3D::3rdparty_cutlass
+        CUDA::cuda_driver
     )
 
     if (TARGET Open3D::3rdparty_cub)

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvBackpropFilterOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvBackpropFilterOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "ContinuousConvBackpropFilterOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/continuous_conv/ContinuousConvBackpropFilter.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit ContinuousConvBackpropFilterOpKernelCUDA(
             OpKernelConstruction* construction)
         : ContinuousConvBackpropFilterOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "ContinuousConvOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/continuous_conv/ContinuousConv.cuh"
 
 using namespace open3d;
@@ -39,7 +39,8 @@ class ContinuousConvOpKernelCUDA : public ContinuousConvOpKernel<TIndex> {
 public:
     explicit ContinuousConvOpKernelCUDA(OpKernelConstruction* construction)
         : ContinuousConvOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeBackpropFilterOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeBackpropFilterOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "ContinuousConvTransposeBackpropFilterOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/continuous_conv/ContinuousConvTransposeBackpropFilter.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit ContinuousConvTransposeBackpropFilterOpKernelCUDA(
             OpKernelConstruction* construction)
         : ContinuousConvTransposeBackpropFilterOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/continuous_conv/ContinuousConvTransposeOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "ContinuousConvTransposeOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/continuous_conv/ContinuousConvTranspose.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit ContinuousConvTransposeOpKernelCUDA(
             OpKernelConstruction* construction)
         : ContinuousConvTransposeOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/misc/BuildSpatialHashTableOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/BuildSpatialHashTableOpKernel.cu
@@ -27,7 +27,7 @@
 
 #define EIGEN_USE_GPU
 #include "BuildSpatialHashTableOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/misc/FixedRadiusSearch.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit BuildSpatialHashTableOpKernelCUDA(
             OpKernelConstruction* construction)
         : BuildSpatialHashTableOpKernel(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/misc/FixedRadiusSearchOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/FixedRadiusSearchOpKernel.cu
@@ -27,7 +27,7 @@
 
 #define EIGEN_USE_GPU
 #include "FixedRadiusSearchOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/misc/FixedRadiusSearch.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ class FixedRadiusSearchOpKernelCUDA : public FixedRadiusSearchOpKernel {
 public:
     explicit FixedRadiusSearchOpKernelCUDA(OpKernelConstruction* construction)
         : FixedRadiusSearchOpKernel(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/InvertNeighborsListOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "InvertNeighborsListOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/misc/InvertNeighborsList.cuh"
 
 using namespace open3d;
@@ -40,7 +40,8 @@ class InvertNeighborsListOpKernelCUDA : public InvertNeighborsListOpKernel {
 public:
     explicit InvertNeighborsListOpKernelCUDA(OpKernelConstruction* construction)
         : InvertNeighborsListOpKernel(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/NmsOpKernel.cu
@@ -47,9 +47,9 @@ public:
         int64_t* ret_keep_indices = nullptr;
         output_allocator.AllocKeepIndices(&ret_keep_indices,
                                           keep_indices.size());
-        OPEN3D_ML_CUDA_CHECK(cudaMemcpy(ret_keep_indices, keep_indices.data(),
-                                        keep_indices.size() * sizeof(int64_t),
-                                        cudaMemcpyHostToDevice));
+        OPEN3D_CUDA_CHECK(cudaMemcpy(ret_keep_indices, keep_indices.data(),
+                                     keep_indices.size() * sizeof(int64_t),
+                                     cudaMemcpyHostToDevice));
     }
 };
 

--- a/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/misc/VoxelizeOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "VoxelizeOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/misc/Voxelize.cuh"
 
 using namespace open3d::ml;
@@ -39,7 +39,8 @@ class VoxelizeOpKernelCUDA : public VoxelizeOpKernel {
 public:
     explicit VoxelizeOpKernelCUDA(OpKernelConstruction* construction)
         : VoxelizeOpKernel(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvBackpropFilterOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvBackpropFilterOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "SparseConvBackpropFilterOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/sparse_conv/SparseConvBackpropFilter.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit SparseConvBackpropFilterOpKernelCUDA(
             OpKernelConstruction* construction)
         : SparseConvBackpropFilterOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "SparseConvOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/sparse_conv/SparseConv.cuh"
 
 using namespace open3d::ml;
@@ -38,7 +38,8 @@ class SparseConvOpKernelCUDA : public SparseConvOpKernel<TIndex> {
 public:
     explicit SparseConvOpKernelCUDA(OpKernelConstruction* construction)
         : SparseConvOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeBackpropFilterOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeBackpropFilterOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "SparseConvTransposeBackpropFilterOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/sparse_conv/SparseConvTransposeBackpropFilter.cuh"
 
 using namespace open3d;
@@ -41,7 +41,8 @@ public:
     explicit SparseConvTransposeBackpropFilterOpKernelCUDA(
             OpKernelConstruction* construction)
         : SparseConvTransposeBackpropFilterOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeOpKernel.cu
+++ b/cpp/open3d/ml/tensorflow/sparse_conv/SparseConvTransposeOpKernel.cu
@@ -26,7 +26,7 @@
 
 #define EIGEN_USE_GPU
 #include "SparseConvTransposeOpKernel.h"
-#include "open3d/ml/Helper.h"
+#include "open3d/core/CUDAUtils.h"
 #include "open3d/ml/impl/sparse_conv/SparseConvTranspose.cuh"
 
 using namespace open3d;
@@ -40,7 +40,8 @@ class SparseConvTransposeOpKernelCUDA
 public:
     explicit SparseConvTransposeOpKernelCUDA(OpKernelConstruction* construction)
         : SparseConvTransposeOpKernel<TIndex>(construction) {
-        texture_alignment = GetCUDACurrentDeviceTextureAlignment();
+        texture_alignment =
+                open3d::core::GetCUDACurrentDeviceTextureAlignment();
     }
 
     void Kernel(tensorflow::OpKernelContext* context,

--- a/cpp/open3d/t/pipelines/kernel/ComputeTransformCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/ComputeTransformCUDA.cu
@@ -104,7 +104,8 @@ void ComputePosePointToPlaneCUDA(const float *source_points_ptr,
     const dim3 blocks((n + kThread1DUnit - 1) / kThread1DUnit);
     const dim3 threads(kThread1DUnit);
 
-    ComputePosePointToPlaneCUDAKernel<<<blocks, threads>>>(
+    ComputePosePointToPlaneCUDAKernel<<<blocks, threads, 0,
+                                        core::cuda::GetStream()>>>(
             source_points_ptr, target_points_ptr, target_normals_ptr,
             correspondences_first, correspondences_second, n, global_sum_ptr);
 

--- a/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
+++ b/cpp/open3d/t/pipelines/kernel/RGBDOdometryCUDA.cu
@@ -154,7 +154,8 @@ void ComputeOdometryResultPointToPlaneCUDA(
     const dim3 blocks((cols + kThreadSize - 1) / kThreadSize,
                       (rows + kThreadSize - 1) / kThreadSize);
     const dim3 threads(kThreadSize, kThreadSize);
-    ComputeOdometryResultPointToPlaneCUDAKernel<<<blocks, threads>>>(
+    ComputeOdometryResultPointToPlaneCUDAKernel<<<blocks, threads, 0,
+                                                  core::cuda::GetStream()>>>(
             source_vertex_indexer, target_vertex_indexer, target_normal_indexer,
             ti, global_sum_ptr, rows, cols, depth_outlier_trunc,
             depth_huber_delta);
@@ -261,7 +262,8 @@ void ComputeOdometryResultIntensityCUDA(
     const dim3 blocks((cols + kThreadSize - 1) / kThreadSize,
                       (rows + kThreadSize - 1) / kThreadSize);
     const dim3 threads(kThreadSize, kThreadSize);
-    ComputeOdometryResultIntensityCUDAKernel<<<blocks, threads>>>(
+    ComputeOdometryResultIntensityCUDAKernel<<<blocks, threads, 0,
+                                               core::cuda::GetStream()>>>(
             source_depth_indexer, target_depth_indexer,
             source_intensity_indexer, target_intensity_indexer,
             target_intensity_dx_indexer, target_intensity_dy_indexer,
@@ -382,7 +384,8 @@ void ComputeOdometryResultHybridCUDA(const core::Tensor& source_depth,
     const dim3 blocks((cols + kThreadSize - 1) / kThreadSize,
                       (rows + kThreadSize - 1) / kThreadSize);
     const dim3 threads(kThreadSize, kThreadSize);
-    ComputeOdometryResultHybridCUDAKernel<<<blocks, threads>>>(
+    ComputeOdometryResultHybridCUDAKernel<<<blocks, threads, 0,
+                                            core::cuda::GetStream()>>>(
             source_depth_indexer, target_depth_indexer,
             source_intensity_indexer, target_intensity_indexer,
             target_depth_dx_indexer, target_depth_dy_indexer,

--- a/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
+++ b/cpp/open3d/t/pipelines/kernel/TransformationConverter.cu
@@ -49,13 +49,15 @@ void PoseToTransformationCUDA(scalar_t *transformation_ptr,
 template <>
 void PoseToTransformationCUDA<float>(float *transformation_ptr,
                                      const float *X_ptr) {
-    PoseToTransformationKernel<float><<<1, 1>>>(transformation_ptr, X_ptr);
+    PoseToTransformationKernel<float>
+            <<<1, 1, 0, core::cuda::GetStream()>>>(transformation_ptr, X_ptr);
 }
 
 template <>
 void PoseToTransformationCUDA<double>(double *transformation_ptr,
                                       const double *X_ptr) {
-    PoseToTransformationKernel<double><<<1, 1>>>(transformation_ptr, X_ptr);
+    PoseToTransformationKernel<double>
+            <<<1, 1, 0, core::cuda::GetStream()>>>(transformation_ptr, X_ptr);
 }
 
 }  // namespace kernel

--- a/cpp/tests/core/CUDAState.cpp
+++ b/cpp/tests/core/CUDAState.cpp
@@ -28,6 +28,10 @@
 
 #include "open3d/core/CUDAState.cuh"
 
+#include <thread>
+#include <vector>
+
+#include "open3d/core/CUDAUtils.h"
 #include "tests/UnitTest.h"
 
 namespace open3d {
@@ -41,6 +45,54 @@ TEST(CUDAState, InitState) {
         for (int j = 0; j < cuda_state->GetNumDevices(); ++j) {
             utility::LogInfo("P2PEnabled {}->{}: {}", i, j,
                              cuda_state->GetP2PEnabled()[i][j]);
+        }
+    }
+}
+
+void CheckScopedStream() {
+    int current_device = core::cuda::GetDevice();
+
+    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_EQ(core::cuda::GetDevice(), current_device);
+
+    cudaStream_t stream;
+    OPEN3D_CUDA_CHECK(cudaStreamCreate(&stream));
+
+    {
+        core::CUDAScopedStream scoped_stream(stream);
+
+        ASSERT_EQ(core::cuda::GetStream(), stream);
+        ASSERT_EQ(core::cuda::GetDevice(), current_device);
+    }
+
+    OPEN3D_CUDA_CHECK(cudaStreamDestroy(stream));
+
+    ASSERT_EQ(core::cuda::GetStream(), core::cuda::GetDefaultStream());
+    ASSERT_EQ(core::cuda::GetDevice(), current_device);
+}
+
+TEST(CUDAState, ScopedStream) { CheckScopedStream(); }
+
+TEST(CUDAState, ScopedStreamMultiThreaded) {
+    std::vector<std::thread> threads;
+
+    const int kIterations = 100000;
+    const int kThreads = 8;
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&kIterations]() {
+            utility::LogDebug("Starting thread with ID {}",
+                              std::this_thread::get_id());
+
+            for (int i = 0; i < kIterations; ++i) {
+                CheckScopedStream();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        if (thread.joinable()) {
+            utility::LogDebug("Joining thread with ID {}", thread.get_id());
+            thread.join();
         }
     }
 }


### PR DESCRIPTION
Highlights:
- Rename `CUDADeviceSwitcher` to `CUDAScopedDevice` and remove `SwitchTo` function so simply its usage.
- Add `CUDAScopedStream` class for setting the global internal per-thread stream state.
- Add support for stream-based allocation (introduced in CUDA 11.2) and copy functions in `CUDAMemoryManager`.

Further changes:
- Add `cuda::{Get,Set}Stream` functions to access the global state. These functions are used to implement `CUDAScopedStream`.
- Add `cuda::{Get,Set}Device` to mirror the stream API. This makes `CUDAScopedDevice`'s implementation look similar to `CUDAScopedStream`. It further allows to hide the implementation detail that CUDA is already capable of managing the device state internally.
- Make all of Open3D's kernel calls aware of the current stream.
- Add unit tests to check thread locality.
- Add `CUDAScopedDeviceStream` in ML ops as a combination of both scoped wrappers. It infers the device from the stream and sets both states simultaneously.

Future work:
- Unify stream usage in ML ops to take advantage of `CUDAScopedStream`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3732)
<!-- Reviewable:end -->
