### PR TITLE
fix args to tensor.index() for torch 1.8 and later

### DIFF
--- a/cpp/open3d/ml/pytorch/sparse_conv/SparseConvOps.cpp
+++ b/cpp/open3d/ml/pytorch/sparse_conv/SparseConvOps.cpp
@@ -188,10 +188,10 @@ public:
                 InvertNeighborsList(inp_features.size(0), neighbors_index,     \
                                     neighbors_row_splits, arange);             \
         torch::Tensor inv_neighbors_kernel_index =                             \
-                neighbors_kernel_index.index(inv_arange).contiguous();         \
+                neighbors_kernel_index.index({inv_arange}).contiguous();       \
         if (neighbors_importance.size(0) > 0) {                                \
             inv_neighbors_importance =                                         \
-                    neighbors_importance.index(inv_arange).contiguous();       \
+                    neighbors_importance.index({inv_arange}).contiguous();     \
         } else {                                                               \
             inv_neighbors_importance = torch::empty(                           \
                     {0}, torch::dtype(feat_dtype).device(device));             \

--- a/cpp/open3d/ml/pytorch/sparse_conv/SparseConvTransposeOps.cpp
+++ b/cpp/open3d/ml/pytorch/sparse_conv/SparseConvTransposeOps.cpp
@@ -210,10 +210,10 @@ public:
                 InvertNeighborsList(inp_features.size(0), neighbors_index,     \
                                     neighbors_row_splits, arange);             \
         torch::Tensor inv_neighbors_kernel_index =                             \
-                neighbors_kernel_index.index(inv_arange).contiguous();         \
+                neighbors_kernel_index.index({inv_arange}).contiguous();       \
         if (neighbors_importance.size(0) > 0) {                                \
             inv_neighbors_importance =                                         \
-                    neighbors_importance.index(inv_arange).contiguous();       \
+                    neighbors_importance.index({inv_arange}).contiguous();     \
         } else {                                                               \
             inv_neighbors_importance = torch::empty(                           \
                     {0}, torch::dtype(feat_dtype).device(device));             \


### PR DESCRIPTION
This PR fixes calls to the tensor.index() function for torch 1.8 and later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3740)
<!-- Reviewable:end -->
