### PR TITLE
Move Numpy I/O to t/io/NumpyIO.h

### DIFF
--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -10,7 +10,6 @@ target_sources(core PRIVATE
     MemoryManagerCached.cpp
     MemoryManagerCPU.cpp
     MemoryManagerStatistic.cpp
-    NumpyIO.cpp
     ShapeUtil.cpp
     Tensor.cpp
     TensorKey.cpp

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -33,7 +33,6 @@
 #include "open3d/core/Device.h"
 #include "open3d/core/Dispatch.h"
 #include "open3d/core/Dtype.h"
-#include "open3d/core/NumpyIO.h"
 #include "open3d/core/ShapeUtil.h"
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/TensorKey.h"
@@ -47,6 +46,7 @@
 #include "open3d/core/linalg/SVD.h"
 #include "open3d/core/linalg/Solve.h"
 #include "open3d/core/linalg/Tri.h"
+#include "open3d/t/io/NumpyIO.h"
 #include "open3d/utility/Logging.h"
 
 namespace open3d {
@@ -1534,11 +1534,11 @@ Tensor Tensor::FromDLPack(const DLManagedTensor* src) {
 }
 
 void Tensor::Save(const std::string& file_name) const {
-    NumpyArray(*this).Save(file_name);
+    t::io::WriteNpy(file_name, *this);
 }
 
 Tensor Tensor::Load(const std::string& file_name) {
-    return NumpyArray::Load(file_name).ToTensor();
+    return t::io::ReadNpy(file_name);
 }
 
 bool Tensor::AllClose(const Tensor& other, double rtol, double atol) const {

--- a/cpp/open3d/t/io/CMakeLists.txt
+++ b/cpp/open3d/t/io/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(tio OBJECT)
 
 target_sources(tio PRIVATE
     ImageIO.cpp
+    NumpyIO.cpp
     PointCloudIO.cpp
     TriangleMeshIO.cpp
 )

--- a/cpp/open3d/t/io/NumpyIO.cpp
+++ b/cpp/open3d/t/io/NumpyIO.cpp
@@ -48,7 +48,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include "open3d/core/NumpyIO.h"
+#include "open3d/t/io/NumpyIO.h"
 
 #include <memory>
 #include <numeric>
@@ -57,18 +57,22 @@
 #include <string>
 #include <vector>
 
+#include "open3d/core/Blob.h"
 #include "open3d/core/Dispatch.h"
+#include "open3d/core/Dtype.h"
+#include "open3d/core/SizeVector.h"
 #include "open3d/utility/Logging.h"
 
 namespace open3d {
-namespace core {
+namespace t {
+namespace io {
 
 static char BigEndianChar() {
     int x = 1;
     return (((char*)&x)[0]) ? '<' : '>';
 }
 
-static char DtypeToChar(const Dtype& dtype) {
+static char DtypeToChar(const core::Dtype& dtype) {
     // Not all dtypes are supported.
     // 'f': float, double, long double
     // 'i': int, char, short, long, long long
@@ -78,17 +82,17 @@ static char DtypeToChar(const Dtype& dtype) {
     // 'c': std::complex<float>, std::complex<double>),
     //      std::complex<long double>)
     // '?': object
-    if (dtype == Dtype::Float32) return 'f';
-    if (dtype == Dtype::Float64) return 'f';
-    if (dtype == Dtype::Int8) return 'i';
-    if (dtype == Dtype::Int16) return 'i';
-    if (dtype == Dtype::Int32) return 'i';
-    if (dtype == Dtype::Int64) return 'i';
-    if (dtype == Dtype::UInt8) return 'u';
-    if (dtype == Dtype::UInt16) return 'u';
-    if (dtype == Dtype::UInt32) return 'u';
-    if (dtype == Dtype::UInt64) return 'u';
-    if (dtype == Dtype::Bool) return 'b';
+    if (dtype == core::Dtype::Float32) return 'f';
+    if (dtype == core::Dtype::Float64) return 'f';
+    if (dtype == core::Dtype::Int8) return 'i';
+    if (dtype == core::Dtype::Int16) return 'i';
+    if (dtype == core::Dtype::Int32) return 'i';
+    if (dtype == core::Dtype::Int64) return 'i';
+    if (dtype == core::Dtype::UInt8) return 'u';
+    if (dtype == core::Dtype::UInt16) return 'u';
+    if (dtype == core::Dtype::UInt32) return 'u';
+    if (dtype == core::Dtype::UInt64) return 'u';
+    if (dtype == core::Dtype::Bool) return 'b';
     utility::LogError("Unsupported dtype: {}", dtype.ToString());
     return '\0';
 }
@@ -103,8 +107,8 @@ static std::string ToByteString(const T& rhs) {
     return ss.str();
 }
 
-static std::vector<char> CreateNumpyHeader(const SizeVector& shape,
-                                           const Dtype& dtype) {
+static std::vector<char> CreateNumpyHeader(const core::SizeVector& shape,
+                                           const core::Dtype& dtype) {
     // {}     -> "()"
     // {1}    -> "(1,)"
     // {1, 2} -> "(1, 2)"
@@ -155,10 +159,11 @@ static std::vector<char> CreateNumpyHeader(const SizeVector& shape,
     return std::vector<char>(s.begin(), s.end());
 }
 
-static std::tuple<char, int64_t, SizeVector, bool> ParseNumpyHeader(FILE* fp) {
+static std::tuple<char, int64_t, core::SizeVector, bool> ParseNumpyHeader(
+        FILE* fp) {
     char type;
     int64_t word_size;
-    SizeVector shape;
+    core::SizeVector shape;
     bool fortran_order;
 
     char buffer[256];
@@ -230,97 +235,135 @@ static std::tuple<char, int64_t, SizeVector, bool> ParseNumpyHeader(FILE* fp) {
     return std::make_tuple(type, word_size, shape, fortran_order);
 }
 
-NumpyArray::NumpyArray(const SizeVector& shape,
-                       char type,
-                       int64_t word_size,
-                       bool fortran_order)
-    : shape_(shape),
-      type_(type),
-      word_size_(word_size),
-      fortran_order_(fortran_order) {
-    num_elements_ = 1;
-    for (size_t i = 0; i < shape_.size(); i++) {
-        num_elements_ *= shape_[i];
+class NumpyArray {
+public:
+    NumpyArray(const core::Tensor& t)
+        : shape_(t.GetShape()),
+          type_(DtypeToChar(t.GetDtype())),
+          word_size_(t.GetDtype().ByteSize()),
+          fortran_order_(false),
+          num_elements_(t.GetShape().NumElements()) {
+        blob_ = t.Contiguous().To(core::Device("CPU:0")).GetBlob();
     }
-    blob_ = std::make_shared<Blob>(num_elements_ * word_size_, Device("CPU:0"));
+
+    NumpyArray(const core::SizeVector& shape,
+               char type,
+               int64_t word_size,
+               bool fortran_order)
+        : shape_(shape),
+          type_(type),
+          word_size_(word_size),
+          fortran_order_(fortran_order) {
+        num_elements_ = 1;
+        for (size_t i = 0; i < shape_.size(); i++) {
+            num_elements_ *= shape_[i];
+        }
+        blob_ = std::make_shared<core::Blob>(num_elements_ * word_size_,
+                                             core::Device("CPU:0"));
+    }
+
+    template <typename T>
+    T* GetDataPtr() {
+        return reinterpret_cast<T*>(blob_->GetDataPtr());
+    }
+
+    template <typename T>
+    const T* GetDataPtr() const {
+        return reinterpret_cast<const T*>(blob_->GetDataPtr());
+    }
+
+    core::Dtype GetDtype() const {
+        if (type_ == 'f' && word_size_ == 4) return core::Dtype::Float32;
+        if (type_ == 'f' && word_size_ == 8) return core::Dtype::Float64;
+        if (type_ == 'i' && word_size_ == 1) return core::Dtype::Int8;
+        if (type_ == 'i' && word_size_ == 2) return core::Dtype::Int16;
+        if (type_ == 'i' && word_size_ == 4) return core::Dtype::Int32;
+        if (type_ == 'i' && word_size_ == 8) return core::Dtype::Int64;
+        if (type_ == 'u' && word_size_ == 1) return core::Dtype::UInt8;
+        if (type_ == 'u' && word_size_ == 2) return core::Dtype::UInt16;
+        if (type_ == 'u' && word_size_ == 4) return core::Dtype::UInt32;
+        if (type_ == 'u' && word_size_ == 8) return core::Dtype::UInt64;
+        if (type_ == 'b') return core::Dtype::Bool;
+
+        return core::Dtype::Undefined;
+    }
+
+    core::SizeVector GetShape() const { return shape_; }
+
+    bool IsFortranOrder() const { return fortran_order_; }
+
+    int64_t NumBytes() const { return num_elements_ * word_size_; }
+
+    core::Tensor ToTensor() const {
+        if (fortran_order_) {
+            utility::LogError("Cannot load Numpy array with fortran_order.");
+        }
+        core::Dtype dtype = GetDtype();
+        if (dtype.GetDtypeCode() == core::Dtype::DtypeCode::Undefined) {
+            utility::LogError(
+                    "Cannot load Numpy array with Numpy dtype={} and "
+                    "word_size={}.",
+                    type_, word_size_);
+        }
+        // t.blob_ is the same as blob_, no need for memory copy.
+        core::Tensor t(shape_, core::shape_util::DefaultStrides(shape_),
+                       const_cast<void*>(GetDataPtr<void>()), dtype, blob_);
+        return t;
+    }
+
+    static NumpyArray CreateFromFile(const std::string& filename) {
+        FILE* fp = fopen(filename.c_str(), "rb");
+        if (!fp) {
+            utility::LogError("Load: Unable to open file {}.", filename);
+            assert(fp);
+        }
+        core::SizeVector shape;
+        int64_t word_size;
+        bool fortran_order;
+        char type;
+        std::tie(type, word_size, shape, fortran_order) = ParseNumpyHeader(fp);
+        NumpyArray arr(shape, type, word_size, fortran_order);
+        size_t nread = fread(arr.GetDataPtr<char>(), 1,
+                             static_cast<size_t>(arr.NumBytes()), fp);
+        if (nread != static_cast<size_t>(arr.NumBytes())) {
+            utility::LogError("Load: failed fread");
+        }
+        fclose(fp);
+        return arr;
+    }
+
+    void Save(std::string filename) const {
+        FILE* fp = fopen(filename.c_str(), "wb");
+        if (!fp) {
+            utility::LogError("Save: Unable to open file {}.", filename);
+            return;
+        }
+        std::vector<char> header = CreateNumpyHeader(shape_, GetDtype());
+        fseek(fp, 0, SEEK_SET);
+        fwrite(&header[0], sizeof(char), header.size(), fp);
+        fseek(fp, 0, SEEK_END);
+        fwrite(GetDataPtr<void>(), static_cast<size_t>(GetDtype().ByteSize()),
+               static_cast<size_t>(shape_.NumElements()), fp);
+        fclose(fp);
+    }
+
+private:
+    std::shared_ptr<core::Blob> blob_ = nullptr;
+    core::SizeVector shape_;
+    char type_;
+    int64_t word_size_;
+    bool fortran_order_;
+    int64_t num_elements_;
+};
+
+core::Tensor ReadNpy(const std::string& filename) {
+    return NumpyArray::CreateFromFile(filename).ToTensor();
 }
 
-NumpyArray::NumpyArray(const Tensor& t)
-    : shape_(t.GetShape()),
-      type_(DtypeToChar(t.GetDtype())),
-      word_size_(t.GetDtype().ByteSize()),
-      fortran_order_(false),
-      num_elements_(t.GetShape().NumElements()) {
-    blob_ = t.Contiguous().To(Device("CPU:0")).GetBlob();
+void WriteNpy(const std::string& filename, const core::Tensor& tensor) {
+    NumpyArray(tensor).Save(filename);
 }
 
-Dtype NumpyArray::GetDtype() const {
-    if (type_ == 'f' && word_size_ == 4) return Dtype::Float32;
-    if (type_ == 'f' && word_size_ == 8) return Dtype::Float64;
-    if (type_ == 'i' && word_size_ == 1) return Dtype::Int8;
-    if (type_ == 'i' && word_size_ == 2) return Dtype::Int16;
-    if (type_ == 'i' && word_size_ == 4) return Dtype::Int32;
-    if (type_ == 'i' && word_size_ == 8) return Dtype::Int64;
-    if (type_ == 'u' && word_size_ == 1) return Dtype::UInt8;
-    if (type_ == 'u' && word_size_ == 2) return Dtype::UInt16;
-    if (type_ == 'u' && word_size_ == 4) return Dtype::UInt32;
-    if (type_ == 'u' && word_size_ == 8) return Dtype::UInt64;
-    if (type_ == 'b') return Dtype::Bool;
-
-    return Dtype::Undefined;
-}
-
-Tensor NumpyArray::ToTensor() const {
-    if (fortran_order_) {
-        utility::LogError("Cannot load Numpy array with fortran_order.");
-    }
-    Dtype dtype = GetDtype();
-    if (dtype.GetDtypeCode() == Dtype::DtypeCode::Undefined) {
-        utility::LogError(
-                "Cannot load Numpy array with Numpy dtype={} and word_size={}.",
-                type_, word_size_);
-    }
-    // t.blob_ is the same as blob_, no need for memory copy.
-    Tensor t(shape_, shape_util::DefaultStrides(shape_),
-             const_cast<void*>(GetDataPtr<void>()), dtype, blob_);
-    return t;
-}
-
-NumpyArray NumpyArray::Load(const std::string& file_name) {
-    FILE* fp = fopen(file_name.c_str(), "rb");
-    if (!fp) {
-        utility::LogError("Load: Unable to open file {}.", file_name);
-        assert(fp);
-    }
-    SizeVector shape;
-    int64_t word_size;
-    bool fortran_order;
-    char type;
-    std::tie(type, word_size, shape, fortran_order) = ParseNumpyHeader(fp);
-    NumpyArray arr(shape, type, word_size, fortran_order);
-    size_t nread = fread(arr.GetDataPtr<char>(), 1,
-                         static_cast<size_t>(arr.NumBytes()), fp);
-    if (nread != static_cast<size_t>(arr.NumBytes())) {
-        utility::LogError("Load: failed fread");
-    }
-    fclose(fp);
-    return arr;
-}
-
-void NumpyArray::Save(std::string file_name) const {
-    FILE* fp = fopen(file_name.c_str(), "wb");
-    if (!fp) {
-        utility::LogError("Save: Unable to open file {}.", file_name);
-        return;
-    }
-    std::vector<char> header = CreateNumpyHeader(shape_, GetDtype());
-    fseek(fp, 0, SEEK_SET);
-    fwrite(&header[0], sizeof(char), header.size(), fp);
-    fseek(fp, 0, SEEK_END);
-    fwrite(GetDataPtr<void>(), static_cast<size_t>(GetDtype().ByteSize()),
-           static_cast<size_t>(shape_.NumElements()), fp);
-    fclose(fp);
-}
-
-}  // namespace core
+}  // namespace io
+}  // namespace t
 }  // namespace open3d

--- a/cpp/open3d/t/io/NumpyIO.cpp
+++ b/cpp/open3d/t/io/NumpyIO.cpp
@@ -69,7 +69,7 @@ namespace io {
 
 static char BigEndianChar() {
     int x = 1;
-    return (((char*)&x)[0]) ? '<' : '>';
+    return ((reinterpret_cast<char*>(&x))[0]) ? '<' : '>';
 }
 
 static char DtypeToChar(const core::Dtype& dtype) {
@@ -101,7 +101,7 @@ template <typename T>
 static std::string ToByteString(const T& rhs) {
     std::stringstream ss;
     for (size_t i = 0; i < sizeof(T); i++) {
-        char val = *((char*)&rhs + i);
+        char val = *(reinterpret_cast<const char*>(&rhs) + i);
         ss << val;
     }
     return ss.str();
@@ -243,7 +243,7 @@ public:
           word_size_(t.GetDtype().ByteSize()),
           fortran_order_(false),
           num_elements_(t.GetShape().NumElements()) {
-        blob_ = t.Contiguous().To(core::Device("CPU:0")).GetBlob();
+        blob_ = t.To(core::Device("CPU:0")).Contiguous().GetBlob();
     }
 
     NumpyArray(const core::SizeVector& shape,

--- a/cpp/open3d/t/io/NumpyIO.cpp
+++ b/cpp/open3d/t/io/NumpyIO.cpp
@@ -315,7 +315,6 @@ public:
         FILE* fp = fopen(filename.c_str(), "rb");
         if (!fp) {
             utility::LogError("Load: Unable to open file {}.", filename);
-            assert(fp);
         }
         core::SizeVector shape;
         int64_t word_size;

--- a/cpp/open3d/t/io/NumpyIO.h
+++ b/cpp/open3d/t/io/NumpyIO.h
@@ -26,57 +26,25 @@
 
 #pragma once
 
-#include "open3d/core/Blob.h"
-#include "open3d/core/Dtype.h"
-#include "open3d/core/SizeVector.h"
+#include <string>
+
 #include "open3d/core/Tensor.h"
 
 namespace open3d {
-namespace core {
+namespace t {
+namespace io {
 
-class NumpyArray {
-public:
-    NumpyArray() = delete;
+/// Read Numpy .npy file to a tensor.
+///
+/// \param filename File name to read from.
+core::Tensor ReadNpy(const std::string& filename);
 
-    NumpyArray(const Tensor& t);
+/// Save a tensor to a Numpy .npy file.
+///
+/// \param filename File name to write to.
+/// \param tensor Tensor to save.
+void WriteNpy(const std::string& filename, const core::Tensor& tensor);
 
-    NumpyArray(const SizeVector& shape,
-               char type,
-               int64_t word_size,
-               bool fortran_order);
-
-    template <typename T>
-    T* GetDataPtr() {
-        return reinterpret_cast<T*>(blob_->GetDataPtr());
-    }
-
-    template <typename T>
-    const T* GetDataPtr() const {
-        return reinterpret_cast<const T*>(blob_->GetDataPtr());
-    }
-
-    Dtype GetDtype() const;
-
-    SizeVector GetShape() const { return shape_; }
-
-    bool IsFortranOrder() const { return fortran_order_; }
-
-    int64_t NumBytes() const { return num_elements_ * word_size_; }
-
-    Tensor ToTensor() const;
-
-    static NumpyArray Load(const std::string& file_name);
-
-    void Save(std::string file_name) const;
-
-private:
-    std::shared_ptr<Blob> blob_ = nullptr;
-    SizeVector shape_;
-    char type_;
-    int64_t word_size_;
-    bool fortran_order_;
-    int64_t num_elements_;
-};
-
-}  // namespace core
+}  // namespace io
+}  // namespace t
 }  // namespace open3d

--- a/cpp/tests/t/io/CMakeLists.txt
+++ b/cpp/tests/t/io/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(tests PRIVATE
     ImageIO.cpp
+    NumpyIO.cpp
     PointCloudIO.cpp
     TriangleMeshIO.cpp
 )

--- a/cpp/tests/t/io/NumpyIO.cpp
+++ b/cpp/tests/t/io/NumpyIO.cpp
@@ -1,0 +1,102 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/t/io/NumpyIO.h"
+
+#include <cmath>
+#include <limits>
+
+#include "open3d/utility/FileSystem.h"
+#include "open3d/utility/Logging.h"
+#include "tests/UnitTest.h"
+#include "tests/core/CoreTest.h"
+
+namespace open3d {
+namespace tests {
+
+class NumpyIOPermuteDevices : public PermuteDevices {};
+INSTANTIATE_TEST_SUITE_P(Tensor,
+                         NumpyIOPermuteDevices,
+                         testing::ValuesIn(PermuteDevices::TestCases()));
+
+TEST_P(NumpyIOPermuteDevices, NpyIO) {
+    const core::Device &device = GetParam();
+    const std::string file_name = "tensor.npy";
+
+    core::Tensor t;
+    core::Tensor t_load;
+
+    // 2x2 tensor.
+    t = core::Tensor::Init<float>({{1, 2}, {3, 4}}, device);
+    t.Save(file_name);
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t.AllClose(t_load.To(device)));
+
+    // Non-contiguous tensor will be stored as contiguous tensor.
+    t = core::Tensor::Init<float>(
+            {{{0, 1, 2, 3}, {4, 5, 6, 7}, {8, 9, 10, 11}},
+             {{12, 13, 14, 15}, {16, 17, 18, 19}, {20, 21, 22, 23}}},
+            device);
+    // t[0:2:1, 0:3:2, 0:4:2]
+    t = t.Slice(0, 0, 2, 1).Slice(1, 0, 3, 2).Slice(2, 0, 4, 2);
+    t.Save(file_name);
+    EXPECT_FALSE(t.IsContiguous());
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t_load.IsContiguous());
+    EXPECT_EQ(t_load.GetShape(), core::SizeVector({2, 2, 2}));
+    EXPECT_EQ(t_load.ToFlatVector<float>(),
+              std::vector<float>({0, 2, 8, 10, 12, 14, 20, 22}));
+
+    // {} tensor (scalar).
+    t = core::Tensor::Init<float>(3.14, device);
+    t.Save(file_name);
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t.AllClose(t_load.To(device)));
+
+    // {0} tensor.
+    t = core::Tensor::Ones({0}, core::Dtype::Float32, device);
+    t.Save(file_name);
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t.AllClose(t_load.To(device)));
+
+    // {0, 0} tensor.
+    t = core::Tensor::Ones({0, 0}, core::Dtype::Float32, device);
+    t.Save(file_name);
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t.AllClose(t_load.To(device)));
+
+    // {0, 1, 0} tensor.
+    t = core::Tensor::Ones({0, 1, 0}, core::Dtype::Float32, device);
+    t.Save(file_name);
+    t_load = core::Tensor::Load(file_name);
+    EXPECT_TRUE(t.AllClose(t_load.To(device)));
+
+    // Clean up.
+    utility::filesystem::RemoveFile(file_name);
+}
+
+}  // namespace tests
+}  // namespace open3d


### PR DESCRIPTION
- Move numpy IO to the `t/io` directory. 
- Hide `NumpyArray` class as implementation details. 
- This is a pure refactoring PR to prepare us for future support for `.npz` file format.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3752)
<!-- Reviewable:end -->
