### PR TITLE
WebRTC datachannel HTML DOM element callbacks

### DIFF
--- a/cpp/open3d/visualization/webrtc_server/WebRTCWindowSystem.h
+++ b/cpp/open3d/visualization/webrtc_server/WebRTCWindowSystem.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -118,6 +119,48 @@ public:
 
     /// Close all WebRTC connections that correspond to a Window.
     void CloseWindowConnections(const std::string& window_uid);
+
+    /// \brief Register callback for an HTML DOM event.
+    ///
+    /// The callback will be executed when the corresponding event is received
+    /// on the WebRTC data channel as a message. This can be sent through
+    /// JavaScript from the client (browser) with a \verb class_name of
+    /// "HTMLDOMEvent". Any arbitrary (\p html_element_id, \p event) may be used
+    /// to register a callback, but see
+    /// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement for
+    /// standard HTML elements and events.  A second callback for the same \p
+    /// html_element_id \p event combination will overwrite the previously
+    /// registered callback.
+    ///
+    /// \code{.cpp}
+    /// // Register callback in C++
+    /// open3d::visualization::webrtc_server::enable_webrtc()
+    /// open3d::visualization::webrtc_server::RegisterHTMLDOMCallback(
+    ///     "open3d-dashboard", "input",
+    ///     lambda data: print(f"Received HTML DOM message with data: {data}"))
+    /// \endcode
+    ///
+    /// \code{.js}
+    /// /* Send message in JavaScript to trigger callback. this is
+    /// WebRTCStreamer object */
+    /// this.dataChannel.send('{"class_name":"HTMLDOMEvent",
+    ///     "element_id":"open3d-dashboard",
+    ///     "event":"input",
+    ///     "data":"Test event"}')
+    /// \endcode
+    ///
+    /// \warning The event data passed to the callback must be validated inside
+    /// the callback before use.
+    ///
+    /// \param html_element_id Id of html element that triggered the \p event.
+    /// \param event Name of event.
+    /// \param callback Function to call when this \p event occurs. The function
+    /// should accept a std::string argument (corresponding to the event data,
+    /// such as form data or updated value of a slider) and return void.
+    void RegisterHTMLDOMCallback(
+            const std::string& html_element_id,
+            const std::string& event,
+            std::function<void(const std::string&)> callback);
 
 private:
     WebRTCWindowSystem();

--- a/cpp/pybind/visualization/webrtc_server/webrtc_window_system.cpp
+++ b/cpp/pybind/visualization/webrtc_server/webrtc_window_system.cpp
@@ -27,6 +27,7 @@
 #include "pybind/visualization/webrtc_server/webrtc_window_system.h"
 
 #include "open3d/visualization/webrtc_server/WebRTCWindowSystem.h"
+#include "pybind/docstring.h"
 
 namespace open3d {
 namespace visualization {
@@ -44,6 +45,60 @@ static void pybind_webrtc_server_functions(py::module &m) {
             "Emulates Open3D WebRTCWindowSystem's HTTP API calls. This is used "
             "when the HTTP handshake server is disabled (e.g. in Jupyter), and "
             "handshakes are done by this function.");
+    m.def(
+            "register_HTML_DOM_callback",
+            [](const std::string &html_element_id, const std::string &event,
+               std::function<void(const std::string &)> callback) {
+                return WebRTCWindowSystem::GetInstance()
+                        ->RegisterHTMLDOMCallback(html_element_id, event,
+                                                  callback);
+            },
+            "html_element_id"_a, "event"_a, "callback"_a,
+            R"(
+Register callback for an HTML DOM event.
+
+The callback will be executed when the corresponding event is received
+on the WebRTC data channel as a message. This can be sent through
+JavaScript from the client (browser) with a ``class_name`` of
+"HTMLDOMEvent". Any arbitrary (``html_element_id``, ``event``) may be used
+to register a callback, but see
+`<https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement>`__ for
+standard HTML elements and events.  A second callback for the same \p
+(``html_element_id``, ``event``) combination will overwrite the previously
+registered callback.
+
+.. code:: python
+
+    # Register callback in Python
+    import open3d as o3d
+    o3d.visualization.webrtc_server.enable_webrtc()
+    o3d.visualization.webrtc_server.register_HTML_DOM_callback(
+        "open3d-dashboard", "input",
+        lambda data: print(f"Received HTML DOM message with data: {data}"))
+
+.. code:: js
+
+    /* Send message in JavaScript to trigger callback. this is WebRTCStreamer object */
+    this.dataChannel.send('{"class_name":"HTMLDOMEvent",
+        "element_id":"open3d-dashboard",
+        "event":"input",
+        "data":"Test event"}')
+
+.. warning:: The event data passed to the callback must be validated inside
+the callback before use.
+            )");
+
+    docstring::FunctionDocInject(
+            m, "register_HTML_DOM_callback",
+            {{"html_element_id",
+              "Id of html element that triggered the ``event``."},
+             {"event", "Name of event."},
+             {"callback",
+              "Function to call when this ``event`` occurs. The function "
+              "should accept a string argument (corresponding to the event "
+              "data, such as form data or updated value of a slider) and not "
+              "return anything."}});
+
     m.def(
             "enable_webrtc",
             []() { WebRTCWindowSystem::GetInstance()->EnableWebRTC(); },


### PR DESCRIPTION
Register server callbacks triggered with messages through the WebRTC datachannel registered for specific HTML DOM elements  and events. An example of use is a radio button form in a browser that selects a tag. When the user clicks a button (input event), the browser sends a WebRTC datachannel message that triggers displaying geometry corresponding to that tag in the remote server.

This provides a general mechanism for JavaScript GUI elements without relying on a separate web server to relay messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3758)
<!-- Reviewable:end -->
