### PR TITLE
Updated ASSIMP processing flags to improve triangle-model loading time

### DIFF
--- a/cpp/open3d/io/file_format/FileASSIMP.cpp
+++ b/cpp/open3d/io/file_format/FileASSIMP.cpp
@@ -56,11 +56,9 @@ FileGeometry ReadFileGeometryTypeFBX(const std::string& path) {
 }
 
 const unsigned int kPostProcessFlags =
-        aiProcess_GenSmoothNormals | aiProcess_JoinIdenticalVertices |
-        aiProcess_ImproveCacheLocality | aiProcess_RemoveRedundantMaterials |
+        aiProcess_GenNormals | aiProcess_RemoveRedundantMaterials |
         aiProcess_Triangulate | aiProcess_GenUVCoords | aiProcess_SortByPType |
-        aiProcess_FindDegenerates | aiProcess_OptimizeMeshes |
-        aiProcess_PreTransformVertices;
+        aiProcess_OptimizeMeshes | aiProcess_PreTransformVertices;
 
 struct TextureImages {
     std::shared_ptr<geometry::Image> albedo;


### PR DESCRIPTION
Updated Flags:
```
const unsigned int kPostProcessFlags =
        aiProcess_GenNormals | aiProcess_RemoveRedundantMaterials |
        aiProcess_Triangulate | aiProcess_GenUVCoords | aiProcess_SortByPType |
        aiProcess_OptimizeMeshes | aiProcess_PreTransformVertices;
```

Loading Time of Redwood dataset: apartment, bedroom, boardroom mesh:
|               | Open3D (master) | Open3D (This PR) | MeshLab |
| ------------- | --------------- | ---------------- | ------- |
| apartment.ply | 277,932         | 6,000            | 5,300   |
| bedroom.ply   | 154,251         | 3,300            | 3,300   |
| boardroom.ply | 316,495         | 6,000            | 5,500   |

*Time of Open3D is more end to end, as compared to MeshLab (there is some lag between when loading time is displayed and mesh is displayed). Also, with only `aiProcess_GenNormals` Open3D is faster or similar to MeshLab in comparison to loading time.

Detailed Open3D IO Profiling: [Link](https://docs.google.com/presentation/d/1zkAtwyu2GvqpjN7-mi5QZQisp8qIWaM_zshbkF0Xa_k/edit?usp=sharing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3743)
<!-- Reviewable:end -->
