### PR TITLE
Cleanup CUDAScopedStream and add stream support to NPPImage

### DIFF
--- a/cpp/benchmarks/core/MemoryManager.cpp
+++ b/cpp/benchmarks/core/MemoryManager.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<DeviceMemoryManager> MakeMemoryManager(
     }
 }
 
-void Synchronize(const Device& device) {
+static void Synchronize(const Device& device) {
     if (device.GetType() == Device::DeviceType::CUDA) {
 #ifdef BUILD_CUDA_MODULE
         OPEN3D_CUDA_CHECK(cudaDeviceSynchronize());

--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(core PRIVATE
 
 if (BUILD_CUDA_MODULE)
     target_sources(core PRIVATE
+        CUDAState.cu
         MemoryManagerCUDA.cu
     )
 

--- a/cpp/open3d/core/CUDAState.cu
+++ b/cpp/open3d/core/CUDAState.cu
@@ -1,0 +1,36 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/CUDAState.cuh"
+
+namespace open3d {
+namespace core {
+
+constexpr CUDAScopedStream::CreateNewStreamTag
+        CUDAScopedStream::CreateNewStream;
+
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/t/geometry/kernel/NPPImage.cpp
+++ b/cpp/open3d/t/geometry/kernel/NPPImage.cpp
@@ -26,8 +26,7 @@
 
 #include "open3d/t/geometry/kernel/NPPImage.h"
 
-#include <nppdefs.h>
-#include <nppi.h>
+#include <npp.h>
 
 #include "open3d/core/CUDAUtils.h"
 #include "open3d/core/Dtype.h"
@@ -41,27 +40,67 @@ namespace t {
 namespace geometry {
 namespace npp {
 
+static NppStreamContext MakeNPPContext() {
+    NppStreamContext context;
+    context.hStream = core::cuda::GetStream();
+    context.nCudaDeviceId = core::cuda::GetDevice();
+
+    cudaDeviceProp device_prop;
+    OPEN3D_CUDA_CHECK(
+            cudaGetDeviceProperties(&device_prop, core::cuda::GetDevice()));
+
+    context.nMultiProcessorCount = device_prop.multiProcessorCount;
+    context.nMaxThreadsPerMultiProcessor =
+            device_prop.maxThreadsPerMultiProcessor;
+    context.nSharedMemPerBlock = device_prop.sharedMemPerBlock;
+
+    int cc_major;
+    OPEN3D_CUDA_CHECK(cudaDeviceGetAttribute(&cc_major,
+                                             cudaDevAttrComputeCapabilityMajor,
+                                             core::cuda::GetDevice()));
+    context.nCudaDevAttrComputeCapabilityMajor = cc_major;
+
+    int cc_minor;
+    OPEN3D_CUDA_CHECK(cudaDeviceGetAttribute(&cc_minor,
+                                             cudaDevAttrComputeCapabilityMinor,
+                                             core::cuda::GetDevice()));
+    context.nCudaDevAttrComputeCapabilityMinor = cc_minor;
+
+// The NPP documentation incorrectly states that nStreamFlags becomes available
+// in NPP 10.2 (CUDA 10.2). Instead, NPP 11.1 (CUDA 11.0) is the first release
+// to expose this member variable.
+#if NPP_VERSION >= 11100
+    unsigned int stream_flags;
+    OPEN3D_CUDA_CHECK(
+            cudaStreamGetFlags(core::cuda::GetStream(), &stream_flags));
+    context.nStreamFlags = stream_flags;
+#endif
+
+    return context;
+}
+
 void RGBToGray(const core::Tensor &src_im, core::Tensor &dst_im) {
     NppiSize size_ROI = {static_cast<int>(dst_im.GetShape(1)),
                          static_cast<int>(dst_im.GetShape(0))};
 
     auto dtype = src_im.GetDtype();
+    auto context = MakeNPPContext();
 #define NPP_ARGS                                           \
     static_cast<const npp_dtype *>(src_im.GetDataPtr()),   \
             src_im.GetStride(0) * dtype.ByteSize(),        \
             static_cast<npp_dtype *>(dst_im.GetDataPtr()), \
-            dst_im.GetStride(0) * dtype.ByteSize(), size_ROI
+            dst_im.GetStride(0) * dtype.ByteSize(), size_ROI, context
     if (dtype == core::Dtype::UInt8) {
         using npp_dtype = Npp8u;
-        nppiRGBToGray_8u_C3C1R(NPP_ARGS);
+        nppiRGBToGray_8u_C3C1R_Ctx(NPP_ARGS);
     } else if (dtype == core::Dtype::UInt16) {
         using npp_dtype = Npp16u;
-        nppiRGBToGray_16u_C3C1R(NPP_ARGS);
+        nppiRGBToGray_16u_C3C1R_Ctx(NPP_ARGS);
     } else if (dtype == core::Dtype::Float32) {
         using npp_dtype = Npp32f;
-        nppiRGBToGray_32f_C3C1R(NPP_ARGS);
+        nppiRGBToGray_32f_C3C1R_Ctx(NPP_ARGS);
     } else {
-        utility::LogError("npp::FilterGaussian(): Unspported dtype {}",
+        utility::LogError("npp::FilterGaussian(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS
@@ -98,42 +137,43 @@ void Resize(const open3d::core::Tensor &src_im,
     }
 
     auto dtype = src_im.GetDtype();
+    auto context = MakeNPPContext();
 #define NPP_ARGS                                                       \
     static_cast<const npp_dtype *>(src_im.GetDataPtr()),               \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_roi, \
             static_cast<npp_dtype *>(dst_im.GetDataPtr()),             \
             dst_im.GetStride(0) * dtype.ByteSize(), dst_size, dst_roi, \
-            it->second
+            it->second, context
 
     if (dtype == core::Dtype::UInt8) {
         using npp_dtype = Npp8u;
         if (src_im.GetShape(2) == 1) {
-            nppiResize_8u_C1R(NPP_ARGS);
+            nppiResize_8u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiResize_8u_C3R(NPP_ARGS);
+            nppiResize_8u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiResize_8u_C4R(NPP_ARGS);
+            nppiResize_8u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::UInt16) {
         using npp_dtype = Npp16u;
         if (src_im.GetShape(2) == 1) {
-            nppiResize_16u_C1R(NPP_ARGS);
+            nppiResize_16u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiResize_16u_C3R(NPP_ARGS);
+            nppiResize_16u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiResize_16u_C4R(NPP_ARGS);
+            nppiResize_16u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::Float32) {
         using npp_dtype = Npp32f;
         if (src_im.GetShape(2) == 1) {
-            nppiResize_32f_C1R(NPP_ARGS);
+            nppiResize_32f_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiResize_32f_C3R(NPP_ARGS);
+            nppiResize_32f_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiResize_32f_C4R(NPP_ARGS);
+            nppiResize_32f_C4R_Ctx(NPP_ARGS);
         }
     } else {
-        utility::LogError("npp::Resize(): Unspported dtype {}",
+        utility::LogError("npp::Resize(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS
@@ -159,42 +199,43 @@ void Dilate(const core::Tensor &src_im, core::Tensor &dst_im, int kernel_size) {
     NppiPoint anchor = {kernel_size / 2, kernel_size / 2};
 
     auto dtype = src_im.GetDtype();
+    auto context = MakeNPPContext();
 #define NPP_ARGS                                                          \
     static_cast<const npp_dtype *>(src_im.GetDataPtr()),                  \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_offset, \
             static_cast<npp_dtype *>(dst_im.GetDataPtr()),                \
             dst_im.GetStride(0) * dtype.ByteSize(), size_ROI,             \
             static_cast<const uint8_t *>(mask.GetDataPtr()), mask_size,   \
-            anchor, NPP_BORDER_REPLICATE
+            anchor, NPP_BORDER_REPLICATE, context
     if (dtype == core::Dtype::Bool || dtype == core::Dtype::UInt8) {
         using npp_dtype = Npp8u;
         if (src_im.GetShape(2) == 1) {
-            nppiDilateBorder_8u_C1R(NPP_ARGS);
+            nppiDilateBorder_8u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiDilateBorder_8u_C3R(NPP_ARGS);
+            nppiDilateBorder_8u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiDilateBorder_8u_C4R(NPP_ARGS);
+            nppiDilateBorder_8u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::UInt16) {
         using npp_dtype = Npp16u;
         if (src_im.GetShape(2) == 1) {
-            nppiDilateBorder_16u_C1R(NPP_ARGS);
+            nppiDilateBorder_16u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiDilateBorder_16u_C3R(NPP_ARGS);
+            nppiDilateBorder_16u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiDilateBorder_16u_C4R(NPP_ARGS);
+            nppiDilateBorder_16u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::Float32) {
         using npp_dtype = Npp32f;
         if (src_im.GetShape(2) == 1) {
-            nppiDilateBorder_32f_C1R(NPP_ARGS);
+            nppiDilateBorder_32f_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiDilateBorder_32f_C3R(NPP_ARGS);
+            nppiDilateBorder_32f_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiDilateBorder_32f_C4R(NPP_ARGS);
+            nppiDilateBorder_32f_C4R_Ctx(NPP_ARGS);
         }
     } else {
-        utility::LogError("npp::Dilate(): Unspported dtype {}",
+        utility::LogError("npp::Dilate(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS
@@ -225,41 +266,42 @@ void Filter(const open3d::core::Tensor &src_im,
             static_cast<const float *>(kernel_flipped.GetDataPtr());
 
     auto dtype = src_im.GetDtype();
+    auto context = MakeNPPContext();
 #define NPP_ARGS                                                          \
     static_cast<const npp_dtype *>(src_im.GetDataPtr()),                  \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_offset, \
             static_cast<npp_dtype *>(dst_im.GetDataPtr()),                \
             dst_im.GetStride(0) * dtype.ByteSize(), size_ROI, kernel_ptr, \
-            kernel_size, anchor, NPP_BORDER_REPLICATE
+            kernel_size, anchor, NPP_BORDER_REPLICATE, context
     if (dtype == core::Dtype::UInt8) {
         using npp_dtype = Npp8u;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBorder32f_8u_C1R(NPP_ARGS);
+            nppiFilterBorder32f_8u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBorder32f_8u_C3R(NPP_ARGS);
+            nppiFilterBorder32f_8u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiFilterBorder32f_8u_C4R(NPP_ARGS);
+            nppiFilterBorder32f_8u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::UInt16) {
         using npp_dtype = Npp16u;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBorder32f_16u_C1R(NPP_ARGS);
+            nppiFilterBorder32f_16u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBorder32f_16u_C3R(NPP_ARGS);
+            nppiFilterBorder32f_16u_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiFilterBorder32f_16u_C4R(NPP_ARGS);
+            nppiFilterBorder32f_16u_C4R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::Float32) {
         using npp_dtype = Npp32f;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBorder_32f_C1R(NPP_ARGS);
+            nppiFilterBorder_32f_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBorder_32f_C3R(NPP_ARGS);
+            nppiFilterBorder_32f_C3R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 4) {
-            nppiFilterBorder_32f_C4R(NPP_ARGS);
+            nppiFilterBorder_32f_C4R_Ctx(NPP_ARGS);
         }
     } else {
-        utility::LogError("npp::Filter(): Unspported dtype {}",
+        utility::LogError("npp::Filter(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS
@@ -281,36 +323,37 @@ void FilterBilateral(const core::Tensor &src_im,
                          static_cast<int>(dst_im.GetShape(0))};
 
     auto dtype = src_im.GetDtype();
+    auto context = MakeNPPContext();
 #define NPP_ARGS                                                               \
     static_cast<const npp_dtype *>(src_im.GetDataPtr()),                       \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_offset,      \
             static_cast<npp_dtype *>(dst_im.GetDataPtr()),                     \
             dst_im.GetStride(0) * dtype.ByteSize(), size_ROI, kernel_size / 2, \
             1, value_sigma *value_sigma, distance_sigma *distance_sigma,       \
-            NPP_BORDER_REPLICATE
+            NPP_BORDER_REPLICATE, context
     if (dtype == core::Dtype::UInt8) {
         using npp_dtype = Npp8u;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBilateralGaussBorder_8u_C1R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_8u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBilateralGaussBorder_8u_C3R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_8u_C3R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::UInt16) {
         using npp_dtype = Npp16u;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBilateralGaussBorder_16u_C1R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_16u_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBilateralGaussBorder_16u_C3R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_16u_C3R_Ctx(NPP_ARGS);
         }
     } else if (dtype == core::Dtype::Float32) {
         using npp_dtype = Npp32f;
         if (src_im.GetShape(2) == 1) {
-            nppiFilterBilateralGaussBorder_32f_C1R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_32f_C1R_Ctx(NPP_ARGS);
         } else if (src_im.GetShape(2) == 3) {
-            nppiFilterBilateralGaussBorder_32f_C3R(NPP_ARGS);
+            nppiFilterBilateralGaussBorder_32f_C3R_Ctx(NPP_ARGS);
         }
     } else {
-        utility::LogError("npp::Filter(): Unspported dtype {}",
+        utility::LogError("npp::Filter(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS
@@ -363,30 +406,31 @@ void FilterSobel(const core::Tensor &src_im,
 
     // Counterintuitive conventions: dy: Horizontal,  dx: Vertical.
     // Probable reason: dy detects horizontal edges, dx detects vertical edges.
+    auto context = MakeNPPContext();
 #define NPP_ARGS_DX                                                       \
     static_cast<const npp_src_dtype *>(src_im.GetDataPtr()),              \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_offset, \
             static_cast<npp_dst_dtype *>(dst_im_dx.GetDataPtr()),         \
             dst_im_dx.GetStride(0) * dst_im_dx.GetDtype().ByteSize(),     \
-            size_ROI, it->second, NPP_BORDER_REPLICATE
+            size_ROI, it->second, NPP_BORDER_REPLICATE, context
 #define NPP_ARGS_DY                                                       \
     static_cast<const npp_src_dtype *>(src_im.GetDataPtr()),              \
             src_im.GetStride(0) * dtype.ByteSize(), src_size, src_offset, \
             static_cast<npp_dst_dtype *>(dst_im_dy.GetDataPtr()),         \
             dst_im_dy.GetStride(0) * dst_im_dy.GetDtype().ByteSize(),     \
-            size_ROI, it->second, NPP_BORDER_REPLICATE
+            size_ROI, it->second, NPP_BORDER_REPLICATE, context
     if (dtype == core::Dtype::UInt8) {
         using npp_src_dtype = Npp8u;
         using npp_dst_dtype = Npp16s;
-        nppiFilterSobelVertBorder_8u16s_C1R(NPP_ARGS_DX);
-        nppiFilterSobelHorizBorder_8u16s_C1R(NPP_ARGS_DY);
+        nppiFilterSobelVertBorder_8u16s_C1R_Ctx(NPP_ARGS_DX);
+        nppiFilterSobelHorizBorder_8u16s_C1R_Ctx(NPP_ARGS_DY);
     } else if (dtype == core::Dtype::Float32) {
         using npp_src_dtype = Npp32f;
         using npp_dst_dtype = Npp32f;
-        nppiFilterSobelVertMaskBorder_32f_C1R(NPP_ARGS_DX);
-        nppiFilterSobelHorizMaskBorder_32f_C1R(NPP_ARGS_DY);
+        nppiFilterSobelVertMaskBorder_32f_C1R_Ctx(NPP_ARGS_DX);
+        nppiFilterSobelHorizMaskBorder_32f_C1R_Ctx(NPP_ARGS_DY);
     } else {
-        utility::LogError("npp::FilterSobel(): Unspported dtype {}",
+        utility::LogError("npp::FilterSobel(): Unsupported dtype {}",
                           dtype.ToString());
     }
 #undef NPP_ARGS_DX


### PR DESCRIPTION
Followup of #3732:
- Stream support for `NPPImage`.
- Additional constructor for `CUDAScopedStream` with automatic stream creation and deletion.
- Updated unit test. The large constant `kIterations = 100000` is used to increase the likelihood of detecting multi-threading bugs as thread creation comes with an initial startup cost. More iterations result in longer execution time and, hence, more attack surface for potential bugs to be detected.

Future changes:
- Unification of `CUDAState.cuh` and `CUDAUtils.h` is deferred to another followup PR. This will include making `cuda::Set{Device,Stream}` an implementation detail.
- Potentially adding python bindings for multi-stream/device functionality will also be considered later based on the result of above unification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3748)
<!-- Reviewable:end -->
