### PR TITLE
New KnnIndex for GPU knn search

### DIFF
--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(core PRIVATE
     nns/FixedRadiusIndex.cpp
     nns/NanoFlannIndex.cpp
     nns/NearestNeighborSearch.cpp
+    nns/KnnIndex.cpp
     nns/NNSIndex.cpp
 )
 
@@ -100,6 +101,7 @@ if (BUILD_CUDA_MODULE)
 
     target_sources(core PRIVATE
         nns/FixedRadiusSearch.cu
+        nns/KnnSearchOps.cu
     )
 endif()
 

--- a/cpp/open3d/core/nns/KnnIndex.cpp
+++ b/cpp/open3d/core/nns/KnnIndex.cpp
@@ -1,0 +1,125 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/nns/KnnIndex.h"
+
+#include "open3d/core/Device.h"
+#include "open3d/core/Dispatch.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+namespace nns {
+
+KnnIndex::KnnIndex(){};
+
+KnnIndex::KnnIndex(const Tensor& dataset_points) {
+    SetTensorData(dataset_points);
+}
+
+KnnIndex::~KnnIndex(){};
+
+bool KnnIndex::SetTensorData(const Tensor& dataset_points) {
+    if (dataset_points.NumDims() != 2) {
+        utility::LogError(
+                "KnnIndex::SetTensorData dataset_points must be 2D matri,x "
+                "with shape {n_dataset_points,d}.");
+    }
+    if (dataset_points.GetShape()[0] <= 0 ||
+        dataset_points.GetShape()[1] <= 0) {
+        utility::LogError("KnnIndex::SetTensorData Failed due to no data.");
+    }
+
+    if (dataset_points.GetDevice().GetType() == Device::DeviceType::CUDA) {
+#ifdef BUILD_CUDA_MODULE
+        dataset_points_ = dataset_points.Contiguous();
+
+        std::vector<int64_t> points_row_splits(
+                {0, dataset_points_.GetShape()[0]});
+        points_row_splits_ = Tensor(points_row_splits, {2}, core::Int64);
+        return true;
+#else
+        utility::LogError(
+                "KnnIndex::SetTensorData GPU Tensor is not supported when "
+                "BUILD_CUDA_MODULE=OFF. Please recompile Open3d With "
+                "BUILD_CUDA_MODULE=ON.");
+#endif
+    } else {
+        utility::LogError(
+                "KnnIndex::SetTensorData CPU Tensor i not supported in "
+                "KnnIndex. Please use NanoFlannIndex instread.");
+    }
+    return false;
+}
+
+std::pair<Tensor, Tensor> KnnIndex::SearchKnn(const Tensor& query_points,
+                                              int knn) const {
+    Dtype dtype = GetDtype();
+    Device device = GetDevice();
+
+    query_points.AssertDtype(dtype);
+    query_points.AssertDevice(device);
+    query_points.AssertShapeCompatible({utility::nullopt, GetDimension()});
+    if (knn <= 0) {
+        utility::LogError("KnnIndex::SearchKnn knn should be larger than 0.");
+    }
+
+    Tensor query_points_ = query_points.Contiguous();
+    std::vector<int64_t> queries_row_splits({0, query_points_.GetShape()[0]});
+    Tensor queries_row_splits_ = Tensor(queries_row_splits, {2}, core::Int64);
+
+    Tensor neighbors_index, neighbors_distance;
+
+#define FN_PARAMETERS                                                        \
+    dataset_points_, points_row_splits_, query_points_, queries_row_splits_, \
+            knn, neighbors_index, neighbors_distance
+
+#define CALL(type, fn)                                              \
+    if (Dtype::FromType<type>() == dtype) {                         \
+        fn<type>(FN_PARAMETERS);                                    \
+        return std::make_pair(neighbors_index, neighbors_distance); \
+    }
+
+    if (device.GetType() == Device::DeviceType::CUDA) {
+#ifdef BUILD_CUDA_MODULE
+        CALL(float, KnnSearchCUDA)
+        CALL(double, KnnSearchCUDA)
+#else
+        utility::LogError(
+                "KnnIndex::SearchKnn BUILD_CUDA_MODULE is OFF. "
+                "Please compile Open3d with BUILD_CUDA_MODULE=ON.");
+#endif
+    } else {
+        utility::LogError(
+                "KnnIndex::SearchKnn BUILD_CUDA_MODULE is OFF. "
+                "Please compile Open3d with BUILD_CUDA_MODULE=ON.");
+    }
+    return std::make_pair(neighbors_index, neighbors_distance);
+}
+
+}  // namespace nns
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/nns/KnnIndex.h
+++ b/cpp/open3d/core/nns/KnnIndex.h
@@ -1,0 +1,98 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "open3d/core/Dtype.h"
+#include "open3d/core/Tensor.h"
+#include "open3d/core/nns/NNSIndex.h"
+#include "open3d/core/nns/NeighborSearchCommon.h"
+#include "open3d/utility/Logging.h"
+
+namespace open3d {
+namespace core {
+namespace nns {
+
+#ifdef BUILD_CUDA_MODULE
+template <class T>
+void KnnSearchCUDA(const Tensor& points,
+                   const Tensor& points_row_splits,
+                   const Tensor& queries,
+                   const Tensor& queries_row_splits,
+                   int knn,
+                   Tensor& neighbors_index,
+                   Tensor& neighbors_distance);
+#endif
+
+class KnnIndex : public NNSIndex {
+public:
+    KnnIndex();
+
+    /// \brief Parameterized Constructor.
+    ///
+    /// \param dataset_points Provides a set of data points as Tensor for KDTree
+    /// construction.
+    KnnIndex(const Tensor& dataset_points);
+    ~KnnIndex();
+    KnnIndex(const KnnIndex&) = delete;
+    KnnIndex& operator=(const KnnIndex&) = delete;
+
+public:
+    bool SetTensorData(const Tensor& dataset_points) override;
+    bool SetTensorData(const Tensor& dataset_points, double radius) override {
+        utility::LogError(
+                "[KnnIndex::SetTensorData with radius not implemented.");
+    }
+
+    std::pair<Tensor, Tensor> SearchKnn(const Tensor& query_points,
+                                        int knn) const override;
+
+    std::tuple<Tensor, Tensor, Tensor> SearchRadius(const Tensor& query_points,
+                                                    const Tensor& radii,
+                                                    bool sort) const override {
+        utility::LogError("KnnIndex::SearchRadius not implemented.");
+    }
+
+    std::tuple<Tensor, Tensor, Tensor> SearchRadius(const Tensor& query_points,
+                                                    double radius,
+                                                    bool sort) const override {
+        utility::LogError("KnnIndex::SearchRadius not implemented.");
+    }
+
+    std::tuple<Tensor, Tensor, Tensor> SearchHybrid(
+            const Tensor& query_points,
+            double radius,
+            int max_knn) const override {
+        utility::LogError("KnnIndex::SearchHybrid not implemented.");
+    }
+
+protected:
+    Tensor points_row_splits_;
+};
+
+}  // namespace nns
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/nns/KnnSearchImpl.cuh
+++ b/cpp/open3d/core/nns/KnnSearchImpl.cuh
@@ -1,0 +1,213 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#pragma once
+
+#include "cub/cub.cuh"
+#include "open3d/core/CUDAUtils.h"
+#include "open3d/core/nns/NeighborSearchCommon.h"
+#include "open3d/utility/Helper.h"
+#include "open3d/utility/MiniVec.h"
+
+namespace open3d {
+namespace core {
+namespace nns {
+namespace impl {
+
+namespace {
+
+template <class T>
+using Vec3 = utility::MiniVec<T, 3>;
+
+template <int METRIC = L2, class T>
+inline __device__ T NeighborsDist(const Vec3<T> &p1, const Vec3<T> &p2) {
+    T dist;
+    if (METRIC == Linf) {
+        Vec3<T> d = (p1 - p2).abs();
+        dist = d[0] > d[1] ? d[0] : d[1];
+        dist = dist > d[2] ? dist : d[2];
+    } else if (METRIC == L1) {
+        Vec3<T> d = (p1 - p2).abs();
+        dist = (d[0] + d[1] + d[2]);
+    } else {
+        Vec3<T> d = p1 - p2;
+        dist = d.dot(d);
+    }
+    return dist;
+}
+
+template <class T>
+inline __device__ void swap(T *x, T *y) {
+    T tmp = *x;
+    *x = *y;
+    *y = tmp;
+}
+
+template <class T, class TIndex>
+inline __device__ void heapify(T *dist, TIndex *idx, int root, int k) {
+    int child = root * 2 + 1;
+
+    while (child < k) {
+        if (child + 1 < k && dist[child + 1] > dist[child]) {
+            child++;
+        }
+        if (dist[root] > dist[child]) {
+            return;
+        }
+        swap<T>(&dist[root], &dist[child]);
+        swap<TIndex>(&idx[root], &idx[child]);
+        root = child;
+        child = root * 2 + 1;
+    }
+}
+
+template <class T, class TIndex>
+__device__ void heap_sort(T *dist, TIndex *idx, int k) {
+    int i;
+    for (i = k - 1; i > 0; i--) {
+        swap<T>(&dist[0], &dist[i]);
+        swap<TIndex>(&idx[0], &idx[i]);
+        heapify<T, TIndex>(dist, idx, 0, i);
+    }
+}
+
+template <class TIndex>
+__device__ int get_bt_idx(TIndex idx, const int64_t *offset) {
+    int i = 0;
+    while (1) {
+        if (idx < offset[i])
+            break;
+        else
+            i++;
+    }
+    return i;
+}
+
+template <class T, class TIndex, int METRIC = L2>
+__global__ void knnquery_cuda_kernel(TIndex *__restrict__ indices_ptr,
+                                     T *__restrict__ distances_ptr,
+                                     size_t num_points,
+                                     const T *__restrict__ points,
+                                     size_t num_queries,
+                                     const T *__restrict__ queries,
+                                     int knn) {
+    int query_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (query_idx >= num_queries) return;
+
+    Vec3<T> query_pos(queries[query_idx * 3 + 0], queries[query_idx * 3 + 1],
+                      queries[query_idx * 3 + 2]);
+
+    T best_dist[100];
+    int best_idx[100];
+
+    for (int i = 0; i < knn; i++) {
+        best_dist[i] = 1e10;
+        best_idx[i] = 0;
+    }
+
+    for (int i = 0; i < num_points; i++) {
+        Vec3<T> dataset_pos(points[i * 3 + 0], points[i * 3 + 1],
+                            points[i * 3 + 2]);
+        T dist = NeighborsDist<METRIC, T>(query_pos, dataset_pos);
+        if (dist < best_dist[0]) {
+            best_dist[0] = dist;
+            best_idx[0] = i;
+            heapify(best_dist, best_idx, 0, knn);
+        }
+    }
+    heap_sort(best_dist, best_idx, knn);
+    for (int i = 0; i < knn; i++) {
+        indices_ptr[i + knn * query_idx] = best_idx[i];
+        distances_ptr[i + knn * query_idx] = best_dist[i];
+    }
+}
+
+template <class T, class TIndex>
+void knnquery_cuda_launcher(const cudaStream_t &stream,
+                            TIndex *indices_ptr,
+                            T *distances_ptr,
+                            size_t num_points,
+                            const T *const points,
+                            size_t num_queries,
+                            const T *const queries,
+                            int knn) {
+    // input: queries: (m, 3), points: (n, 3), idx: (m, knn)
+    const int BLOCKSIZE = 256;
+    dim3 block(BLOCKSIZE, 1, 1);
+    dim3 grid(0, 1, 1);
+    grid.x = utility::DivUp(num_queries, block.x);
+
+    if (grid.x) {
+        knnquery_cuda_kernel<T, TIndex><<<grid, block, 0, stream>>>(
+                indices_ptr, distances_ptr, num_points, points, num_queries,
+                queries, knn);
+    }
+}
+
+}  // namespace
+
+template <class T, class OUTPUT_ALLOCATOR>
+void KnnSearchCUDA(const cudaStream_t stream,
+                   size_t num_points,
+                   const T *const points,
+                   size_t num_queries,
+                   const T *const queries,
+                   size_t points_row_splits_size,
+                   const int64_t *const points_row_splits,
+                   size_t queries_row_splits_size,
+                   const int64_t *const queries_row_splits,
+                   int knn,
+                   OUTPUT_ALLOCATOR &output_allocator) {
+    const int batch_size = points_row_splits_size - 1;
+
+    const size_t num_indices = num_queries * knn;
+
+    int64_t *indices_ptr;
+    T *distances_ptr;
+
+    output_allocator.AllocIndices(&indices_ptr, num_indices);
+    output_allocator.AllocDistances(&distances_ptr, num_indices);
+
+    for (int i = 0; i < batch_size; ++i) {
+        const size_t num_queries_i =
+                queries_row_splits[i + 1] - queries_row_splits[i];
+        const size_t num_points_i =
+                points_row_splits[i + 1] - points_row_splits[i];
+
+        const T *const points_i = points + 3 * points_row_splits[i];
+        const T *const queries_i = queries + 3 * queries_row_splits[i];
+        int64_t *indices_ptr_i = indices_ptr + queries_row_splits[i] * knn;
+        T *distances_ptr_i = distances_ptr + queries_row_splits[i] * knn;
+        knnquery_cuda_launcher(stream, indices_ptr_i, distances_ptr_i,
+                               num_points_i, points_i, num_queries_i, queries_i,
+                               knn);
+    }
+}
+
+}  // namespace impl
+}  // namespace nns
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/nns/KnnSearchOps.cu
+++ b/cpp/open3d/core/nns/KnnSearchOps.cu
@@ -1,0 +1,77 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/Tensor.h"
+#include "open3d/core/nns/FixedRadiusIndex.h"
+#include "open3d/core/nns/KnnIndex.h"
+#include "open3d/core/nns/KnnSearchImpl.cuh"
+
+namespace open3d {
+namespace core {
+namespace nns {
+
+template <class T>
+void KnnSearchCUDA(const Tensor& points,
+                   const Tensor& points_row_splits,
+                   const Tensor& queries,
+                   const Tensor& queries_row_splits,
+                   int knn,
+                   Tensor& neighbors_index,
+                   Tensor& neighbors_distance) {
+    const cudaStream_t stream = 0;
+
+    Device device = points.GetDevice();
+    NeighborSearchAllocator<T> output_allocator(device);
+
+    int num_points = points.GetShape()[0];
+    int num_queries = queries.GetShape()[0];
+    knn = num_points > knn ? knn : num_points;
+
+    open3d::core::nns::impl::KnnSearchCUDA(
+            stream, points.GetShape()[0], points.GetDataPtr<T>(),
+            queries.GetShape()[0], queries.GetDataPtr<T>(),
+            points_row_splits.GetShape()[0],
+            points_row_splits.GetDataPtr<int64_t>(),
+            queries_row_splits.GetShape()[0],
+            queries_row_splits.GetDataPtr<int64_t>(), knn, output_allocator);
+
+    neighbors_index =
+            output_allocator.NeighborsIndex().View({num_queries, knn});
+    neighbors_distance =
+            output_allocator.NeighborsDistance().View({num_queries, knn});
+}
+
+#define INSTANTIATE(T)                                                        \
+    template void KnnSearchCUDA<T>(                                           \
+            const Tensor& points, const Tensor& points_row_splits,            \
+            const Tensor& queries, const Tensor& queries_row_splits, int knn, \
+            Tensor& neighbors_index, Tensor& neighbors_distance);
+
+INSTANTIATE(float)
+INSTANTIATE(double)
+}  // namespace nns
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/nns/NanoFlannIndex.h
+++ b/cpp/open3d/core/nns/NanoFlannIndex.h
@@ -30,6 +30,7 @@
 
 #include "open3d/core/Tensor.h"
 #include "open3d/core/nns/NNSIndex.h"
+#include "open3d/core/nns/NeighborSearchCommon.h"
 #include "open3d/utility/Logging.h"
 
 // Forward declarations.
@@ -52,7 +53,7 @@ namespace core {
 namespace nns {
 
 /// Distance metric enum.
-enum Metric { L1, L2, Linf };
+// enum Metric { L1, L2, Linf };
 
 /// Base struct for Index holder
 struct NanoFlannIndexHolderBase {

--- a/cpp/open3d/core/nns/NearestNeighborSearch.cpp
+++ b/cpp/open3d/core/nns/NearestNeighborSearch.cpp
@@ -42,8 +42,8 @@ bool NearestNeighborSearch::SetIndex() {
 bool NearestNeighborSearch::KnnIndex() {
     if (dataset_points_.GetDevice().GetType() == Device::DeviceType::CUDA) {
 #ifdef WITH_FAISS
-        faiss_index_.reset(new FaissIndex());
-        return faiss_index_->SetTensorData(dataset_points_);
+        knn_index_.reset(new KnnIndex());
+        return knn_index_->SetTensorData(dataset_points_);
 #else
         utility::LogError(
                 "[NearestNeighborSearch::KnnIndex] Currently, Faiss is "
@@ -103,8 +103,8 @@ bool NearestNeighborSearch::HybridIndex(utility::optional<double> radius) {
 std::pair<Tensor, Tensor> NearestNeighborSearch::KnnSearch(
         const Tensor& query_points, int knn) {
 #ifdef WITH_FAISS
-    if (faiss_index_) {
-        return faiss_index_->SearchKnn(query_points, knn);
+    if (knn_index_) {
+        return knn_index_->SearchKnn(query_points, knn);
     }
 #endif
     if (nanoflann_index_) {

--- a/cpp/open3d/core/nns/NearestNeighborSearch.h
+++ b/cpp/open3d/core/nns/NearestNeighborSearch.h
@@ -31,6 +31,7 @@
 #include "open3d/core/Tensor.h"
 #include "open3d/core/nns/FaissIndex.h"
 #include "open3d/core/nns/FixedRadiusIndex.h"
+#include "open3d/core/nns/KnnIndex.h"
 #include "open3d/core/nns/NanoFlannIndex.h"
 #include "open3d/utility/Optional.h"
 
@@ -140,6 +141,7 @@ protected:
     std::unique_ptr<NanoFlannIndex> nanoflann_index_;
     std::unique_ptr<FaissIndex> faiss_index_;
     std::unique_ptr<nns::FixedRadiusIndex> fixed_radius_index_;
+    std::unique_ptr<nns::KnnIndex> knn_index_;
     const Tensor dataset_points_;
 };
 }  // namespace nns

--- a/cpp/tests/core/CMakeLists.txt
+++ b/cpp/tests/core/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(tests PRIVATE
 if (BUILD_CUDA_MODULE)
     target_sources(tests PRIVATE
         FixedRadiusIndex.cpp
+        KnnIndex.cpp
     )
 endif()
 

--- a/cpp/tests/core/KnnIndex.cpp
+++ b/cpp/tests/core/KnnIndex.cpp
@@ -1,0 +1,99 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018-2021 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+#include "open3d/core/nns/KnnIndex.h"
+
+#include <cmath>
+#include <limits>
+
+#include "core/CoreTest.h"
+#include "open3d/core/Device.h"
+#include "open3d/core/Dtype.h"
+#include "open3d/core/SizeVector.h"
+#include "open3d/core/Tensor.h"
+#include "open3d/utility/Helper.h"
+#include "tests/UnitTest.h"
+#include "tests/core/CoreTest.h"
+
+using namespace open3d;
+using namespace std;
+
+namespace open3d {
+namespace tests {
+
+TEST(KnnIndex, KnnSearch) {
+    // Set up Knn index.
+    int size = 10;
+    core::Device device = core::Device("CUDA:0");
+    std::vector<float> points{0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.2, 0.0,
+                              0.1, 0.0, 0.0, 0.1, 0.1, 0.0, 0.1, 0.2, 0.0, 0.2,
+                              0.0, 0.0, 0.2, 0.1, 0.0, 0.2, 0.2, 0.1, 0.0, 0.0};
+    core::Tensor dataset_points(points, {size, 3}, core::Float32, device);
+    core::nns::KnnIndex knn_index(dataset_points);
+
+    core::Tensor query_points(
+            std::vector<float>({0.064705, 0.043921, 0.087843}), {1, 3},
+            core::Float32, device);
+
+    // If k <= 0.
+    EXPECT_THROW(knn_index.SearchKnn(query_points, -1), std::runtime_error);
+    EXPECT_THROW(knn_index.SearchKnn(query_points, 0), std::runtime_error);
+
+    // If k == 3.
+    core::Tensor indices, distances;
+    core::SizeVector shape;
+    std::tie(indices, distances) = knn_index.SearchKnn(query_points, 3);
+
+    shape = core::SizeVector{1, 3};
+    EXPECT_EQ(indices.GetShape(), shape);
+    EXPECT_EQ(distances.GetShape(), shape);
+    EXPECT_EQ(indices.ToFlatVector<int64_t>(), std::vector<int64_t>({1, 4, 9}));
+    ExpectEQ(distances.ToFlatVector<float>(),
+             std::vector<float>({0.00626358, 0.00747938, 0.0108912}));
+
+    // If k > size.result.
+    std::tie(indices, distances) = knn_index.SearchKnn(query_points, 12);
+    EXPECT_EQ(indices.ToFlatVector<int64_t>(),
+              std::vector<int64_t>({1, 4, 9, 0, 3, 2, 5, 7, 6, 8}));
+    ExpectEQ(distances.ToFlatVector<float>(),
+             std::vector<float>({0.00626358, 0.00747938, 0.0108912, 0.0138322,
+                                 0.015048, 0.018695, 0.0199108, 0.0286952,
+                                 0.0362638, 0.0411266}));
+
+    // Multiple points.
+    query_points =
+            core::Tensor(std::vector<float>({0.064705, 0.043921, 0.087843,
+                                             0.064705, 0.043921, 0.087843}),
+                         {2, 3}, core::Float32, device);
+    std::tie(indices, distances) = knn_index.SearchKnn(query_points, 3);
+    EXPECT_EQ(indices.ToFlatVector<int64_t>(),
+              std::vector<int64_t>({1, 4, 9, 1, 4, 9}));
+    ExpectEQ(distances.ToFlatVector<float>(),
+             std::vector<float>({0.00626358, 0.00747938, 0.0108912, 0.00626358,
+                                 0.00747938, 0.0108912}));
+}
+
+}  // namespace tests
+}  // namespace open3d


### PR DESCRIPTION
Since there are some concerns with Faiss, here we introduce a new class for GPU Knn search.

Current issues regarding Faiss are listed below. 
1.  It takes a huge amount of compilation time.
2. But we only utilize a small part of it (e.g.  IndexFlat)
3. Although we need more investigation, the performance of Faiss under some applications (e.g. EsimateNormals, etc) are not satisfactory

This PR implements brute force knn search with heap sort.
Unittest passes, now we need to benchmark this.

* Note: Large part of this code is brought from HengShuang's original implementation.


