### PR TITLE
Add missing include in Logging.h

### DIFF
--- a/cpp/open3d/utility/Logging.h
+++ b/cpp/open3d/utility/Logging.h
@@ -42,6 +42,7 @@
 #endif
 #endif
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 


### PR DESCRIPTION
`fmt 6.0.0` implicitly includes `fmt/ostream.h` in one of its other header files. In (at least) `fmt 8.0.0`, this include has changed such that stream-based support is no longer automatically provided which causes compilation errors. Explicitly include the header file to fix compilation errors with recent versions of `fmt`.

Issue: #3754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3763)
<!-- Reviewable:end -->
