### PR TITLE
Ensure CUDAState is initialized before Cacher

### DIFF
--- a/cpp/open3d/core/MemoryManagerCached.cpp
+++ b/cpp/open3d/core/MemoryManagerCached.cpp
@@ -36,6 +36,10 @@
 #include "open3d/core/MemoryManager.h"
 #include "open3d/utility/Logging.h"
 
+#ifdef BUILD_CUDA_MODULE
+#include "open3d/core/CUDAState.cuh"
+#endif
+
 namespace open3d {
 namespace core {
 
@@ -363,6 +367,11 @@ public:
         // Since destruction of static instances happens in reverse order,
         // this guarantees that the Logger can be used at any point in time.
         utility::Logger::GetInstance();
+
+#ifdef BUILD_CUDA_MODULE
+        // Ensure CUDAState is initialized before Cacher.
+        CUDAState::GetInstance();
+#endif
 
         static Cacher instance;
         return instance;


### PR DESCRIPTION
Fixes CUDA error in even some very simple code:
```diff
diff --git a/examples/cpp/CMakeLists.txt b/examples/cpp/CMakeLists.txt
index dbbe5b785..241cb8540 100644
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -27,6 +27,7 @@ macro(open3d_add_example EXAMPLE_CPP_NAME)
     list(APPEND EXAMPLE_TARGETS ${EXAMPLE_CPP_NAME})
 endmacro()
 
+open3d_add_example(DebugBenchmark)
 open3d_add_example(CameraPoseTrajectory)
 open3d_add_example(ColorMapOptimization)
 open3d_add_example(DepthCapture)
diff --git a/examples/cpp/DebugBenchmark.cpp b/examples/cpp/DebugBenchmark.cpp
new file mode 100644
index 000000000..fbfb4bc9c
--- /dev/null
+++ b/examples/cpp/DebugBenchmark.cpp
@@ -0,0 +1,13 @@
+// Compile with -DBUILD_CUDA_MODULE=ON
+// This example gives error:
+// cpp/open3d/core/CUDAState.cuh:86 CUDA runtime error: driver shutting down
+
+#include "open3d/Open3D.h"
+
+int main() {
+    using namespace open3d;
+    core::Tensor t = core::Tensor::Empty({2, 3}, core::Dtype::Float32,
+                                         core::Device("CUDA:0"));
+    utility::LogInfo("Done.");
+    return 0;
+}
```

Error:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  [Open3D Error] (void open3d::core::__OPEN3D_CUDA_CHECK(cudaError_t, const char*, int)) repo/Open3D/cpp/open3d/core/CUDAUtils.h:78: repo/Open3D/cpp/open3d/core/CUDAState.cuh:86 CUDA runtime error: driver shutting down
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3745)
<!-- Reviewable:end -->
