### PR TITLE
Fix inconsistencies in 3rdparty dependency handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ option(USE_SYSTEM_JPEG            "Use system pre-installed jpeg"            OFF
 option(USE_SYSTEM_LIBLZF          "Use system pre-installed liblzf"          OFF)
 option(USE_SYSTEM_PNG             "Use system pre-installed png"             OFF)
 option(USE_SYSTEM_PYBIND11        "Use system pre-installed pybind11"        OFF)
-option(USE_SYSTEM_QHULL           "Use system pre-installed qhull"           OFF)
+option(USE_SYSTEM_QHULLCPP        "Use system pre-installed qhullcpp"        OFF)
 option(USE_SYSTEM_TINYGLTF        "Use system pre-installed tinygltf"        OFF)
 option(USE_SYSTEM_TINYOBJLOADER   "Use system pre-installed tinyobjloader"   OFF)
 option(BUILD_FILAMENT_FROM_SOURCE "Build filament from source"               OFF)
@@ -744,51 +744,50 @@ open3d_aligned_print("Build Benchmarks" "${BUILD_BENCHMARKS}")
 open3d_aligned_print("Bundle Open3D-ML" "${BUNDLE_OPEN3D_ML}")
 open3d_aligned_print("Build RPC interface" "${BUILD_RPC_INTERFACE}")
 if(GLIBCXX_USE_CXX11_ABI)
-    set(usage "1")
+    open3d_aligned_print("Force GLIBCXX_USE_CXX11_ABI=" "1")
 else()
-    set(usage "0")
+    open3d_aligned_print("Force GLIBCXX_USE_CXX11_ABI=" "0")
 endif()
-open3d_aligned_print("Force GLIBCXX_USE_CXX11_ABI=" "${usage}")
+
 message(STATUS "================================================================================")
 message(STATUS "Third-Party Dependencies:")
-set(deps
-    EIGEN3
-    FAISS
-    FILAMENT
-    FMT
+set(3RDPARTY_DEPENDENCIES
+    Eigen3
+    faiss
+    filament
+    fmt
     GLEW
     GLFW
-    GOOGLETEST
-    IMGUI
-    IPPICV
+    googletest
+    imgui
+    ippicv
     JPEG
-    JSONCPP
-    LIBLZF
-    OPENGL
+    jsoncpp
+    liblzf
+    OpenGL
     PNG
-    PYBIND11
-    QHULL
-    LIBREALSENSE
-    TINYFILEDIALOGS
-    TINYGLTF
-    TINYOBJLOADER
-    WEBRTC
+    qhullcpp
+    librealsense
+    tinyfiledialogs
+    TinyGLTF
+    tinyobjloader
+    WebRTC
 )
-foreach(dep IN ITEMS ${deps})
-    if(${dep}_TARGET)
-        if(NOT USE_SYSTEM_${dep})
-            set(usage "yes (build from source)")
+foreach(dep IN LISTS 3RDPARTY_DEPENDENCIES)
+    string(TOLOWER "${dep}" dep_lower)
+    string(TOUPPER "${dep}" dep_upper)
+    if(TARGET Open3D::3rdparty_${dep_lower})
+        if(NOT USE_SYSTEM_${dep_upper})
+            open3d_aligned_print("${dep}" "yes (build from source)")
         else()
-            set(usage "yes")
-            if(${dep}_VERSION_STRING)
-                set(usage "${usage} (v${${dep}_VERSION_STRING})")
-            elseif(${dep}_VERSION)
-                set(usage "${usage} (v${${dep}_VERSION})")
+            if(3rdparty_${dep_lower}_VERSION)
+                open3d_aligned_print("${dep}" "yes (v${3rdparty_${dep_lower}_VERSION})")
+            else()
+                open3d_aligned_print("${dep}" "yes")
             endif()
         endif()
     else()
-        set(usage "no")
+        open3d_aligned_print("${dep}" "no")
     endif()
-    open3d_aligned_print("${dep}" "${usage}")
 endforeach()
 message(STATUS "================================================================================")

--- a/cpp/tools/CMakeLists.txt
+++ b/cpp/tools/CMakeLists.txt
@@ -12,7 +12,7 @@ macro(open3d_add_tool TOOL_NAME)
 endmacro()
 
 open3d_add_tool(ConvertPointCloud)
-open3d_add_tool(GLInfo                  Open3D::3rdparty_glfw3 Open3D::3rdparty_opengl)
+open3d_add_tool(GLInfo                  Open3D::3rdparty_glfw Open3D::3rdparty_opengl)
 open3d_add_tool(ManuallyCropGeometry)
 open3d_add_tool(MergeMesh)
 open3d_add_tool(ViewGeometry)


### PR DESCRIPTION
Summary:

- Add `PUBLIC` and `HEADER` keywords to `open3d_pkg_config_3rdparty_library` and `open3d_find_package_3rdparty_library`. They are used to control target installation like in the other functions. Note that `HEADER` is internally unused in above functions, but for consistency it must be added nonetheless.
- Add `PACKAGE_VERSION_VAR` option to `open3d_find_package_3rdparty_library` to specify non-standard version variables.
- Make dependency names consistent between `USE_SYSTEM_*` variables and `Open3D::3rdparty_*` targets.
- Fix `filament` dependency not being added to the list of `HEADER` targets.
- Fix `parallelstl` dependency not being added to the list of `PUBLIC` targets.
- Fix `PNG` dependency not being installed when using `USE_SYSTEM_PNG`.
- Fix installation of public targets, e.g. `fmt`, when using `USE_SYSTEM_*`.
- Fix broken dependency information prints.

Fixes #3754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d/3772)
<!-- Reviewable:end -->
